### PR TITLE
Feat(chat): foundations

### DIFF
--- a/.github/workflows/chat-ci.yml
+++ b/.github/workflows/chat-ci.yml
@@ -1,0 +1,128 @@
+name: chat ci
+
+# fires only on chat-touching changes (and on edits to this workflow itself, so
+# a misconfigured file gets caught on its own PR). other services will get their
+# own per-path workflow files as their owners land them
+on:
+  pull_request:
+    paths:
+      - 'services/chat/**'
+      - '.github/workflows/chat-ci.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'services/chat/**'
+      - '.github/workflows/chat-ci.yml'
+    # release tags trigger the workflow regardless of path filters so the publish
+    # job can attach a :v1.2.3 tag to the image. naming uses chat-vX.Y.Z so
+    # per-service tags don't collide once other services publish on tag too
+    tags:
+      - 'chat-v*'
+
+# cancel an in-flight run when a newer push lands on the same PR/branch; saves
+# minutes on rapid-fire pushes (especially since we run those on github's doodoo workers)
+concurrency:
+  group: chat-ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: setup buildx
+        uses: docker/setup-buildx-action@v3
+
+      # build the test image dev uses locally, then run it. keeps CI and local
+      # dotnet test invocation identical (same SDK pin, same restore graph, same
+      # entrypoint) so a passing local run is a passing CI run
+      - name: build test image
+        uses: docker/build-push-action@v6
+        with:
+          context: services/chat
+          file: services/chat/Dockerfile.test
+          load: true
+          tags: chat-test-runner
+          cache-from: type=gha,scope=chat-Dockerfile.test
+          cache-to: type=gha,scope=chat-Dockerfile.test,mode=max
+
+      - name: run tests
+        run: docker run --rm chat-test-runner
+
+  docker:
+    name: docker
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: setup buildx
+        uses: docker/setup-buildx-action@v3
+
+      # only the production image is gated. Dockerfile.dev is dev-loop only;
+      # breakage there doesn't block a deploy and isn't worth CI time. cache
+      # scope matches the publish job below so main reuses warm layers
+      - name: build production image
+        uses: docker/build-push-action@v6
+        with:
+          context: services/chat
+          file: services/chat/Dockerfile
+          push: false
+          cache-from: type=gha,scope=chat-Dockerfile
+          cache-to: type=gha,scope=chat-Dockerfile,mode=max
+
+  publish:
+    name: publish chat -> ghcr
+    runs-on: ubuntu-latest
+    # ship from main pushes (rolling :latest, :sha-<short>) and from chat-v*
+    # tag pushes (semver tags). PRs never publish: no secret leakage, no clutter
+    if: >-
+      github.event_name == 'push' &&
+      (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/chat-v'))
+    needs: [test, docker]
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: setup buildx
+        uses: docker/setup-buildx-action@v3
+
+      # GITHUB_TOKEN is auto-issued per run and scoped to this repo only; no
+      # PAT or secret management required for publishing to ghcr
+      - name: login to ghcr
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # tag matrix:
+      #   main pushes     -> :latest (moving) + :sha-<short> (immutable per commit)
+      #   chat-vX.Y.Z tag -> :vX.Y.Z + :X + :X.Y (so deploys can pin to 1, 1.2, or 1.2.3)
+      - name: image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}/chat
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=sha,format=short,prefix=sha-,enable={{is_default_branch}}
+            type=match,pattern=chat-v(\d+\.\d+\.\d+),group=1
+            type=match,pattern=chat-v(\d+\.\d+)\.\d+,group=1
+            type=match,pattern=chat-v(\d+)\.\d+\.\d+,group=1
+
+      - name: build + push
+        uses: docker/build-push-action@v6
+        with:
+          context: services/chat
+          file: services/chat/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # share cache scope with the docker validation job above so a main-
+          # branch run picks up warm layers from the matrix run that just ran
+          cache-from: type=gha,scope=chat-Dockerfile
+          cache-to: type=gha,scope=chat-Dockerfile,mode=max

--- a/services/chat/.env.example
+++ b/services/chat/.env.example
@@ -1,2 +1,18 @@
+#    ╭─────────────────────────────────────────────────────────────────────╮
+#    │                      ScyllaDB connection.                           │
+#    │   Contact points + keyspace for the Chat Service to bind its        │
+#    │   Cassandra session to. The contact points are container DNS names  │
+#    │   on the ft_transcendence network in dev; in compose.yaml /         │
+#    │   Tiltfile they default to `chat-db`.                               │
+#    ╰─────────────────────────────────────────────────────────────────────╯
+
 ScyllaDb__ContactPoints=
 ScyllaDb__Keyspace=
+
+#    ╭─────────────────────────────────────────────────────────────────────╮
+#    │                        JWT validation.                              │
+#    │   Jwt__SecretKey is wired in compose.yaml / Tiltfile from the root  │
+#    │   .env's JWT_SECRET (same shared secret as the Auth Service).       │
+#    │   This service only validates tokens (signature + expiry); it       │
+#    │   never issues them.                                                │
+#    ╰─────────────────────────────────────────────────────────────────────╯

--- a/services/chat/Chat.Mutation.slnx
+++ b/services/chat/Chat.Mutation.slnx
@@ -1,0 +1,11 @@
+<Solution>
+    <Folder Name="/src/">
+        <Project Path="src/Chat.Application/Chat.Application.csproj"/>
+        <Project Path="src/Chat.Domain/Chat.Domain.csproj"/>
+    </Folder>
+    <Folder Name="/tests/">
+        <Project Path="tests/Chat.ArchitectureTests/Chat.ArchitectureTests.csproj" BuildByDefault="false"/>
+        <Project Path="tests/Chat.UnitTests/Chat.UnitTests.csproj" BuildByDefault="false"/>
+        <Project Path="tests/Chat.FunctionalTests/Chat.FunctionalTests.csproj" BuildByDefault="false"/>
+    </Folder>
+</Solution>

--- a/services/chat/Chat.slnx
+++ b/services/chat/Chat.slnx
@@ -8,5 +8,7 @@
     </Folder>
     <Folder Name="/tests/">
         <Project Path="tests/Chat.ArchitectureTests/Chat.ArchitectureTests.csproj" BuildByDefault="false"/>
+        <Project Path="tests/Chat.UnitTests/Chat.UnitTests.csproj" BuildByDefault="false"/>
+        <Project Path="tests/Chat.FunctionalTests/Chat.FunctionalTests.csproj" BuildByDefault="false"/>
     </Folder>
 </Solution>

--- a/services/chat/Dockerfile.test
+++ b/services/chat/Dockerfile.test
@@ -8,6 +8,8 @@ COPY src/Chat.Infrastructure/Chat.Infrastructure.csproj src/Chat.Infrastructure/
 COPY src/Chat.Persistence/Chat.Persistence.csproj src/Chat.Persistence/
 COPY src/Chat.Presentation/Chat.Presentation.csproj src/Chat.Presentation/
 COPY tests/Chat.ArchitectureTests/Chat.ArchitectureTests.csproj tests/Chat.ArchitectureTests/
+COPY tests/Chat.UnitTests/Chat.UnitTests.csproj tests/Chat.UnitTests/
+COPY tests/Chat.FunctionalTests/Chat.FunctionalTests.csproj tests/Chat.FunctionalTests/
 
 RUN dotnet restore
 

--- a/services/chat/Tiltfile
+++ b/services/chat/Tiltfile
@@ -3,6 +3,7 @@ load('../../tiltlib.star', 'read_dotenv', 'detect_engine', 'run_flags', 'contain
 root_env    = read_dotenv('../../.env')
 MQ_USER     = root_env.get('RABBITMQ_USER', 'guest')
 MQ_PASS     = root_env.get('RABBITMQ_PASS', 'guest')
+JWT_SECRET  = root_env.get('JWT_SECRET', '')
 BASE_URL    = root_env.get('BASE_URL',     'https://localhost:1443')
 BASE_API_URL = root_env.get('BASE_API_URL', 'https://localhost:1443/api')
 DOCKER      = detect_engine()
@@ -44,6 +45,7 @@ local_resource(
         '-e BackendConfiguration__BaseApiUrl=' + BASE_API_URL + ' ' +
         '-e Services__GuildService=http://guild:8080 ' +
         '-e DOTNET_USE_POLLING_FILE_WATCHER=1 ' +
+        '-e Jwt__SecretKey=' + JWT_SECRET + ' ' +
         '-v $(pwd)/src:/app/src ' +
         'chat-service'
     ),

--- a/services/chat/Tiltfile
+++ b/services/chat/Tiltfile
@@ -12,6 +12,7 @@ local_resource(
     'chat-db',
     serve_cmd=container_serve(DOCKER, FLAGS, 'chat-db',
         '--network ft_transcendence ' +
+        '-p 9042:9042 ' +
         '-v chat_db_data:/var/lib/scylla ' +
         'docker.io/scylladb/scylla:6.2'
     ),

--- a/services/chat/compose.yaml
+++ b/services/chat/compose.yaml
@@ -44,6 +44,7 @@ services:
       BackendConfiguration__BaseUrl: ${BASE_URL}
       BackendConfiguration__BaseApiUrl: ${BASE_API_URL}
       Services__GuildService: http://guild:8080
+      Jwt__SecretKey: ${JWT_SECRET}
     depends_on:
       rabbitmq:
         condition: service_healthy

--- a/services/chat/dotnet-tools.json
+++ b/services/chat/dotnet-tools.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "dotnet-stryker": {
+      "version": "4.14.2",
+      "commands": [
+        "dotnet-stryker"
+      ],
+      "rollForward": false
+    }
+  }
+}

--- a/services/chat/schema/V0001__init.cql
+++ b/services/chat/schema/V0001__init.cql
@@ -1,11 +1,143 @@
 CREATE KEYSPACE IF NOT EXISTS chat
-    WITH replication = { 'class': 'SimpleStrategy', 'replication_factor': 1 };
+    WITH replication = {
+        'class': 'NetworkTopologyStrategy',
+        'replication_factor': 1   -- bump to 3 in production
+    }
+    AND durable_writes = true
+    -- Tablets are enabled by default in Scylla 6.x but don't yet support
+    -- COUNTER columns, which message_reaction_counts and dm_unread_counts
+    -- rely on. Disable until Scylla closes that gap.
+    AND tablets = {'enabled': false};
 
-CREATE TABLE IF NOT EXISTS chat.messages (
-    channel_id uuid,
-    bucket     int,
-    sent_at    timeuuid,
-    author_id  uuid,
-    content    text,
-    PRIMARY KEY ((channel_id, bucket), sent_at)
-) WITH CLUSTERING ORDER BY (sent_at DESC);
+USE chat;
+
+CREATE TABLE IF NOT EXISTS messages (
+    channel_id  BIGINT,
+    created_at  TIMESTAMP,
+    id          BIGINT,
+    author_id   BIGINT,
+    -- NULL for attachment-only messages
+    content     TEXT,
+    edited_at   TIMESTAMP,
+    -- soft delete: set is_deleted = true and NULL out content on delete
+    is_deleted  BOOLEAN,
+    -- reply threading: NULL = top-level message
+    reply_to_id BIGINT,
+    PRIMARY KEY ((channel_id), created_at, id)
+) WITH CLUSTERING ORDER BY (created_at DESC, id DESC)
+   AND comment = 'Channel message history, partitioned per channel';
+
+CREATE TABLE IF NOT EXISTS direct_messages (
+    conversation_id BIGINT,
+    created_at      TIMESTAMP,
+    id              BIGINT,
+    sender_id       BIGINT,
+    recipient_id    BIGINT,
+    content         TEXT,
+    edited_at       TIMESTAMP,
+    is_deleted      BOOLEAN,
+    reply_to_id     BIGINT,
+    PRIMARY KEY ((conversation_id), created_at, id)
+) WITH CLUSTERING ORDER BY (created_at DESC, id DESC)
+   AND comment = 'DM history, partitioned per conversation pair';
+
+CREATE TABLE IF NOT EXISTS message_attachments (
+    channel_id  BIGINT,
+    message_id  BIGINT,
+    id          BIGINT,
+    url         TEXT,
+    filename    TEXT,
+    size_bytes  BIGINT,
+    mime_type   TEXT,
+    PRIMARY KEY ((channel_id, message_id), id)
+) WITH comment = 'File attachment metadata per channel message';
+
+CREATE TABLE IF NOT EXISTS dm_attachments (
+    conversation_id BIGINT,
+    message_id      BIGINT,
+    id              BIGINT,
+    url             TEXT,
+    filename        TEXT,
+    size_bytes      BIGINT,
+    mime_type       TEXT,
+    PRIMARY KEY ((conversation_id, message_id), id)
+) WITH comment = 'File attachment metadata per DM';
+
+CREATE TABLE IF NOT EXISTS draft_attachments (
+    id          BIGINT PRIMARY KEY,
+    uploader_id BIGINT,
+    url         TEXT,
+    filename    TEXT,
+    size_bytes  BIGINT,
+    mime_type   TEXT,
+    created_at  TIMESTAMP
+) WITH default_time_to_live = 3600
+   AND comment = 'Pre-message attachment uploads; auto-expires in 1h';
+
+CREATE TABLE IF NOT EXISTS attachment_lookup (
+    attachment_id   BIGINT PRIMARY KEY,
+    -- routing
+    is_dm           BOOLEAN,
+    -- for channel attachments (is_dm = false)
+    channel_id      BIGINT,
+    -- for DM attachments (is_dm = true)
+    conversation_id BIGINT,
+    -- common
+    message_id      BIGINT
+) WITH comment = 'Maps attachment_id -> owning message PK for REST downloads';
+
+CREATE TABLE IF NOT EXISTS message_reactions (
+    channel_id  BIGINT,
+    message_id  BIGINT,
+    emoji       TEXT,
+    user_id     BIGINT,
+    created_at  TIMESTAMP,
+    PRIMARY KEY ((channel_id, message_id), emoji, user_id)
+) WITH comment = 'Per-user reaction records; used to check if the current user already reacted';
+
+CREATE TABLE IF NOT EXISTS message_reaction_counts (
+    channel_id  BIGINT,
+    message_id  BIGINT,
+    emoji       TEXT,
+    count       COUNTER,
+    PRIMARY KEY ((channel_id, message_id), emoji)
+) WITH comment = 'Reaction totals per emoji; COUNTER for atomic increments';
+
+CREATE TABLE IF NOT EXISTS channel_read_states (
+    user_id              BIGINT,
+    channel_id           BIGINT,
+    last_read_message_id BIGINT,
+    last_read_at         TIMESTAMP,
+    PRIMARY KEY ((user_id), channel_id)
+) WITH comment = 'Per-user last-read position per channel';
+
+CREATE TABLE IF NOT EXISTS user_conversations (
+    user_id          BIGINT,
+    partner_id       BIGINT,
+    conversation_id  BIGINT,
+    last_message_at  TIMESTAMP,
+    -- first ~100 chars of the most recent message for the DM sidebar preview
+    last_preview     TEXT,
+    is_archived      BOOLEAN,
+    PRIMARY KEY ((user_id), partner_id)
+) WITH comment = 'DM conversation index per user; sort by last_message_at in application layer';
+
+CREATE TABLE IF NOT EXISTS dm_unread_counts (
+    user_id     BIGINT,
+    partner_id  BIGINT,
+    count       COUNTER,
+    PRIMARY KEY ((user_id), partner_id)
+) WITH comment = 'Unread DM message count per conversation; reset on read';
+
+CREATE TABLE IF NOT EXISTS message_lookup (
+    message_id       BIGINT PRIMARY KEY,
+    -- routing
+    is_dm            BOOLEAN,
+    -- for channel messages (is_dm = false)
+    channel_id       BIGINT,
+    -- for DMs (is_dm = true)
+    conversation_id  BIGINT,
+    -- common
+    created_at       TIMESTAMP,
+    author_id        BIGINT
+) WITH comment = 'Auxiliary lookup: message_id → full PK + author_id for REST mutations';

--- a/services/chat/schema/V0002__nonce_dedup_and_dm_read.cql
+++ b/services/chat/schema/V0002__nonce_dedup_and_dm_read.cql
@@ -1,0 +1,27 @@
+USE chat;
+
+CREATE TABLE IF NOT EXISTS message_nonce_dedup (
+    author_id   BIGINT,
+    channel_id  BIGINT,
+    nonce       TEXT,
+    message_id  BIGINT,
+    PRIMARY KEY ((author_id, channel_id), nonce)
+) WITH default_time_to_live = 600
+   AND comment = 'Idempotency dedup for POST /channels/{id}/messages; auto-expires after the 10-minute window';
+
+CREATE TABLE IF NOT EXISTS dm_nonce_dedup (
+    sender_id     BIGINT,
+    recipient_id  BIGINT,
+    nonce         TEXT,
+    message_id    BIGINT,
+    PRIMARY KEY ((sender_id, recipient_id), nonce)
+) WITH default_time_to_live = 600
+   AND comment = 'Idempotency dedup for POST /dms/{user_id}/messages; auto-expires after the 10-minute window';
+
+CREATE TABLE IF NOT EXISTS dm_read_states (
+    user_id              BIGINT,
+    partner_id           BIGINT,
+    last_read_message_id BIGINT,
+    last_read_at         TIMESTAMP,
+    PRIMARY KEY ((user_id), partner_id)
+) WITH comment = 'Per-user last-read position per DM partner';

--- a/services/chat/src/Chat.Application/Abstractions/Authentication/ICurrentUser.cs
+++ b/services/chat/src/Chat.Application/Abstractions/Authentication/ICurrentUser.cs
@@ -1,0 +1,6 @@
+namespace Chat.Application.Abstractions.Authentication;
+
+public interface ICurrentUser
+{
+	long UserId { get; }
+}

--- a/services/chat/src/Chat.Application/Abstractions/IChannelBroadcaster.cs
+++ b/services/chat/src/Chat.Application/Abstractions/IChannelBroadcaster.cs
@@ -1,0 +1,8 @@
+using Chat.Application.Features.Messages.Common;
+
+namespace Chat.Application.Abstractions;
+
+public interface IChannelBroadcaster
+{
+	Task BroadcastMessageAsync(long channelId, MessageResponse message, CancellationToken ct);
+}

--- a/services/chat/src/Chat.Application/Abstractions/IClock.cs
+++ b/services/chat/src/Chat.Application/Abstractions/IClock.cs
@@ -1,0 +1,6 @@
+namespace Chat.Application.Abstractions;
+
+public interface IClock
+{
+	DateTimeOffset UtcNow { get; }
+}

--- a/services/chat/src/Chat.Application/Abstractions/IGuildClient.cs
+++ b/services/chat/src/Chat.Application/Abstractions/IGuildClient.cs
@@ -2,7 +2,7 @@ namespace Chat.Application.Abstractions;
 
 public interface IGuildClient
 {
-	Task<ChannelMembership?> GetMembershipAsync(Guid channelId, Guid userId, CancellationToken ct);
+	Task<ChannelMembership?> GetMembershipAsync(long channelId, long userId, CancellationToken ct);
 }
 
 public sealed record ChannelMembership(bool IsMember, long Permissions);

--- a/services/chat/src/Chat.Application/Abstractions/IGuildClient.cs
+++ b/services/chat/src/Chat.Application/Abstractions/IGuildClient.cs
@@ -5,4 +5,4 @@ public interface IGuildClient
 	Task<ChannelMembership?> GetMembershipAsync(long channelId, long userId, CancellationToken ct);
 }
 
-public sealed record ChannelMembership(bool IsMember, long Permissions);
+public sealed record ChannelMembership(bool IsMember, long GuildId, long Permissions);

--- a/services/chat/src/Chat.Application/Abstractions/ISnowflakeIdGenerator.cs
+++ b/services/chat/src/Chat.Application/Abstractions/ISnowflakeIdGenerator.cs
@@ -1,0 +1,6 @@
+namespace Chat.Application.Abstractions;
+
+public interface ISnowflakeIdGenerator
+{
+	long NextId();
+}

--- a/services/chat/src/Chat.Application/Abstractions/Persistence/IMessageRepository.cs
+++ b/services/chat/src/Chat.Application/Abstractions/Persistence/IMessageRepository.cs
@@ -1,0 +1,8 @@
+using Chat.Domain.Messages;
+
+namespace Chat.Application.Abstractions.Persistence;
+
+public interface IMessageRepository
+{
+	Task AddAsync(Message message, CancellationToken ct);
+}

--- a/services/chat/src/Chat.Application/Abstractions/Persistence/IMessageRepository.cs
+++ b/services/chat/src/Chat.Application/Abstractions/Persistence/IMessageRepository.cs
@@ -4,5 +4,7 @@ namespace Chat.Application.Abstractions.Persistence;
 
 public interface IMessageRepository
 {
-	Task AddAsync(Message message, CancellationToken ct);
+	Task AddAsync(Message message, string? nonce, CancellationToken ct);
+	Task<long?> FindNonceAsync(long authorId, long channelId, string nonce, CancellationToken ct);
+	Task<Message?> GetByIdAsync(long messageId, CancellationToken ct);
 }

--- a/services/chat/src/Chat.Application/Contracts/Events.cs
+++ b/services/chat/src/Chat.Application/Contracts/Events.cs
@@ -1,10 +1,10 @@
 namespace Chat.Application.Contracts;
 
-public sealed record ChatMessageSent(Guid ChannelId, Guid GuildId, Guid AuthorId, string Content, Guid[] Mentions);
-public sealed record CallIncoming(Guid CallId, Guid CallerId, Guid CalleeId, string CallType);
-public sealed record UserOnline(Guid UserId);
-public sealed record UserOffline(Guid UserId);
+public sealed record ChatMessageSent(long ChannelId, long GuildId, long AuthorId, long MessageId, string Content, long[] Mentions);
+public sealed record CallIncoming(long CallId, long CallerId, long CalleeId, string CallType);
+public sealed record UserOnline(long UserId);
+public sealed record UserOffline(long UserId);
 
-public sealed record GuildMemberJoined(Guid GuildId, Guid UserId);
-public sealed record GuildMemberLeft(Guid GuildId, Guid UserId);
-public sealed record UserLoggedOut(Guid UserId);
+public sealed record GuildMemberJoined(long GuildId, long UserId);
+public sealed record GuildMemberLeft(long GuildId, long UserId);
+public sealed record UserLoggedOut(long UserId);

--- a/services/chat/src/Chat.Application/Features/Messages/Common/MessageResponse.cs
+++ b/services/chat/src/Chat.Application/Features/Messages/Common/MessageResponse.cs
@@ -1,0 +1,31 @@
+using Chat.Domain.Messages;
+
+namespace Chat.Application.Features.Messages.Common;
+
+/// <summary>
+/// wire shape that mirrors the contract's <c>ReceiveMessage</c> event. snowflake
+/// IDs are quoted strings so JS clients can hold them without precision loss.
+/// attachments and reactions are empty arrays on freshly-created messages
+/// </summary>
+public sealed record MessageResponse(
+	string Id,
+	string ChannelId,
+	string AuthorId,
+	string? Content,
+	string? ReplyToId,
+	DateTimeOffset? EditedAt,
+	DateTimeOffset CreatedAt,
+	object[] Attachments,
+	object[] Reactions)
+{
+	public static MessageResponse From(Message m) => new(
+		Id: m.Id.ToString(),
+		ChannelId: m.ChannelId.ToString(),
+		AuthorId: m.AuthorId.ToString(),
+		Content: m.Content,
+		ReplyToId: m.ReplyToId?.ToString(),
+		EditedAt: m.EditedAt,
+		CreatedAt: m.CreatedAt,
+		Attachments: [],
+		Reactions: []);
+}

--- a/services/chat/src/Chat.Application/Features/Messages/Common/MessageResponse.cs
+++ b/services/chat/src/Chat.Application/Features/Messages/Common/MessageResponse.cs
@@ -16,9 +16,10 @@ public sealed record MessageResponse(
 	DateTimeOffset? EditedAt,
 	DateTimeOffset CreatedAt,
 	object[] Attachments,
-	object[] Reactions)
+	object[] Reactions,
+	string? Nonce)
 {
-	public static MessageResponse From(Message m) => new(
+	public static MessageResponse From(Message m, string? nonce) => new(
 		Id: m.Id.ToString(),
 		ChannelId: m.ChannelId.ToString(),
 		AuthorId: m.AuthorId.ToString(),
@@ -27,5 +28,6 @@ public sealed record MessageResponse(
 		EditedAt: m.EditedAt,
 		CreatedAt: m.CreatedAt,
 		Attachments: [],
-		Reactions: []);
+		Reactions: [],
+		Nonce: nonce);
 }

--- a/services/chat/src/Chat.Application/Features/Messages/SendMessage/SendMessageCommand.cs
+++ b/services/chat/src/Chat.Application/Features/Messages/SendMessage/SendMessageCommand.cs
@@ -4,5 +4,5 @@ using Chat.Domain.Results;
 
 namespace Chat.Application.Features.Messages.SendMessage;
 
-public sealed record SendMessageCommand(long ChannelId, string? Content, long? ReplyToId)
+public sealed record SendMessageCommand(long ChannelId, string? Content, long? ReplyToId, string? Nonce)
 	: ICommand<Result<MessageResponse>>;

--- a/services/chat/src/Chat.Application/Features/Messages/SendMessage/SendMessageCommand.cs
+++ b/services/chat/src/Chat.Application/Features/Messages/SendMessage/SendMessageCommand.cs
@@ -1,0 +1,8 @@
+using Chat.Application.Abstractions.Messaging;
+using Chat.Application.Features.Messages.Common;
+using Chat.Domain.Results;
+
+namespace Chat.Application.Features.Messages.SendMessage;
+
+public sealed record SendMessageCommand(long ChannelId, string? Content, long? ReplyToId)
+	: ICommand<Result<MessageResponse>>;

--- a/services/chat/src/Chat.Application/Features/Messages/SendMessage/SendMessageHandler.cs
+++ b/services/chat/src/Chat.Application/Features/Messages/SendMessage/SendMessageHandler.cs
@@ -24,11 +24,15 @@ internal sealed class SendMessageHandler(
 	// for the source of truth on permission numbering
 	private const long SendMessages = 1L << 0;
 	private const long Administrator = 1L << 8;
+	private const int MaxNonceLen = 64;
 
 	public async Task<Result<MessageResponse>> HandleAsync(
 		SendMessageCommand command,
 		CancellationToken cancellationToken = default)
 	{
+		if (command.Nonce is { Length: > MaxNonceLen })
+			return MessageFailures.NonceTooLong;
+
 		var userId = currentUser.UserId;
 
 		var membership = await guildClient.GetMembershipAsync(command.ChannelId, userId, cancellationToken);
@@ -56,7 +60,7 @@ internal sealed class SendMessageHandler(
 		var message = messageResult.Value;
 		await repository.AddAsync(message, cancellationToken);
 
-		var response = MessageResponse.From(message);
+		var response = MessageResponse.From(message, command.Nonce);
 
 		await eventBus.PublishAsync(
 			new ChatMessageSent(
@@ -64,7 +68,7 @@ internal sealed class SendMessageHandler(
 				GuildId: membership.GuildId,
 				AuthorId: userId,
 				MessageId: messageId,
-				Content: message.Content ?? string.Empty,
+				Content: message.Content!,
 				Mentions: []),
 			cancellationToken);
 

--- a/services/chat/src/Chat.Application/Features/Messages/SendMessage/SendMessageHandler.cs
+++ b/services/chat/src/Chat.Application/Features/Messages/SendMessage/SendMessageHandler.cs
@@ -1,0 +1,75 @@
+using Chat.Application.Abstractions;
+using Chat.Application.Abstractions.Authentication;
+using Chat.Application.Abstractions.Messaging;
+using Chat.Application.Abstractions.Persistence;
+using Chat.Application.Contracts;
+using Chat.Application.Features.Messages.Common;
+using Chat.Domain.Messages;
+using Chat.Domain.Results;
+
+namespace Chat.Application.Features.Messages.SendMessage;
+
+internal sealed class SendMessageHandler(
+	ICurrentUser currentUser,
+	IGuildClient guildClient,
+	IMessageRepository repository,
+	ISnowflakeIdGenerator ids,
+	IClock clock,
+	IEventBus eventBus,
+	IChannelBroadcaster broadcaster)
+	: ICommandHandler<SendMessageCommand, Result<MessageResponse>>
+{
+	// permission bits mirror the Guild Service domain so this stays a pure
+	// bitmask check; see services/guild/src/Guild.Domain/Guild/Permission.cs
+	// for the source of truth on permission numbering
+	private const long SendMessages = 1L << 0;
+	private const long Administrator = 1L << 8;
+
+	public async Task<Result<MessageResponse>> HandleAsync(
+		SendMessageCommand command,
+		CancellationToken cancellationToken = default)
+	{
+		var userId = currentUser.UserId;
+
+		var membership = await guildClient.GetMembershipAsync(command.ChannelId, userId, cancellationToken);
+		if (membership is null)
+			return MessageFailures.ChannelNotFound;
+
+		if (!membership.IsMember)
+			return MessageFailures.NotAMember;
+
+		if ((membership.Permissions & (SendMessages | Administrator)) == 0)
+			return MessageFailures.MissingSendPermission;
+
+		var messageId = ids.NextId();
+
+		var messageResult = Message.Create(
+			id: messageId,
+			channelId: command.ChannelId,
+			authorId: userId,
+			content: command.Content,
+			replyToId: command.ReplyToId,
+			now: clock.UtcNow);
+		if (messageResult.IsFailure)
+			return messageResult.Error;
+
+		var message = messageResult.Value;
+		await repository.AddAsync(message, cancellationToken);
+
+		var response = MessageResponse.From(message);
+
+		await eventBus.PublishAsync(
+			new ChatMessageSent(
+				ChannelId: command.ChannelId,
+				GuildId: membership.GuildId,
+				AuthorId: userId,
+				MessageId: messageId,
+				Content: message.Content ?? string.Empty,
+				Mentions: []),
+			cancellationToken);
+
+		await broadcaster.BroadcastMessageAsync(command.ChannelId, response, cancellationToken);
+
+		return response;
+	}
+}

--- a/services/chat/src/Chat.Application/Features/Messages/SendMessage/SendMessageHandler.cs
+++ b/services/chat/src/Chat.Application/Features/Messages/SendMessage/SendMessageHandler.cs
@@ -45,6 +45,17 @@ internal sealed class SendMessageHandler(
 		if ((membership.Permissions & (SendMessages | Administrator)) == 0)
 			return MessageFailures.MissingSendPermission;
 
+		if (command.Nonce is not null)
+		{
+			var existingId = await repository.FindNonceAsync(userId, command.ChannelId, command.Nonce, cancellationToken);
+			if (existingId is not null)
+			{
+				var existing = await repository.GetByIdAsync(existingId.Value, cancellationToken);
+				if (existing is not null)
+					return MessageResponse.From(existing, command.Nonce);
+			}
+		}
+
 		var messageId = ids.NextId();
 
 		var messageResult = Message.Create(
@@ -58,7 +69,7 @@ internal sealed class SendMessageHandler(
 			return messageResult.Error;
 
 		var message = messageResult.Value;
-		await repository.AddAsync(message, cancellationToken);
+		await repository.AddAsync(message, command.Nonce, cancellationToken);
 
 		var response = MessageResponse.From(message, command.Nonce);
 

--- a/services/chat/src/Chat.Domain/Messages/Message.cs
+++ b/services/chat/src/Chat.Domain/Messages/Message.cs
@@ -1,0 +1,74 @@
+using Chat.Domain.Results;
+
+namespace Chat.Domain.Messages;
+
+public sealed class Message
+{
+	public const int MaxContentLen = 4000;
+
+	// driver-friendly constructor (nope, it's not just an EF Core thingy 🥀)
+	private Message() { }
+
+	private Message(
+		long id,
+		long channelId,
+		long authorId,
+		string? content,
+		long? replyToId,
+		DateTimeOffset? editedAt,
+		bool isDeleted,
+		DateTimeOffset createdAt)
+	{
+		Id = id;
+		ChannelId = channelId;
+		AuthorId = authorId;
+		Content = content;
+		ReplyToId = replyToId;
+		EditedAt = editedAt;
+		IsDeleted = isDeleted;
+		CreatedAt = createdAt;
+	}
+
+	public long Id { get; private set; }
+	public long ChannelId { get; private set; }
+	public long AuthorId { get; private set; }
+	public string? Content { get; private set; }
+	public long? ReplyToId { get; private set; }
+	public DateTimeOffset? EditedAt { get; private set; }
+	public bool IsDeleted { get; private set; }
+	public DateTimeOffset CreatedAt { get; private set; }
+
+	public static Result<Message> Create(
+		long id,
+		long channelId,
+		long authorId,
+		string? content,
+		long? replyToId,
+		DateTimeOffset now)
+	{
+		if (id <= 0)
+			return MessageFailures.InvalidId;
+
+		if (channelId <= 0)
+			return MessageFailures.InvalidChannelId;
+
+		if (authorId <= 0)
+			return MessageFailures.InvalidAuthorId;
+
+		if (string.IsNullOrWhiteSpace(content))
+			return MessageFailures.ContentRequired;
+
+		if (content.Length > MaxContentLen)
+			return MessageFailures.ContentTooLong;
+
+		return new Message(
+			id: id,
+			channelId: channelId,
+			authorId: authorId,
+			content: content,
+			replyToId: replyToId,
+			editedAt: null,
+			isDeleted: false,
+			createdAt: now);
+	}
+}

--- a/services/chat/src/Chat.Domain/Messages/Message.cs
+++ b/services/chat/src/Chat.Domain/Messages/Message.cs
@@ -38,6 +38,17 @@ public sealed class Message
 	public bool IsDeleted { get; private set; }
 	public DateTimeOffset CreatedAt { get; private set; }
 
+	public static Message Reconstitute(
+		long id,
+		long channelId,
+		long authorId,
+		string? content,
+		long? replyToId,
+		DateTimeOffset? editedAt,
+		bool isDeleted,
+		DateTimeOffset createdAt)
+		=> new(id, channelId, authorId, content, replyToId, editedAt, isDeleted, createdAt);
+
 	public static Result<Message> Create(
 		long id,
 		long channelId,

--- a/services/chat/src/Chat.Domain/Results/MessageFailures.cs
+++ b/services/chat/src/Chat.Domain/Results/MessageFailures.cs
@@ -28,4 +28,7 @@ public static class MessageFailures
 
 	public static readonly Failure MissingSendPermission =
 		new("Message.MissingSendPermission", "Caller lacks SEND_MESSAGES permission on this channel.");
+
+	public static readonly Failure NonceTooLong =
+		new("Message.NonceTooLong", "Nonce must be 64 characters or fewer.");
 }

--- a/services/chat/src/Chat.Domain/Results/MessageFailures.cs
+++ b/services/chat/src/Chat.Domain/Results/MessageFailures.cs
@@ -1,0 +1,31 @@
+using Chat.Domain.Messages;
+
+namespace Chat.Domain.Results;
+
+public static class MessageFailures
+{
+	public static readonly Failure ContentRequired =
+		new("Message.ContentRequired", "Message content is required.");
+
+	public static readonly Failure ContentTooLong =
+		new("Message.ContentTooLong",
+			$"Message content must be {Message.MaxContentLen} characters or fewer.");
+
+	public static readonly Failure InvalidId =
+		new("Message.InvalidId", "Message id must be a positive snowflake.");
+
+	public static readonly Failure InvalidChannelId =
+		new("Message.InvalidChannelId", "Channel id must be a positive snowflake.");
+
+	public static readonly Failure InvalidAuthorId =
+		new("Message.InvalidAuthorId", "Author id must be a positive snowflake.");
+
+	public static readonly Failure ChannelNotFound =
+		new("Message.ChannelNotFound", "Channel not found.");
+
+	public static readonly Failure NotAMember =
+		new("Message.NotAMember", "Caller is not a member of the guild that owns this channel.");
+
+	public static readonly Failure MissingSendPermission =
+		new("Message.MissingSendPermission", "Caller lacks SEND_MESSAGES permission on this channel.");
+}

--- a/services/chat/src/Chat.Infrastructure/Authentication/CurrentUser.cs
+++ b/services/chat/src/Chat.Infrastructure/Authentication/CurrentUser.cs
@@ -1,0 +1,30 @@
+using System.Security.Claims;
+using Chat.Application.Abstractions.Authentication;
+using Microsoft.AspNetCore.Http;
+
+namespace Chat.Infrastructure.Authentication;
+
+internal sealed class CurrentUser(IHttpContextAccessor accessor) : ICurrentUser
+{
+	public long UserId
+	{
+		get
+		{
+			var user = accessor.HttpContext?.User
+				?? throw new InvalidOperationException("No HttpContext is available.");
+
+			// JwtBearer maps the JWT "sub" claim onto ClaimTypes.NameIdentifier
+			// by default; fall back to the raw "sub" string if a custom token
+			// validator left the claim un-mapped
+			var sub = user.FindFirstValue(ClaimTypes.NameIdentifier)
+				?? user.FindFirstValue("sub")
+				?? throw new InvalidOperationException("Authenticated user has no 'sub' claim.");
+
+			if (!long.TryParse(sub, out var id))
+				throw new InvalidOperationException(
+					$"Authenticated user 'sub' claim ('{sub}') is not a valid snowflake ID.");
+
+			return id;
+		}
+	}
+}

--- a/services/chat/src/Chat.Infrastructure/Chat.Infrastructure.csproj
+++ b/services/chat/src/Chat.Infrastructure/Chat.Infrastructure.csproj
@@ -12,10 +12,11 @@
     </ItemGroup>
 
     <ItemGroup>
+        <FrameworkReference Include="Microsoft.AspNetCore.App"/>
+    </ItemGroup>
+
+    <ItemGroup>
         <PackageReference Include="MassTransit.RabbitMQ" Version="8.4.1"/>
-        <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.0"/>
-        <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.0"/>
-        <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.0"/>
     </ItemGroup>
 
 </Project>

--- a/services/chat/src/Chat.Infrastructure/DependencyInjection.cs
+++ b/services/chat/src/Chat.Infrastructure/DependencyInjection.cs
@@ -73,7 +73,7 @@ public static class DependencyInjection
 		services.AddHttpClient<IGuildClient, GuildClient>((sp, c) =>
 		{
 			var opts = sp.GetRequiredService<IOptions<ServicesOptions>>().Value;
-			c.BaseAddress = new Uri(opts.GuildService.TrimEnd('/') + "/");
+			c.BaseAddress = new Uri(opts.GuildService.TrimEnd('/') + "/internal/");
 		});
 
 		return services;

--- a/services/chat/src/Chat.Infrastructure/DependencyInjection.cs
+++ b/services/chat/src/Chat.Infrastructure/DependencyInjection.cs
@@ -1,5 +1,7 @@
 using Chat.Application.Abstractions;
+using Chat.Application.Abstractions.Authentication;
 using Chat.Application.Contracts;
+using Chat.Infrastructure.Authentication;
 using Chat.Infrastructure.Http;
 using Chat.Infrastructure.Messaging;
 using Chat.Infrastructure.Messaging.Consumers;
@@ -26,6 +28,11 @@ public static class DependencyInjection
 
 		services.AddOptions<RabbitMqOptions>()
 			.BindConfiguration("RabbitMQ")
+			.ValidateDataAnnotations()
+			.ValidateOnStart();
+
+		services.AddOptions<SnowflakeOptions>()
+			.BindConfiguration("Snowflake")
 			.ValidateDataAnnotations()
 			.ValidateOnStart();
 
@@ -56,7 +63,12 @@ public static class DependencyInjection
 			});
 		});
 
+		services.AddHttpContextAccessor();
+
 		services.AddScoped<IEventBus, EventBus>();
+		services.AddSingleton<IClock, SystemClock>();
+		services.AddSingleton<ISnowflakeIdGenerator, SnowflakeIdGenerator>();
+		services.AddScoped<ICurrentUser, CurrentUser>();
 
 		services.AddHttpClient<IGuildClient, GuildClient>((sp, c) =>
 		{

--- a/services/chat/src/Chat.Infrastructure/Http/GuildClient.cs
+++ b/services/chat/src/Chat.Infrastructure/Http/GuildClient.cs
@@ -1,11 +1,17 @@
 using System.Net.Http.Json;
+using System.Text.Json;
 using Chat.Application.Abstractions;
 
 namespace Chat.Infrastructure.Http;
 
 internal sealed class GuildClient(HttpClient http) : IGuildClient
 {
-	public Task<ChannelMembership?> GetMembershipAsync(Guid channelId, Guid userId, CancellationToken ct) =>
+	private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
+	{
+		PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+	};
+
+	public Task<ChannelMembership?> GetMembershipAsync(long channelId, long userId, CancellationToken ct) =>
 		http.GetFromJsonAsync<ChannelMembership>(
-			$"channels/{channelId}/membership?user_id={userId}", ct);
+			$"channels/{channelId}/membership?user_id={userId}", JsonOptions, ct);
 }

--- a/services/chat/src/Chat.Infrastructure/Http/GuildClient.cs
+++ b/services/chat/src/Chat.Infrastructure/Http/GuildClient.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
 using Chat.Application.Abstractions;
@@ -11,7 +12,18 @@ internal sealed class GuildClient(HttpClient http) : IGuildClient
 		PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
 	};
 
-	public Task<ChannelMembership?> GetMembershipAsync(long channelId, long userId, CancellationToken ct) =>
-		http.GetFromJsonAsync<ChannelMembership>(
-			$"channels/{channelId}/membership?user_id={userId}", JsonOptions, ct);
+	public async Task<ChannelMembership?> GetMembershipAsync(long channelId, long userId, CancellationToken ct)
+	{
+		try
+		{
+			return await http.GetFromJsonAsync<ChannelMembership>(
+				$"channels/{channelId}/membership?user_id={userId}", JsonOptions, ct);
+		}
+		// GetFromJsonAsync throws on non-2xx; map 404 to null so the handler's
+		// `membership is null -> ChannelNotFound` branch fires as intended
+		catch (HttpRequestException e) when (e.StatusCode == HttpStatusCode.NotFound)
+		{
+			return null;
+		}
+	}
 }

--- a/services/chat/src/Chat.Infrastructure/Options/SnowflakeOptions.cs
+++ b/services/chat/src/Chat.Infrastructure/Options/SnowflakeOptions.cs
@@ -1,0 +1,12 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Chat.Infrastructure.Options;
+
+public sealed class SnowflakeOptions
+{
+	[Range(0, 1023)]
+	public long WorkerId { get; init; } = 3;
+
+	// 2024-11-12 08:42:00 UTC
+	public long Epoch { get; init; } = 1731397320000L;
+}

--- a/services/chat/src/Chat.Infrastructure/SnowflakeIdGenerator.cs
+++ b/services/chat/src/Chat.Infrastructure/SnowflakeIdGenerator.cs
@@ -1,0 +1,77 @@
+using Chat.Application.Abstractions;
+using Chat.Infrastructure.Options;
+using Microsoft.Extensions.Options;
+
+namespace Chat.Infrastructure;
+
+internal sealed class SnowflakeIdGenerator : ISnowflakeIdGenerator
+{
+	private const int WorkerIdBits = 10;
+	private const int SequenceBits = 12;
+	private const int TimestampLeftShift = SequenceBits + WorkerIdBits;
+	private const long MaxWorkerId = (1L << WorkerIdBits) - 1;
+	private const long MaxSequence = (1L << SequenceBits) - 1;
+
+	private readonly long _workerId;
+	private readonly long _epoch;
+	private long _sequence = 0;
+	private long _lastTimestamp = -1;
+	private readonly IClock _clock;
+	private readonly Lock _lock = new();
+
+	public SnowflakeIdGenerator(IClock clock, IOptions<SnowflakeOptions> options)
+	{
+		var snowflakeOptions = options.Value;
+
+		_workerId = snowflakeOptions.WorkerId;
+		_epoch = snowflakeOptions.Epoch;
+		_clock = clock;
+
+		if (_workerId is < 0 or > MaxWorkerId)
+			throw new ArgumentException(
+				$"Worker ID must be between 0 and {MaxWorkerId}, but got {_workerId}",
+				nameof(snowflakeOptions.WorkerId)
+			);
+	}
+
+	public long NextId()
+	{
+		lock (_lock)
+		{
+			var timestamp = GetCurrentTimestamp();
+
+			if (timestamp < _lastTimestamp)
+				throw new InvalidOperationException(
+					"Clock moved backwards. Refusing to generate ID for timestamp " +
+					$"{timestamp} ms. Last known timestamp was {_lastTimestamp} ms."
+				);
+
+			if (timestamp == _lastTimestamp)
+			{
+				_sequence = (_sequence + 1) & MaxSequence;
+				if (_sequence == 0) // sequence overflow inside the same millisecond
+					timestamp = WaitUntilNextMillisecond(_lastTimestamp);
+			}
+			else
+				_sequence = 0;
+
+			_lastTimestamp = timestamp;
+
+			return ((timestamp - _epoch) << TimestampLeftShift)
+				| (_workerId << SequenceBits)
+				| _sequence;
+		}
+	}
+
+	private long GetCurrentTimestamp() => _clock.UtcNow.ToUnixTimeMilliseconds();
+
+	private long WaitUntilNextMillisecond(long lastTimestamp)
+	{
+		var timestamp = GetCurrentTimestamp();
+		while (timestamp <= lastTimestamp)
+		{
+			timestamp = GetCurrentTimestamp();
+		}
+		return timestamp;
+	}
+}

--- a/services/chat/src/Chat.Infrastructure/SystemClock.cs
+++ b/services/chat/src/Chat.Infrastructure/SystemClock.cs
@@ -1,0 +1,8 @@
+using Chat.Application.Abstractions;
+
+namespace Chat.Infrastructure;
+
+internal sealed class SystemClock : IClock
+{
+	public DateTimeOffset UtcNow => DateTimeOffset.UtcNow;
+}

--- a/services/chat/src/Chat.Persistence/DependencyInjection.cs
+++ b/services/chat/src/Chat.Persistence/DependencyInjection.cs
@@ -30,6 +30,7 @@ public static class DependencyInjection
 					return builder.Build().Connect(opts.Keyspace);
 				});
 
+		services.AddSingleton<MessageStatements>();
 		services.AddScoped<IMessageRepository, MessageRepository>();
 		return services;
 	}

--- a/services/chat/src/Chat.Persistence/DependencyInjection.cs
+++ b/services/chat/src/Chat.Persistence/DependencyInjection.cs
@@ -1,6 +1,8 @@
 using Cassandra;
+using Chat.Application.Abstractions.Persistence;
 using Chat.Persistence.Health;
 using Chat.Persistence.Options;
+using Chat.Persistence.Repositories;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
@@ -27,6 +29,8 @@ public static class DependencyInjection
 						builder.WithCredentials(opts.Username, opts.Password);
 					return builder.Build().Connect(opts.Keyspace);
 				});
+
+		services.AddScoped<IMessageRepository, MessageRepository>();
 		return services;
 	}
 

--- a/services/chat/src/Chat.Persistence/Repositories/MessageRepository.cs
+++ b/services/chat/src/Chat.Persistence/Repositories/MessageRepository.cs
@@ -4,35 +4,12 @@ using Chat.Domain.Messages;
 
 namespace Chat.Persistence.Repositories;
 
-internal sealed class MessageRepository(ISession session) : IMessageRepository
+internal sealed class MessageRepository(ISession session, MessageStatements statements) : IMessageRepository
 {
-	private readonly Lazy<Task<PreparedStatement>> _insertMessage = new(() => session.PrepareAsync(
-		"INSERT INTO messages " +
-		"(channel_id, created_at, id, author_id, content, edited_at, is_deleted, reply_to_id) " +
-		"VALUES (?, ?, ?, ?, ?, ?, ?, ?)"));
-
-	private readonly Lazy<Task<PreparedStatement>> _insertLookup = new(() => session.PrepareAsync(
-		"INSERT INTO message_lookup " +
-		"(message_id, is_dm, channel_id, conversation_id, created_at, author_id) " +
-		"VALUES (?, false, ?, ?, ?, ?)"));
-
-	private readonly Lazy<Task<PreparedStatement>> _insertNonce = new(() => session.PrepareAsync(
-		"INSERT INTO message_nonce_dedup (author_id, channel_id, nonce, message_id) VALUES (?, ?, ?, ?)"));
-
-	private readonly Lazy<Task<PreparedStatement>> _findNonce = new(() => session.PrepareAsync(
-		"SELECT message_id FROM message_nonce_dedup WHERE author_id = ? AND channel_id = ? AND nonce = ?"));
-
-	private readonly Lazy<Task<PreparedStatement>> _selectLookup = new(() => session.PrepareAsync(
-		"SELECT channel_id, created_at FROM message_lookup WHERE message_id = ?"));
-
-	private readonly Lazy<Task<PreparedStatement>> _selectMessage = new(() => session.PrepareAsync(
-		"SELECT channel_id, created_at, id, author_id, content, edited_at, is_deleted, reply_to_id " +
-		"FROM messages WHERE channel_id = ? AND created_at = ? AND id = ?"));
-
 	public async Task AddAsync(Message message, string? nonce, CancellationToken ct)
 	{
-		var insertMessage = await _insertMessage.Value;
-		var insertLookup = await _insertLookup.Value;
+		var insertMessage = await statements.InsertMessage.Value;
+		var insertLookup = await statements.InsertLookup.Value;
 
 		var createdAt = message.CreatedAt.UtcDateTime;
 		var editedAt = message.EditedAt?.UtcDateTime;
@@ -57,7 +34,7 @@ internal sealed class MessageRepository(ISession session) : IMessageRepository
 
 		if (nonce is not null)
 		{
-			var insertNonce = await _insertNonce.Value;
+			var insertNonce = await statements.InsertNonce.Value;
 			batch.Add(insertNonce.Bind(message.AuthorId, message.ChannelId, nonce, message.Id));
 		}
 
@@ -66,7 +43,7 @@ internal sealed class MessageRepository(ISession session) : IMessageRepository
 
 	public async Task<long?> FindNonceAsync(long authorId, long channelId, string nonce, CancellationToken ct)
 	{
-		var stmt = await _findNonce.Value;
+		var stmt = await statements.FindNonce.Value;
 		var row = await session.ExecuteAsync(stmt.Bind(authorId, channelId, nonce));
 		var first = row.FirstOrDefault();
 		return first?.GetValue<long>("message_id");
@@ -74,7 +51,7 @@ internal sealed class MessageRepository(ISession session) : IMessageRepository
 
 	public async Task<Message?> GetByIdAsync(long messageId, CancellationToken ct)
 	{
-		var selectLookup = await _selectLookup.Value;
+		var selectLookup = await statements.SelectLookup.Value;
 		var lookupRow = (await session.ExecuteAsync(selectLookup.Bind(messageId))).FirstOrDefault();
 		if (lookupRow is null)
 			return null;
@@ -82,7 +59,7 @@ internal sealed class MessageRepository(ISession session) : IMessageRepository
 		var channelId = lookupRow.GetValue<long>("channel_id");
 		var createdAt = lookupRow.GetValue<DateTime>("created_at");
 
-		var selectMessage = await _selectMessage.Value;
+		var selectMessage = await statements.SelectMessage.Value;
 		var msgRow = (await session.ExecuteAsync(selectMessage.Bind(channelId, createdAt, messageId))).FirstOrDefault();
 		if (msgRow is null)
 			return null;

--- a/services/chat/src/Chat.Persistence/Repositories/MessageRepository.cs
+++ b/services/chat/src/Chat.Persistence/Repositories/MessageRepository.cs
@@ -1,0 +1,57 @@
+using Cassandra;
+using Chat.Application.Abstractions.Persistence;
+using Chat.Domain.Messages;
+
+namespace Chat.Persistence.Repositories;
+
+internal sealed class MessageRepository(ISession session) : IMessageRepository
+{
+	// statements are prepared lazily once per process and reused. AsyncLazy via
+	// Task<PreparedStatement> means concurrent first-callers all await the same
+	// in-flight prepare instead of racing the driver
+	private readonly Lazy<Task<PreparedStatement>> _insertMessage = new(() => session.PrepareAsync(
+		"INSERT INTO messages " +
+		"(channel_id, created_at, id, author_id, content, edited_at, is_deleted, reply_to_id) " +
+		"VALUES (?, ?, ?, ?, ?, ?, ?, ?)"));
+
+	private readonly Lazy<Task<PreparedStatement>> _insertLookup = new(() => session.PrepareAsync(
+		"INSERT INTO message_lookup " +
+		"(message_id, is_dm, channel_id, conversation_id, created_at, author_id) " +
+		"VALUES (?, false, ?, ?, ?, ?)"));
+
+	public async Task AddAsync(Message message, CancellationToken ct)
+	{
+		var insertMessage = await _insertMessage.Value;
+		var insertLookup = await _insertLookup.Value;
+
+		var createdAt = message.CreatedAt.UtcDateTime;
+		var editedAt = message.EditedAt?.UtcDateTime;
+
+		var messageStmt = insertMessage.Bind(
+			message.ChannelId,
+			createdAt,
+			message.Id,
+			message.AuthorId,
+			message.Content,
+			editedAt,
+			message.IsDeleted,
+			message.ReplyToId);
+
+		var lookupStmt = insertLookup.Bind(
+			message.Id,
+			message.ChannelId,
+			// conversation_id is bound NULL: regular CQL INSERTs accept null
+			// binds for non-key columns, which is what we want for channel
+			// messages (this row is the channel-vs-DM discriminator)
+			(long?)null,
+			createdAt,
+			message.AuthorId);
+
+		var batch = new BatchStatement()
+			.SetBatchType(BatchType.Logged)
+			.Add(messageStmt)
+			.Add(lookupStmt);
+
+		await session.ExecuteAsync(batch);
+	}
+}

--- a/services/chat/src/Chat.Persistence/Repositories/MessageRepository.cs
+++ b/services/chat/src/Chat.Persistence/Repositories/MessageRepository.cs
@@ -6,9 +6,6 @@ namespace Chat.Persistence.Repositories;
 
 internal sealed class MessageRepository(ISession session) : IMessageRepository
 {
-	// statements are prepared lazily once per process and reused. AsyncLazy via
-	// Task<PreparedStatement> means concurrent first-callers all await the same
-	// in-flight prepare instead of racing the driver
 	private readonly Lazy<Task<PreparedStatement>> _insertMessage = new(() => session.PrepareAsync(
 		"INSERT INTO messages " +
 		"(channel_id, created_at, id, author_id, content, edited_at, is_deleted, reply_to_id) " +
@@ -19,7 +16,20 @@ internal sealed class MessageRepository(ISession session) : IMessageRepository
 		"(message_id, is_dm, channel_id, conversation_id, created_at, author_id) " +
 		"VALUES (?, false, ?, ?, ?, ?)"));
 
-	public async Task AddAsync(Message message, CancellationToken ct)
+	private readonly Lazy<Task<PreparedStatement>> _insertNonce = new(() => session.PrepareAsync(
+		"INSERT INTO message_nonce_dedup (author_id, channel_id, nonce, message_id) VALUES (?, ?, ?, ?)"));
+
+	private readonly Lazy<Task<PreparedStatement>> _findNonce = new(() => session.PrepareAsync(
+		"SELECT message_id FROM message_nonce_dedup WHERE author_id = ? AND channel_id = ? AND nonce = ?"));
+
+	private readonly Lazy<Task<PreparedStatement>> _selectLookup = new(() => session.PrepareAsync(
+		"SELECT channel_id, created_at FROM message_lookup WHERE message_id = ?"));
+
+	private readonly Lazy<Task<PreparedStatement>> _selectMessage = new(() => session.PrepareAsync(
+		"SELECT channel_id, created_at, id, author_id, content, edited_at, is_deleted, reply_to_id " +
+		"FROM messages WHERE channel_id = ? AND created_at = ? AND id = ?"));
+
+	public async Task AddAsync(Message message, string? nonce, CancellationToken ct)
 	{
 		var insertMessage = await _insertMessage.Value;
 		var insertLookup = await _insertLookup.Value;
@@ -27,31 +37,64 @@ internal sealed class MessageRepository(ISession session) : IMessageRepository
 		var createdAt = message.CreatedAt.UtcDateTime;
 		var editedAt = message.EditedAt?.UtcDateTime;
 
-		var messageStmt = insertMessage.Bind(
-			message.ChannelId,
-			createdAt,
-			message.Id,
-			message.AuthorId,
-			message.Content,
-			editedAt,
-			message.IsDeleted,
-			message.ReplyToId);
-
-		var lookupStmt = insertLookup.Bind(
-			message.Id,
-			message.ChannelId,
-			// conversation_id is bound NULL: regular CQL INSERTs accept null
-			// binds for non-key columns, which is what we want for channel
-			// messages (this row is the channel-vs-DM discriminator)
-			(long?)null,
-			createdAt,
-			message.AuthorId);
-
 		var batch = new BatchStatement()
 			.SetBatchType(BatchType.Logged)
-			.Add(messageStmt)
-			.Add(lookupStmt);
+			.Add(insertMessage.Bind(
+				message.ChannelId,
+				createdAt,
+				message.Id,
+				message.AuthorId,
+				message.Content,
+				editedAt,
+				message.IsDeleted,
+				message.ReplyToId))
+			.Add(insertLookup.Bind(
+				message.Id,
+				message.ChannelId,
+				(long?)null,
+				createdAt,
+				message.AuthorId));
+
+		if (nonce is not null)
+		{
+			var insertNonce = await _insertNonce.Value;
+			batch.Add(insertNonce.Bind(message.AuthorId, message.ChannelId, nonce, message.Id));
+		}
 
 		await session.ExecuteAsync(batch);
+	}
+
+	public async Task<long?> FindNonceAsync(long authorId, long channelId, string nonce, CancellationToken ct)
+	{
+		var stmt = await _findNonce.Value;
+		var row = await session.ExecuteAsync(stmt.Bind(authorId, channelId, nonce));
+		var first = row.FirstOrDefault();
+		return first?.GetValue<long>("message_id");
+	}
+
+	public async Task<Message?> GetByIdAsync(long messageId, CancellationToken ct)
+	{
+		var selectLookup = await _selectLookup.Value;
+		var lookupRow = (await session.ExecuteAsync(selectLookup.Bind(messageId))).FirstOrDefault();
+		if (lookupRow is null)
+			return null;
+
+		var channelId = lookupRow.GetValue<long>("channel_id");
+		var createdAt = lookupRow.GetValue<DateTime>("created_at");
+
+		var selectMessage = await _selectMessage.Value;
+		var msgRow = (await session.ExecuteAsync(selectMessage.Bind(channelId, createdAt, messageId))).FirstOrDefault();
+		if (msgRow is null)
+			return null;
+
+		return Message.Reconstitute(
+			id: msgRow.GetValue<long>("id"),
+			channelId: msgRow.GetValue<long>("channel_id"),
+			authorId: msgRow.GetValue<long>("author_id"),
+			content: msgRow.GetValue<string>("content"),
+			replyToId: msgRow.GetValue<long?>("reply_to_id"),
+			editedAt: msgRow.GetValue<DateTime?>("edited_at"),
+			isDeleted: msgRow.GetValue<bool>("is_deleted"),
+			createdAt: new DateTimeOffset(createdAt, TimeSpan.Zero));
 	}
 }

--- a/services/chat/src/Chat.Persistence/Repositories/MessageStatements.cs
+++ b/services/chat/src/Chat.Persistence/Repositories/MessageStatements.cs
@@ -1,0 +1,29 @@
+using Cassandra;
+
+namespace Chat.Persistence.Repositories;
+
+internal sealed class MessageStatements(ISession session)
+{
+	public Lazy<Task<PreparedStatement>> InsertMessage { get; } = new(() => session.PrepareAsync(
+		"INSERT INTO messages " +
+		"(channel_id, created_at, id, author_id, content, edited_at, is_deleted, reply_to_id) " +
+		"VALUES (?, ?, ?, ?, ?, ?, ?, ?)"));
+
+	public Lazy<Task<PreparedStatement>> InsertLookup { get; } = new(() => session.PrepareAsync(
+		"INSERT INTO message_lookup " +
+		"(message_id, is_dm, channel_id, conversation_id, created_at, author_id) " +
+		"VALUES (?, false, ?, ?, ?, ?)"));
+
+	public Lazy<Task<PreparedStatement>> InsertNonce { get; } = new(() => session.PrepareAsync(
+		"INSERT INTO message_nonce_dedup (author_id, channel_id, nonce, message_id) VALUES (?, ?, ?, ?)"));
+
+	public Lazy<Task<PreparedStatement>> FindNonce { get; } = new(() => session.PrepareAsync(
+		"SELECT message_id FROM message_nonce_dedup WHERE author_id = ? AND channel_id = ? AND nonce = ?"));
+
+	public Lazy<Task<PreparedStatement>> SelectLookup { get; } = new(() => session.PrepareAsync(
+		"SELECT channel_id, created_at FROM message_lookup WHERE message_id = ?"));
+
+	public Lazy<Task<PreparedStatement>> SelectMessage { get; } = new(() => session.PrepareAsync(
+		"SELECT channel_id, created_at, id, author_id, content, edited_at, is_deleted, reply_to_id " +
+		"FROM messages WHERE channel_id = ? AND created_at = ? AND id = ?"));
+}

--- a/services/chat/src/Chat.Presentation/Chat.Presentation.csproj
+++ b/services/chat/src/Chat.Presentation/Chat.Presentation.csproj
@@ -16,6 +16,7 @@
 
     <ItemGroup>
         <PackageReference Include="Carter" Version="10.0.0"/>
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.2"/>
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.2"/>
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3"/>
         <PackageReference Include="Scalar.AspNetCore" Version="2.6.0"/>

--- a/services/chat/src/Chat.Presentation/Endpoints/ErrorBody.cs
+++ b/services/chat/src/Chat.Presentation/Endpoints/ErrorBody.cs
@@ -1,0 +1,3 @@
+namespace Chat.Presentation.Endpoints;
+
+public sealed record ErrorBody(string Error);

--- a/services/chat/src/Chat.Presentation/Endpoints/MessagesEndpoint.cs
+++ b/services/chat/src/Chat.Presentation/Endpoints/MessagesEndpoint.cs
@@ -1,0 +1,52 @@
+using Carter;
+using Chat.Application.Abstractions.Messaging;
+using Chat.Application.Features.Messages.Common;
+using Chat.Application.Features.Messages.SendMessage;
+using Chat.Domain.Results;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+
+namespace Chat.Presentation.Endpoints;
+
+public sealed class MessagesEndpoint : ICarterModule
+{
+	public void AddRoutes(IEndpointRouteBuilder endpoints)
+	{
+		var group = endpoints.MapGroup("/channels/{channelId:long}/messages");
+		group.MapPost("/", SendAsync);
+	}
+
+	private static async Task<Results<
+		Created<MessageResponse>,
+		BadRequest<ErrorBody>,
+		JsonHttpResult<ErrorBody>,
+		NotFound<ErrorBody>>>
+	SendAsync(
+		long channelId,
+		SendMessageRequest request,
+		ICommandHandler<SendMessageCommand, Result<MessageResponse>> handler,
+		CancellationToken cancellationToken)
+	{
+		var result = await handler.HandleAsync(
+			new SendMessageCommand(channelId, request.Content, request.ReplyToId, request.Nonce),
+			cancellationToken);
+
+		return result.Succeeded
+			? TypedResults.Created($"/channels/{channelId}/messages/{result.Value.Id}", result.Value)
+			: MapError(result.Error);
+	}
+
+	private static Results<Created<MessageResponse>, BadRequest<ErrorBody>, JsonHttpResult<ErrorBody>, NotFound<ErrorBody>>
+		MapError(Failure failure) => failure.Code switch
+		{
+			"Message.ChannelNotFound" => TypedResults.NotFound(new ErrorBody(failure.Message)),
+			"Message.NotAMember" => TypedResults.Json(new ErrorBody(failure.Message), statusCode: StatusCodes.Status403Forbidden),
+			"Message.MissingSendPermission" => TypedResults.Json(new ErrorBody(failure.Message), statusCode: StatusCodes.Status403Forbidden),
+			_ => TypedResults.BadRequest(new ErrorBody(failure.Message)),
+		};
+
+	private sealed record SendMessageRequest(
+		string? Content,
+		long? ReplyToId,
+		string? Nonce);
+}

--- a/services/chat/src/Chat.Presentation/Hubs/ChatHub.cs
+++ b/services/chat/src/Chat.Presentation/Hubs/ChatHub.cs
@@ -1,7 +1,9 @@
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.SignalR;
 
 namespace Chat.Presentation.Hubs;
 
+[Authorize]
 public sealed class ChatHub : Hub<IChatClient>
 {
 	public Task Echo(string message) =>

--- a/services/chat/src/Chat.Presentation/Hubs/ChatHub.cs
+++ b/services/chat/src/Chat.Presentation/Hubs/ChatHub.cs
@@ -1,30 +1,32 @@
-using Chat.Application.Abstractions.Messaging;
-using Chat.Application.Features.Messages.Common;
-using Chat.Application.Features.Messages.SendMessage;
-using Chat.Domain.Results;
+using Chat.Application.Abstractions;
+using Chat.Application.Abstractions.Authentication;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.SignalR;
 
 namespace Chat.Presentation.Hubs;
 
 [Authorize]
-public sealed class ChatHub(
-	ICommandHandler<SendMessageCommand, Result<MessageResponse>> sendHandler)
-	: Hub<IChatClient>
+public sealed class ChatHub(IGuildClient guildClient, ICurrentUser currentUser) : Hub<IChatClient>
 {
-	public async Task SendMessage(SendMessagePayload payload)
-	{
-		var result = await sendHandler.HandleAsync(
-			new SendMessageCommand(payload.ChannelId, payload.Content, payload.ReplyToId),
-			Context.ConnectionAborted);
+	private const long ReadMessages = 1L << 1;
+	private const long Administrator = 1L << 8;
 
-		if (result.IsFailure)
+	public async Task JoinChannel(long channelId)
+	{
+		var membership = await guildClient.GetMembershipAsync(channelId, currentUser.UserId, Context.ConnectionAborted);
+
+		if (membership is null || !membership.IsMember)
 		{
-			// success path is fanned-out by IChannelBroadcaster inside the
-			// handler; the caller learns about it through ReceiveMessage like
-			// every other subscriber, so the hub method itself only surfaces
-			// failures
-			await Clients.Caller.Error(result.Error.Code, result.Error.Message);
+			await Clients.Caller.Error("Channel.NotFound", "Channel not found.");
+			return;
 		}
+
+		if ((membership.Permissions & (ReadMessages | Administrator)) == 0)
+		{
+			await Clients.Caller.Error("Channel.MissingReadPermission", "Caller lacks READ_MESSAGES permission on this channel.");
+			return;
+		}
+
+		await Groups.AddToGroupAsync(Context.ConnectionId, $"channel:{channelId}", Context.ConnectionAborted);
 	}
 }

--- a/services/chat/src/Chat.Presentation/Hubs/ChatHub.cs
+++ b/services/chat/src/Chat.Presentation/Hubs/ChatHub.cs
@@ -1,11 +1,30 @@
+using Chat.Application.Abstractions.Messaging;
+using Chat.Application.Features.Messages.Common;
+using Chat.Application.Features.Messages.SendMessage;
+using Chat.Domain.Results;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.SignalR;
 
 namespace Chat.Presentation.Hubs;
 
 [Authorize]
-public sealed class ChatHub : Hub<IChatClient>
+public sealed class ChatHub(
+	ICommandHandler<SendMessageCommand, Result<MessageResponse>> sendHandler)
+	: Hub<IChatClient>
 {
-	public Task Echo(string message) =>
-		Clients.Caller.ReceiveMessage(message);
+	public async Task SendMessage(SendMessagePayload payload)
+	{
+		var result = await sendHandler.HandleAsync(
+			new SendMessageCommand(payload.ChannelId, payload.Content, payload.ReplyToId),
+			Context.ConnectionAborted);
+
+		if (result.IsFailure)
+		{
+			// success path is fanned-out by IChannelBroadcaster inside the
+			// handler; the caller learns about it through ReceiveMessage like
+			// every other subscriber, so the hub method itself only surfaces
+			// failures
+			await Clients.Caller.Error(result.Error.Code, result.Error.Message);
+		}
+	}
 }

--- a/services/chat/src/Chat.Presentation/Hubs/IChatClient.cs
+++ b/services/chat/src/Chat.Presentation/Hubs/IChatClient.cs
@@ -1,6 +1,9 @@
+using Chat.Application.Features.Messages.Common;
+
 namespace Chat.Presentation.Hubs;
 
 public interface IChatClient
 {
-	Task ReceiveMessage(string message);
+	Task ReceiveMessage(MessageResponse message);
+	Task Error(string code, string message);
 }

--- a/services/chat/src/Chat.Presentation/Hubs/SendMessagePayload.cs
+++ b/services/chat/src/Chat.Presentation/Hubs/SendMessagePayload.cs
@@ -1,0 +1,3 @@
+namespace Chat.Presentation.Hubs;
+
+public sealed record SendMessagePayload(long ChannelId, string? Content, long? ReplyToId);

--- a/services/chat/src/Chat.Presentation/Hubs/SendMessagePayload.cs
+++ b/services/chat/src/Chat.Presentation/Hubs/SendMessagePayload.cs
@@ -1,3 +1,0 @@
-namespace Chat.Presentation.Hubs;
-
-public sealed record SendMessagePayload(long ChannelId, string? Content, long? ReplyToId);

--- a/services/chat/src/Chat.Presentation/Hubs/SignalRChannelBroadcaster.cs
+++ b/services/chat/src/Chat.Presentation/Hubs/SignalRChannelBroadcaster.cs
@@ -1,0 +1,21 @@
+using Chat.Application.Abstractions;
+using Chat.Application.Features.Messages.Common;
+using Microsoft.AspNetCore.SignalR;
+
+namespace Chat.Presentation.Hubs;
+
+/// <summary>
+/// fans out <see cref="MessageResponse"/> to every connection subscribed to a
+/// channel group. lives in Presentation because <c>IHubContext</c> is a SignalR
+/// abstraction and <c>Chat.Infrastructure</c> must stay free of ASP.NET deps
+///
+/// note: users are not yet auto-joined to channel groups on connect (issue
+/// #66). until that lands, broadcasts are effectively a no-op in dev. the
+/// call site is correct so it light up the moment group membership wires up
+/// </summary>
+internal sealed class SignalRChannelBroadcaster(IHubContext<ChatHub, IChatClient> hub)
+	: IChannelBroadcaster
+{
+	public Task BroadcastMessageAsync(long channelId, MessageResponse message, CancellationToken ct) =>
+		hub.Clients.Group($"channel:{channelId}").ReceiveMessage(message);
+}

--- a/services/chat/src/Chat.Presentation/Hubs/SignalingHub.cs
+++ b/services/chat/src/Chat.Presentation/Hubs/SignalingHub.cs
@@ -6,15 +6,15 @@ namespace Chat.Presentation.Hubs;
 [Authorize]
 public sealed class SignalingHub : Hub<ISignalingClient>
 {
-	public Task SendOffer(Guid targetUserId, string sdp) =>
+	public Task SendOffer(long targetUserId, string sdp) =>
 		Clients.User(targetUserId.ToString())
 			.Offer(Context.UserIdentifier, sdp);
 
-	public Task SendAnswer(Guid targetUserId, string sdp) =>
+	public Task SendAnswer(long targetUserId, string sdp) =>
 		Clients.User(targetUserId.ToString())
 			.Answer(Context.UserIdentifier, sdp);
 
-	public Task SendIceCandidate(Guid targetUserId, string candidate) =>
+	public Task SendIceCandidate(long targetUserId, string candidate) =>
 		Clients.User(targetUserId.ToString())
 			.IceCandidate(Context.UserIdentifier, candidate);
 }

--- a/services/chat/src/Chat.Presentation/Hubs/SignalingHub.cs
+++ b/services/chat/src/Chat.Presentation/Hubs/SignalingHub.cs
@@ -1,7 +1,9 @@
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.SignalR;
 
 namespace Chat.Presentation.Hubs;
 
+[Authorize]
 public sealed class SignalingHub : Hub<ISignalingClient>
 {
 	public Task SendOffer(Guid targetUserId, string sdp) =>

--- a/services/chat/src/Chat.Presentation/Program.cs
+++ b/services/chat/src/Chat.Presentation/Program.cs
@@ -1,15 +1,21 @@
+using System.Text;
 using System.Text.Json;
 using Carter;
 using Chat.Application;
 using Chat.Infrastructure;
 using Chat.Persistence;
 using Chat.Presentation.Hubs;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Microsoft.IdentityModel.Tokens;
 using Scalar.AspNetCore;
 
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Host.ConfigureHostOptions(o => o.ShutdownTimeout = TimeSpan.FromSeconds(5));
+
+builder.Services.ConfigureHttpJsonOptions(o =>
+	o.SerializerOptions.PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower);
 
 builder.Services.AddOpenApi();
 builder.Services.AddHealthChecks()
@@ -20,6 +26,38 @@ builder.Services.AddApplication()
 	.AddPersistence();
 builder.Services.AddCarter();
 
+var jwtSecret = builder.Configuration["Jwt:SecretKey"]
+	?? throw new InvalidOperationException("Jwt:SecretKey is not configured.");
+
+builder.Services
+	.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+	.AddJwtBearer(options =>
+	{
+		options.TokenValidationParameters = new TokenValidationParameters
+		{
+			ValidateIssuerSigningKey = true,
+			IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwtSecret)),
+			ValidateLifetime = true,
+			ValidateIssuer = false,
+			ValidateAudience = false,
+		};
+		// SignalR sends the JWT as ?access_token=... on the WebSocket upgrade
+		// request because browsers can't attach custom headers to WS handshakes
+		// bad browsers, time to switch to raw sockets! /j
+		options.Events = new JwtBearerEvents
+		{
+			OnMessageReceived = ctx =>
+			{
+				var accessToken = ctx.Request.Query["access_token"];
+				var path = ctx.HttpContext.Request.Path;
+				if (!string.IsNullOrEmpty(accessToken) && path.StartsWithSegments("/hubs"))
+					ctx.Token = accessToken;
+				return Task.CompletedTask;
+			},
+		};
+	});
+builder.Services.AddAuthorization();
+
 var app = builder.Build();
 
 if (app.Environment.IsDevelopment())
@@ -27,6 +65,9 @@ if (app.Environment.IsDevelopment())
 	app.MapOpenApi();
 	app.MapScalarApiReference();
 }
+
+app.UseAuthentication();
+app.UseAuthorization();
 
 app.MapHealthChecks("/healthz", new HealthCheckOptions
 {
@@ -50,3 +91,5 @@ app.MapHub<ChatHub>("/hubs/chat");
 app.MapHub<SignalingHub>("/hubs/signaling");
 
 app.Run();
+
+public partial class Program;

--- a/services/chat/src/Chat.Presentation/Program.cs
+++ b/services/chat/src/Chat.Presentation/Program.cs
@@ -2,11 +2,13 @@ using System.Text;
 using System.Text.Json;
 using Carter;
 using Chat.Application;
+using Chat.Application.Abstractions;
 using Chat.Infrastructure;
 using Chat.Persistence;
 using Chat.Presentation.Hubs;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.IdentityModel.Tokens;
 using Scalar.AspNetCore;
 
@@ -24,6 +26,7 @@ builder.Services.AddSignalR();
 builder.Services.AddApplication()
 	.AddInfrastructure()
 	.AddPersistence();
+builder.Services.AddScoped<IChannelBroadcaster, SignalRChannelBroadcaster>();
 builder.Services.AddCarter();
 
 var jwtSecret = builder.Configuration["Jwt:SecretKey"]

--- a/services/chat/src/Chat.Presentation/Program.cs
+++ b/services/chat/src/Chat.Presentation/Program.cs
@@ -53,7 +53,7 @@ builder.Services
 			{
 				var accessToken = ctx.Request.Query["access_token"];
 				var path = ctx.HttpContext.Request.Path;
-				if (!string.IsNullOrEmpty(accessToken) && path.StartsWithSegments("/hubs"))
+				if (!string.IsNullOrEmpty(accessToken) && path.StartsWithSegments("/v1/hubs"))
 					ctx.Token = accessToken;
 				return Task.CompletedTask;
 			},
@@ -89,9 +89,10 @@ app.MapHealthChecks("/healthz", new HealthCheckOptions
 		}));
 	},
 });
-app.MapCarter();
-app.MapHub<ChatHub>("/hubs/chat");
-app.MapHub<SignalingHub>("/hubs/signaling");
+var v1 = app.MapGroup("/v1").RequireAuthorization();
+v1.MapCarter();
+app.MapHub<ChatHub>("/v1/hubs/chat");
+app.MapHub<SignalingHub>("/v1/hubs/signaling");
 
 app.Run();
 

--- a/services/chat/stryker-config.json
+++ b/services/chat/stryker-config.json
@@ -1,0 +1,14 @@
+{
+	"stryker-config": {
+		"solution": "Chat.Mutation.slnx",
+		"test-projects": [
+			"tests/Chat.UnitTests/Chat.UnitTests.csproj",
+			"tests/Chat.FunctionalTests/Chat.FunctionalTests.csproj"
+		],
+		"reporters": ["progress", "html", "json"],
+		"mutate": [
+			"**/*.cs",
+			"!**/Results/*.cs"
+		]
+	}
+}

