### PR TITLE
Features/auth/oauth

### DIFF
--- a/services/auth/src/Auth.Application/Abstractions/OAuth/IOAuthProviderClient.cs
+++ b/services/auth/src/Auth.Application/Abstractions/OAuth/IOAuthProviderClient.cs
@@ -1,12 +1,11 @@
 using Auth.Domain.Results;
+using Auth.Domain.AuthUser;
 
 namespace Auth.Application.Abstractions.OAuth;
 
 public interface IOAuthProviderClient
 {
-    string BuildAuthorizationUrl(string state);
-
-    Task<Result<string>> GetUserIdAsync(
-        string code,
-        CancellationToken cancellationToken = default);
+    Uri                         BuildAuthorizationUrl(string state);
+    Task<Result<OAuthUserInfo>> ExchangeCodeAsync(string code,
+                                    CancellationToken cancellationToken = default);
 }

--- a/services/auth/src/Auth.Application/Abstractions/OAuth/IOAuthProviderClient.cs
+++ b/services/auth/src/Auth.Application/Abstractions/OAuth/IOAuthProviderClient.cs
@@ -6,6 +6,6 @@ namespace Auth.Application.Abstractions.OAuth;
 public interface IOAuthProviderClient
 {
     Uri                         BuildAuthorizationUrl(string state);
-    Task<Result<OAuthUserInfo>> ExchangeCodeAsync(string code,
+    Task<Result<OAuthUserInfo>> ExchangeCodeAsync(string code, string state,
                                     CancellationToken cancellationToken = default);
 }

--- a/services/auth/src/Auth.Application/Features/OAuth/OAuthCallbackCommand.cs
+++ b/services/auth/src/Auth.Application/Features/OAuth/OAuthCallbackCommand.cs
@@ -4,5 +4,7 @@ using Auth.Domain.Results;
 
 namespace Auth.Application.Features.OAuth;
 
-public sealed record OAuthCallbackCommand(OAuthProvider Provider, string Code)
-    : ICommand<Result<OAuthCallbackResult>>;
+public sealed record OAuthCallbackCommand(
+                        OAuthProvider Provider,
+                        string Code,
+                        string State): ICommand<Result<OAuthCallbackResult>>;

--- a/services/auth/src/Auth.Application/Features/OAuth/OAuthCallbackCommand.cs
+++ b/services/auth/src/Auth.Application/Features/OAuth/OAuthCallbackCommand.cs
@@ -1,0 +1,8 @@
+using Auth.Application.Abstractions.Messaging;
+using Auth.Domain.AuthUser;
+using Auth.Domain.Results;
+
+namespace Auth.Application.Features.OAuth;
+
+public sealed record OAuthCallbackCommand(OAuthProvider Provider, string Code)
+    : ICommand<Result<OAuthCallbackResult>>;

--- a/services/auth/src/Auth.Application/Features/OAuth/OAuthCallbackHandler.cs
+++ b/services/auth/src/Auth.Application/Features/OAuth/OAuthCallbackHandler.cs
@@ -1,0 +1,12 @@
+using Auth.Application.Abstractions.Messaging;
+using Auth.Domain.Results;
+
+namespace Auth.Application.Features.OAuth;
+
+internal sealed class OAuthCallbackHandler
+    : ICommandHandler<OAuthCallbackCommand, Result<OAuthCallbackResult>>
+{
+    public Task<Result<OAuthCallbackResult>> HandleAsync(
+        OAuthCallbackCommand command, CancellationToken cancellationToken = default)
+        => throw new NotImplementedException();
+}

--- a/services/auth/src/Auth.Application/Features/OAuth/OAuthCallbackHandler.cs
+++ b/services/auth/src/Auth.Application/Features/OAuth/OAuthCallbackHandler.cs
@@ -1,12 +1,76 @@
+using Auth.Application.Abstractions;
+using Auth.Application.Abstractions.Events;
 using Auth.Application.Abstractions.Messaging;
+using Auth.Application.Abstractions.OAuth;
+using Auth.Application.Abstractions.Persistence;
+using Auth.Application.Abstractions.Security;
+using Auth.Application.Events;
+using Auth.Domain.AuthUser;
 using Auth.Domain.Results;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Auth.Application.Features.OAuth;
 
-internal sealed class OAuthCallbackHandler
+internal sealed class OAuthCallbackHandler(
+    IServiceProvider sp,
+    IAuthUserRepository repository,
+    ITokenGenerator tokenGenerator,
+    ISecretHasher hasher,
+    IIdGenerator idGenerator,
+    IClock clock,
+    IEventBus eventBus)
     : ICommandHandler<OAuthCallbackCommand, Result<OAuthCallbackResult>>
 {
-    public Task<Result<OAuthCallbackResult>> HandleAsync(
+    public async Task<Result<OAuthCallbackResult>> HandleAsync(
         OAuthCallbackCommand command, CancellationToken cancellationToken = default)
-        => throw new NotImplementedException();
+    {
+        var client = sp.GetKeyedService<IOAuthProviderClient>(command.Provider);
+        if (client is null)
+            return AuthFailures.InvalidOAuthProvider;
+
+        var userInfoResult = await client.ExchangeCodeAsync(command.Code, command.State, cancellationToken);
+        if (userInfoResult.IsFailure)
+            return userInfoResult.Error;
+
+        var userInfo = userInfoResult.Value;
+        var now = clock.UtcNow;
+
+        var existingUser = await repository.GetByOAuthAsync(command.Provider, userInfo.ProviderId, cancellationToken);
+
+        bool isNewUser;
+        AuthUser user;
+
+        if (existingUser is not null)
+        {
+            user = existingUser;
+            isNewUser = false;
+        }
+        else
+        {
+            var id = idGenerator.NextId();
+            var createResult = AuthUser.CreateOAuthUser(id, command.Provider, userInfo.ProviderId, now);
+            if (createResult.IsFailure)
+                return createResult.Error;
+
+            user = createResult.Value;
+            await repository.AddAsync(user, cancellationToken);
+            isNewUser = true;
+        }
+
+        var rawRefreshToken = tokenGenerator.GenerateRefreshToken();
+        var setTokenResult = user.SetRefreshToken(
+            hasher.Hash(rawRefreshToken),
+            now,
+            now.Add(tokenGenerator.GetRefreshTokenLifetime()));
+        if (setTokenResult.IsFailure)
+            return setTokenResult.Error;
+
+        await repository.SaveChangesAsync(cancellationToken);
+        if (isNewUser)
+            await eventBus.PublishAsync(
+                new UserRegisteredEvent(user.Id, userInfo.Email ?? string.Empty), cancellationToken);
+
+        var accessToken = tokenGenerator.GenerateAccessToken(user.Id);
+        return new OAuthCallbackResult(accessToken, rawRefreshToken, isNewUser);
+    }
 }

--- a/services/auth/src/Auth.Application/Features/OAuth/OAuthCallbackResult.cs
+++ b/services/auth/src/Auth.Application/Features/OAuth/OAuthCallbackResult.cs
@@ -1,0 +1,3 @@
+namespace Auth.Application.Features.OAuth;
+
+public sealed record OAuthCallbackResult(string AccessToken, string RefreshToken, bool IsNewUser);

--- a/services/auth/src/Auth.Application/Features/OAuth/OAuthLoginCommand.cs
+++ b/services/auth/src/Auth.Application/Features/OAuth/OAuthLoginCommand.cs
@@ -1,0 +1,8 @@
+using Auth.Application.Abstractions.Messaging;
+using Auth.Domain.AuthUser;
+using Auth.Domain.Results;
+
+namespace Auth.Application.Features.OAuth;
+
+public sealed record OAuthLoginCommand(OAuthProvider Provider)
+    : ICommand<Result<OAuthLoginResult>>;

--- a/services/auth/src/Auth.Application/Features/OAuth/OAuthLoginHandler.cs
+++ b/services/auth/src/Auth.Application/Features/OAuth/OAuthLoginHandler.cs
@@ -1,12 +1,33 @@
+using System.Security.Cryptography;
 using Auth.Application.Abstractions.Messaging;
+using Auth.Application.Abstractions.OAuth;
+using Auth.Domain.AuthUser;
 using Auth.Domain.Results;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Auth.Application.Features.OAuth;
 
-internal sealed class OAuthLoginHandler
+internal sealed class OAuthLoginHandler(IServiceProvider sp)
     : ICommandHandler<OAuthLoginCommand, Result<OAuthLoginResult>>
 {
     public Task<Result<OAuthLoginResult>> HandleAsync(
         OAuthLoginCommand command, CancellationToken cancellationToken = default)
-        => throw new NotImplementedException();
+    {
+        var client = sp.GetKeyedService<IOAuthProviderClient>(command.Provider);
+        if (client is null)
+            return Task.FromResult<Result<OAuthLoginResult>>(AuthFailures.InvalidOAuthProvider);
+
+        var state = GenerateState();
+        return Task.FromResult<Result<OAuthLoginResult>>(
+            new OAuthLoginResult(client.BuildAuthorizationUrl(state), state)
+        );
+    }
+
+    private static string GenerateState()
+    {
+        var bytes = new byte[32];
+        RandomNumberGenerator.Fill(bytes);
+        return Convert.ToBase64String(bytes)
+            .Replace('+', '-').Replace('/', '_').TrimEnd('=');
+    }
 }

--- a/services/auth/src/Auth.Application/Features/OAuth/OAuthLoginHandler.cs
+++ b/services/auth/src/Auth.Application/Features/OAuth/OAuthLoginHandler.cs
@@ -1,0 +1,12 @@
+using Auth.Application.Abstractions.Messaging;
+using Auth.Domain.Results;
+
+namespace Auth.Application.Features.OAuth;
+
+internal sealed class OAuthLoginHandler
+    : ICommandHandler<OAuthLoginCommand, Result<OAuthLoginResult>>
+{
+    public Task<Result<OAuthLoginResult>> HandleAsync(
+        OAuthLoginCommand command, CancellationToken cancellationToken = default)
+        => throw new NotImplementedException();
+}

--- a/services/auth/src/Auth.Application/Features/OAuth/OAuthLoginResult.cs
+++ b/services/auth/src/Auth.Application/Features/OAuth/OAuthLoginResult.cs
@@ -1,0 +1,3 @@
+namespace Auth.Application.Features.OAuth;
+
+public sealed record OAuthLoginResult(Uri RedirectUri, string State);

--- a/services/auth/src/Auth.Domain/AuthUser/OAuthProvider.cs
+++ b/services/auth/src/Auth.Domain/AuthUser/OAuthProvider.cs
@@ -2,8 +2,8 @@ namespace Auth.Domain.AuthUser;
 
 public enum OAuthProvider
 {
-    Unknown,
-    Github,
-    Google,
-    FortyTwo
+    Unknown = 0,
+    Github = 1,
+    Google = 2,
+    FortyTwo = 3
 }

--- a/services/auth/src/Auth.Domain/AuthUser/OAuthUserInfo.cs
+++ b/services/auth/src/Auth.Domain/AuthUser/OAuthUserInfo.cs
@@ -1,4 +1,4 @@
 namespace Auth.Domain.AuthUser;
 
 #nullable enable
-public sealed record OAuthUserInfo(string ProviderId, string? Email);
+public sealed record OAuthUserInfo(string ProviderId, string? Email, bool? EmailVerified);

--- a/services/auth/src/Auth.Domain/AuthUser/OAuthUserInfo.cs
+++ b/services/auth/src/Auth.Domain/AuthUser/OAuthUserInfo.cs
@@ -1,0 +1,4 @@
+namespace Auth.Domain.AuthUser;
+
+#nullable enable
+public sealed record OAuthUserInfo(string ProviderId, string? Email);

--- a/services/auth/src/Auth.Domain/Results/AuthFailures.cs
+++ b/services/auth/src/Auth.Domain/Results/AuthFailures.cs
@@ -34,4 +34,7 @@ public static class AuthFailures
 
     public static readonly Failure OAuthProviderError =
         new("Auth.OAuthProviderError", "OAuth provider returned an error.");
+
+    public static readonly Failure OAuthUpstreamError =
+        new("Auth.OAuthUpstreamError", "OAuth provider is temporarily unavailable.");
 }

--- a/services/auth/src/Auth.Domain/Results/AuthFailures.cs
+++ b/services/auth/src/Auth.Domain/Results/AuthFailures.cs
@@ -28,4 +28,10 @@ public static class AuthFailures
 
     public static readonly Failure InvalidAuthUserState =
         new("Auth.InvalidAuthUserState", "Auth user state is invalid.");
+
+    public static readonly Failure InvalidOAuthState =
+        new("Auth.InvalidOAuthState", "OAuth state is invalid or expired.");
+
+    public static readonly Failure OAuthProviderError =
+        new("Auth.OAuthProviderError", "OAuth provider returned an error.");
 }

