### PR TITLE
Fix/jwt env again

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,4 +25,4 @@ BASE_API_URL=
 #    │   ───── Example: a-very-long-secret-key-at-least-32-chars ─────     │
 #    ╰─────────────────────────────────────────────────────────────────────╯
 
-JWT_SECRETKEY=
+JWT_SECRET=

--- a/services/gateway/.env.example
+++ b/services/gateway/.env.example
@@ -1,7 +1,3 @@
-# Temp value for the JWT secret
-# for example: HelloWorld123
-JWT_SECRET=
-
 # Services url and ports
 # for example: http://auth:8000
 AUTH_SERVICE_URL=

--- a/services/gateway/Tiltfile
+++ b/services/gateway/Tiltfile
@@ -1,7 +1,10 @@
-load('../../tiltlib.star', 'detect_engine', 'run_flags', 'container_serve')
+load('../../tiltlib.star', 'detect_engine', 'read_dotenv', 'run_flags', 'container_serve')
 
-DOCKER = detect_engine()
-FLAGS  = run_flags(DOCKER)
+root_env = read_dotenv('../../.env')
+JWT_SECRET   = root_env.get('JWT_SECRET', '')
+
+DOCKER   = detect_engine()
+FLAGS    = run_flags(DOCKER)
 
 local_resource(
     'gateway',
@@ -10,6 +13,7 @@ local_resource(
         '--network ft_transcendence ' +
         '--env-file .env ' +
         '-e DEV=true ' +
+        '-e JWT_SECRET=' + JWT_SECRET + ' ' +
         '-v $(pwd):/app ' +
         'gateway-service'
     ),

--- a/services/gateway/compose.yaml
+++ b/services/gateway/compose.yaml
@@ -7,6 +7,8 @@ services:
       context: ${PWD}/services/gateway
       dockerfile: Dockerfile
     env_file: ${PWD}/services/gateway/.env
+    environment:
+      JWT_SECRET: ${JWT_SECRET}
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "./healthcheck_binary"]


### PR DESCRIPTION
Rename `JWT_SECRETKEY` in `JWT_SECRET`.
Gateway and Auth services retrieve `JWT_SECRET` from root env, thanks to Tilt or Compose.