### PR TITLE
Features/auth/refresh

### DIFF
--- a/services/auth/src/Auth.Application/Abstractions/Persistence/IAuthUserRepository.cs
+++ b/services/auth/src/Auth.Application/Abstractions/Persistence/IAuthUserRepository.cs
@@ -7,6 +7,10 @@ namespace Auth.Application.Abstractions.Persistence;
 public interface IAuthUserRepository
 {
     Task<AuthUser?> GetByIdAsync(long id, CancellationToken cancellationToken = default);
+
+    Task<AuthUser?> GetByRefreshTokenHashAsync(
+        string hash, CancellationToken cancellationToken = default);
+
     Task<AuthUser?> GetByEmailAsync(string email, CancellationToken cancellationToken = default);
     Task<AuthUser?> GetByOAuthAsync(
         OAuthProvider provider,

--- a/services/auth/src/Auth.Application/Abstractions/Security/ISecretHasher.cs
+++ b/services/auth/src/Auth.Application/Abstractions/Security/ISecretHasher.cs
@@ -4,4 +4,6 @@ public interface ISecretHasher
 {
     string Hash(string value);
     bool Verify(string value, string hash);
+
+    string HashDeterministic(string value);
 }

--- a/services/auth/src/Auth.Application/Features/Refresh/RefreshCommand.cs
+++ b/services/auth/src/Auth.Application/Features/Refresh/RefreshCommand.cs
@@ -1,0 +1,8 @@
+using Auth.Application.Abstractions.Messaging;
+using Auth.Domain.Results;
+
+namespace Auth.Application.Features.Refresh;
+
+public sealed record RefreshCommand(
+    string RefreshToken
+) : ICommand<Result<RefreshResult>>;

--- a/services/auth/src/Auth.Application/Features/Refresh/RefreshHandler.cs
+++ b/services/auth/src/Auth.Application/Features/Refresh/RefreshHandler.cs
@@ -17,7 +17,7 @@ internal sealed class RefreshHandler(
         RefreshCommand command,
         CancellationToken cancellationToken = default)
     {
-        var hash = secretHasher.Hash(command.RefreshToken);
+        var hash = secretHasher.HashDeterministic(command.RefreshToken);
         var user = await userRepository.GetByRefreshTokenHashAsync(hash, cancellationToken);
 
         if (user is null || user.IsDeleted)
@@ -31,7 +31,7 @@ internal sealed class RefreshHandler(
         var now = clock.UtcNow;
 
         user.SetRefreshToken(
-            secretHasher.Hash(newRefreshToken),
+            secretHasher.HashDeterministic(newRefreshToken),
             now,
             now.Add(tokenGenerator.GetRefreshTokenLifetime())
         );

--- a/services/auth/src/Auth.Application/Features/Refresh/RefreshHandler.cs
+++ b/services/auth/src/Auth.Application/Features/Refresh/RefreshHandler.cs
@@ -1,0 +1,43 @@
+using Auth.Application.Abstractions;
+using Auth.Application.Abstractions.Messaging;
+using Auth.Application.Abstractions.Persistence;
+using Auth.Application.Abstractions.Security;
+using Auth.Domain.Results;
+
+namespace Auth.Application.Features.Refresh;
+
+internal sealed class RefreshHandler(
+    IAuthUserRepository userRepository,
+    ISecretHasher secretHasher,
+    ITokenGenerator tokenGenerator,
+    IClock clock
+) : ICommandHandler<RefreshCommand, Result<RefreshResult>>
+{
+    public async Task<Result<RefreshResult>> HandleAsync(
+        RefreshCommand command,
+        CancellationToken cancellationToken = default)
+    {
+        var hash = secretHasher.Hash(command.RefreshToken);
+        var user = await userRepository.GetByRefreshTokenHashAsync(hash, cancellationToken);
+
+        if (user is null || user.IsDeleted)
+            return AuthFailures.InvalidRefreshToken;
+
+        if (user.RefreshToken is null || !user.RefreshToken.IsActive(clock.UtcNow))
+            return AuthFailures.InvalidRefreshToken;
+
+        var newAccessToken = tokenGenerator.GenerateAccessToken(user.Id);
+        var newRefreshToken = tokenGenerator.GenerateRefreshToken();
+        var now = clock.UtcNow;
+
+        user.SetRefreshToken(
+            secretHasher.Hash(newRefreshToken),
+            now,
+            now.Add(tokenGenerator.GetRefreshTokenLifetime())
+        );
+
+        await userRepository.SaveChangesAsync(cancellationToken);
+
+        return new RefreshResult(newAccessToken, newRefreshToken);
+    }
+}

--- a/services/auth/src/Auth.Application/Features/Refresh/RefreshResult.cs
+++ b/services/auth/src/Auth.Application/Features/Refresh/RefreshResult.cs
@@ -1,0 +1,6 @@
+namespace Auth.Application.Features.Refresh;
+
+public sealed record RefreshResult(
+    string AccessToken,
+    string RefreshToken
+);

--- a/services/auth/src/Auth.Infrastructure/DependencyInjection.cs
+++ b/services/auth/src/Auth.Infrastructure/DependencyInjection.cs
@@ -42,7 +42,7 @@ public static class DependencyInjection
         services.AddSingleton<IEventBus, EventBus>();
         services.AddSingleton<IClock, SystemClock>();
         services.AddSingleton<IIdGenerator, SnowflakeIdGenerator>();
-        services.AddSingleton<ISecretHasher, BcryptHasher>();
+        services.AddSingleton<ISecretHasher, SecretHasher>();
         services.AddSingleton<ITokenGenerator, TokenGenerator>();
 
         // services.AddKeyedTransient<IOAuthProviderClient, GithubOAuthProviderClient>(OAuthProvider.Github);

--- a/services/auth/src/Auth.Infrastructure/Security/SecretHasher.cs
+++ b/services/auth/src/Auth.Infrastructure/Security/SecretHasher.cs
@@ -1,9 +1,11 @@
+using System.Security.Cryptography;
+using System.Text;
 using Auth.Application.Abstractions.Security;
 using BCryptNet = BCrypt.Net.BCrypt;
 
 namespace Auth.Infrastructure.Security;
 
-internal sealed class BcryptHasher : ISecretHasher
+internal sealed class SecretHasher : ISecretHasher
 {
     private const int WorkFactor = 12;
 
@@ -11,4 +13,10 @@ internal sealed class BcryptHasher : ISecretHasher
         BCryptNet.EnhancedHashPassword(value, workFactor: WorkFactor);
 
     public bool Verify(string value, string hash) => BCryptNet.EnhancedVerify(value, hash);
+
+    public string HashDeterministic(string value)
+    {
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(value));
+        return Convert.ToHexString(bytes).ToLowerInvariant();
+    }
 }

--- a/services/auth/src/Auth.Persistence/Repositories/AuthUserRepository.cs
+++ b/services/auth/src/Auth.Persistence/Repositories/AuthUserRepository.cs
@@ -15,6 +15,14 @@ internal sealed class AuthUserRepository(AuthDbContext context) : IAuthUserRepos
             .FirstOrDefaultAsync(u => u.Id == id, cancellationToken);
     }
 
+    public async Task<AuthUser?> GetByRefreshTokenHashAsync(string hash, CancellationToken cancellationToken = default)
+    {
+        return await context.AuthUsers
+            .FirstOrDefaultAsync(
+                u => u.RefreshToken != null && u.RefreshToken.Hash == hash,
+                cancellationToken);
+    }
+
     public async Task<AuthUser?> GetByEmailAsync(string email, CancellationToken cancellationToken = default)
     {
         return await context.AuthUsers

--- a/services/auth/src/Auth.Presentation/Contracts/Refresh/RefreshResponse.cs
+++ b/services/auth/src/Auth.Presentation/Contracts/Refresh/RefreshResponse.cs
@@ -1,0 +1,3 @@
+namespace Auth.Presentation.Contracts.Refresh;
+
+public sealed record RefreshResponse(string AccessToken);

--- a/services/auth/src/Auth.Presentation/Endpoints/RefreshEndpoint.cs
+++ b/services/auth/src/Auth.Presentation/Endpoints/RefreshEndpoint.cs
@@ -1,0 +1,63 @@
+using Carter;
+using Microsoft.Extensions.Options;
+using Auth.Application.Abstractions;
+using Auth.Application.Abstractions.Messaging;
+using Auth.Application.Features.Refresh;
+using Auth.Domain.Results;
+using Auth.Infrastructure.Options;
+using Auth.Presentation.Contracts.Refresh;
+
+using RefreshEndpointHttpResults = Microsoft.AspNetCore.Http.HttpResults.Results<
+    Microsoft.AspNetCore.Http.HttpResults.Ok<
+        Auth.Presentation.Contracts.Refresh.RefreshResponse
+    >,
+    Microsoft.AspNetCore.Http.HttpResults.UnauthorizedHttpResult
+>;
+
+namespace Auth.Presentation.Endpoints;
+
+public sealed class RefreshEndpoint : ICarterModule
+{
+    public void AddRoutes(IEndpointRouteBuilder endpoints)
+    {
+        endpoints.MapPost("/refresh", async (
+            HttpContext ctx,
+            ICommandHandler<RefreshCommand, Result<RefreshResult>> handler,
+            IClock clock,
+            IOptions<RefreshTokenOptions> options
+        ) => await Refresh(ctx, handler, clock, options.Value));
+    }
+
+    private static async Task<RefreshEndpointHttpResults> Refresh(
+        HttpContext ctx,
+        ICommandHandler<RefreshCommand, Result<RefreshResult>> handler,
+        IClock clock,
+        RefreshTokenOptions options)
+    {
+        var rawToken = ctx.Request.Cookies[options.CookieName];
+        if (string.IsNullOrEmpty(rawToken))
+            return TypedResults.Unauthorized();
+
+        var command = new RefreshCommand(rawToken);
+        var result = await handler.HandleAsync(command, ctx.RequestAborted);
+
+        return result.Match<RefreshEndpointHttpResults>(
+            r =>
+            {
+                ctx.Response.Cookies.Append(
+                    options.CookieName,
+                    r.RefreshToken,
+                    new CookieOptions
+                    {
+                        HttpOnly = options.HttpOnly,
+                        Secure = options.Secure,
+                        SameSite = SameSiteMode.Strict,
+                        Expires = clock.UtcNow.AddDays(options.TtlDays)
+                    }
+                );
+                return TypedResults.Ok(new RefreshResponse(r.AccessToken));
+            },
+            _ => TypedResults.Unauthorized()
+        );
+    }
+}


### PR DESCRIPTION
## What

Implements the `POST /auth/v1/refresh` endpoint (issue #18) — including a new deterministic hashing strategy for refresh tokens.

## Why

Access tokens are short-lived (15 min). Users need a way to obtain a new one without re-authenticating, using the `HttpOnly` refresh token cookie set at login/register. This endpoint validates the cookie, rotates the token, and issues a fresh access token.

## Changes

- **`RefreshCommand` / `RefreshResult`** — command carrying the raw refresh token from the cookie; result carrying the new `AccessToken` and `RefreshToken`
- **`RefreshHandler`** — hashes the incoming token deterministically, resolves the user via `GetByRefreshTokenHashAsync`, validates the token is present and active (`IsActive(now)`), rotates both tokens, and persists via `SaveChangesAsync`; any failure (user not found, soft-deleted, token expired/missing) returns `InvalidRefreshToken`
- **`ISecretHasher.HashDeterministic`** — new method on the abstraction for SHA-256 hashing; unlike `Hash` (bcrypt), it is deterministic so the same input always produces the same output, making DB lookup by token hash possible without storing the raw token
- **`SecretHasher`** — renamed from `BcryptHasher` (more accurate now that it handles two hashing strategies); implements `HashDeterministic` via `SHA256.HashData`, hex-encoded lowercase
- **`IAuthUserRepository.GetByRefreshTokenHashAsync`** — new query method on the abstraction; implemented in `AuthUserRepository` with an EF Core `FirstOrDefaultAsync` on the owned `RefreshToken.Hash` property
- **`RefreshResponse`** — presentation DTO exposing only `AccessToken` (rotated refresh token goes in the cookie)
- **`RefreshEndpoint`** — Carter `ICarterModule`, maps `POST /refresh`; reads the raw token from the `HttpOnly` cookie (early `401` if absent), delegates to `RefreshHandler`, sets the rotated refresh token cookie, returns `200 OK` with the new access token or `401 Unauthorized` on any failure

## Notes

> **Why two hashing strategies?** Bcrypt is intentionally slow and non-deterministic (salted), which is ideal for passwords. Refresh tokens however need to be looked up by hash in DB — bcrypt can't be used for that since the same input produces a different hash each time. SHA-256 is used instead: fast, deterministic, and sufficient for a high-entropy random token (no need for slow hashing when the input is already unpredictable).

> **Token rotation** — every successful refresh invalidates the old token hash and writes a new one. Reusing a consumed token returns `401`, which also acts as a basic reuse-detection signal.

---

Closes #18