### PR TITLE
Commons assets to auth tests

### DIFF
--- a/services/auth/Auth.slnx
+++ b/services/auth/Auth.slnx
@@ -6,4 +6,9 @@
     <Project Path="src/Auth.Persistence/Auth.Persistence.csproj" />
     <Project Path="src/Auth.Presentation/Auth.Presentation.csproj" />
   </Folder>
+  <Folder Name="/tests/">
+    <Project Path="tests/Auth.UnitTests/Auth.UnitTests.csproj" />
+    <Project Path="tests/Auth.FunctionalTests/Auth.FunctionalTests.csproj" />
+    <Project Path="tests/Auth.ArchitectureTests/Auth.ArchitectureTests.csproj" />
+  </Folder>
 </Solution>

--- a/services/auth/Dockerfile.test
+++ b/services/auth/Dockerfile.test
@@ -1,0 +1,21 @@
+FROM mcr.microsoft.com/dotnet/sdk:10.0
+
+WORKDIR /app
+
+COPY Auth.slnx ./
+COPY Directory.Build.props ./
+COPY src/Auth.Domain/Auth.Domain.csproj             src/Auth.Domain/
+COPY src/Auth.Application/Auth.Application.csproj   src/Auth.Application/
+COPY src/Auth.Infrastructure/Auth.Infrastructure.csproj src/Auth.Infrastructure/
+COPY src/Auth.Persistence/Auth.Persistence.csproj   src/Auth.Persistence/
+COPY src/Auth.Presentation/Auth.Presentation.csproj src/Auth.Presentation/
+COPY tests/Auth.UnitTests/Auth.UnitTests.csproj                 tests/Auth.UnitTests/
+COPY tests/Auth.FunctionalTests/Auth.FunctionalTests.csproj     tests/Auth.FunctionalTests/
+COPY tests/Auth.ArchitectureTests/Auth.ArchitectureTests.csproj tests/Auth.ArchitectureTests/
+
+RUN dotnet restore
+
+COPY src/   ./src/
+COPY tests/ ./tests/
+
+CMD ["dotnet", "test", "--no-restore", "--logger", "console;verbosity=normal"]