--- a/services/chat/tests/Chat.FunctionalTests/Chat.FunctionalTests.csproj
+++ b/services/chat/tests/Chat.FunctionalTests/Chat.FunctionalTests.csproj
@@ -1,0 +1,35 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <RootNamespace>Chat.FunctionalTests</RootNamespace>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <FrameworkReference Include="Microsoft.AspNetCore.App"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing"      Version="10.0.1"/>
+        <PackageReference Include="Microsoft.AspNetCore.SignalR.Client"   Version="10.0.2"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk"                Version="17.12.0"/>
+        <PackageReference Include="xunit"                                 Version="2.9.3"/>
+        <PackageReference Include="xunit.runner.visualstudio"             Version="2.8.2">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\src\Chat.Domain\Chat.Domain.csproj"/>
+        <ProjectReference Include="..\..\src\Chat.Application\Chat.Application.csproj"/>
+        <ProjectReference Include="..\..\src\Chat.Infrastructure\Chat.Infrastructure.csproj"/>
+        <ProjectReference Include="..\..\src\Chat.Persistence\Chat.Persistence.csproj"/>
+        <ProjectReference Include="..\..\src\Chat.Presentation\Chat.Presentation.csproj"/>
+        <ProjectReference Include="..\Chat.UnitTests\Chat.UnitTests.csproj"/>
+    </ItemGroup>
+
+</Project>

