### PR TITLE
Features/auth/logout

### DIFF
--- a/services/auth/src/Auth.Application/Abstractions/Security/ICurrentUser.cs
+++ b/services/auth/src/Auth.Application/Abstractions/Security/ICurrentUser.cs
@@ -1,0 +1,6 @@
+namespace Auth.Application.Abstractions.Security;
+
+public interface ICurrentUser
+{
+	long Id { get; }
+}

--- a/services/auth/src/Auth.Application/Features/Logout/LogoutCommand.cs
+++ b/services/auth/src/Auth.Application/Features/Logout/LogoutCommand.cs
@@ -1,0 +1,6 @@
+using Auth.Application.Abstractions.Messaging;
+using Auth.Domain.Results;
+
+namespace Auth.Application.Features.Logout;
+
+public sealed record LogoutCommand(long UserId) : ICommand<Result>;

--- a/services/auth/src/Auth.Application/Features/Logout/LogoutHandler.cs
+++ b/services/auth/src/Auth.Application/Features/Logout/LogoutHandler.cs
@@ -1,0 +1,32 @@
+using Auth.Application.Abstractions;
+using Auth.Application.Abstractions.Events;
+using Auth.Application.Abstractions.Messaging;
+using Auth.Application.Abstractions.Persistence;
+using Auth.Application.Events;
+using Auth.Domain.Results;
+
+namespace Auth.Application.Features.Logout;
+
+internal sealed class LogoutHandler(
+    IAuthUserRepository userRepository,
+    IEventBus eventBus,
+    IClock clock
+) : ICommandHandler<LogoutCommand, Result>
+{
+    public async Task<Result> HandleAsync(
+        LogoutCommand command,
+        CancellationToken cancellationToken = default)
+    {
+        var user = await userRepository.GetByIdAsync(command.UserId, cancellationToken);
+
+        if (user is null || user.IsDeleted)
+            return AuthFailures.InvalidAccessToken;
+
+        user.RevokeRefreshToken(clock.UtcNow);
+        await userRepository.SaveChangesAsync(cancellationToken);
+
+        await eventBus.PublishAsync(new UserLoggedOutEvent(command.UserId), cancellationToken);
+
+        return Result.Ok();
+    }
+}

--- a/services/auth/src/Auth.Domain/Results/AuthFailures.cs
+++ b/services/auth/src/Auth.Domain/Results/AuthFailures.cs
@@ -14,17 +14,11 @@ public static class AuthFailures
     public static readonly Failure InvalidCredentials =
         new("Auth.InvalidCredentials", "Invalid credentials.");
 
-    public static readonly Failure MissingRefreshToken =
-        new("Auth.MissingRefreshToken", "Refresh token is missing.");
-
+    public static readonly Failure InvalidAccessToken =
+        new("Auth.InvalidAccessToken", "Access token is invalid.");
+        
     public static readonly Failure InvalidRefreshToken =
         new("Auth.InvalidRefreshToken", "Refresh token is invalid.");
-
-    public static readonly Failure ExpiredRefreshToken =
-        new("Auth.ExpiredRefreshToken", "Refresh token is expired.");
-
-    public static readonly Failure RevokedRefreshToken =
-        new("Auth.RevokedRefreshToken", "Refresh token is revoked.");
 
     public static readonly Failure InvalidOAuthProvider =
         new("Auth.InvalidOAuthProvider", "OAuth provider is invalid.");

--- a/services/auth/src/Auth.Infrastructure/Auth.Infrastructure.csproj
+++ b/services/auth/src/Auth.Infrastructure/Auth.Infrastructure.csproj
@@ -5,10 +5,12 @@
     </ItemGroup>
 
     <ItemGroup>
+        <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    </ItemGroup>
+
+    <ItemGroup>
         <PackageReference Include="BCrypt.Net-Next" Version="4.1.0" />
         <PackageReference Include="MassTransit.RabbitMQ" Version="8.4.1" />
-        <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.0" />
         <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.3.0" />
     </ItemGroup>
 

--- a/services/auth/src/Auth.Infrastructure/DependencyInjection.cs
+++ b/services/auth/src/Auth.Infrastructure/DependencyInjection.cs
@@ -39,11 +39,13 @@ public static class DependencyInjection
             })
         );
 
+        services.AddHttpContextAccessor();
         services.AddSingleton<IEventBus, EventBus>();
         services.AddSingleton<IClock, SystemClock>();
         services.AddSingleton<IIdGenerator, SnowflakeIdGenerator>();
         services.AddSingleton<ISecretHasher, BcryptHasher>();
         services.AddSingleton<ITokenGenerator, TokenGenerator>();
+        services.AddTransient<ICurrentUser, CurrentUser>();
 
         // services.AddKeyedTransient<IOAuthProviderClient, GithubOAuthProviderClient>(OAuthProvider.Github);
         // services.AddKeyedTransient<IOAuthProviderClient, GoogleOAuthProviderClient>(OAuthProvider.Google);