--- a/services/auth/Tiltfile
+++ b/services/auth/Tiltfile
@@ -39,6 +39,18 @@ local_resource(
 )
 
 local_resource(
+    'auth-test',
+    cmd=(
+        DOCKER + ' build -t auth-test-service -f Dockerfile.test . && ' +
+        DOCKER + ' run --rm auth-test-service'
+    ),
+    deps=['Dockerfile.test', 'src', 'tests'],
+    auto_init=False,
+    trigger_mode=TRIGGER_MODE_MANUAL,
+    labels=['auth'],
+)
+
+local_resource(
     'auth',
     cmd=DOCKER + ' build -t auth-service -f Dockerfile.dev .',
     serve_cmd=container_serve(DOCKER, FLAGS + '--init ', 'auth',

--- a/services/auth/tests/Auth.ArchitectureTests/Assemblies.cs
+++ b/services/auth/tests/Auth.ArchitectureTests/Assemblies.cs
@@ -1,0 +1,23 @@
+using System.Reflection;
+using Auth.Application;
+using Auth.Domain;
+using Auth.Infrastructure;
+using Auth.Persistence;
+using Auth.Presentation;
+
+namespace Auth.ArchitectureTests;
+
+internal static class Assemblies
+{
+    internal static readonly Assembly Domain         = typeof(IDomainAssemblyMarker).Assembly;
+    internal static readonly Assembly Application    = typeof(IApplicationAssemblyMarker).Assembly;
+    internal static readonly Assembly Infrastructure = typeof(IInfrastructureAssemblyMarker).Assembly;
+    internal static readonly Assembly Persistence    = typeof(IPersistenceAssemblyMarker).Assembly;
+    internal static readonly Assembly Presentation   = typeof(IPresentationAssemblyMarker).Assembly;
+
+    internal static bool References(this Assembly subject, Assembly target)
+    {
+        return subject.GetReferencedAssemblies()
+            .Any(r => string.Equals(r.Name, target.GetName().Name, StringComparison.Ordinal));
+    }
+}

--- a/services/auth/tests/Auth.ArchitectureTests/Auth.ArchitectureTests.csproj
+++ b/services/auth/tests/Auth.ArchitectureTests/Auth.ArchitectureTests.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <RootNamespace>Auth.ArchitectureTests</RootNamespace>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <FrameworkReference Include="Microsoft.AspNetCore.App"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Carter"                     Version="10.0.0"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk"    Version="17.12.0"/>
+        <PackageReference Include="xunit"                     Version="2.9.3"/>
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\src\Auth.Domain\Auth.Domain.csproj"/>
+        <ProjectReference Include="..\..\src\Auth.Application\Auth.Application.csproj"/>
+        <ProjectReference Include="..\..\src\Auth.Infrastructure\Auth.Infrastructure.csproj"/>
+        <ProjectReference Include="..\..\src\Auth.Persistence\Auth.Persistence.csproj"/>
+        <ProjectReference Include="..\..\src\Auth.Presentation\Auth.Presentation.csproj"/>
+    </ItemGroup>
+
+</Project>

--- a/services/auth/tests/Auth.ArchitectureTests/DomainPurityTests.cs
+++ b/services/auth/tests/Auth.ArchitectureTests/DomainPurityTests.cs
@@ -1,0 +1,55 @@
+using Xunit;
+
+namespace Auth.ArchitectureTests;
+
+public sealed class DomainPurityTests
+{
+    private static readonly string[] DomainForbiddenPrefixes =
+    [
+        "MassTransit",
+        "Carter",
+        "Microsoft.AspNetCore",
+        "Microsoft.EntityFrameworkCore",
+        "Microsoft.Extensions",
+        "System.ComponentModel.DataAnnotations",
+    ];
+
+    private static readonly string[] ApplicationForbiddenPrefixes =
+    [
+        "MassTransit",
+        "Carter",
+        "Microsoft.AspNetCore",
+        "Microsoft.EntityFrameworkCore",
+        "Npgsql",
+    ];
+
+    [Fact]
+    public void Domain_DoesNotReference_AnyFrameworkAssemblies()
+    {
+        var violations = Assemblies.Domain
+            .GetReferencedAssemblies()
+            .Select(a => a.Name!)
+            .Where(name => DomainForbiddenPrefixes.Any(prefix =>
+                name.StartsWith(prefix, StringComparison.Ordinal)))
+            .ToList();
+
+        Assert.True(violations.Count == 0,
+            "Domain references framework assemblies it must not depend on:\n  - " +
+            string.Join("\n  - ", violations));
+    }
+
+    [Fact]
+    public void Application_DoesNotReference_InfrastructureFrameworks()
+    {
+        var violations = Assemblies.Application
+            .GetReferencedAssemblies()
+            .Select(a => a.Name!)
+            .Where(name => ApplicationForbiddenPrefixes.Any(prefix =>
+                name.StartsWith(prefix, StringComparison.Ordinal)))
+            .ToList();
+
+        Assert.True(violations.Count == 0,
+            "Application references infrastructure-specific assemblies it must not depend on:\n  - " +
+            string.Join("\n  - ", violations));
+    }
+}

--- a/services/auth/tests/Auth.ArchitectureTests/EndpointConventionTests.cs
+++ b/services/auth/tests/Auth.ArchitectureTests/EndpointConventionTests.cs
@@ -1,0 +1,47 @@
+using System.Reflection;
+using Carter;
+using Microsoft.AspNetCore.Http;
+using Xunit;
+
+namespace Auth.ArchitectureTests;
+
+public sealed class EndpointConventionTests
+{
+    private static readonly Type IResultType = typeof(IResult);
+    private static readonly Type TaskType    = typeof(Task<>);
+
+    private static IEnumerable<MethodInfo> HandlerMethodsIn(Assembly assembly) =>
+        assembly.GetTypes()
+            .Where(t => !t.IsAbstract && t.IsAssignableTo(typeof(ICarterModule)))
+            .SelectMany(t => t.GetMethods(
+                BindingFlags.Public | BindingFlags.NonPublic |
+                BindingFlags.Instance | BindingFlags.Static |
+                BindingFlags.DeclaredOnly))
+            .Where(m => m.Name != nameof(ICarterModule.AddRoutes));
+
+    private static bool ReturnsPlainIResult(MethodInfo method)
+    {
+        var returnType = method.ReturnType;
+
+        if (returnType == IResultType)
+            return true;
+
+        if (returnType.IsGenericType && returnType.GetGenericTypeDefinition() == TaskType)
+            return returnType.GetGenericArguments()[0] == IResultType;
+
+        return false;
+    }
+
+    [Fact]
+    public void EndpointHandlers_MustNotReturn_PlainIResult()
+    {
+        var violations = HandlerMethodsIn(Assemblies.Presentation)
+            .Where(ReturnsPlainIResult)
+            .Select(m => $"{m.DeclaringType!.Name}.{m.Name} returns {m.ReturnType.Name}")
+            .ToList();
+
+        Assert.True(violations.Count == 0,
+            "The following handlers return plain IResult, breaking OpenAPI type inference:\n  - " +
+            string.Join("\n  - ", violations));
+    }
+}

--- a/services/auth/tests/Auth.ArchitectureTests/HandlerConventionTests.cs
+++ b/services/auth/tests/Auth.ArchitectureTests/HandlerConventionTests.cs
@@ -1,0 +1,66 @@
+using System.Reflection;
+using Auth.Application.Abstractions.Messaging;
+using Xunit;
+
+namespace Auth.ArchitectureTests;
+
+public sealed class HandlerConventionTests
+{
+    private static readonly Type[] HandlerInterfaces =
+    [
+        typeof(IQueryHandler<,>),
+        typeof(ICommandHandler<>),
+        typeof(ICommandHandler<,>),
+    ];
+
+    private static IEnumerable<Type> HandlersIn(Assembly assembly)
+    {
+        return assembly.GetTypes()
+            .Where(t => !t.IsAbstract && !t.IsInterface)
+            .Where(t => t.GetInterfaces()
+                .Any(i => i.IsGenericType &&
+                        HandlerInterfaces.Contains(i.GetGenericTypeDefinition())));
+    }
+
+    [Fact]
+    public void AllHandlers_MustBe_InternalSealed()
+    {
+        var allAssemblies = new[]
+        {
+            Assemblies.Domain,
+            Assemblies.Application,
+            Assemblies.Infrastructure,
+            Assemblies.Persistence,
+        };
+
+        var violations = allAssemblies
+            .SelectMany(HandlersIn)
+            .Where(t => !(t.IsNotPublic && t.IsSealed))
+            .Select(t => $"{t.Assembly.GetName().Name}: {t.FullName}")
+            .ToList();
+
+        Assert.True(violations.Count == 0,
+            "The following handlers are not 'internal sealed':\n  - " +
+            string.Join("\n  - ", violations));
+    }
+
+    [Fact]
+    public void AllHandlers_MustResideIn_ApplicationAssembly()
+    {
+        var forbiddenAssemblies = new[]
+        {
+            Assemblies.Domain,
+            Assemblies.Infrastructure,
+            Assemblies.Persistence,
+        };
+
+        var violations = forbiddenAssemblies
+            .SelectMany(HandlersIn)
+            .Select(t => $"{t.Assembly.GetName().Name}: {t.FullName}")
+            .ToList();
+
+        Assert.True(violations.Count == 0,
+            "The following handlers were found outside Auth.Application:\n  - " +
+            string.Join("\n  - ", violations));
+    }
+}

--- a/services/auth/tests/Auth.ArchitectureTests/LayerDependencyTests.cs
+++ b/services/auth/tests/Auth.ArchitectureTests/LayerDependencyTests.cs
@@ -1,0 +1,55 @@
+using Xunit;
+
+namespace Auth.ArchitectureTests;
+
+public sealed class LayerDependencyTests
+{
+    [Fact]
+    public void Domain_DoesNotReference_Application()
+    {
+        Assert.False(Assemblies.Domain.References(Assemblies.Application),
+            "Domain must not depend on Application.");
+    }
+
+    [Fact]
+    public void Domain_DoesNotReference_Infrastructure()
+    {
+        Assert.False(Assemblies.Domain.References(Assemblies.Infrastructure),
+            "Domain must not depend on Infrastructure.");
+    }
+
+    [Fact]
+    public void Domain_DoesNotReference_Persistence()
+    {
+        Assert.False(Assemblies.Domain.References(Assemblies.Persistence),
+            "Domain must not depend on Persistence.");
+    }
+
+    [Fact]
+    public void Application_DoesNotReference_Infrastructure()
+    {
+        Assert.False(Assemblies.Application.References(Assemblies.Infrastructure),
+            "Application must not depend on Infrastructure.");
+    }
+
+    [Fact]
+    public void Application_DoesNotReference_Persistence()
+    {
+        Assert.False(Assemblies.Application.References(Assemblies.Persistence),
+            "Application must not depend on Persistence.");
+    }
+
+    [Fact]
+    public void Infrastructure_DoesNotReference_Persistence()
+    {
+        Assert.False(Assemblies.Infrastructure.References(Assemblies.Persistence),
+            "Infrastructure must not depend on Persistence.");
+    }
+
+    [Fact]
+    public void Persistence_DoesNotReference_Infrastructure()
+    {
+        Assert.False(Assemblies.Persistence.References(Assemblies.Infrastructure),
+            "Persistence must not depend on Infrastructure.");
+    }
+}

--- a/services/auth/tests/Auth.FunctionalTests/Auth.FunctionalTests.csproj
+++ b/services/auth/tests/Auth.FunctionalTests/Auth.FunctionalTests.csproj
@@ -1,0 +1,34 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <RootNamespace>Auth.FunctionalTests</RootNamespace>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <FrameworkReference Include="Microsoft.AspNetCore.App"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing"       Version="10.0.1"/>
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.1"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk"                 Version="17.12.0"/>
+        <PackageReference Include="xunit"                                  Version="2.9.3"/>
+        <PackageReference Include="xunit.runner.visualstudio"              Version="2.8.2">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\src\Auth.Domain\Auth.Domain.csproj"/>
+        <ProjectReference Include="..\..\src\Auth.Application\Auth.Application.csproj"/>
+        <ProjectReference Include="..\..\src\Auth.Infrastructure\Auth.Infrastructure.csproj"/>
+        <ProjectReference Include="..\..\src\Auth.Persistence\Auth.Persistence.csproj"/>
+        <ProjectReference Include="..\..\src\Auth.Presentation\Auth.Presentation.csproj"/>
+    </ItemGroup>
+
+</Project>

--- a/services/auth/tests/Auth.FunctionalTests/Infrastructure/AuthApiFactory.cs
+++ b/services/auth/tests/Auth.FunctionalTests/Infrastructure/AuthApiFactory.cs
@@ -1,0 +1,104 @@
+using Auth.Application.Abstractions.Events;
+using Auth.Persistence.Db;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace Auth.FunctionalTests.Infrastructure;
+
+public sealed class AuthApiFactory : WebApplicationFactory<Program>
+{
+    public const string JwtSecret =
+        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+    static AuthApiFactory()
+    {
+        Environment.SetEnvironmentVariable("Jwt__SecretKey", JwtSecret);
+        Environment.SetEnvironmentVariable("POSTGRES_USER", "test");
+        Environment.SetEnvironmentVariable("POSTGRES_PASSWORD", "test");
+    }
+
+    private readonly string _dbName = "auth-tests-" + Guid.NewGuid();
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.UseEnvironment("Testing");
+
+        builder.ConfigureAppConfiguration((_, config) =>
+        {
+            config.AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Database:Host"]     = "test",
+                ["Database:Port"]     = "5432",
+                ["Database:Name"]     = "test",
+                ["Database:User"]     = "test",
+                ["Database:Password"] = "test",
+
+                ["Jwt:SecretKey"]  = JwtSecret,
+                ["Jwt:Issuer"]     = "auth-service",
+                ["Jwt:Audience"]   = "transcendence-api",
+
+                ["RabbitMq:Host"]        = "localhost",
+                ["RabbitMq:VirtualHost"] = "/",
+                ["RabbitMq:Username"]    = "test",
+                ["RabbitMq:Password"]    = "test",
+
+                ["RefreshToken:TtlDays"]    = "7",
+                ["RefreshToken:ByteLength"] = "64",
+                ["RefreshToken:CookieName"] = "refresh_token",
+            });
+        });
+
+        builder.ConfigureTestServices(services =>
+        {
+            ReplaceDbContext(services);
+            StripMassTransit(services);
+
+            services.RemoveAll<IEventBus>();
+            services.AddSingleton<IEventBus, NoopEventBus>();
+        });
+    }
+
+    private void ReplaceDbContext(IServiceCollection services)
+    {
+        var toRemove = services
+            .Where(d =>
+                (d.ServiceType.FullName ?? string.Empty)
+                    .StartsWith("Microsoft.EntityFrameworkCore", StringComparison.Ordinal)
+                || (d.ServiceType.FullName ?? string.Empty)
+                    .StartsWith("Npgsql", StringComparison.Ordinal)
+                || (d.ImplementationType?.FullName ?? string.Empty)
+                    .StartsWith("Microsoft.EntityFrameworkCore", StringComparison.Ordinal)
+                || (d.ImplementationType?.FullName ?? string.Empty)
+                    .StartsWith("Npgsql", StringComparison.Ordinal))
+            .ToList();
+        foreach (var d in toRemove)
+            services.Remove(d);
+
+        services.RemoveAll<AuthDbContext>();
+        services.AddDbContext<AuthDbContext>(o => o.UseInMemoryDatabase(_dbName));
+    }
+
+    private static void StripMassTransit(IServiceCollection services)
+    {
+        var toRemove = services
+            .Where(d =>
+                (d.ServiceType.FullName ?? string.Empty)
+                    .StartsWith("MassTransit", StringComparison.Ordinal)
+                || (d.ImplementationType?.FullName ?? string.Empty)
+                    .StartsWith("MassTransit", StringComparison.Ordinal))
+            .ToList();
+        foreach (var d in toRemove)
+            services.Remove(d);
+    }
+
+    private sealed class NoopEventBus : IEventBus
+    {
+        public Task PublishAsync<T>(T message, CancellationToken cancellationToken = default)
+            where T : class, IEvent => Task.CompletedTask;
+    }
+}