--- a/services/auth/src/Auth.Infrastructure/Auth.Infrastructure.csproj
+++ b/services/auth/src/Auth.Infrastructure/Auth.Infrastructure.csproj
@@ -10,7 +10,6 @@
 
     <ItemGroup>
         <PackageReference Include="BCrypt.Net-Next" Version="4.1.0" />
-        <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.0" />
         <PackageReference Include="MassTransit.RabbitMQ" Version="8.4.1" />
         <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.3.0" />
     </ItemGroup>

--- a/services/auth/src/Auth.Infrastructure/Auth.Infrastructure.csproj
+++ b/services/auth/src/Auth.Infrastructure/Auth.Infrastructure.csproj
@@ -10,6 +10,7 @@
 
     <ItemGroup>
         <PackageReference Include="BCrypt.Net-Next" Version="4.1.0" />
+        <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.0" />
         <PackageReference Include="MassTransit.RabbitMQ" Version="8.4.1" />
         <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.3.0" />
     </ItemGroup>

--- a/services/auth/src/Auth.Infrastructure/DependencyInjection.cs
+++ b/services/auth/src/Auth.Infrastructure/DependencyInjection.cs
@@ -1,7 +1,9 @@
 using System.Reflection;
 using Auth.Application.Abstractions;
 using Auth.Application.Abstractions.Events;
+using Auth.Application.Abstractions.OAuth;
 using Auth.Application.Abstractions.Security;
+using Auth.Infrastructure.OAuth;
 using Auth.Infrastructure.Options;
 using Auth.Infrastructure.Security;
 using MassTransit;