--- a/services/auth/src/Auth.Infrastructure/Security/CurrentUser.cs
+++ b/services/auth/src/Auth.Infrastructure/Security/CurrentUser.cs
@@ -1,0 +1,27 @@
+using System.Security.Claims;
+using Auth.Application.Abstractions.Security;
+using Microsoft.AspNetCore.Http;
+
+namespace Auth.Infrastructure.Security;
+
+internal sealed class CurrentUser(IHttpContextAccessor accessor) : ICurrentUser
+{
+	public long Id
+	{
+		get
+		{
+			var user = accessor.HttpContext?.User
+				?? throw new InvalidOperationException("No HttpContext is available.");
+
+			var sub = user.FindFirstValue(ClaimTypes.NameIdentifier)
+				?? user.FindFirstValue("sub")
+				?? throw new InvalidOperationException("Authenticated user has no 'sub' claim.");
+
+			if (!long.TryParse(sub, out var id))
+				throw new InvalidOperationException(
+					$"Authenticated user 'sub' claim ('{sub}') is not a valid snowflake ID.");
+
+			return id;
+		}
+	}
+}

--- a/services/auth/src/Auth.Presentation/Auth.Presentation.csproj
+++ b/services/auth/src/Auth.Presentation/Auth.Presentation.csproj
@@ -9,6 +9,7 @@
 
     <ItemGroup>
         <PackageReference Include="Carter" Version="10.0.0"/>
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.2"/>
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.2"/>
         <PackageReference Include="Scalar.AspNetCore" Version="2.6.0"/>
         <!-- Needed by dotnet-ef for migrations generation -->

--- a/services/auth/src/Auth.Presentation/DependencyInjection.cs
+++ b/services/auth/src/Auth.Presentation/DependencyInjection.cs
@@ -1,0 +1,40 @@
+using Auth.Infrastructure.Options;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Microsoft.IdentityModel.Tokens;
+using System.Text;
+
+namespace Auth.Presentation;
+
+public static class DependencyInjection
+{
+    public static IServiceCollection AddJwtAuthentication(this IServiceCollection services)
+    {
+        services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+                .AddJwtBearer();
+
+        services.AddAuthorization();
+
+        services.AddOptions<JwtBearerOptions>(JwtBearerDefaults.AuthenticationScheme)
+                .Configure<IOptions<JwtOptions>>((bearerOpts, jwtOpts) =>
+                {
+                    var jwt = jwtOpts.Value;
+                    var secretKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwt.SecretKey));
+                    bearerOpts.MapInboundClaims = false;
+                    bearerOpts.TokenValidationParameters = new TokenValidationParameters
+                    {
+                        ValidateIssuer           = true,
+                        ValidIssuer              = jwt.Issuer,
+                        ValidateAudience         = true,
+                        ValidAudience            = jwt.Audience,
+                        ValidateIssuerSigningKey = true,
+                        IssuerSigningKey         = secretKey,
+                        ValidateLifetime         = true,
+                        ClockSkew                = TimeSpan.Zero,
+                    };
+                });
+
+        return services;
+    }
+}

--- a/services/auth/src/Auth.Presentation/Endpoints/LogoutEndpoint.cs
+++ b/services/auth/src/Auth.Presentation/Endpoints/LogoutEndpoint.cs
@@ -2,6 +2,7 @@ using Carter;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.Extensions.Options;
 using Auth.Application.Abstractions.Messaging;
+using Auth.Application.Abstractions.Security;
 using Auth.Application.Features.Logout;
 using Auth.Domain.Results;
 using Auth.Infrastructure.Options;