--- a/services/chat/tests/Chat.FunctionalTests/Endpoints/SendMessageEndpointTests.cs
+++ b/services/chat/tests/Chat.FunctionalTests/Endpoints/SendMessageEndpointTests.cs
@@ -141,6 +141,27 @@ public sealed class SendMessageEndpointTests(ChatApiFactory factory)
 		Assert.Null(body!.Nonce);
 	}
 
+	[Fact]
+	public async Task Post_SameNonce_Returns201WithOriginalMessage()
+	{
+		factory.WithMembership(channelId: 100, userId: 42, guildId: 9, permissions: SendMessagesPermission);
+		var client = BuildClient(userId: 42);
+
+		var first = await client.PostAsJsonAsync("/v1/channels/100/messages",
+			new { content = "hello", nonce = "dedup-nonce" });
+		var firstBody = await first.Content.ReadFromJsonAsync<MessageBody>(JsonOptions);
+
+		var second = await client.PostAsJsonAsync("/v1/channels/100/messages",
+			new { content = "hello", nonce = "dedup-nonce" });
+		var secondBody = await second.Content.ReadFromJsonAsync<MessageBody>(JsonOptions);
+
+		Assert.Equal(HttpStatusCode.Created, second.StatusCode);
+		Assert.Equal(firstBody!.Id, secondBody!.Id);
+		Assert.Equal(firstBody.CreatedAt, secondBody.CreatedAt);
+		Assert.Equal("dedup-nonce", secondBody.Nonce);
+		Assert.Single(factory.SavedMessages);
+	}
+
 	private sealed record MessageBody(
 		string Id,
 		string ChannelId,

--- a/services/chat/tests/Chat.FunctionalTests/Endpoints/SendMessageEndpointTests.cs
+++ b/services/chat/tests/Chat.FunctionalTests/Endpoints/SendMessageEndpointTests.cs
@@ -1,0 +1,153 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Chat.Application.Contracts;
+using Chat.FunctionalTests.Infrastructure;
+using Xunit;
+
+namespace Chat.FunctionalTests.Endpoints;
+
+public sealed class SendMessageEndpointTests(ChatApiFactory factory)
+	: IClassFixture<ChatApiFactory>, IAsyncLifetime
+{
+	private const long SendMessagesPermission = 1L << 0;
+
+	private static readonly JsonSerializerOptions JsonOptions = new()
+	{
+		PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+		PropertyNameCaseInsensitive = true,
+	};
+
+	public Task InitializeAsync()
+	{
+		factory.GuildClient.Result = null;
+		factory.MessageRepository.Reset();
+		factory.EventBus.Reset();
+		factory.Broadcaster.Reset();
+		return Task.CompletedTask;
+	}
+
+	public Task DisposeAsync() => Task.CompletedTask;
+
+	private HttpClient BuildClient(long userId)
+	{
+		var client = factory.CreateClient();
+		var token = TestTokens.Issue(ChatApiFactory.JwtSecret, userId: userId);
+		client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+		return client;
+	}
+
+	[Fact]
+	public async Task Post_WithoutToken_Returns401()
+	{
+		var client = factory.CreateClient();
+
+		var response = await client.PostAsJsonAsync("/v1/channels/100/messages",
+			new { content = "hi" });
+
+		Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+	}
+
+	[Fact]
+	public async Task Post_HappyPath_Returns201_PersistsAndPublishesAndBroadcasts()
+	{
+		factory.WithMembership(channelId: 100, userId: 42, guildId: 9, permissions: SendMessagesPermission);
+		var client = BuildClient(userId: 42);
+
+		var response = await client.PostAsJsonAsync("/v1/channels/100/messages",
+			new { content = "hello world", nonce = "test-nonce-1" });
+
+		Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+
+		var body = await response.Content.ReadFromJsonAsync<MessageBody>(JsonOptions);
+		Assert.NotNull(body);
+		Assert.Equal("100", body.ChannelId);
+		Assert.Equal("42", body.AuthorId);
+		Assert.Equal("hello world", body.Content);
+		Assert.Null(body.ReplyToId);
+		Assert.Null(body.EditedAt);
+		Assert.Equal("test-nonce-1", body.Nonce);
+		Assert.True(long.TryParse(body.Id, out var messageId));
+
+		var saved = Assert.Single(factory.SavedMessages);
+		Assert.Equal(messageId, saved.Id);
+		Assert.Equal(100L, saved.ChannelId);
+		Assert.Equal(42L, saved.AuthorId);
+
+		var evt = Assert.Single(factory.EventBus.PublishedOf<ChatMessageSent>());
+		Assert.Equal(100L, evt.ChannelId);
+		Assert.Equal(9L, evt.GuildId);
+		Assert.Equal(42L, evt.AuthorId);
+		Assert.Equal(messageId, evt.MessageId);
+
+		var (broadcastChannel, broadcastMsg) = Assert.Single(factory.Broadcaster.Broadcasts);
+		Assert.Equal(100L, broadcastChannel);
+		Assert.Equal(body.Id, broadcastMsg.Id);
+		Assert.Equal("test-nonce-1", broadcastMsg.Nonce);
+	}
+
+	[Fact]
+	public async Task Post_MissingPermission_Returns403_NoSideEffects()
+	{
+		factory.WithMembership(channelId: 100, userId: 42, guildId: 9, permissions: 0);
+		var client = BuildClient(userId: 42);
+
+		var response = await client.PostAsJsonAsync("/v1/channels/100/messages",
+			new { content = "hi" });
+
+		Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+		Assert.Empty(factory.SavedMessages);
+		Assert.Empty(factory.EventBus.Published);
+		Assert.Empty(factory.Broadcaster.Broadcasts);
+	}
+
+	[Fact]
+	public async Task Post_ChannelNotFound_Returns404()
+	{
+		factory.GuildClient.Result = null;
+		var client = BuildClient(userId: 42);
+
+		var response = await client.PostAsJsonAsync("/v1/channels/100/messages",
+			new { content = "hi" });
+
+		Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+	}
+
+	[Fact]
+	public async Task Post_NonceTooLong_Returns400()
+	{
+		factory.WithMembership(channelId: 100, userId: 42, guildId: 9, permissions: SendMessagesPermission);
+		var client = BuildClient(userId: 42);
+		var longNonce = new string('x', 65);
+
+		var response = await client.PostAsJsonAsync("/v1/channels/100/messages",
+			new { content = "hi", nonce = longNonce });
+
+		Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+	}
+
+	[Fact]
+	public async Task Post_NoNonce_Returns201WithNullNonce()
+	{
+		factory.WithMembership(channelId: 100, userId: 42, guildId: 9, permissions: SendMessagesPermission);
+		var client = BuildClient(userId: 42);
+
+		var response = await client.PostAsJsonAsync("/v1/channels/100/messages",
+			new { content = "hello" });
+
+		Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+		var body = await response.Content.ReadFromJsonAsync<MessageBody>(JsonOptions);
+		Assert.Null(body!.Nonce);
+	}
+
+	private sealed record MessageBody(
+		string Id,
+		string ChannelId,
+		string AuthorId,
+		string? Content,
+		string? ReplyToId,
+		DateTimeOffset? EditedAt,
+		DateTimeOffset CreatedAt,
+		string? Nonce);
+}

--- a/services/chat/tests/Chat.FunctionalTests/Endpoints/SendMessageHubTests.cs
+++ b/services/chat/tests/Chat.FunctionalTests/Endpoints/SendMessageHubTests.cs
@@ -1,0 +1,177 @@
+using Chat.Application.Contracts;
+using Chat.FunctionalTests.Infrastructure;
+using Microsoft.AspNetCore.Http.Connections;
+using Microsoft.AspNetCore.SignalR.Client;
+using Xunit;
+
+namespace Chat.FunctionalTests.Endpoints;
+
+public sealed class SendMessageHubTests(ChatApiFactory factory) : IClassFixture<ChatApiFactory>, IAsyncLifetime
+{
+	private const long SendMessagesPermission = 1L << 0;
+
+	public Task InitializeAsync()
+	{
+		// reset shared fake state so tests within the class fixture are
+		// independent. xUnit calls this once per test before construction
+		factory.GuildClient.Result = null;
+		factory.MessageRepository.Reset();
+		factory.EventBus.Reset();
+		factory.Broadcaster.Reset();
+		return Task.CompletedTask;
+	}
+
+	public Task DisposeAsync() => Task.CompletedTask;
+
+	/// <summary>
+	/// builds a HubConnection wired into the in-process test server. the
+	/// standard ASP.NET pattern is to override HttpMessageHandlerFactory so
+	/// negotiation goes through TestServer, and to override WebSocketFactory
+	/// so the WebSocket transport tunnels through TestServer's bidirectional
+	/// stream. Kestrel never actually binds in test mode (good)
+	///
+	/// JWT is forwarded BOTH via the Authorization header (CreateWebSocketClient
+	/// adds it to the upgrade request) AND via ?access_token=... in the query
+	/// string (Program.cs's JwtBearer OnMessageReceived prefers query for hub
+	/// paths). either one alone is sufficient
+	/// </summary>
+	private HubConnection BuildHubConnection(string? token)
+	{
+		var server = factory.Server;
+		var hubUri = new UriBuilder(server.BaseAddress) { Path = "/hubs/chat" }.Uri;
+
+		return new HubConnectionBuilder()
+			.WithUrl(hubUri, options =>
+			{
+				options.Transports = HttpTransportType.WebSockets;
+				options.SkipNegotiation = true;
+				options.HttpMessageHandlerFactory = _ => server.CreateHandler();
+				options.WebSocketFactory = async (context, ct) =>
+				{
+					var wsClient = server.CreateWebSocketClient();
+					wsClient.ConfigureRequest = req =>
+					{
+						if (token is not null)
+							req.Headers["Authorization"] = $"Bearer {token}";
+					};
+
+					var uri = context.Uri;
+					if (token is not null)
+					{
+						var separator = string.IsNullOrEmpty(uri.Query) ? "?" : "&";
+						uri = new Uri(uri + separator + "access_token=" + token);
+					}
+
+					return await wsClient.ConnectAsync(uri, ct);
+				};
+			})
+			.Build();
+	}
+
+	[Fact]
+	public async Task Connect_WithoutToken_IsRejected()
+	{
+		var connection = BuildHubConnection(token: null);
+
+		// [Authorize] on the hub causes the upgrade to fail; SignalR surfaces
+		// this as an exception bubbling out of StartAsync
+		await Assert.ThrowsAnyAsync<Exception>(() => connection.StartAsync());
+		Assert.NotEqual(HubConnectionState.Connected, connection.State);
+
+		await connection.DisposeAsync();
+	}
+
+	[Fact]
+	public async Task Connect_WithToken_SucceedsAndConnects()
+	{
+		var token = TestTokens.Issue(ChatApiFactory.JwtSecret, userId: 42);
+		var connection = BuildHubConnection(token);
+
+		await connection.StartAsync();
+
+		Assert.Equal(HubConnectionState.Connected, connection.State);
+
+		await connection.DisposeAsync();
+	}
+
+	[Fact]
+	public async Task SendMessage_HappyPath_PersistsAndPublishesAndBroadcasts()
+	{
+		factory.WithMembership(channelId: 100, userId: 42, guildId: 9, permissions: SendMessagesPermission);
+
+		var token = TestTokens.Issue(ChatApiFactory.JwtSecret, userId: 42);
+		var connection = BuildHubConnection(token);
+
+		// subscribe to Error so we can assert the hub did NOT push one to the
+		// caller. ReceiveMessage isn't observed: users aren't auto-joined to
+		// channel groups yet (#66), so the test asserts on the broadcaster
+		// fake rather than on a round-trip through SignalR
+		var errors = new List<(string Code, string Message)>();
+		connection.On<string, string>("Error", (code, message) => errors.Add((code, message)));
+
+		await connection.StartAsync();
+
+		await connection.InvokeAsync("SendMessage", new
+		{
+			ChannelId = 100L,
+			Content = "hello world",
+			ReplyToId = (long?)null,
+		});
+
+		await connection.DisposeAsync();
+
+		Assert.Empty(errors);
+
+		var saved = Assert.Single(factory.SavedMessages);
+		Assert.Equal(100L, saved.ChannelId);
+		Assert.Equal(42L, saved.AuthorId);
+		Assert.Equal("hello world", saved.Content);
+
+		var evt = Assert.Single(factory.EventBus.PublishedOf<ChatMessageSent>());
+		Assert.Equal(100L, evt.ChannelId);
+		Assert.Equal(9L, evt.GuildId);
+		Assert.Equal(42L, evt.AuthorId);
+		Assert.Equal(saved.Id, evt.MessageId);
+
+		var (broadcastChannel, broadcastResponse) = Assert.Single(factory.Broadcaster.Broadcasts);
+		Assert.Equal(100L, broadcastChannel);
+		Assert.Equal(saved.Id.ToString(), broadcastResponse.Id);
+	}
+
+	[Fact]
+	public async Task SendMessage_MissingPermission_SurfacesErrorEventToCaller_NoSideEffects()
+	{
+		factory.WithMembership(channelId: 100, userId: 42, guildId: 9, permissions: 0);
+
+		var token = TestTokens.Issue(ChatApiFactory.JwtSecret, userId: 42);
+		var connection = BuildHubConnection(token);
+
+		// completion source so the test can await the Error push instead of
+		// guessing at a timeout. timeout is the safety net, not the primary
+		// synchronisation
+		var errorReceived = new TaskCompletionSource<(string Code, string Message)>(
+			TaskCreationOptions.RunContinuationsAsynchronously);
+		connection.On<string, string>("Error", (code, message) =>
+			errorReceived.TrySetResult((code, message)));
+
+		await connection.StartAsync();
+
+		await connection.InvokeAsync("SendMessage", new
+		{
+			ChannelId = 100L,
+			Content = "hi",
+			ReplyToId = (long?)null,
+		});
+
+		var winner = await Task.WhenAny(errorReceived.Task, Task.Delay(TimeSpan.FromSeconds(2)));
+		Assert.Same(errorReceived.Task, winner);
+		var (code, _) = await errorReceived.Task;
+		Assert.Equal("Message.MissingSendPermission", code);
+
+		await connection.DisposeAsync();
+
+		Assert.Empty(factory.SavedMessages);
+		Assert.Empty(factory.EventBus.PublishedOf<ChatMessageSent>());
+		Assert.Empty(factory.Broadcaster.Broadcasts);
+	}
+}

--- a/services/chat/tests/Chat.FunctionalTests/Endpoints/SendMessageHubTests.cs
+++ b/services/chat/tests/Chat.FunctionalTests/Endpoints/SendMessageHubTests.cs
@@ -1,4 +1,3 @@
-using Chat.Application.Contracts;
 using Chat.FunctionalTests.Infrastructure;
 using Microsoft.AspNetCore.Http.Connections;
 using Microsoft.AspNetCore.SignalR.Client;
@@ -6,39 +5,16 @@ using Xunit;
 
 namespace Chat.FunctionalTests.Endpoints;
 
-public sealed class SendMessageHubTests(ChatApiFactory factory) : IClassFixture<ChatApiFactory>, IAsyncLifetime
+/// <summary>
+/// smoke tests for ChatHub connection/auth. sending messages is REST-only
+/// per contract — see SendMessageEndpointTests for those cases.
+/// </summary>
+public sealed class ChatHubTests(ChatApiFactory factory) : IClassFixture<ChatApiFactory>
 {
-	private const long SendMessagesPermission = 1L << 0;
-
-	public Task InitializeAsync()
-	{
-		// reset shared fake state so tests within the class fixture are
-		// independent. xUnit calls this once per test before construction
-		factory.GuildClient.Result = null;
-		factory.MessageRepository.Reset();
-		factory.EventBus.Reset();
-		factory.Broadcaster.Reset();
-		return Task.CompletedTask;
-	}
-
-	public Task DisposeAsync() => Task.CompletedTask;
-
-	/// <summary>
-	/// builds a HubConnection wired into the in-process test server. the
-	/// standard ASP.NET pattern is to override HttpMessageHandlerFactory so
-	/// negotiation goes through TestServer, and to override WebSocketFactory
-	/// so the WebSocket transport tunnels through TestServer's bidirectional
-	/// stream. Kestrel never actually binds in test mode (good)
-	///
-	/// JWT is forwarded BOTH via the Authorization header (CreateWebSocketClient
-	/// adds it to the upgrade request) AND via ?access_token=... in the query
-	/// string (Program.cs's JwtBearer OnMessageReceived prefers query for hub
-	/// paths). either one alone is sufficient
-	/// </summary>
 	private HubConnection BuildHubConnection(string? token)
 	{
 		var server = factory.Server;
-		var hubUri = new UriBuilder(server.BaseAddress) { Path = "/hubs/chat" }.Uri;
+		var hubUri = new UriBuilder(server.BaseAddress) { Path = "/v1/hubs/chat" }.Uri;
 
 		return new HubConnectionBuilder()
 			.WithUrl(hubUri, options =>
@@ -73,8 +49,6 @@ public sealed class SendMessageHubTests(ChatApiFactory factory) : IClassFixture<
 	{
 		var connection = BuildHubConnection(token: null);
 
-		// [Authorize] on the hub causes the upgrade to fail; SignalR surfaces
-		// this as an exception bubbling out of StartAsync
 		await Assert.ThrowsAnyAsync<Exception>(() => connection.StartAsync());
 		Assert.NotEqual(HubConnectionState.Connected, connection.State);
 
@@ -92,86 +66,5 @@ public sealed class SendMessageHubTests(ChatApiFactory factory) : IClassFixture<
 		Assert.Equal(HubConnectionState.Connected, connection.State);
 
 		await connection.DisposeAsync();
-	}
-
-	[Fact]
-	public async Task SendMessage_HappyPath_PersistsAndPublishesAndBroadcasts()
-	{
-		factory.WithMembership(channelId: 100, userId: 42, guildId: 9, permissions: SendMessagesPermission);
-
-		var token = TestTokens.Issue(ChatApiFactory.JwtSecret, userId: 42);
-		var connection = BuildHubConnection(token);
-
-		// subscribe to Error so we can assert the hub did NOT push one to the
-		// caller. ReceiveMessage isn't observed: users aren't auto-joined to
-		// channel groups yet (#66), so the test asserts on the broadcaster
-		// fake rather than on a round-trip through SignalR
-		var errors = new List<(string Code, string Message)>();
-		connection.On<string, string>("Error", (code, message) => errors.Add((code, message)));
-
-		await connection.StartAsync();
-
-		await connection.InvokeAsync("SendMessage", new
-		{
-			ChannelId = 100L,
-			Content = "hello world",
-			ReplyToId = (long?)null,
-		});
-
-		await connection.DisposeAsync();
-
-		Assert.Empty(errors);
-
-		var saved = Assert.Single(factory.SavedMessages);
-		Assert.Equal(100L, saved.ChannelId);
-		Assert.Equal(42L, saved.AuthorId);
-		Assert.Equal("hello world", saved.Content);
-
-		var evt = Assert.Single(factory.EventBus.PublishedOf<ChatMessageSent>());
-		Assert.Equal(100L, evt.ChannelId);
-		Assert.Equal(9L, evt.GuildId);
-		Assert.Equal(42L, evt.AuthorId);
-		Assert.Equal(saved.Id, evt.MessageId);
-
-		var (broadcastChannel, broadcastResponse) = Assert.Single(factory.Broadcaster.Broadcasts);
-		Assert.Equal(100L, broadcastChannel);
-		Assert.Equal(saved.Id.ToString(), broadcastResponse.Id);
-	}
-
-	[Fact]
-	public async Task SendMessage_MissingPermission_SurfacesErrorEventToCaller_NoSideEffects()
-	{
-		factory.WithMembership(channelId: 100, userId: 42, guildId: 9, permissions: 0);
-
-		var token = TestTokens.Issue(ChatApiFactory.JwtSecret, userId: 42);
-		var connection = BuildHubConnection(token);
-
-		// completion source so the test can await the Error push instead of
-		// guessing at a timeout. timeout is the safety net, not the primary
-		// synchronisation
-		var errorReceived = new TaskCompletionSource<(string Code, string Message)>(
-			TaskCreationOptions.RunContinuationsAsynchronously);
-		connection.On<string, string>("Error", (code, message) =>
-			errorReceived.TrySetResult((code, message)));
-
-		await connection.StartAsync();
-
-		await connection.InvokeAsync("SendMessage", new
-		{
-			ChannelId = 100L,
-			Content = "hi",
-			ReplyToId = (long?)null,
-		});
-
-		var winner = await Task.WhenAny(errorReceived.Task, Task.Delay(TimeSpan.FromSeconds(2)));
-		Assert.Same(errorReceived.Task, winner);
-		var (code, _) = await errorReceived.Task;
-		Assert.Equal("Message.MissingSendPermission", code);
-
-		await connection.DisposeAsync();
-
-		Assert.Empty(factory.SavedMessages);
-		Assert.Empty(factory.EventBus.PublishedOf<ChatMessageSent>());
-		Assert.Empty(factory.Broadcaster.Broadcasts);
 	}
 }

--- a/services/chat/tests/Chat.FunctionalTests/Infrastructure/ChatApiFactory.cs
+++ b/services/chat/tests/Chat.FunctionalTests/Infrastructure/ChatApiFactory.cs
@@ -1,0 +1,135 @@
+using Cassandra;
+using Chat.Application.Abstractions;
+using Chat.Application.Abstractions.Persistence;
+using Chat.UnitTests.Fakes;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Chat.FunctionalTests.Infrastructure;
+
+/// <summary>
+/// boots the Chat Service against in-memory fakes (no Scylla, no RabbitMQ, no
+/// real Guild Service). each factory instance gets its own set of fakes so test
+/// classes don't bleed state into each other
+/// </summary>
+public sealed class ChatApiFactory : WebApplicationFactory<Program>
+{
+	public const string JwtSecret =
+		"0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+	// Program.cs reads builder.Configuration["Jwt:SecretKey"] *eagerly* during
+	// host startup, so set the env var here once for the whole process. all
+	// factory instances write the same constant so this is safe
+	static ChatApiFactory()
+	{
+		Environment.SetEnvironmentVariable("Jwt__SecretKey", JwtSecret);
+	}
+
+	// fakes are shared across the factory instance so tests can both inject
+	// canned membership/permission rows and assert on what the handler did
+	public FakeGuildClient GuildClient { get; } = new();
+	public FakeMessageRepository MessageRepository { get; } = new();
+	public FakeEventBus EventBus { get; } = new();
+	public FakeChannelBroadcaster Broadcaster { get; } = new();
+	public FakeClock Clock { get; } = new();
+	public FakeIdGenerator IdGenerator { get; } = new();
+
+	public IReadOnlyList<Chat.Domain.Messages.Message> SavedMessages => MessageRepository.Saved;
+
+	public void WithMembership(long channelId, long userId, long guildId, long permissions)
+	{
+		// FakeGuildClient ignores the lookup keys for now (it returns whatever
+		// Result is set to). this signature lets the test stay declarative
+		// even though the fake only models a single canned response
+		_ = channelId;
+		_ = userId;
+		GuildClient.Result = new ChannelMembership(IsMember: true, GuildId: guildId, Permissions: permissions);
+	}
+
+	public void WithoutMembership() => GuildClient.Result = null;
+
+	protected override void ConfigureWebHost(IWebHostBuilder builder)
+	{
+		builder.UseEnvironment("Testing");
+
+		builder.ConfigureAppConfiguration((_, config) =>
+		{
+			config.AddInMemoryCollection(new Dictionary<string, string?>
+			{
+				// ScyllaDbOptions still validates even though ISession is
+				// replaced below; keep the bind happy
+				["ScyllaDb:ContactPoints"] = "localhost",
+				["ScyllaDb:Keyspace"] = "chat",
+				["ScyllaDb:Port"] = "9042",
+
+				["Jwt:SecretKey"] = JwtSecret,
+
+				["RabbitMQ:Host"] = "localhost",
+				["RabbitMQ:VirtualHost"] = "/",
+				["RabbitMQ:Username"] = "test",
+				["RabbitMQ:Password"] = "test",
+
+				["Snowflake:WorkerId"] = "3",
+
+				["BackendConfiguration:BaseUrl"] = "http://localhost",
+				["BackendConfiguration:BaseApiUrl"] = "http://localhost/api",
+
+				["Services:GuildService"] = "http://localhost:5101",
+			});
+		});
+
+		builder.ConfigureTestServices(services =>
+		{
+			StripMassTransit(services);
+			StripCassandra(services);
+
+			// swap real ports for fakes; explicit singleton registration so
+			// the fields on the factory and the values DI hands to handlers
+			// reference the same instance
+			services.RemoveAll<IEventBus>();
+			services.AddSingleton<IEventBus>(EventBus);
+
+			services.RemoveAll<IGuildClient>();
+			services.AddSingleton<IGuildClient>(GuildClient);
+
+			services.RemoveAll<IMessageRepository>();
+			services.AddSingleton<IMessageRepository>(MessageRepository);
+
+			services.RemoveAll<IChannelBroadcaster>();
+			services.AddSingleton<IChannelBroadcaster>(Broadcaster);
+
+			services.RemoveAll<IClock>();
+			services.AddSingleton<IClock>(Clock);
+
+			services.RemoveAll<ISnowflakeIdGenerator>();
+			services.AddSingleton<ISnowflakeIdGenerator>(IdGenerator);
+		});
+	}
+
+	private static void StripMassTransit(IServiceCollection services)
+	{
+		var toRemove = services
+			.Where(d =>
+				(d.ServiceType.FullName ?? string.Empty)
+					.StartsWith("MassTransit", StringComparison.Ordinal)
+				|| (d.ImplementationType?.FullName ?? string.Empty)
+					.StartsWith("MassTransit", StringComparison.Ordinal))
+			.ToList();
+
+		foreach (var d in toRemove)
+			services.Remove(d);
+	}
+
+	private static void StripCassandra(IServiceCollection services)
+	{
+		// remove the singleton ISession factory so we never try to dial Scylla
+		// from the test host. the IMessageRepository swap above means nothing
+		// will resolve ISession from the container, but be explicit anyway
+		services.RemoveAll<ISession>();
+		services.RemoveAll<ICluster>();
+	}
+}

--- a/services/chat/tests/Chat.FunctionalTests/Infrastructure/TestTokens.cs
+++ b/services/chat/tests/Chat.FunctionalTests/Infrastructure/TestTokens.cs
@@ -1,0 +1,36 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+using Microsoft.IdentityModel.Tokens;
+
+namespace Chat.FunctionalTests.Infrastructure;
+
+/// <summary>
+/// issues HS256-signed JWTs whose <c>sub</c> claim drives the
+/// <c>CurrentUser</c> binding in the running pipeline. the signing key must
+/// match <c>ChatApiFactory.JwtSecret</c> so the bearer middleware accepts it
+/// </summary>
+internal static class TestTokens
+{
+	public static string Issue(string secret, long userId, DateTimeOffset? expiresAt = null)
+	{
+		var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(secret));
+		var creds = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
+		var now = DateTimeOffset.UtcNow;
+		var exp = expiresAt ?? now.AddHours(1);
+
+		var claims = new[]
+		{
+			new Claim(JwtRegisteredClaimNames.Sub, userId.ToString()),
+			new Claim(JwtRegisteredClaimNames.Iat, now.ToUnixTimeSeconds().ToString(),
+				ClaimValueTypes.Integer64),
+		};
+
+		var token = new JwtSecurityToken(
+			claims: claims,
+			expires: exp.UtcDateTime,
+			signingCredentials: creds);
+
+		return new JwtSecurityTokenHandler().WriteToken(token);
+	}
+}

--- a/services/chat/tests/Chat.UnitTests/Application/SendMessageHandlerTests.cs
+++ b/services/chat/tests/Chat.UnitTests/Application/SendMessageHandlerTests.cs
@@ -169,6 +169,50 @@ public sealed class SendMessageHandlerTests
 	}
 
 	[Fact]
+	public async Task NonceDedupHit_ReturnsSameMessage_NoSideEffects()
+	{
+		var (h, handler) = BuildHandler(userId: 42);
+		h.GuildClient.Result = new ChannelMembership(IsMember: true, GuildId: 9, Permissions: SendMessagesPermission);
+
+		// first call — persists the message
+		var first = await handler.HandleAsync(new SendMessageCommand(ChannelId: 100, Content: "hello", ReplyToId: null, Nonce: "my-nonce"));
+		Assert.True(first.Succeeded);
+
+		h.EventBus.Reset();
+		h.Broadcaster.Reset();
+
+		// second call with the same nonce — must return the original message
+		var second = await handler.HandleAsync(new SendMessageCommand(ChannelId: 100, Content: "hello", ReplyToId: null, Nonce: "my-nonce"));
+
+		Assert.True(second.Succeeded);
+		Assert.Equal(first.Value.Id, second.Value.Id);
+		Assert.Equal(first.Value.CreatedAt, second.Value.CreatedAt);
+		Assert.Equal("my-nonce", second.Value.Nonce);
+
+		// no new persist, event, or broadcast on the retry
+		Assert.Single(h.Repository.Saved);
+		Assert.Empty(h.EventBus.Published);
+		Assert.Empty(h.Broadcaster.Broadcasts);
+	}
+
+	[Fact]
+	public async Task NonceDedupMiss_DifferentNonce_CreatesTwoMessages()
+	{
+		var (h, handler) = BuildHandler(userId: 42);
+		h.GuildClient.Result = new ChannelMembership(IsMember: true, GuildId: 9, Permissions: SendMessagesPermission);
+
+		var first = await handler.HandleAsync(new SendMessageCommand(ChannelId: 100, Content: "hello", ReplyToId: null, Nonce: "nonce-a"));
+		var second = await handler.HandleAsync(new SendMessageCommand(ChannelId: 100, Content: "hello", ReplyToId: null, Nonce: "nonce-b"));
+
+		Assert.True(first.Succeeded);
+		Assert.True(second.Succeeded);
+		Assert.NotEqual(first.Value.Id, second.Value.Id);
+		Assert.Equal(2, h.Repository.Saved.Count);
+		Assert.Equal(2, h.EventBus.Published.Count);
+		Assert.Equal(2, h.Broadcaster.Broadcasts.Count);
+	}
+
+	[Fact]
 	public async Task ContentRequired_DomainFailureBubblesUp_NoSideEffects()
 	{
 		var (h, handler) = BuildHandler();

--- a/services/chat/tests/Chat.UnitTests/Application/SendMessageHandlerTests.cs
+++ b/services/chat/tests/Chat.UnitTests/Application/SendMessageHandlerTests.cs
@@ -1,0 +1,157 @@
+using Chat.Application.Abstractions;
+using Chat.Application.Contracts;
+using Chat.Application.Features.Messages.Common;
+using Chat.Application.Features.Messages.SendMessage;
+using Chat.Domain.Results;
+using Chat.UnitTests.Fakes;
+using Xunit;
+
+namespace Chat.UnitTests.Application;
+
+public sealed class SendMessageHandlerTests
+{
+	// matches the constants in SendMessageHandler
+	private const long SendMessagesPermission = 1L << 0;
+	private const long AdministratorPermission = 1L << 8;
+
+	private sealed record Harness(
+		FakeCurrentUser CurrentUser,
+		FakeGuildClient GuildClient,
+		FakeMessageRepository Repository,
+		FakeIdGenerator IdGenerator,
+		FakeClock Clock,
+		FakeEventBus EventBus,
+		FakeChannelBroadcaster Broadcaster);
+
+	private static (Harness Harness,
+		Chat.Application.Abstractions.Messaging.ICommandHandler<SendMessageCommand, Result<MessageResponse>> Handler)
+		BuildHandler(long userId = 42)
+	{
+		var currentUser = new FakeCurrentUser { UserId = userId };
+		var guildClient = new FakeGuildClient();
+		var repository = new FakeMessageRepository();
+		var ids = new FakeIdGenerator();
+		var clock = new FakeClock();
+		var eventBus = new FakeEventBus();
+		var broadcaster = new FakeChannelBroadcaster();
+
+		var handler = HandlerFactory.CreateCommand<SendMessageCommand, Result<MessageResponse>>(
+			currentUser, guildClient, repository, ids, clock, eventBus, broadcaster);
+
+		return (new Harness(currentUser, guildClient, repository, ids, clock, eventBus, broadcaster), handler);
+	}
+
+	[Fact]
+	public async Task ChannelNotFound_ReturnsChannelNotFound_NoSideEffects()
+	{
+		var (h, handler) = BuildHandler();
+		h.GuildClient.Result = null;
+
+		var result = await handler.HandleAsync(new SendMessageCommand(ChannelId: 100, Content: "hi", ReplyToId: null));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal(MessageFailures.ChannelNotFound, result.Error);
+		Assert.Empty(h.Repository.Saved);
+		Assert.Empty(h.EventBus.Published);
+		Assert.Empty(h.Broadcaster.Broadcasts);
+	}
+
+	[Fact]
+	public async Task NonMember_ReturnsNotAMember_NoSideEffects()
+	{
+		var (h, handler) = BuildHandler();
+		h.GuildClient.Result = new ChannelMembership(IsMember: false, GuildId: 5, Permissions: 0);
+
+		var result = await handler.HandleAsync(new SendMessageCommand(ChannelId: 100, Content: "hi", ReplyToId: null));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal(MessageFailures.NotAMember, result.Error);
+		Assert.Empty(h.Repository.Saved);
+	}
+
+	[Fact]
+	public async Task MissingSendPermission_ReturnsMissingSendPermission_NoSideEffects()
+	{
+		var (h, handler) = BuildHandler();
+		h.GuildClient.Result = new ChannelMembership(IsMember: true, GuildId: 5, Permissions: 0);
+
+		var result = await handler.HandleAsync(new SendMessageCommand(ChannelId: 100, Content: "hi", ReplyToId: null));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal(MessageFailures.MissingSendPermission, result.Error);
+		Assert.Empty(h.Repository.Saved);
+		Assert.Empty(h.EventBus.Published);
+		Assert.Empty(h.Broadcaster.Broadcasts);
+	}
+
+	[Fact]
+	public async Task AdministratorBypassesSendMessages_HappyPath()
+	{
+		var (h, handler) = BuildHandler();
+		// admin bit set, SEND_MESSAGES clear: should still go through
+		h.GuildClient.Result = new ChannelMembership(IsMember: true, GuildId: 5, Permissions: AdministratorPermission);
+
+		var result = await handler.HandleAsync(new SendMessageCommand(ChannelId: 100, Content: "hi", ReplyToId: null));
+
+		Assert.True(result.Succeeded);
+		Assert.Single(h.Repository.Saved);
+		Assert.Single(h.EventBus.Published);
+		Assert.Single(h.Broadcaster.Broadcasts);
+	}
+
+	[Fact]
+	public async Task HappyPath_PopulatesResponse_PersistsMessage_PublishesEvent_Broadcasts()
+	{
+		var (h, handler) = BuildHandler(userId: 42);
+		h.GuildClient.Result = new ChannelMembership(IsMember: true, GuildId: 9, Permissions: SendMessagesPermission);
+
+		var result = await handler.HandleAsync(new SendMessageCommand(ChannelId: 100, Content: "hello", ReplyToId: 7));
+
+		Assert.True(result.Succeeded);
+		var response = result.Value;
+
+		Assert.Equal("100", response.ChannelId);
+		Assert.Equal("42", response.AuthorId);
+		Assert.Equal("hello", response.Content);
+		Assert.Equal("7", response.ReplyToId);
+		Assert.True(long.TryParse(response.Id, out var responseId));
+		Assert.Empty(response.Attachments);
+		Assert.Empty(response.Reactions);
+		Assert.Null(response.EditedAt);
+
+		// repo persisted the new message
+		var saved = Assert.Single(h.Repository.Saved);
+		Assert.Equal(responseId, saved.Id);
+		Assert.Equal(100L, saved.ChannelId);
+		Assert.Equal(42L, saved.AuthorId);
+
+		// event published with the right MessageId / GuildId / AuthorId
+		var evt = Assert.Single(h.EventBus.PublishedOf<ChatMessageSent>());
+		Assert.Equal(100L, evt.ChannelId);
+		Assert.Equal(9L, evt.GuildId);
+		Assert.Equal(42L, evt.AuthorId);
+		Assert.Equal(responseId, evt.MessageId);
+		Assert.Equal("hello", evt.Content);
+		Assert.Empty(evt.Mentions);
+
+		// broadcast went out exactly once
+		var (broadcastChannel, broadcastMessage) = Assert.Single(h.Broadcaster.Broadcasts);
+		Assert.Equal(100L, broadcastChannel);
+		Assert.Same(response, broadcastMessage);
+	}
+
+	[Fact]
+	public async Task ContentRequired_DomainFailureBubblesUp_NoSideEffects()
+	{
+		var (h, handler) = BuildHandler();
+		h.GuildClient.Result = new ChannelMembership(IsMember: true, GuildId: 5, Permissions: SendMessagesPermission);
+
+		var result = await handler.HandleAsync(new SendMessageCommand(ChannelId: 100, Content: "   ", ReplyToId: null));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal(MessageFailures.ContentRequired, result.Error);
+		Assert.Empty(h.Repository.Saved);
+		Assert.Empty(h.EventBus.Published);
+		Assert.Empty(h.Broadcaster.Broadcasts);
+	}
+}

--- a/services/chat/tests/Chat.UnitTests/Application/SendMessageHandlerTests.cs
+++ b/services/chat/tests/Chat.UnitTests/Application/SendMessageHandlerTests.cs
@@ -47,7 +47,7 @@ public sealed class SendMessageHandlerTests
 		var (h, handler) = BuildHandler();
 		h.GuildClient.Result = null;
 
-		var result = await handler.HandleAsync(new SendMessageCommand(ChannelId: 100, Content: "hi", ReplyToId: null));
+		var result = await handler.HandleAsync(new SendMessageCommand(ChannelId: 100, Content: "hi", ReplyToId: null, Nonce: null));
 
 		Assert.True(result.IsFailure);
 		Assert.Equal(MessageFailures.ChannelNotFound, result.Error);
@@ -62,7 +62,7 @@ public sealed class SendMessageHandlerTests
 		var (h, handler) = BuildHandler();
 		h.GuildClient.Result = new ChannelMembership(IsMember: false, GuildId: 5, Permissions: 0);
 
-		var result = await handler.HandleAsync(new SendMessageCommand(ChannelId: 100, Content: "hi", ReplyToId: null));
+		var result = await handler.HandleAsync(new SendMessageCommand(ChannelId: 100, Content: "hi", ReplyToId: null, Nonce: null));
 
 		Assert.True(result.IsFailure);
 		Assert.Equal(MessageFailures.NotAMember, result.Error);
@@ -75,7 +75,7 @@ public sealed class SendMessageHandlerTests
 		var (h, handler) = BuildHandler();
 		h.GuildClient.Result = new ChannelMembership(IsMember: true, GuildId: 5, Permissions: 0);
 
-		var result = await handler.HandleAsync(new SendMessageCommand(ChannelId: 100, Content: "hi", ReplyToId: null));
+		var result = await handler.HandleAsync(new SendMessageCommand(ChannelId: 100, Content: "hi", ReplyToId: null, Nonce: null));
 
 		Assert.True(result.IsFailure);
 		Assert.Equal(MessageFailures.MissingSendPermission, result.Error);
@@ -91,7 +91,7 @@ public sealed class SendMessageHandlerTests
 		// admin bit set, SEND_MESSAGES clear: should still go through
 		h.GuildClient.Result = new ChannelMembership(IsMember: true, GuildId: 5, Permissions: AdministratorPermission);
 
-		var result = await handler.HandleAsync(new SendMessageCommand(ChannelId: 100, Content: "hi", ReplyToId: null));
+		var result = await handler.HandleAsync(new SendMessageCommand(ChannelId: 100, Content: "hi", ReplyToId: null, Nonce: null));
 
 		Assert.True(result.Succeeded);
 		Assert.Single(h.Repository.Saved);
@@ -105,7 +105,7 @@ public sealed class SendMessageHandlerTests
 		var (h, handler) = BuildHandler(userId: 42);
 		h.GuildClient.Result = new ChannelMembership(IsMember: true, GuildId: 9, Permissions: SendMessagesPermission);
 
-		var result = await handler.HandleAsync(new SendMessageCommand(ChannelId: 100, Content: "hello", ReplyToId: 7));
+		var result = await handler.HandleAsync(new SendMessageCommand(ChannelId: 100, Content: "hello", ReplyToId: 7, Nonce: null));
 
 		Assert.True(result.Succeeded);
 		var response = result.Value;
@@ -141,12 +141,40 @@ public sealed class SendMessageHandlerTests
 	}
 
 	[Fact]
+	public async Task Nonce64Chars_MaxAllowed_Succeeds()
+	{
+		var (h, handler) = BuildHandler();
+		h.GuildClient.Result = new ChannelMembership(IsMember: true, GuildId: 5, Permissions: SendMessagesPermission);
+		var nonce = new string('x', 64);
+
+		var result = await handler.HandleAsync(new SendMessageCommand(ChannelId: 100, Content: "hi", ReplyToId: null, Nonce: nonce));
+
+		Assert.True(result.Succeeded);
+		Assert.Equal(nonce, result.Value.Nonce);
+	}
+
+	[Fact]
+	public async Task Nonce65Chars_OneTooLong_ReturnsNonceTooLong_NoSideEffects()
+	{
+		var (h, handler) = BuildHandler();
+		h.GuildClient.Result = new ChannelMembership(IsMember: true, GuildId: 5, Permissions: SendMessagesPermission);
+
+		var result = await handler.HandleAsync(new SendMessageCommand(ChannelId: 100, Content: "hi", ReplyToId: null, Nonce: new string('x', 65)));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal(MessageFailures.NonceTooLong, result.Error);
+		Assert.Empty(h.Repository.Saved);
+		Assert.Empty(h.EventBus.Published);
+		Assert.Empty(h.Broadcaster.Broadcasts);
+	}
+
+	[Fact]
 	public async Task ContentRequired_DomainFailureBubblesUp_NoSideEffects()
 	{
 		var (h, handler) = BuildHandler();
 		h.GuildClient.Result = new ChannelMembership(IsMember: true, GuildId: 5, Permissions: SendMessagesPermission);
 
-		var result = await handler.HandleAsync(new SendMessageCommand(ChannelId: 100, Content: "   ", ReplyToId: null));
+		var result = await handler.HandleAsync(new SendMessageCommand(ChannelId: 100, Content: "   ", ReplyToId: null, Nonce: null));
 
 		Assert.True(result.IsFailure);
 		Assert.Equal(MessageFailures.ContentRequired, result.Error);

--- a/services/chat/tests/Chat.UnitTests/Chat.UnitTests.csproj
+++ b/services/chat/tests/Chat.UnitTests/Chat.UnitTests.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <RootNamespace>Chat.UnitTests</RootNamespace>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <FrameworkReference Include="Microsoft.AspNetCore.App"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk"      Version="17.12.0"/>
+        <PackageReference Include="xunit"                       Version="2.9.3"/>
+        <PackageReference Include="xunit.runner.visualstudio"   Version="2.8.2">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\src\Chat.Domain\Chat.Domain.csproj"/>
+        <ProjectReference Include="..\..\src\Chat.Application\Chat.Application.csproj"/>
+        <ProjectReference Include="..\..\src\Chat.Infrastructure\Chat.Infrastructure.csproj"/>
+        <ProjectReference Include="..\..\src\Chat.Persistence\Chat.Persistence.csproj"/>
+        <ProjectReference Include="..\..\src\Chat.Presentation\Chat.Presentation.csproj"/>
+    </ItemGroup>
+
+</Project>

--- a/services/chat/tests/Chat.UnitTests/Domain/MessageTests.cs
+++ b/services/chat/tests/Chat.UnitTests/Domain/MessageTests.cs
@@ -1,0 +1,125 @@
+using Chat.Domain.Messages;
+using Chat.Domain.Results;
+using Xunit;
+
+namespace Chat.UnitTests.Domain;
+
+public sealed class MessageTests
+{
+	private static readonly DateTimeOffset Now =
+		new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+	[Fact]
+	public void Create_HappyPath_PopulatesProperties()
+	{
+		var result = Message.Create(
+			id: 1001,
+			channelId: 42,
+			authorId: 7,
+			content: "hello world",
+			replyToId: null,
+			now: Now);
+
+		Assert.True(result.Succeeded);
+		var message = result.Value;
+
+		Assert.Equal(1001L, message.Id);
+		Assert.Equal(42L, message.ChannelId);
+		Assert.Equal(7L, message.AuthorId);
+		Assert.Equal("hello world", message.Content);
+		Assert.Null(message.ReplyToId);
+		Assert.Null(message.EditedAt);
+		Assert.False(message.IsDeleted);
+		Assert.Equal(Now, message.CreatedAt);
+	}
+
+	[Fact]
+	public void Create_WithReplyToId_PersistsReplyToId()
+	{
+		var result = Message.Create(
+			id: 1001, channelId: 42, authorId: 7,
+			content: "reply", replyToId: 999, now: Now);
+
+		Assert.True(result.Succeeded);
+		Assert.Equal(999L, result.Value.ReplyToId);
+	}
+
+	[Theory]
+	[InlineData(null)]
+	[InlineData("")]
+	[InlineData("   ")]
+	[InlineData("\t\n")]
+	public void Create_BlankContent_ReturnsContentRequired(string? content)
+	{
+		var result = Message.Create(
+			id: 1, channelId: 1, authorId: 1,
+			content: content, replyToId: null, now: Now);
+
+		Assert.True(result.IsFailure);
+		Assert.Equal(MessageFailures.ContentRequired, result.Error);
+	}
+
+	[Fact]
+	public void Create_ContentTooLong_ReturnsContentTooLong()
+	{
+		var content = new string('x', Message.MaxContentLen + 1);
+
+		var result = Message.Create(
+			id: 1, channelId: 1, authorId: 1,
+			content: content, replyToId: null, now: Now);
+
+		Assert.True(result.IsFailure);
+		Assert.Equal(MessageFailures.ContentTooLong, result.Error);
+	}
+
+	[Fact]
+	public void Create_ContentExactlyAtMax_Succeeds()
+	{
+		var content = new string('x', Message.MaxContentLen);
+
+		var result = Message.Create(
+			id: 1, channelId: 1, authorId: 1,
+			content: content, replyToId: null, now: Now);
+
+		Assert.True(result.Succeeded);
+	}
+
+	[Theory]
+	[InlineData(0)]
+	[InlineData(-1)]
+	public void Create_NonPositiveId_ReturnsInvalidId(long id)
+	{
+		var result = Message.Create(
+			id: id, channelId: 1, authorId: 1,
+			content: "hi", replyToId: null, now: Now);
+
+		Assert.True(result.IsFailure);
+		Assert.Equal(MessageFailures.InvalidId, result.Error);
+	}
+
+	[Theory]
+	[InlineData(0)]
+	[InlineData(-1)]
+	public void Create_NonPositiveChannelId_ReturnsInvalidChannelId(long channelId)
+	{
+		var result = Message.Create(
+			id: 1, channelId: channelId, authorId: 1,
+			content: "hi", replyToId: null, now: Now);
+
+		Assert.True(result.IsFailure);
+		Assert.Equal(MessageFailures.InvalidChannelId, result.Error);
+	}
+
+	[Theory]
+	[InlineData(0)]
+	[InlineData(-1)]
+	public void Create_NonPositiveAuthorId_ReturnsInvalidAuthorId(long authorId)
+	{
+		var result = Message.Create(
+			id: 1, channelId: 1, authorId: authorId,
+			content: "hi", replyToId: null, now: Now);
+
+		Assert.True(result.IsFailure);
+		Assert.Equal(MessageFailures.InvalidAuthorId, result.Error);
+	}
+}

--- a/services/chat/tests/Chat.UnitTests/Fakes/FakeChannelBroadcaster.cs
+++ b/services/chat/tests/Chat.UnitTests/Fakes/FakeChannelBroadcaster.cs
@@ -1,0 +1,19 @@
+using Chat.Application.Abstractions;
+using Chat.Application.Features.Messages.Common;
+
+namespace Chat.UnitTests.Fakes;
+
+public sealed class FakeChannelBroadcaster : IChannelBroadcaster
+{
+	private readonly List<(long ChannelId, MessageResponse Message)> _broadcasts = [];
+
+	public IReadOnlyList<(long ChannelId, MessageResponse Message)> Broadcasts => _broadcasts;
+
+	public void Reset() => _broadcasts.Clear();
+
+	public Task BroadcastMessageAsync(long channelId, MessageResponse message, CancellationToken ct)
+	{
+		_broadcasts.Add((channelId, message));
+		return Task.CompletedTask;
+	}
+}

--- a/services/chat/tests/Chat.UnitTests/Fakes/FakeClock.cs
+++ b/services/chat/tests/Chat.UnitTests/Fakes/FakeClock.cs
@@ -1,0 +1,24 @@
+using Chat.Application.Abstractions;
+
+namespace Chat.UnitTests.Fakes;
+
+public sealed class FakeClock : IClock
+{
+	private DateTimeOffset _now;
+
+	public FakeClock()
+		: this(new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero))
+	{
+	}
+
+	public FakeClock(DateTimeOffset anchor)
+	{
+		_now = anchor;
+	}
+
+	public DateTimeOffset UtcNow => _now;
+
+	public void Set(DateTimeOffset value) => _now = value;
+
+	public void Advance(TimeSpan delta) => _now = _now.Add(delta);
+}

--- a/services/chat/tests/Chat.UnitTests/Fakes/FakeCurrentUser.cs
+++ b/services/chat/tests/Chat.UnitTests/Fakes/FakeCurrentUser.cs
@@ -1,0 +1,8 @@
+using Chat.Application.Abstractions.Authentication;
+
+namespace Chat.UnitTests.Fakes;
+
+public sealed class FakeCurrentUser : ICurrentUser
+{
+	public long UserId { get; set; }
+}

--- a/services/chat/tests/Chat.UnitTests/Fakes/FakeEventBus.cs
+++ b/services/chat/tests/Chat.UnitTests/Fakes/FakeEventBus.cs
@@ -1,0 +1,21 @@
+using Chat.Application.Abstractions;
+
+namespace Chat.UnitTests.Fakes;
+
+public sealed class FakeEventBus : IEventBus
+{
+	private readonly List<object> _published = [];
+
+	public IReadOnlyList<object> Published => _published;
+
+	public IReadOnlyList<T> PublishedOf<T>() where T : class =>
+		_published.OfType<T>().ToList();
+
+	public void Reset() => _published.Clear();
+
+	public Task PublishAsync<T>(T message, CancellationToken cancellationToken = default) where T : class
+	{
+		_published.Add(message);
+		return Task.CompletedTask;
+	}
+}

--- a/services/chat/tests/Chat.UnitTests/Fakes/FakeGuildClient.cs
+++ b/services/chat/tests/Chat.UnitTests/Fakes/FakeGuildClient.cs
@@ -1,0 +1,11 @@
+using Chat.Application.Abstractions;
+
+namespace Chat.UnitTests.Fakes;
+
+public sealed class FakeGuildClient : IGuildClient
+{
+	public ChannelMembership? Result { get; set; }
+
+	public Task<ChannelMembership?> GetMembershipAsync(long channelId, long userId, CancellationToken ct)
+		=> Task.FromResult(Result);
+}

--- a/services/chat/tests/Chat.UnitTests/Fakes/FakeIdGenerator.cs
+++ b/services/chat/tests/Chat.UnitTests/Fakes/FakeIdGenerator.cs
@@ -1,0 +1,15 @@
+using Chat.Application.Abstractions;
+
+namespace Chat.UnitTests.Fakes;
+
+public sealed class FakeIdGenerator : ISnowflakeIdGenerator
+{
+	private long _current;
+
+	public FakeIdGenerator(long seed = 1_000_000_000_000_000_000L)
+	{
+		_current = seed;
+	}
+
+	public long NextId() => ++_current;
+}

--- a/services/chat/tests/Chat.UnitTests/Fakes/FakeMessageRepository.cs
+++ b/services/chat/tests/Chat.UnitTests/Fakes/FakeMessageRepository.cs
@@ -6,14 +6,33 @@ namespace Chat.UnitTests.Fakes;
 public sealed class FakeMessageRepository : IMessageRepository
 {
 	private readonly List<Message> _saved = [];
+	private readonly Dictionary<(long AuthorId, long ChannelId, string Nonce), long> _nonces = [];
 
 	public IReadOnlyList<Message> Saved => _saved;
 
-	public void Reset() => _saved.Clear();
+	public void Reset()
+	{
+		_saved.Clear();
+		_nonces.Clear();
+	}
 
-	public Task AddAsync(Message message, CancellationToken ct)
+	public Task AddAsync(Message message, string? nonce, CancellationToken ct)
 	{
 		_saved.Add(message);
+		if (nonce is not null)
+			_nonces[(message.AuthorId, message.ChannelId, nonce)] = message.Id;
 		return Task.CompletedTask;
+	}
+
+	public Task<long?> FindNonceAsync(long authorId, long channelId, string nonce, CancellationToken ct)
+	{
+		_nonces.TryGetValue((authorId, channelId, nonce), out var messageId);
+		return Task.FromResult(messageId == 0 ? null : (long?)messageId);
+	}
+
+	public Task<Message?> GetByIdAsync(long messageId, CancellationToken ct)
+	{
+		var message = _saved.FirstOrDefault(m => m.Id == messageId);
+		return Task.FromResult(message);
 	}
 }

--- a/services/chat/tests/Chat.UnitTests/Fakes/FakeMessageRepository.cs
+++ b/services/chat/tests/Chat.UnitTests/Fakes/FakeMessageRepository.cs
@@ -1,0 +1,19 @@
+using Chat.Application.Abstractions.Persistence;
+using Chat.Domain.Messages;
+
+namespace Chat.UnitTests.Fakes;
+
+public sealed class FakeMessageRepository : IMessageRepository
+{
+	private readonly List<Message> _saved = [];
+
+	public IReadOnlyList<Message> Saved => _saved;
+
+	public void Reset() => _saved.Clear();
+
+	public Task AddAsync(Message message, CancellationToken ct)
+	{
+		_saved.Add(message);
+		return Task.CompletedTask;
+	}
+}

--- a/services/chat/tests/Chat.UnitTests/Fakes/HandlerFactory.cs
+++ b/services/chat/tests/Chat.UnitTests/Fakes/HandlerFactory.cs
@@ -1,0 +1,34 @@
+using System.Reflection;
+using Chat.Application;
+using Chat.Application.Abstractions.Messaging;
+
+namespace Chat.UnitTests.Fakes;
+
+/// <summary>
+/// application handlers are <c>internal sealed</c> by architectural convention
+/// (see <c>HandlerConventionTests.AllHandlers_MustBe_InternalSealed</c>). to
+/// exercise them from a separate test assembly without granting
+/// <c>InternalsVisibleTo</c>, locate the concrete handler in the Application
+/// assembly by the interface it implements and instantiate it via reflection
+/// </summary>
+internal static class HandlerFactory
+{
+	private static readonly Assembly ApplicationAssembly =
+		typeof(IApplicationAssemblyMarker).Assembly;
+
+	internal static ICommandHandler<TCommand, TResult> CreateCommand<TCommand, TResult>(
+		params object[] ctorArgs)
+		where TCommand : class, ICommand<TResult>
+		where TResult : class
+	{
+		var handlerType = FindImplementer(typeof(ICommandHandler<,>).MakeGenericType(typeof(TCommand), typeof(TResult)));
+		return (ICommandHandler<TCommand, TResult>)Activator.CreateInstance(handlerType, ctorArgs)!;
+	}
+
+	private static Type FindImplementer(Type closedInterface)
+	{
+		return ApplicationAssembly.GetTypes()
+			.Single(t => t is { IsAbstract: false, IsInterface: false } &&
+						 closedInterface.IsAssignableFrom(t));
+	}
+}

--- a/services/chat/tools/HubTester/Program.cs
+++ b/services/chat/tools/HubTester/Program.cs
@@ -1,14 +1,14 @@
 using Cocona;
 using Microsoft.AspNetCore.SignalR.Client;
 
-const string DefaultChatHub = "https://localhost:1443/api/chat/hubs/chat";
-const string DefaultSignalingHub = "https://localhost:1443/api/chat/hubs/signaling";
+const string DefaultChatHub = "https://localhost:1443/api/chat/v1/hubs/chat";
+const string DefaultSignalingHub = "https://localhost:1443/api/chat/v1/hubs/signaling";
 
 var app = CoconaApp.Create();
 
-app.AddCommand("echo", async ([Argument] string message, string url = DefaultChatHub) =>
+app.AddCommand("echo", async ([Argument] string message, string url = DefaultChatHub, string? token = null) =>
 {
-	await using var conn = Build(url);
+	await using var conn = Build(url, token);
 	conn.On<string>("ReceiveMessage", m => Console.WriteLine($"<- ReceiveMessage: {m}"));
 
 	await conn.StartAsync();
@@ -17,23 +17,32 @@ app.AddCommand("echo", async ([Argument] string message, string url = DefaultCha
 	await Task.Delay(500);
 }).WithDescription("invoke ChatHub.Echo and print the broadcast back. surely it will respond, right?");
 
-app.AddCommand("listen", async (string url = DefaultChatHub, int seconds = 60) =>
+app.AddCommand("listen", async (string url = DefaultChatHub, string? token = null, long[]? channel = null, int seconds = 60) =>
 {
-	await using var conn = Build(url);
-	conn.On<object>("ReceiveMessage",     m => Console.WriteLine($"<- ReceiveMessage: {m}"));
+	await using var conn = Build(url, token);
+	conn.On<object>("ReceiveMessage",       m => Console.WriteLine($"<- ReceiveMessage: {m}"));
 	conn.On<object>("ReceiveDirectMessage", m => Console.WriteLine($"<- ReceiveDirectMessage: {m}"));
-	conn.On<object>("MessageEdited",      m => Console.WriteLine($"<- MessageEdited: {m}"));
-	conn.On<object>("MessageDeleted",     m => Console.WriteLine($"<- MessageDeleted: {m}"));
-	conn.On<object>("UserPresence",       m => Console.WriteLine($"<- UserPresence: {m}"));
+	conn.On<object>("MessageEdited",        m => Console.WriteLine($"<- MessageEdited: {m}"));
+	conn.On<object>("MessageDeleted",       m => Console.WriteLine($"<- MessageDeleted: {m}"));
+	conn.On<object>("UserPresence",         m => Console.WriteLine($"<- UserPresence: {m}"));
+	conn.On<string, string>("Error",        (code, msg) => Console.WriteLine($"<- Error: {code} — {msg}"));
 
 	await conn.StartAsync();
-	Console.WriteLine($"connected to {url}, listening {seconds}s...");
+	Console.WriteLine($"connected to {url}");
+
+	foreach (var channelId in channel ?? [])
+	{
+		await conn.InvokeAsync("JoinChannel", channelId);
+		Console.WriteLine($"-> JoinChannel({channelId})");
+	}
+
+	Console.WriteLine($"listening {seconds}s...");
 	await Task.Delay(TimeSpan.FromSeconds(seconds));
 }).WithDescription("hold a connection open and print every server-pushed event");
 
-app.AddCommand("signal-listen", async (string url = DefaultSignalingHub, int seconds = 60) =>
+app.AddCommand("signal-listen", async (string url = DefaultSignalingHub, string? token = null, int seconds = 60) =>
 {
-	await using var conn = Build(url);
+	await using var conn = Build(url, token);
 	conn.On<object, object>("Offer",        (from, sdp)  => Console.WriteLine($"<- Offer from={from} sdp={sdp}"));
 	conn.On<object, object>("Answer",       (from, sdp)  => Console.WriteLine($"<- Answer from={from} sdp={sdp}"));
 	conn.On<object, object>("IceCandidate", (from, cand) => Console.WriteLine($"<- IceCandidate from={from} cand={cand}"));
@@ -45,15 +54,19 @@ app.AddCommand("signal-listen", async (string url = DefaultSignalingHub, int sec
 
 app.Run();
 
-static HubConnection Build(string url) =>
+static HubConnection Build(string url, string? token) =>
 	new HubConnectionBuilder()
 		.WithUrl(url, opts =>
 		{
+			opts.Transports = Microsoft.AspNetCore.Http.Connections.HttpTransportType.WebSockets;
+			opts.SkipNegotiation = true;
 			opts.HttpMessageHandlerFactory = _ => new HttpClientHandler
 			{
 				ServerCertificateCustomValidationCallback = HttpClientHandler.DangerousAcceptAnyServerCertificateValidator,
 			};
 			opts.WebSocketConfiguration = ws =>
 				ws.RemoteCertificateValidationCallback = (_, _, _, _) => true;
+			if (token is not null)
+				opts.AccessTokenProvider = () => Task.FromResult<string?>(token);
 		})
 		.Build();


### PR DESCRIPTION
Resolves #38
Resolves #67
Resolves #72

Refs #66 (details below)

## Summary
Foundation work for the Chat Service so we don't have to worry about the scary plumbing:
- replaces the old prototype ScyllaDB schema with the contract-aligned version
- wires JWT bearer + SignalR `access_token` auth
- purges `Guid` -> `long` for all IDs
- probably done some permanent damage to my will to live
- lands the first vertical slice (`POST /channels/:id/messages`) end-to-end :D

## What we currently have :D
- Contract-aligned Scylla schema (15 tables, tablets disabled for COUNTER support), applied via versioned CQL migrations (`V0001__init`, `V0002__nonce_dedup_and_dm_read`)
- JWT bearer + `[Authorize]` on both hubs + SignalR `?access_token=` handler
- Snowflake `long` IDs throughout events / clients / hubs
- `Message` domain aggregate, `SendMessageHandler`, Scylla `MessageRepository` (logged batch: messages + message_lookup + nonce dedup), `IChannelBroadcaster` + SignalR impl
- `POST /v1/channels/:id/messages` REST endpoint: nonce echo + 64-char validation, 10-minute idempotency window via `message_nonce_dedup` (dedup hit returns original message, no re-persist / re-broadcast / re-publish), permission check via Guild Service -> persist -> broadcast `ReceiveMessage` -> publish `chat.message_sent`
- `ChatHub.JoinChannel` invocation: READ_MESSAGES check -> adds connection to `channel:{id}` SignalR group so `ReceiveMessage` broadcasts land
- Unit (24) + functional (9) + architecture (17) tests; 100% mutation score on Domain + Application

## What's postponed for later :(
- Auto-joining channel SignalR groups on `OnConnectedAsync` -> see #66 (blocked: no Guild endpoint to fetch all user channels yet)