--- a/services/auth/tests/Auth.FunctionalTests/Infrastructure/AuthApiFactory.cs
+++ b/services/auth/tests/Auth.FunctionalTests/Infrastructure/AuthApiFactory.cs
@@ -1,4 +1,8 @@
+using Auth.Application.Abstractions;
 using Auth.Application.Abstractions.Events;
+using Auth.Application.Abstractions.Persistence;
+using Auth.Application.Abstractions.Security;
+using Auth.Domain.AuthUser;
 using Auth.Persistence.Db;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
@@ -23,6 +27,25 @@ public sealed class AuthApiFactory : WebApplicationFactory<Program>
     }
 
     private readonly string _dbName = "auth-tests-" + Guid.NewGuid();
+
+    public async Task SeedEmailUserAsync(string email, string rawPassword)
+    {
+        using var scope = Services.CreateScope();
+        var sp     = scope.ServiceProvider;
+        var repo   = sp.GetRequiredService<IAuthUserRepository>();
+        var hasher = sp.GetRequiredService<ISecretHasher>();
+        var clock  = sp.GetRequiredService<IClock>();
+        var idGen  = sp.GetRequiredService<IIdGenerator>();
+
+        var user = AuthUser.CreateEmailPasswordUser(
+            id: idGen.NextId(),
+            email: email,
+            passwordHash: hasher.Hash(rawPassword),
+            now: clock.UtcNow).Value;
+
+        await repo.AddAsync(user);
+        await repo.SaveChangesAsync();
+    }
 
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {

--- a/services/auth/tests/Auth.FunctionalTests/Infrastructure/AuthApiFactory.cs
+++ b/services/auth/tests/Auth.FunctionalTests/Infrastructure/AuthApiFactory.cs
@@ -55,6 +55,8 @@ public sealed class AuthApiFactory : WebApplicationFactory<Program>
         {
             config.AddInMemoryCollection(new Dictionary<string, string?>
             {
+                ["App:BaseUrl"]       = "https://localhost:1443",
+
                 ["Database:Host"]     = "test",
                 ["Database:Port"]     = "5432",
                 ["Database:Name"]     = "test",
@@ -73,6 +75,18 @@ public sealed class AuthApiFactory : WebApplicationFactory<Program>
                 ["RefreshToken:TtlDays"]    = "7",
                 ["RefreshToken:ByteLength"] = "64",
                 ["RefreshToken:CookieName"] = "refresh_token",
+
+                ["OAuth:FortyTwo:ClientId"]     = "test",
+                ["OAuth:FortyTwo:ClientSecret"] = "test",
+                ["OAuth:FortyTwo:RedirectUri"]  = "https://localhost:1443/auth/callback/42",
+
+                ["OAuth:Github:ClientId"]     = "test",
+                ["OAuth:Github:ClientSecret"] = "test",
+                ["OAuth:Github:RedirectUri"]  = "https://localhost:1443/auth/callback/github",
+
+                ["OAuth:Google:ClientId"]     = "test",
+                ["OAuth:Google:ClientSecret"] = "test",
+                ["OAuth:Google:RedirectUri"]  = "https://localhost:1443/auth/callback/google",
             });
         });
 