@@ -14,18 +16,14 @@ public static class DependencyInjection
 {
     public static IServiceCollection AddInfrastructure(this IServiceCollection services)
     {
-        var optionsTypes = typeof(DependencyInjection).Assembly.GetTypes()
-            .Where(t => t is { IsAbstract: false, IsInterface: false } &&
-                        typeof(IOptions).IsAssignableFrom(t));
+        SetupFromAssembly(services,
+            t => typeof(IOptions).IsAssignableFrom(t),
+            nameof(ConfigureOptions));
 
-        foreach (var optionType in optionsTypes)
-        {
-            var configureOptionsMethod = typeof(DependencyInjection)
-                .GetMethod("ConfigureOptions", BindingFlags.NonPublic | BindingFlags.Static)!
-                .MakeGenericMethod(optionType);
-
-            configureOptionsMethod.Invoke(null, [services]);
-        }
+        SetupFromAssembly(services,
+            t => typeof(IOAuthProviderClient).IsAssignableFrom(t) &&
+                t.GetCustomAttribute<OAuthProviderKeyAttribute>() is not null,
+            nameof(RegisterOAuthProvider));
 
         services.AddMassTransit(x =>
             x.UsingRabbitMq((ctx, conf) => {
@@ -47,19 +45,38 @@ public static class DependencyInjection
         services.AddSingleton<ITokenGenerator, TokenGenerator>();
         services.AddTransient<ICurrentUser, CurrentUser>();
 
-        // services.AddKeyedTransient<IOAuthProviderClient, GithubOAuthProviderClient>(OAuthProvider.Github);
-        // services.AddKeyedTransient<IOAuthProviderClient, GoogleOAuthProviderClient>(OAuthProvider.Google);
-        // services.AddKeyedTransient<IOAuthProviderClient, FortyTwoOAuthProviderClient>(OAuthProvider.FortyTwo);
-
         return services;
     }
 
-    private static OptionsBuilder<T> ConfigureOptions<T>(IServiceCollection services)
+    private static void SetupFromAssembly(
+        IServiceCollection services,
+        Func<Type, bool> filter,
+        string methodName)
+    {
+        var method = typeof(DependencyInjection)
+            .GetMethod(methodName, BindingFlags.NonPublic | BindingFlags.Static)!;
+
+        foreach (var type in typeof(DependencyInjection).Assembly.GetTypes()
+            .Where(t => t is { IsAbstract: false, IsInterface: false } && filter(t)))
+        {
+            method.MakeGenericMethod(type).Invoke(null, [services]);
+        }
+    }
+
+    private static void ConfigureOptions<T>(IServiceCollection services)
         where T : class, IOptions
     {
-        return services.AddOptions<T>()
+        services.AddOptions<T>()
             .BindConfiguration(T.SectionName)
             .ValidateDataAnnotations()
             .ValidateOnStart();
+    }
+
+    private static void RegisterOAuthProvider<T>(IServiceCollection services)
+        where T : class, IOAuthProviderClient
+    {
+        var key = typeof(T).GetCustomAttribute<OAuthProviderKeyAttribute>()!.Provider;
+        services.AddHttpClient<T>();
+        services.AddKeyedTransient<IOAuthProviderClient, T>(key);
     }
 }

--- a/services/auth/src/Auth.Infrastructure/OAuth/FortyTwoOAuthProvider.cs
+++ b/services/auth/src/Auth.Infrastructure/OAuth/FortyTwoOAuthProvider.cs
@@ -57,6 +57,7 @@ internal sealed class FortyTwoOAuthProvider(
         [property: JsonPropertyName("expires_in")]   int ExpiresIn,
         [property: JsonPropertyName("created_at")]   long CreatedAt);
 
+#nullable enable
     private sealed record FortyTwoUserResp(
         [property: JsonPropertyName("id")]    long    Id,
         [property: JsonPropertyName("email")] string? Email);

--- a/services/auth/src/Auth.Infrastructure/OAuth/FortyTwoOAuthProvider.cs
+++ b/services/auth/src/Auth.Infrastructure/OAuth/FortyTwoOAuthProvider.cs
@@ -1,0 +1,63 @@
+using System.Text.Json.Serialization;
+using Auth.Domain.AuthUser;
+using Auth.Domain.Results;
+using Auth.Infrastructure.Options.OAuth;
+using Microsoft.Extensions.Options;
+
+namespace Auth.Infrastructure.OAuth;
+
+[OAuthProviderKey(OAuthProvider.FortyTwo)]
+internal sealed class FortyTwoOAuthProvider(
+    HttpClient http,
+    IOptions<FortyTwoOAuthOptions> options) : OAuthProviderBase(http)
+{
+    private readonly FortyTwoOAuthOptions _opts = options.Value;
+
+    public override Uri BuildAuthorizationUrl(string state)
+    {
+        var qs = BuildQueryString(
+            ("client_id", _opts.ClientId),
+            ("redirect_uri", _opts.RedirectUri),
+            ("response_type", "code"),
+            ("scope", "public"),
+            ("state", state));
+        return new Uri($"{_opts.AuthorizationEndpoint}?{qs}");
+    }
+
+    public override async Task<Result<OAuthUserInfo>> ExchangeCodeAsync(
+        string code, string state, CancellationToken cancellationToken = default)
+    {
+        var tokenResult = await FetchToken<FortyTwoTokenResp>(
+            _opts.TokenEndpoint,
+            new() {
+                ["grant_type"]    = "authorization_code",
+                ["client_id"]     = _opts.ClientId,
+                ["client_secret"] = _opts.ClientSecret,
+                ["code"]          = code,
+                ["redirect_uri"]  = _opts.RedirectUri,
+                ["state"]         = state,
+            },
+            cancellationToken);
+        if (tokenResult.IsFailure)
+            return tokenResult.Error;
+
+        var userResult = await FetchAuthenticated<FortyTwoUserResp>(
+            _opts.UserEndpoint, tokenResult.Value.AccessToken, cancellationToken);
+        if (userResult.IsFailure)
+            return userResult.Error;
+
+        var user = userResult.Value;
+        return new OAuthUserInfo(user.Id.ToString(), user.Email, user.Email is not null);
+    }
+
+    private sealed record FortyTwoTokenResp(
+        [property: JsonPropertyName("access_token")] string AccessToken,
+        [property: JsonPropertyName("token_type")]   string TokenType,
+        [property: JsonPropertyName("scope")]        string Scope,
+        [property: JsonPropertyName("expires_in")]   int ExpiresIn,
+        [property: JsonPropertyName("created_at")]   long CreatedAt);
+
+    private sealed record FortyTwoUserResp(
+        [property: JsonPropertyName("id")]    long    Id,
+        [property: JsonPropertyName("email")] string? Email);
+}

--- a/services/auth/src/Auth.Infrastructure/OAuth/GithubOAuthProvider.cs
+++ b/services/auth/src/Auth.Infrastructure/OAuth/GithubOAuthProvider.cs
@@ -1,0 +1,89 @@
+using System.Text.Json.Serialization;
+using Auth.Domain.AuthUser;
+using Auth.Domain.Results;
+using Auth.Infrastructure.Options.OAuth;
+using Microsoft.Extensions.Options;
+
+namespace Auth.Infrastructure.OAuth;
+
+[OAuthProviderKey(OAuthProvider.Github)]
+internal sealed class GithubOAuthProvider(
+    HttpClient http,
+    IOptions<GithubOAuthOptions> options) : OAuthProviderBase(http)
+{
+    private readonly GithubOAuthOptions _opts = options.Value;
+
+    public override Uri BuildAuthorizationUrl(string state)
+    {
+        var qs = BuildQueryString(
+            ("client_id", _opts.ClientId),
+            ("redirect_uri", _opts.RedirectUri),
+            ("scope", "read:user user:email"),
+            ("state", state));
+        return new Uri($"{_opts.AuthorizationEndpoint}?{qs}");
+    }
+
+    public override async Task<Result<OAuthUserInfo>> ExchangeCodeAsync(
+        string code, string _, CancellationToken cancellationToken = default)
+    {
+        var tokenResult = await FetchToken<GithubTokenResp>(
+            _opts.TokenEndpoint,
+            new() {
+                ["client_id"]     = _opts.ClientId,
+                ["client_secret"] = _opts.ClientSecret,
+                ["code"]          = code,
+                ["redirect_uri"]  = _opts.RedirectUri,
+            },
+            cancellationToken);
+        if (tokenResult.IsFailure)
+            return tokenResult.Error;
+        var token = tokenResult.Value;
+
+        var userResult = await FetchAuthenticated<GithubUserResp>(
+            _opts.UserEndpoint, token.AccessToken, cancellationToken);
+        if (userResult.IsFailure)
+            return userResult.Error;
+        var user = userResult.Value;
+
+        var email    = user.Email;
+        var verified = false;
+
+        if (token.Scopes.Split(',').Contains("user:email"))
+        {
+            var fieldsResult = await GetEmailFields(token.AccessToken, cancellationToken);
+            if (fieldsResult.IsFailure)
+                return fieldsResult.Error;
+
+            var (emailVerified, primaryEmail) = fieldsResult.Value;
+            email    = primaryEmail  ?? email;
+            verified = emailVerified ?? false;
+        }
+
+        return new OAuthUserInfo(user.Id.ToString(), email, verified);
+    }
+
+    private async Task<Result<(bool? Verified, string? Email)>> GetEmailFields(string accessToken, CancellationToken ct)
+    {
+        var result = await FetchAuthenticated<IReadOnlyList<GithubEmailResp>>(
+            _opts.EmailEndpoint, accessToken, ct);
+        if (result.IsFailure)
+            return result.Error;
+
+        var best = result.Value.FirstOrDefault(e => e.Primary)
+                ?? result.Value.FirstOrDefault(e => e.Verified);
+        return (best?.Verified, best?.Email);
+    }
+
+    private sealed record GithubTokenResp(
+        [property: JsonPropertyName("access_token")] string AccessToken,
+        [property: JsonPropertyName("scope")]        string Scopes);
+
+    private sealed record GithubUserResp(
+        [property: JsonPropertyName("id")]    long    Id,
+        [property: JsonPropertyName("email")] string? Email);
+
+    private sealed record GithubEmailResp(
+        [property: JsonPropertyName("email")]    string Email,
+        [property: JsonPropertyName("primary")]  bool   Primary,
+        [property: JsonPropertyName("verified")] bool   Verified);
+}

--- a/services/auth/src/Auth.Infrastructure/OAuth/GithubOAuthProvider.cs
+++ b/services/auth/src/Auth.Infrastructure/OAuth/GithubOAuthProvider.cs
@@ -62,6 +62,7 @@ internal sealed class GithubOAuthProvider(
         return new OAuthUserInfo(user.Id.ToString(), email, verified);
     }
 
+#nullable enable
     private async Task<Result<(bool? Verified, string? Email)>> GetEmailFields(string accessToken, CancellationToken ct)
     {
         var result = await FetchAuthenticated<IReadOnlyList<GithubEmailResp>>(

--- a/services/auth/src/Auth.Infrastructure/OAuth/GoogleOAuthProvider.cs
+++ b/services/auth/src/Auth.Infrastructure/OAuth/GoogleOAuthProvider.cs
@@ -1,0 +1,69 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Auth.Domain.AuthUser;
+using Auth.Domain.Results;
+using Auth.Infrastructure.Options.OAuth;
+using Microsoft.Extensions.Options;
+
+namespace Auth.Infrastructure.OAuth;
+
+[OAuthProviderKey(OAuthProvider.Google)]
+internal sealed class GoogleOAuthProvider(
+    HttpClient http,
+    IOptions<GoogleOAuthOptions> options) : OAuthProviderBase(http)
+{
+    private readonly GoogleOAuthOptions _opts = options.Value;
+
+    public override Uri BuildAuthorizationUrl(string state)
+    {
+        var qs = BuildQueryString(
+            ("client_id", _opts.ClientId),
+            ("redirect_uri", _opts.RedirectUri),
+            ("response_type", "code"),
+            ("scope", "openid email"),
+            ("state", state));
+        return new Uri($"{_opts.AuthorizationEndpoint}?{qs}");
+    }
+
+    public override async Task<Result<OAuthUserInfo>> ExchangeCodeAsync(
+        string code, string _, CancellationToken cancellationToken = default)
+    {
+        var tokenResult = await FetchToken<GoogleTokenResp>(
+            _opts.TokenEndpoint,
+            new() {
+                ["client_id"]     = _opts.ClientId,
+                ["client_secret"] = _opts.ClientSecret,
+                ["code"]          = code,
+                ["redirect_uri"]  = _opts.RedirectUri,
+                ["grant_type"]    = "authorization_code",
+            },
+            cancellationToken);
+        if (tokenResult.IsFailure)
+            return tokenResult.Error;
+
+        var payload = DecodeIdToken(tokenResult.Value.IdToken);
+        return new OAuthUserInfo(payload.Sub, payload.Email, payload.EmailVerified);
+    }
+
+    private static GoogleIdTokenPayload DecodeIdToken(string idToken)
+    {
+        var parts = idToken.Split('.');
+        if (parts.Length != 3)
+            throw new FormatException("Invalid JWT format.");
+
+        var base64 = parts[1].Replace('-', '+').Replace('_', '/');
+        base64 = base64.PadRight(base64.Length + (4 - base64.Length % 4) % 4, '=');
+
+        return JsonSerializer.Deserialize<GoogleIdTokenPayload>(Convert.FromBase64String(base64))!;
+    }
+
+    private sealed record GoogleTokenResp(
+        [property: JsonPropertyName("access_token")] string AccessToken,
+        [property: JsonPropertyName("id_token")]     string IdToken);
+
+    private sealed record GoogleIdTokenPayload(
+        [property: JsonPropertyName("sub")]   string  Sub,
+        [property: JsonPropertyName("email")] string? Email,
+        [property: JsonPropertyName(
+                        "email_verified")]    bool?   EmailVerified);
+}

--- a/services/auth/src/Auth.Infrastructure/OAuth/GoogleOAuthProvider.cs
+++ b/services/auth/src/Auth.Infrastructure/OAuth/GoogleOAuthProvider.cs
@@ -41,26 +41,42 @@ internal sealed class GoogleOAuthProvider(
         if (tokenResult.IsFailure)
             return tokenResult.Error;
 
-        var payload = DecodeIdToken(tokenResult.Value.IdToken);
+        var payloadResult = DecodeIdToken(tokenResult.Value.IdToken);
+        if (payloadResult.IsFailure)
+            return payloadResult.Error;
+
+        var payload = payloadResult.Value;
         return new OAuthUserInfo(payload.Sub, payload.Email, payload.EmailVerified);
     }
 
-    private static GoogleIdTokenPayload DecodeIdToken(string idToken)
+    private static Result<GoogleIdTokenPayload> DecodeIdToken(string idToken)
     {
-        var parts = idToken.Split('.');
-        if (parts.Length != 3)
-            throw new FormatException("Invalid JWT format.");
+        try
+        {
+            var parts = idToken.Split('.');
+            if (parts.Length != 3)
+                return AuthFailures.OAuthUpstreamError;
 
-        var base64 = parts[1].Replace('-', '+').Replace('_', '/');
-        base64 = base64.PadRight(base64.Length + (4 - base64.Length % 4) % 4, '=');
+            var base64 = parts[1].Replace('-', '+').Replace('_', '/');
+            base64 = base64.PadRight(base64.Length + (4 - base64.Length % 4) % 4, '=');
 
-        return JsonSerializer.Deserialize<GoogleIdTokenPayload>(Convert.FromBase64String(base64))!;
+            var payload = JsonSerializer.Deserialize<GoogleIdTokenPayload>(Convert.FromBase64String(base64));
+            if (payload is null || string.IsNullOrEmpty(payload.Sub))
+                return AuthFailures.OAuthUpstreamError;
+
+            return payload;
+        }
+        catch (Exception ex) when (ex is FormatException or JsonException)
+        {
+            return AuthFailures.OAuthUpstreamError;
+        }
     }
 
     private sealed record GoogleTokenResp(
         [property: JsonPropertyName("access_token")] string AccessToken,
         [property: JsonPropertyName("id_token")]     string IdToken);
 
+#nullable enable
     private sealed record GoogleIdTokenPayload(
         [property: JsonPropertyName("sub")]   string  Sub,
         [property: JsonPropertyName("email")] string? Email,

--- a/services/auth/src/Auth.Infrastructure/OAuth/OAuthProviderBase.cs
+++ b/services/auth/src/Auth.Infrastructure/OAuth/OAuthProviderBase.cs
@@ -1,5 +1,6 @@
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
+using System.Text.Json;
 using Auth.Application.Abstractions.OAuth;
 using Auth.Domain.AuthUser;
 using Auth.Domain.Results;
@@ -36,15 +37,25 @@ internal abstract class OAuthProviderBase(HttpClient http) : IOAuthProviderClien
 
     protected async Task<Result<T>> Send<T>(HttpRequestMessage request, CancellationToken ct)
     {
-        var response = await http.SendAsync(request, ct);
+        // ? Intentionnaly let the exception throw => 500
+        var response = await http.SendAsync(request, ct); 
+
         if (!response.IsSuccessStatusCode)
-            return AuthFailures.OAuthProviderError;
+            return (int)response.StatusCode >= 500
+                ? AuthFailures.OAuthUpstreamError
+                : AuthFailures.OAuthProviderError;
 
-        var data = await response.Content.ReadFromJsonAsync<T>(ct);
-        if (data is null)
-            return AuthFailures.OAuthProviderError;
-
-        return data;
+        try
+        {
+            var data = await response.Content.ReadFromJsonAsync<T>(ct);
+            return data is null
+                ? AuthFailures.OAuthUpstreamError
+                : data;
+        }
+        catch (JsonException)
+        {
+            return AuthFailures.OAuthUpstreamError;
+        }
     }
 
     protected static string BuildQueryString(params (string key, string value)[] pairs)

--- a/services/auth/src/Auth.Infrastructure/OAuth/OAuthProviderBase.cs
+++ b/services/auth/src/Auth.Infrastructure/OAuth/OAuthProviderBase.cs
@@ -1,0 +1,53 @@
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using Auth.Application.Abstractions.OAuth;
+using Auth.Domain.AuthUser;
+using Auth.Domain.Results;
+
+namespace Auth.Infrastructure.OAuth;
+
+internal abstract class OAuthProviderBase(HttpClient http) : IOAuthProviderClient
+{
+    private static readonly ProductInfoHeaderValue UserAgent = new("ft_transcendence", "1.0");
+
+    public abstract Uri BuildAuthorizationUrl(string state);
+    public abstract Task<Result<OAuthUserInfo>> ExchangeCodeAsync(
+        string code, string state, CancellationToken cancellationToken = default);
+
+    protected async Task<Result<T>> FetchToken<T>(
+        string tokenEndpoint, Dictionary<string, string> formContent, CancellationToken ct)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Post, tokenEndpoint)
+        {
+            Content = new FormUrlEncodedContent(formContent)
+        };
+        request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+        return await Send<T>(request, ct);
+    }
+
+    protected async Task<Result<T>> FetchAuthenticated<T>(
+        string url, string accessToken, CancellationToken ct)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, url);
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
+        request.Headers.UserAgent.Add(UserAgent);
+        return await Send<T>(request, ct);
+    }
+
+    protected async Task<Result<T>> Send<T>(HttpRequestMessage request, CancellationToken ct)
+    {
+        var response = await http.SendAsync(request, ct);
+        if (!response.IsSuccessStatusCode)
+            return AuthFailures.OAuthProviderError;
+
+        var data = await response.Content.ReadFromJsonAsync<T>(ct);
+        if (data is null)
+            return AuthFailures.OAuthProviderError;
+
+        return data;
+    }
+
+    protected static string BuildQueryString(params (string key, string value)[] pairs)
+        => string.Join("&", pairs.Select(p =>
+            $"{Uri.EscapeDataString(p.key)}={Uri.EscapeDataString(p.value)}"));
+}

--- a/services/auth/src/Auth.Infrastructure/OAuth/OAuthProviderKeyAttribute.cs
+++ b/services/auth/src/Auth.Infrastructure/OAuth/OAuthProviderKeyAttribute.cs
@@ -1,0 +1,9 @@
+using Auth.Domain.AuthUser;
+
+namespace Auth.Infrastructure.OAuth;
+
+[AttributeUsage(AttributeTargets.Class)]
+internal sealed class OAuthProviderKeyAttribute(OAuthProvider provider) : Attribute
+{
+    public OAuthProvider Provider => provider;
+}

--- a/services/auth/src/Auth.Infrastructure/Options/AppOptions.cs
+++ b/services/auth/src/Auth.Infrastructure/Options/AppOptions.cs
@@ -1,0 +1,11 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Auth.Infrastructure.Options;
+
+public sealed class AppOptions : IOptions
+{
+    static string IOptions.SectionName => "App";
+
+    [Required]
+    public required string BaseUrl { get; init; }
+}

--- a/services/auth/src/Auth.Infrastructure/Options/Oauth/FortyTwoOAuthOptions.cs
+++ b/services/auth/src/Auth.Infrastructure/Options/Oauth/FortyTwoOAuthOptions.cs
@@ -2,7 +2,7 @@ namespace Auth.Infrastructure.Options.OAuth;
 
 public sealed class FortyTwoOAuthOptions : OAuthProviderOptions, IOptions
 {
-    public static string SectionName => "OAuth.FortyTwo";
+    public static string SectionName => "OAuth:FortyTwo";
 
     public override required string AuthorizationEndpoint
         { get; init; } = "https://api.intra.42.fr/oauth/authorize";

--- a/services/auth/src/Auth.Infrastructure/Options/Oauth/FortyTwoOAuthOptions.cs
+++ b/services/auth/src/Auth.Infrastructure/Options/Oauth/FortyTwoOAuthOptions.cs
@@ -1,0 +1,15 @@
+namespace Auth.Infrastructure.Options.OAuth;
+
+public sealed class FortyTwoOAuthOptions : OAuthProviderOptions, IOptions
+{
+    public static string SectionName => "OAuth.FortyTwo";
+
+    public override required string AuthorizationEndpoint
+        { get; init; } = "https://api.intra.42.fr/oauth/authorize";
+
+    public override required string TokenEndpoint
+        { get; init; } = "https://api.intra.42.fr/oauth/token";
+
+    public override required string UserEndpoint
+        { get; init; } = "https://api.intra.42.fr/v2/me";
+}

--- a/services/auth/src/Auth.Infrastructure/Options/Oauth/GithubOAuthOptions.cs
+++ b/services/auth/src/Auth.Infrastructure/Options/Oauth/GithubOAuthOptions.cs
@@ -2,7 +2,7 @@ namespace Auth.Infrastructure.Options.OAuth;
 
 public sealed class GithubOAuthOptions : OAuthProviderOptions, IOptions
 {
-    public static string SectionName => "OAuth.Github";
+    public static string SectionName => "OAuth:Github";
 
     public override required string AuthorizationEndpoint
         { get; init; } = "https://github.com/login/oauth/authorize";

--- a/services/auth/src/Auth.Infrastructure/Options/Oauth/GithubOAuthOptions.cs
+++ b/services/auth/src/Auth.Infrastructure/Options/Oauth/GithubOAuthOptions.cs
@@ -1,0 +1,18 @@
+namespace Auth.Infrastructure.Options.OAuth;
+
+public sealed class GithubOAuthOptions : OAuthProviderOptions, IOptions
+{
+    public static string SectionName => "OAuth.Github";
+
+    public override required string AuthorizationEndpoint
+        { get; init; } = "https://github.com/login/oauth/authorize";
+
+    public override required string TokenEndpoint
+        { get; init; } = "https://github.com/login/oauth/access_token";
+
+    public override required string UserEndpoint
+        { get; init; } = "https://api.github.com/user";
+
+    public required string EmailEndpoint
+        { get; init; } = "https://api.github.com/user/emails";
+}

--- a/services/auth/src/Auth.Infrastructure/Options/Oauth/GoogleOAuthOptions.cs
+++ b/services/auth/src/Auth.Infrastructure/Options/Oauth/GoogleOAuthOptions.cs
@@ -2,7 +2,7 @@ namespace Auth.Infrastructure.Options.OAuth;
 
 public sealed class GoogleOAuthOptions : OAuthProviderOptions, IOptions
 {
-    public static string SectionName => "OAuth.Google";
+    public static string SectionName => "OAuth:Google";
 
     public override required string AuthorizationEndpoint
         { get; init; } = "https://accounts.google.com/o/oauth2/v2/auth";

--- a/services/auth/src/Auth.Infrastructure/Options/Oauth/GoogleOAuthOptions.cs
+++ b/services/auth/src/Auth.Infrastructure/Options/Oauth/GoogleOAuthOptions.cs
@@ -11,5 +11,5 @@ public sealed class GoogleOAuthOptions : OAuthProviderOptions, IOptions
         { get; init; } = "https://oauth2.googleapis.com/token";
 
     public override required string UserEndpoint
-        { get; init; } = String.Empty;
+        { get; init; } = "null";
 }

--- a/services/auth/src/Auth.Infrastructure/Options/Oauth/GoogleOAuthOptions.cs
+++ b/services/auth/src/Auth.Infrastructure/Options/Oauth/GoogleOAuthOptions.cs
@@ -1,0 +1,15 @@
+namespace Auth.Infrastructure.Options.OAuth;
+
+public sealed class GoogleOAuthOptions : OAuthProviderOptions, IOptions
+{
+    public static string SectionName => "OAuth.Google";
+
+    public override required string AuthorizationEndpoint
+        { get; init; } = "https://accounts.google.com/o/oauth2/v2/auth";
+
+    public override required string TokenEndpoint
+        { get; init; } = "https://oauth2.googleapis.com/token";
+
+    public override required string UserEndpoint
+        { get; init; } = String.Empty;
+}

--- a/services/auth/src/Auth.Infrastructure/Options/Oauth/OAuthProviderOptions.cs
+++ b/services/auth/src/Auth.Infrastructure/Options/Oauth/OAuthProviderOptions.cs
@@ -1,0 +1,13 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Auth.Infrastructure.Options.OAuth;
+
+public abstract class OAuthProviderOptions
+{
+    [Required] public required string ClientId { get; init; }
+    [Required] public required string ClientSecret { get; init; }
+    [Required] public required string RedirectUri { get; init; }
+    [Required] public virtual required string AuthorizationEndpoint { get; init; }
+    [Required] public virtual required string TokenEndpoint { get; init; }
+    [Required] public virtual required string UserEndpoint { get; init; }
+}

--- a/services/auth/src/Auth.Infrastructure/Options/Oauth/OAuthStateCookieOptions.cs
+++ b/services/auth/src/Auth.Infrastructure/Options/Oauth/OAuthStateCookieOptions.cs
@@ -1,0 +1,17 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Auth.Infrastructure.Options.OAuth;
+
+public sealed class OAuthStateCookieOptions : IOptions
+{
+    static string IOptions.SectionName => "OAuthStateCookie";
+
+    [Required]
+    public required string CookieName { get; init; }
+
+    [Required, Range(1, int.MaxValue)]
+    public required int TtlMinutes { get; init; }
+
+    public bool HttpOnly { get; init; } = true;
+    public bool Secure { get; init; } = true;
+}

--- a/services/auth/src/Auth.Presentation/Endpoints/OAuthEndpoint.cs
+++ b/services/auth/src/Auth.Presentation/Endpoints/OAuthEndpoint.cs
@@ -33,7 +33,7 @@ public sealed class OAuthEndpoint : ICarterModule
 
     public void AddRoutes(IEndpointRouteBuilder app)
     {
-        app.MapGet("/auth/oauth/{provider}", async (
+        app.MapGet("/oauth/{provider}", async (
             string provider,
             ICommandHandler<OAuthLoginCommand, Result<OAuthLoginResult>> handler,
             IClock clock,
@@ -41,7 +41,7 @@ public sealed class OAuthEndpoint : ICarterModule
             HttpResponse resp
         ) => await InitOAuth(provider, handler, clock, stateOptions.Value, resp));
 
-        app.MapGet("/auth/oauth/{provider}/callback", async (
+        app.MapGet("/oauth/{provider}/callback", async (
             string provider,
             string code,
             string state,

--- a/services/auth/src/Auth.Presentation/Endpoints/OAuthEndpoint.cs
+++ b/services/auth/src/Auth.Presentation/Endpoints/OAuthEndpoint.cs
@@ -1,0 +1,128 @@
+using System.Collections.Frozen;
+using Auth.Application.Abstractions;
+using Auth.Application.Abstractions.Messaging;
+using Auth.Application.Features.OAuth;
+using Auth.Domain.AuthUser;
+using Auth.Domain.Results;
+using Auth.Infrastructure.Options;
+using Auth.Infrastructure.Options.OAuth;
+using Carter;
+using Microsoft.Extensions.Options;
+using Auth.Presentation.Contracts;
+
+using InitOAuthHttpResults = Microsoft.AspNetCore.Http.HttpResults.Results<
+    Microsoft.AspNetCore.Http.HttpResults.RedirectHttpResult,
+    Microsoft.AspNetCore.Http.HttpResults.BadRequest<Auth.Presentation.Contracts.ErrorResponse>
+>;
+using OAuthCallbackHttpResults = Microsoft.AspNetCore.Http.HttpResults.Results<
+    Microsoft.AspNetCore.Http.HttpResults.RedirectHttpResult,
+    Microsoft.AspNetCore.Http.HttpResults.BadRequest<Auth.Presentation.Contracts.ErrorResponse>
+>;
+
+namespace Auth.Presentation.Endpoints;
+
+public sealed class OAuthEndpoint : ICarterModule
+{
+    private static readonly FrozenDictionary<string, OAuthProvider> ProviderMap =
+        new Dictionary<string, OAuthProvider>
+        {
+            ["fortytwo"] = OAuthProvider.FortyTwo,
+            ["google"]   = OAuthProvider.Google,
+            ["github"]   = OAuthProvider.Github,
+        }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
+
+    public void AddRoutes(IEndpointRouteBuilder app)
+    {
+        app.MapGet("/auth/oauth/{provider}", async (
+            string provider,
+            ICommandHandler<OAuthLoginCommand, Result<OAuthLoginResult>> handler,
+            IClock clock,
+            IOptions<OAuthStateCookieOptions> stateOptions,
+            HttpResponse resp
+        ) => await InitOAuth(provider, handler, clock, stateOptions.Value, resp));
+
+        app.MapGet("/auth/oauth/{provider}/callback", async (
+            string provider,
+            string code,
+            string state,
+            ICommandHandler<OAuthCallbackCommand, Result<OAuthCallbackResult>> handler,
+            IClock clock,
+            IOptions<OAuthStateCookieOptions> stateOptions,
+            IOptions<RefreshTokenOptions> refreshOptions,
+            IOptions<AppOptions> appOptions,
+            HttpContext ctx
+        ) => await OAuthCallback(provider, code, state, handler, clock, stateOptions.Value, refreshOptions.Value, appOptions.Value, ctx));
+    }
+
+    private static async Task<InitOAuthHttpResults> InitOAuth(
+        string provider,
+        ICommandHandler<OAuthLoginCommand, Result<OAuthLoginResult>> handler,
+        IClock clock,
+        OAuthStateCookieOptions stateOpts,
+        HttpResponse resp)
+    {
+        if (!ProviderMap.TryGetValue(provider, out var oauthProvider))
+            return TypedResults.BadRequest(new ErrorResponse(AuthFailures.InvalidOAuthProvider.Message));
+
+        var result = await handler.HandleAsync(new OAuthLoginCommand(oauthProvider));
+
+        return result.Match<InitOAuthHttpResults>(
+            r =>
+            {
+                resp.Cookies.Append(stateOpts.CookieName, r.State, new CookieOptions
+                {
+                    HttpOnly = stateOpts.HttpOnly,
+                    Secure   = stateOpts.Secure,
+                    SameSite = SameSiteMode.Lax,
+                    Expires  = clock.UtcNow.AddMinutes(stateOpts.TtlMinutes),
+                });
+                return TypedResults.Redirect(r.RedirectUri.ToString());
+            },
+            failure => TypedResults.BadRequest(new ErrorResponse(failure.Message))
+        );
+    }
+
+    private static async Task<OAuthCallbackHttpResults> OAuthCallback(
+        string provider,
+        string code,
+        string state,
+        ICommandHandler<OAuthCallbackCommand, Result<OAuthCallbackResult>> handler,
+        IClock clock,
+        OAuthStateCookieOptions stateOpts,
+        RefreshTokenOptions refreshOpts,
+        AppOptions appOpts,
+        HttpContext ctx)
+    {
+        if (!ProviderMap.TryGetValue(provider, out var oauthProvider))
+            return TypedResults.BadRequest(new ErrorResponse(AuthFailures.InvalidOAuthProvider.Message));
+
+        var storedState = ctx.Request.Cookies[stateOpts.CookieName];
+        if (string.IsNullOrEmpty(storedState) || storedState != state)
+            return TypedResults.BadRequest(new ErrorResponse(AuthFailures.InvalidOAuthState.Message));
+
+        ctx.Response.Cookies.Delete(stateOpts.CookieName);
+
+        var result = await handler.HandleAsync(new OAuthCallbackCommand(oauthProvider, code, state));
+
+        return result.Match<OAuthCallbackHttpResults>(
+            r =>
+            {
+                ctx.Response.Cookies.Append(refreshOpts.CookieName, r.RefreshToken, new CookieOptions
+                {
+                    HttpOnly = refreshOpts.HttpOnly,
+                    Secure   = refreshOpts.Secure,
+                    SameSite = SameSiteMode.Strict,
+                    Expires  = clock.UtcNow.AddDays(refreshOpts.TtlDays),
+                });
+
+                var baseUrl = appOpts.BaseUrl.TrimEnd('/');
+                var destination = r.IsNewUser
+                    ? $"{baseUrl}/?access_token={r.AccessToken}&new_user=true"
+                    : $"{baseUrl}/?access_token={r.AccessToken}";
+
+                return TypedResults.Redirect(destination);
+            },
+            failure => TypedResults.BadRequest(new ErrorResponse(failure.Message))
+        );
+    }
+}

--- a/services/auth/src/Auth.Presentation/Endpoints/OAuthEndpoint.cs
+++ b/services/auth/src/Auth.Presentation/Endpoints/OAuthEndpoint.cs
@@ -16,7 +16,8 @@ using InitOAuthHttpResults = Microsoft.AspNetCore.Http.HttpResults.Results<
 >;
 using OAuthCallbackHttpResults = Microsoft.AspNetCore.Http.HttpResults.Results<
     Microsoft.AspNetCore.Http.HttpResults.RedirectHttpResult,
-    Microsoft.AspNetCore.Http.HttpResults.BadRequest<Auth.Presentation.Contracts.ErrorResponse>
+    Microsoft.AspNetCore.Http.HttpResults.BadRequest<Auth.Presentation.Contracts.ErrorResponse>,
+    Microsoft.AspNetCore.Http.HttpResults.JsonHttpResult<Auth.Presentation.Contracts.ErrorResponse>
 >;
 
 namespace Auth.Presentation.Endpoints;
@@ -104,25 +105,28 @@ public sealed class OAuthEndpoint : ICarterModule
 
         var result = await handler.HandleAsync(new OAuthCallbackCommand(oauthProvider, code, state));
 
-        return result.Match<OAuthCallbackHttpResults>(
-            r =>
-            {
-                ctx.Response.Cookies.Append(refreshOpts.CookieName, r.RefreshToken, new CookieOptions
-                {
-                    HttpOnly = refreshOpts.HttpOnly,
-                    Secure   = refreshOpts.Secure,
-                    SameSite = SameSiteMode.Strict,
-                    Expires  = clock.UtcNow.AddDays(refreshOpts.TtlDays),
-                });
+        if (result.IsFailure)
+        {
+            var error = new ErrorResponse(result.Error.Message);
+            return result.Error == AuthFailures.OAuthUpstreamError
+                ? TypedResults.Json(error, statusCode: StatusCodes.Status502BadGateway)
+                : TypedResults.BadRequest(error);
+        }
 
-                var baseUrl = appOpts.BaseUrl.TrimEnd('/');
-                var destination = r.IsNewUser
-                    ? $"{baseUrl}/?access_token={r.AccessToken}&new_user=true"
-                    : $"{baseUrl}/?access_token={r.AccessToken}";
+        var r = result.Value;
+        ctx.Response.Cookies.Append(refreshOpts.CookieName, r.RefreshToken, new CookieOptions
+        {
+            HttpOnly = refreshOpts.HttpOnly,
+            Secure   = refreshOpts.Secure,
+            SameSite = SameSiteMode.Strict,
+            Expires  = clock.UtcNow.AddDays(refreshOpts.TtlDays),
+        });
 
-                return TypedResults.Redirect(destination);
-            },
-            failure => TypedResults.BadRequest(new ErrorResponse(failure.Message))
-        );
+        var baseUrl = appOpts.BaseUrl.TrimEnd('/');
+        var destination = r.IsNewUser
+            ? $"{baseUrl}/?access_token={r.AccessToken}&new_user=true"
+            : $"{baseUrl}/?access_token={r.AccessToken}";
+
+        return TypedResults.Redirect(destination);
     }
 }

--- a/services/auth/src/Auth.Presentation/appsettings.Development.json
+++ b/services/auth/src/Auth.Presentation/appsettings.Development.json
@@ -14,7 +14,7 @@
     "Username": "guest",
     "Password": "guest"
   },
-  "Frontend": {
+  "App": {
     "BaseUrl": "https://localhost:1443"
   },
   "OAuth": {

--- a/services/auth/src/Auth.Presentation/appsettings.Development.json
+++ b/services/auth/src/Auth.Presentation/appsettings.Development.json
@@ -21,17 +21,17 @@
     "FortyTwo": {
       "ClientId": "REPLACE_ME",
       "ClientSecret": "REPLACE_ME",
-      "RedirectUri": "https://localhost:1443/api/v1/auth/oauth/fortytwo/callback"
+      "RedirectUri": "https://localhost:1443/api/auth/v1/oauth/fortytwo/callback"
     },
     "Google": {
       "ClientId": "REPLACE_ME",
       "ClientSecret": "REPLACE_ME",
-      "RedirectUri": "https://localhost:1443/api/v1/auth/oauth/google/callback"
+      "RedirectUri": "https://localhost:1443/api/auth/v1/oauth/google/callback"
     },
     "Github": {
       "ClientId": "REPLACE_ME",
       "ClientSecret": "REPLACE_ME",
-      "RedirectUri": "https://localhost:1443/api/v1/auth/oauth/github/callback"
+      "RedirectUri": "https://localhost:1443/api/auth/v1/oauth/github/callback"
     }
   }
 }

--- a/services/auth/src/Auth.Presentation/appsettings.Development.json
+++ b/services/auth/src/Auth.Presentation/appsettings.Development.json
@@ -1,0 +1,37 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Debug",
+      "Microsoft.AspNetCore": "Information",
+      "Microsoft.EntityFrameworkCore.Database": "Information"
+    }
+  },
+  "Jwt": {
+    "SecretKey": "dev-only-secret-key-must-be-at-least-32-chars"
+  },
+  "RabbitMq": {
+    "Host": "localhost",
+    "Username": "guest",
+    "Password": "guest"
+  },
+  "Frontend": {
+    "BaseUrl": "https://localhost:1443"
+  },
+  "OAuth": {
+    "FortyTwo": {
+      "ClientId": "REPLACE_ME",
+      "ClientSecret": "REPLACE_ME",
+      "RedirectUri": "https://localhost:1443/api/v1/auth/oauth/fortytwo/callback"
+    },
+    "Google": {
+      "ClientId": "REPLACE_ME",
+      "ClientSecret": "REPLACE_ME",
+      "RedirectUri": "https://localhost:1443/api/v1/auth/oauth/google/callback"
+    },
+    "Github": {
+      "ClientId": "REPLACE_ME",
+      "ClientSecret": "REPLACE_ME",
+      "RedirectUri": "https://localhost:1443/api/v1/auth/oauth/github/callback"
+    }
+  }
+}

--- a/services/auth/src/Auth.Presentation/appsettings.json
+++ b/services/auth/src/Auth.Presentation/appsettings.json
@@ -2,8 +2,7 @@
   "Logging": {
     "LogLevel": {
       "Default": "Information",
-      "Microsoft.AspNetCore": "Warning",
-      "Microsoft.EntityFrameworkCore.Database": "Information"
+      "Microsoft.AspNetCore": "Warning"
     }
   },
   "Jwt": {
@@ -19,8 +18,11 @@
     "Secure": true
   },
   "RabbitMq": {
-    "Host": "localhost",
+    "Host": "rabbitmq",
     "Port": 5672,
     "VirtualHost": "/"
+  },
+  "Frontend": {
+    "BaseUrl": ""
   }
 }

--- a/services/auth/src/Auth.Presentation/appsettings.json
+++ b/services/auth/src/Auth.Presentation/appsettings.json
@@ -22,7 +22,13 @@
     "Port": 5672,
     "VirtualHost": "/"
   },
-  "Frontend": {
+  "App": {
     "BaseUrl": ""
+  },
+  "OAuthStateCookie": {
+    "CookieName": "oauth_state",
+    "TtlMinutes": 10,
+    "HttpOnly": true,
+    "Secure": true
   }
 }


### PR DESCRIPTION
## What

Implements the OAuth 2.0 Authorization Code flow (issue #20) — `GET /auth/oauth/{provider}` and `GET /auth/oauth/{provider}/callback` — for GitHub, Google, and 42.

## Changes

**Domain / Application**
- **`OAuthUserInfo`** — new record included `Email` returned by all provider clients, replacing the raw `string` user ID
- **`IOAuthProviderClient`** — `BuildAuthorizationUrl` now returns `Uri`; `GetUserIdAsync` replaced by `ExchangeCodeAsync(code, state, ct)` returning `Result<OAuthUserInfo>`
- **`OAuthLoginCommand` / `OAuthLoginHandler`** — generates a cryptographically random URL-safe `state` (32 bytes, base64url), resolves the provider client via keyed DI, and returns the redirect `Uri` + state
- **`OAuthCallbackCommand` / `OAuthCallbackHandler`** — exchanges the code via the provider client, upserts the `AuthUser` (create + publish `user.registered` if new, reuse if existing), rotates the refresh token, and returns access + refresh tokens with an `IsNewUser` flag
- **`AuthFailures`** — added `InvalidOAuthState` and `OAuthProviderError`

**Infrastructure**
- **`OAuthProviderBase`** — abstract base with shared HTTP helpers: `FetchToken`, `FetchAuthenticated`, `Send<T>`, `BuildQueryString`
- **`FortyTwoOAuthProvider`** — forwards `state` in the token request per 42's API requirement
- **`GoogleOAuthProvider`** — decodes user identity from the `id_token` JWT payload locally, permit to done only one HTTP call.
- **`GithubOAuthProvider`** — calls `/user/emails` to retrieve the primary verified email when the `user:email` scope is granted

- **`OAuthProviderOptions`** — abstract base with `ClientId`, `ClientSecret`, `RedirectUri`, and virtual endpoint URLs; concrete classes (`FortyTwoOAuthOptions`, `GoogleOAuthOptions`, `GithubOAuthOptions`) override endpoints with provider defaults
- **`OAuthStateCookieOptions`** / **`AppOptions`** — new options classes for the state cookie TTL/name and the base redirect URL
- **`SecretHasher`** / **`ISecretHasher.HashDeterministic`** — carried over from #18 (SHA-256, required for refresh token lookup)

**Presentation**
- **`OAuthEndpoint`** — Carter `ICarterModule`; `GET /auth/oauth/{provider}` stores the state in a short-lived `HttpOnly` cookie (`SameSite=Lax`, TTL from `OAuthStateCookieOptions`) and redirects to the provider consent screen; `GET /auth/oauth/{provider}/callback` validates the state cookie, deletes it, delegates to `OAuthCallbackHandler`, sets the refresh token cookie, and redirects to `{BaseUrl}/?access_token=...&new_user=true` (new users) or `{BaseUrl}/?access_token=...` (returning users); unknown provider → `400`
- **`appsettings.Development.json`** — new dev-only file with `SecretKey`, local RabbitMQ, `App.BaseUrl`, and `REPLACE_ME` placeholders for all three provider credentials
- **`appsettings.json`** — `App.BaseUrl` and `OAuthStateCookie` defaults added; `RabbitMQ.Host` corrected to `rabbitmq` (container name); EF Core log level moved to dev settings only

## Notes

> **State cookie `SameSite=Lax`** — the OAuth callback is a cross-site redirect from the provider, so `Strict` would silently drop the cookie. `Lax` is the correct mode here; the refresh token cookie remains `Strict`.

> **Google `id_token` decoding** — the payload is base64url-decoded locally. No signature verification is performed since the token was just issued in a direct server-to-server response (not passed by a client), which is safe per the OAuth spec.

> **`IsNewUser` flag** — the frontend receives `new_user=true` in the redirect query string when the OAuth user was created for the first time, allowing it to show an onboarding flow without a separate API call.

---

Closes #20