### PR TITLE
Infra: move air's tmp dir off the host bind mount

### DIFF
--- a/services/gateway/.air.toml
+++ b/services/gateway/.air.toml
@@ -3,14 +3,14 @@
 env_files = []
 root = "."
 testdata_dir = "testdata"
-tmp_dir = "tmp"
+tmp_dir = "/tmp/air"
 
 [build]
   args_bin = []
-  bin = "./tmp/main"
-  cmd = "CGO_ENABLED=0 go build -o ./tmp/main ./cmd/gateway/"
+  bin = "/tmp/air/main"
+  cmd = "CGO_ENABLED=0 go build -o /tmp/air/main ./cmd/gateway/"
   delay = 1000
-  entrypoint = ["./tmp/main"]
+  entrypoint = ["/tmp/air/main"]
   exclude_dir = ["assets", "tmp", "vendor", "testdata"]
   exclude_file = []
   exclude_regex = ["_test.go"]


### PR DESCRIPTION
Ensure gateway binary live outside the bind-mounted project dir so build outputs never land on the host fs (avoids cross-engine UID-ownership leftovers, e.g. host-root files from an older docker run blocking a rootless-podman rebuild)

This was the primary reason /docs was so unreliable and broke every now and then