--- a/services/auth/tests/Auth.FunctionalTests/Infrastructure/JsonOptions.cs
+++ b/services/auth/tests/Auth.FunctionalTests/Infrastructure/JsonOptions.cs
@@ -1,0 +1,21 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+
+namespace Auth.FunctionalTests.Infrastructure;
+
+internal static class JsonOptions
+{
+    public static readonly JsonSerializerOptions SnakeCase = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+    };
+}
+
+internal static class HttpContentExtensions
+{
+    public static async Task<JsonNode> ReadJsonAsync(this HttpResponseMessage resp)
+    {
+        var json = await resp.Content.ReadAsStringAsync();
+        return JsonNode.Parse(json)!;
+    }
+}

--- a/services/auth/tests/Auth.UnitTests/Auth.UnitTests.csproj
+++ b/services/auth/tests/Auth.UnitTests/Auth.UnitTests.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <RootNamespace>Auth.UnitTests</RootNamespace>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <FrameworkReference Include="Microsoft.AspNetCore.App"/>
+    </ItemGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk"               Version="17.12.0"/>
+        <PackageReference Include="xunit"                                Version="2.9.3"/>
+        <PackageReference Include="xunit.runner.visualstudio"            Version="2.8.2">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\..\src\Auth.Domain\Auth.Domain.csproj"/>
+        <ProjectReference Include="..\..\src\Auth.Application\Auth.Application.csproj"/>
+        <ProjectReference Include="..\..\src\Auth.Infrastructure\Auth.Infrastructure.csproj"/>
+        <ProjectReference Include="..\..\src\Auth.Persistence\Auth.Persistence.csproj"/>
+        <ProjectReference Include="..\..\src\Auth.Presentation\Auth.Presentation.csproj"/>
+    </ItemGroup>
+
+</Project>