@@ -18,23 +19,21 @@ public sealed class LogoutEndpoint : ICarterModule
     public void AddRoutes(IEndpointRouteBuilder endpoints)
     {
         endpoints.MapPost("/logout", async (
-            HttpContext ctx,
+            ICurrentUser currentUser,
             ICommandHandler<LogoutCommand, Result> handler,
-            IOptions<RefreshTokenOptions> options
-        ) => await Logout(ctx, handler, options.Value))
+            IOptions<RefreshTokenOptions> options,
+            HttpContext ctx
+        ) => await Logout(currentUser, handler, options.Value, ctx))
         .RequireAuthorization();
     }
 
     private static async Task<LogoutEndpointHttpResults> Logout(
-        HttpContext ctx,
+        ICurrentUser currentUser,
         ICommandHandler<LogoutCommand, Result> handler,
-        RefreshTokenOptions options)
+        RefreshTokenOptions options,
+        HttpContext ctx)
     {
-        var userIdStr = ctx.User.FindFirst("sub")?.Value;
-        if (!long.TryParse(userIdStr, out var userId))
-            return TypedResults.Unauthorized();
-
-        var command = new LogoutCommand(userId);
+        var command = new LogoutCommand(currentUser.Id);
         var result = await handler.HandleAsync(command, ctx.RequestAborted);
 
         return result.Match<LogoutEndpointHttpResults>(

--- a/services/auth/src/Auth.Presentation/Endpoints/LogoutEndpoint.cs
+++ b/services/auth/src/Auth.Presentation/Endpoints/LogoutEndpoint.cs
@@ -1,0 +1,53 @@
+using Carter;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.Extensions.Options;
+using Auth.Application.Abstractions.Messaging;
+using Auth.Application.Features.Logout;
+using Auth.Domain.Results;
+using Auth.Infrastructure.Options;
+
+using LogoutEndpointHttpResults = Microsoft.AspNetCore.Http.HttpResults.Results<
+    Microsoft.AspNetCore.Http.HttpResults.NoContent,
+    Microsoft.AspNetCore.Http.HttpResults.UnauthorizedHttpResult
+>;
+
+namespace Auth.Presentation.Endpoints;
+
+public sealed class LogoutEndpoint : ICarterModule
+{
+    public void AddRoutes(IEndpointRouteBuilder endpoints)
+    {
+        endpoints.MapPost("/logout", async (
+            HttpContext ctx,
+            ICommandHandler<LogoutCommand, Result> handler,
+            IOptions<RefreshTokenOptions> options
+        ) => await Logout(ctx, handler, options.Value))
+        .RequireAuthorization();
+    }
+
+    private static async Task<LogoutEndpointHttpResults> Logout(
+        HttpContext ctx,
+        ICommandHandler<LogoutCommand, Result> handler,
+        RefreshTokenOptions options)
+    {
+        var userIdStr = ctx.User.FindFirst("sub")?.Value;
+        if (!long.TryParse(userIdStr, out var userId))
+            return TypedResults.Unauthorized();
+
+        var command = new LogoutCommand(userId);
+        var result = await handler.HandleAsync(command, ctx.RequestAborted);
+
+        return result.Match<LogoutEndpointHttpResults>(
+            () =>
+            {
+                ctx.Response.Cookies.Delete(options.CookieName, new CookieOptions
+                {
+                    Secure   = options.Secure,
+                    SameSite = SameSiteMode.Strict,
+                });
+                return TypedResults.NoContent();
+            },
+            _ => TypedResults.Unauthorized()
+        );
+    }
+}

--- a/services/auth/src/Auth.Presentation/Program.cs
+++ b/services/auth/src/Auth.Presentation/Program.cs
@@ -3,6 +3,7 @@ using Auth.Application;
 using Auth.Infrastructure;
 using Auth.Persistence;
 using Auth.Presentation.Middleware;
+using Auth.Presentation;
 using Scalar.AspNetCore;
 using System.Text.Json;
 
@@ -18,7 +19,8 @@ builder.Services.AddOpenApi()
 
 builder.Services.AddApplication()
                 .AddInfrastructure()
-                .AddPersistence();
+                .AddPersistence()
+                .AddJwtAuthentication();
 
 builder.Services.AddCarter();
 
@@ -35,6 +37,8 @@ if (app.Environment.IsDevelopment())
 }
 
 app.UseMiddleware<ExceptionHandlingMiddleware>();
+app.UseAuthentication();
+app.UseAuthorization();
 
 app.MapHealthChecks("/healthz");
 var v1 = app.MapGroup("/v1");


### PR DESCRIPTION
## What

Implements the `POST /auth/logout` endpoint (issue #19) , including JWT Bearer authentication wired into the ASP.NET Core pipeline.

## Why

Authenticated users need a way to explicitly terminate their session: revoke their refresh token and clear the cookie. This endpoint is also the trigger for the `user.logged_out` RabbitMQ event consumed by downstream services.

## Changes

- **`LogoutCommand`** — command carrying the `UserId` extracted from the JWT `sub` claim
- **`LogoutHandler`** — resolves the user by ID, calls `RevokeRefreshToken(now)` on the domain entity, persists via `SaveChangesAsync`, and publishes a `user.logged_out` event via `IEventBus`; returns `InvalidAccessToken` if the user is not found or soft-deleted
- **`AuthFailures` cleanup** — removed the now-unused granular refresh token failures (`MissingRefreshToken`, `ExpiredRefreshToken`, `RevokedRefreshToken`) and introduced `InvalidAccessToken`; all refresh token failure cases are collapsed into `InvalidRefreshToken`
- **`DependencyInjection` (Presentation)** — new `AddJwtAuthentication` extension; configures `JwtBearer` with parameters driven by `JwtOptions` 
- **`Microsoft.AspNetCore.Authentication.JwtBearer`** — added to `Auth.Presentation.csproj`
- **`Program.cs`** — registers `AddJwtAuthentication()` and adds `UseAuthentication()` / `UseAuthorization()` to the middleware pipeline
- **`LogoutEndpoint`** — Carter `ICarterModule`, maps `POST /logout` with `.RequireAuthorization()`; extracts `UserId` from the `sub` claim (early `401` if missing or unparseable), delegates to `LogoutHandler`, deletes the refresh token cookie on success, returns `204 No Content` or `401 Unauthorized`

## Notes

> **Cookie deletion** — `Cookies.Delete` is called with the same `Secure` and `SameSite` attributes used at login/register to ensure the browser actually removes the cookie (mismatched attributes can silently prevent deletion).

---

Closes #19