### PR TITLE
feat(auth/pres): add global exception handling middleware

### DIFF
--- a/services/auth/src/Auth.Infrastructure/Security/TokenGenerator.cs
+++ b/services/auth/src/Auth.Infrastructure/Security/TokenGenerator.cs
@@ -34,7 +34,7 @@ internal sealed class TokenGenerator(
             issuer: _jwtOptions.Issuer,
             audience: _jwtOptions.Audience,
             claims: claims,
-            expires: DateTime.UtcNow.AddMinutes(_jwtOptions.AccessTokenTtlMinutes),
+            expires: clock.UtcNow.AddMinutes(_jwtOptions.AccessTokenTtlMinutes).DateTime,
             signingCredentials: credentials
         );
 

--- a/services/auth/src/Auth.Presentation/Contracts/ErrorResponse.cs
+++ b/services/auth/src/Auth.Presentation/Contracts/ErrorResponse.cs
@@ -1,0 +1,3 @@
+namespace Auth.Presentation.Contracts;
+
+public sealed record ErrorResponse(string Error);

--- a/services/auth/src/Auth.Presentation/Middleware/ExceptionHandlingMiddleware.cs
+++ b/services/auth/src/Auth.Presentation/Middleware/ExceptionHandlingMiddleware.cs
@@ -1,0 +1,22 @@
+using Auth.Presentation.Contracts;
+
+namespace Auth.Presentation.Middleware;
+
+public sealed class ExceptionHandlingMiddleware(RequestDelegate next, ILogger<ExceptionHandlingMiddleware> logger)
+{
+    public async Task InvokeAsync(HttpContext ctx)
+    {
+        try
+        {
+            await next(ctx);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Unhandled exception on {Method} {Path}", ctx.Request.Method, ctx.Request.Path);
+
+            ctx.Response.StatusCode = StatusCodes.Status500InternalServerError;
+            ctx.Response.ContentType = "application/json";
+            await ctx.Response.WriteAsJsonAsync(new ErrorResponse("An unexpected error occurred."));
+        }
+    }
+}

--- a/services/auth/src/Auth.Presentation/Program.cs
+++ b/services/auth/src/Auth.Presentation/Program.cs
@@ -2,9 +2,8 @@ using Carter;
 using Auth.Application;
 using Auth.Infrastructure;
 using Auth.Persistence;
+using Auth.Presentation.Middleware;
 using Scalar.AspNetCore;
-using Auth.Persistence.Db;
-using Microsoft.EntityFrameworkCore;
 using System.Text.Json;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -34,6 +33,8 @@ if (app.Environment.IsDevelopment())
         options.AddServer(new ScalarServer($"{apiUrl}/auth"));
     });
 }
+
+app.UseMiddleware<ExceptionHandlingMiddleware>();
 
 app.MapHealthChecks("/healthz");
 var v1 = app.MapGroup("/v1");


### PR DESCRIPTION
Return a clean `500 JSON` response on **unhandled** exceptions instead of **leaking** stack traces.
Logs the full error **server-side** via `ILogger`.