--- a/services/auth/tests/Auth.UnitTests/Fakes/FakeAuthUserRepository.cs
+++ b/services/auth/tests/Auth.UnitTests/Fakes/FakeAuthUserRepository.cs
@@ -1,0 +1,44 @@
+using Auth.Application.Abstractions.Persistence;
+using Auth.Domain.AuthUser;
+
+namespace Auth.UnitTests.Fakes;
+
+internal sealed class FakeAuthUserRepository : IAuthUserRepository
+{
+    private readonly Dictionary<long, AuthUser> _store = new();
+
+    public IReadOnlyDictionary<long, AuthUser> Store => _store;
+
+    public Task<AuthUser?> GetByIdAsync(long id, CancellationToken cancellationToken = default)
+    {
+        _store.TryGetValue(id, out var user);
+        return Task.FromResult(user);
+    }
+
+    public Task<AuthUser?> GetByEmailAsync(string email, CancellationToken cancellationToken = default)
+    {
+        var user = _store.Values.FirstOrDefault(u =>
+            u.Email?.Value.Equals(email, StringComparison.OrdinalIgnoreCase) == true);
+        return Task.FromResult(user);
+    }
+
+    public Task<AuthUser?> GetByOAuthAsync(
+        OAuthProvider provider, string oauthId, CancellationToken cancellationToken = default)
+    {
+        var user = _store.Values.FirstOrDefault(u =>
+            u.OAuthIdentity?.Provider == provider &&
+            u.OAuthIdentity.Id == oauthId);
+        return Task.FromResult(user);
+    }
+
+    public Task AddAsync(AuthUser user, CancellationToken cancellationToken = default)
+    {
+        _store[user.Id] = user;
+        return Task.CompletedTask;
+    }
+
+    public void Update(AuthUser user) => _store[user.Id] = user;
+
+    public Task SaveChangesAsync(CancellationToken cancellationToken = default)
+        => Task.CompletedTask;
+}

--- a/services/auth/tests/Auth.UnitTests/Fakes/FakeAuthUserRepository.cs
+++ b/services/auth/tests/Auth.UnitTests/Fakes/FakeAuthUserRepository.cs
@@ -15,6 +15,12 @@ internal sealed class FakeAuthUserRepository : IAuthUserRepository
         return Task.FromResult(user);
     }
 
+    public Task<AuthUser?> GetByRefreshTokenHashAsync(string hash, CancellationToken cancellationToken = default)
+    {
+        var user = _store.Values.FirstOrDefault(u => u.RefreshToken?.Hash == hash);
+        return Task.FromResult(user);
+    }
+
     public Task<AuthUser?> GetByEmailAsync(string email, CancellationToken cancellationToken = default)
     {
         var user = _store.Values.FirstOrDefault(u =>

--- a/services/auth/tests/Auth.UnitTests/Fakes/FakeClock.cs
+++ b/services/auth/tests/Auth.UnitTests/Fakes/FakeClock.cs
@@ -1,0 +1,8 @@
+using Auth.Application.Abstractions;
+
+namespace Auth.UnitTests.Fakes;
+
+internal sealed class FakeClock : IClock
+{
+    public DateTimeOffset UtcNow => DateTimeOffset.UtcNow;
+}

--- a/services/auth/tests/Auth.UnitTests/Fakes/FakeEventBus.cs
+++ b/services/auth/tests/Auth.UnitTests/Fakes/FakeEventBus.cs
@@ -1,0 +1,17 @@
+using Auth.Application.Abstractions.Events;
+
+namespace Auth.UnitTests.Fakes;
+
+internal sealed class FakeEventBus : IEventBus
+{
+    private readonly List<object> _published = [];
+
+    public IReadOnlyList<object> Published => _published;
+
+    public Task PublishAsync<T>(T message, CancellationToken cancellationToken = default)
+        where T : class, IEvent
+    {
+        _published.Add(message);
+        return Task.CompletedTask;
+    }
+}

--- a/services/auth/tests/Auth.UnitTests/Fakes/FakeIdGenerator.cs
+++ b/services/auth/tests/Auth.UnitTests/Fakes/FakeIdGenerator.cs
@@ -1,0 +1,12 @@
+using Auth.Application.Abstractions;
+
+namespace Auth.UnitTests.Fakes;
+
+internal sealed class FakeIdGenerator : IIdGenerator
+{
+    private long _current;
+
+    public FakeIdGenerator(long seed = 1_000_000_000_000_000_000L) => _current = seed;
+
+    public long NextId() => ++_current;
+}

--- a/services/auth/tests/Auth.UnitTests/Fakes/FakeSecretHasher.cs
+++ b/services/auth/tests/Auth.UnitTests/Fakes/FakeSecretHasher.cs
@@ -1,0 +1,12 @@
+using Auth.Application.Abstractions.Security;
+
+namespace Auth.UnitTests.Fakes;
+
+internal sealed class FakeSecretHasher : ISecretHasher
+{
+    public string Hash(string value) => $"hashed:{value}";
+
+    public bool Verify(string value, string hash) => hash == $"hashed:{value}";
+
+    public string HashDeterministic(string value) => $"det:{value}";
+}

--- a/services/auth/tests/Auth.UnitTests/Fakes/FakeTokenGenerator.cs
+++ b/services/auth/tests/Auth.UnitTests/Fakes/FakeTokenGenerator.cs
@@ -1,0 +1,12 @@
+using Auth.Application.Abstractions.Security;
+
+namespace Auth.UnitTests.Fakes;
+
+internal sealed class FakeTokenGenerator : ITokenGenerator
+{
+    public string GenerateAccessToken(long userId) => $"access-token-{userId}";
+
+    public string GenerateRefreshToken() => "fake-refresh-token";
+
+    public TimeSpan GetRefreshTokenLifetime() => TimeSpan.FromDays(7);
+}

--- a/services/auth/tests/Auth.UnitTests/Fakes/HandlerFactory.cs
+++ b/services/auth/tests/Auth.UnitTests/Fakes/HandlerFactory.cs
@@ -1,0 +1,33 @@
+using System.Reflection;
+using Auth.Application;
+using Auth.Application.Abstractions.Messaging;
+
+namespace Auth.UnitTests.Fakes;
+
+/// <summary>
+/// application handlers are <c>internal sealed</c> by convention.
+/// locate the concrete type via reflection and instantiate it without needing
+/// <c>InternalsVisibleTo</c> on the production assembly.
+/// </summary>
+internal static class HandlerFactory
+{
+    private static readonly Assembly ApplicationAssembly =
+        typeof(IApplicationAssemblyMarker).Assembly;
+
+    internal static ICommandHandler<TCommand, TResult> CreateCommand<TCommand, TResult>(
+        params object[] ctorArgs)
+        where TCommand : class, ICommand<TResult>
+        where TResult : class
+    {
+        var handlerType = FindImplementer(
+            typeof(ICommandHandler<,>).MakeGenericType(typeof(TCommand), typeof(TResult)));
+        return (ICommandHandler<TCommand, TResult>)Activator.CreateInstance(handlerType, ctorArgs)!;
+    }
+
+    private static Type FindImplementer(Type closedInterface)
+    {
+        return ApplicationAssembly.GetTypes()
+            .Single(t => t is { IsAbstract: false, IsInterface: false } &&
+                        closedInterface.IsAssignableFrom(t));
+    }
+}


### PR DESCRIPTION
Add test infrastructure and architecture tests

  Sets up the full testing foundation for the auth service:
  - A dedicated `Dockerfile.test` and service in `Tiltfile`
  - Architecture tests project, covering layer isolation, endpoint shape, and handler conventions
  - Shared test infrastructure: AuthApiFactory with WebApplicationFactory setup and SeedEmailUserAsync helper

>   Base unit and functional test structure reused by all endpoint-specific branches