### PR TITLE
Test/auth/refresh

### DIFF
--- a/services/auth/tests/Auth.FunctionalTests/Endpoints/LoginEndpointTests.cs
+++ b/services/auth/tests/Auth.FunctionalTests/Endpoints/LoginEndpointTests.cs
@@ -1,0 +1,84 @@
+using System.Net;
+using Auth.FunctionalTests.Infrastructure;
+using Xunit;
+
+namespace Auth.FunctionalTests.Endpoints;
+
+public sealed class LoginEndpointTests(AuthApiFactory factory)
+    : IClassFixture<AuthApiFactory>
+{
+    private readonly HttpClient _client = factory.CreateClient(
+        new() { AllowAutoRedirect = false });
+
+    private static StringContent JsonBody(string email, string password) =>
+        new($$"""{"email":"{{email}}","password":"{{password}}"}""",
+            System.Text.Encoding.UTF8, "application/json");
+
+    private Task SeedUser(string email, string password) =>
+        factory.SeedEmailUserAsync(email, password);
+
+    [Fact]
+    public async Task ValidCredentials_Returns200_WithTokensAndCookie()
+    {
+        await SeedUser("login_valid@example.com", "password123");
+
+        var resp = await _client.PostAsync("/v1/login",
+            JsonBody("login_valid@example.com", "password123"));
+
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+
+        var json = await resp.ReadJsonAsync();
+        Assert.NotNull(json["user_id"]?.GetValue<long>());
+        Assert.NotEmpty(json["access_token"]!.GetValue<string>());
+
+        var setCookie = Assert.Single(
+            resp.Headers.GetValues("Set-Cookie"),
+            h => h.StartsWith("refresh_token=", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains("HttpOnly", setCookie, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ValidCredentials_RefreshToken_IsRotated()
+    {
+        await SeedUser("login_rotate@example.com", "password123");
+
+        var first  = await _client.PostAsync("/v1/login", JsonBody("login_rotate@example.com", "password123"));
+        var second = await _client.PostAsync("/v1/login", JsonBody("login_rotate@example.com", "password123"));
+
+        var cookie1 = first.Headers.GetValues("Set-Cookie")
+            .Single(h => h.StartsWith("refresh_token=", StringComparison.OrdinalIgnoreCase));
+        var cookie2 = second.Headers.GetValues("Set-Cookie")
+            .Single(h => h.StartsWith("refresh_token=", StringComparison.OrdinalIgnoreCase));
+
+        Assert.NotEqual(cookie1, cookie2);
+    }
+
+    [Fact]
+    public async Task WrongPassword_Returns401()
+    {
+        await SeedUser("login_wrongpw@example.com", "correct-password");
+
+        var resp = await _client.PostAsync("/v1/login",
+            JsonBody("login_wrongpw@example.com", "wrong-password"));
+
+        Assert.Equal(HttpStatusCode.Unauthorized, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task UnknownEmail_Returns401()
+    {
+        var resp = await _client.PostAsync("/v1/login",
+            JsonBody("nobody@example.com", "password123"));
+
+        Assert.Equal(HttpStatusCode.Unauthorized, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task MissingBody_Returns400()
+    {
+        var resp = await _client.PostAsync("/v1/login",
+            new StringContent("{}", System.Text.Encoding.UTF8, "application/json"));
+
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+}

--- a/services/auth/tests/Auth.FunctionalTests/Endpoints/RefreshEndpointTests.cs
+++ b/services/auth/tests/Auth.FunctionalTests/Endpoints/RefreshEndpointTests.cs
@@ -1,0 +1,84 @@
+using System.Net;
+using Auth.FunctionalTests.Infrastructure;
+using Xunit;
+
+namespace Auth.FunctionalTests.Endpoints;
+
+public sealed class RefreshEndpointTests(AuthApiFactory factory)
+    : IClassFixture<AuthApiFactory>
+{
+    private readonly HttpClient _client = factory.CreateClient(
+        new() { AllowAutoRedirect = false });
+
+    private Task<string> SeedUser(string email, string password) =>
+        factory.SeedUserWithRefreshTokenAsync(email, password);
+
+    private HttpRequestMessage RefreshRequest(string? rawToken)
+    {
+        var req = new HttpRequestMessage(HttpMethod.Post, "/v1/refresh");
+        if (rawToken is not null)
+            req.Headers.Add("Cookie", $"refresh_token={rawToken}");
+        return req;
+    }
+
+    [Fact]
+    public async Task ValidToken_Returns200_WithNewAccessTokenAndCookie()
+    {
+        var rawToken = await SeedUser("refresh_valid@example.com", "password123");
+
+        var resp = await _client.SendAsync(RefreshRequest(rawToken));
+
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+
+        var json = await resp.ReadJsonAsync();
+        Assert.NotEmpty(json["access_token"]!.GetValue<string>());
+
+        var setCookie = Assert.Single(
+            resp.Headers.GetValues("Set-Cookie"),
+            h => h.StartsWith("refresh_token=", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains("HttpOnly", setCookie, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ValidToken_RotatesCookie()
+    {
+        var rawToken = await SeedUser("refresh_rotate@example.com", "password123");
+
+        var first  = await _client.SendAsync(RefreshRequest(rawToken));
+        var newToken = first.Headers.GetValues("Set-Cookie")
+            .Single(h => h.StartsWith("refresh_token=", StringComparison.OrdinalIgnoreCase))
+            .Split(';')[0]
+            .Split('=', 2)[1];
+
+        var second = await _client.SendAsync(RefreshRequest(newToken));
+
+        Assert.Equal(HttpStatusCode.OK, second.StatusCode);
+    }
+
+    [Fact]
+    public async Task MissingCookie_Returns401()
+    {
+        var resp = await _client.SendAsync(RefreshRequest(rawToken: null));
+
+        Assert.Equal(HttpStatusCode.Unauthorized, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task UnknownToken_Returns401()
+    {
+        var resp = await _client.SendAsync(RefreshRequest("garbage-token-xyz"));
+
+        Assert.Equal(HttpStatusCode.Unauthorized, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task UsedToken_Returns401()
+    {
+        var rawToken = await SeedUser("refresh_used@example.com", "password123");
+
+        await _client.SendAsync(RefreshRequest(rawToken));
+        var resp = await _client.SendAsync(RefreshRequest(rawToken));
+
+        Assert.Equal(HttpStatusCode.Unauthorized, resp.StatusCode);
+    }
+}

--- a/services/auth/tests/Auth.FunctionalTests/Infrastructure/AuthApiFactory.cs
+++ b/services/auth/tests/Auth.FunctionalTests/Infrastructure/AuthApiFactory.cs
@@ -3,6 +3,7 @@ using Auth.Application.Abstractions.Events;
 using Auth.Application.Abstractions.Persistence;
 using Auth.Application.Abstractions.Security;
 using Auth.Domain.AuthUser;
+using Auth.Domain.Results;
 using Auth.Persistence.Db;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
@@ -45,6 +46,36 @@ public sealed class AuthApiFactory : WebApplicationFactory<Program>
 
         await repo.AddAsync(user);
         await repo.SaveChangesAsync();
+    }
+
+    public async Task<string> SeedUserWithRefreshTokenAsync(string email, string rawPassword)
+    {
+        using var scope  = Services.CreateScope();
+        var sp           = scope.ServiceProvider;
+        var repo         = sp.GetRequiredService<IAuthUserRepository>();
+        var hasher       = sp.GetRequiredService<ISecretHasher>();
+        var clock        = sp.GetRequiredService<IClock>();
+        var idGen        = sp.GetRequiredService<IIdGenerator>();
+        var tokenGen     = sp.GetRequiredService<ITokenGenerator>();
+
+        var rawRefreshToken = tokenGen.GenerateRefreshToken();
+        var now             = clock.UtcNow;
+
+        var user = AuthUser.CreateEmailPasswordUser(
+            id: idGen.NextId(),
+            email: email,
+            passwordHash: hasher.Hash(rawPassword),
+            now: now).Value;
+
+        user.SetRefreshToken(
+            hasher.HashDeterministic(rawRefreshToken),
+            now,
+            now.Add(tokenGen.GetRefreshTokenLifetime()));
+
+        await repo.AddAsync(user);
+        await repo.SaveChangesAsync();
+
+        return rawRefreshToken;
     }
 
     protected override void ConfigureWebHost(IWebHostBuilder builder)

--- a/services/auth/tests/Auth.UnitTests/Application/LoginHandlerTests.cs
+++ b/services/auth/tests/Auth.UnitTests/Application/LoginHandlerTests.cs
@@ -1,0 +1,120 @@
+using Auth.Application.Features.Login;
+using Auth.Domain.AuthUser;
+using Auth.Domain.Results;
+using Auth.UnitTests.Fakes;
+using Xunit;
+
+namespace Auth.UnitTests.Application;
+
+public sealed class LoginHandlerTests
+{
+    private readonly FakeIdGenerator        _idGenerator = new();
+    private readonly FakeAuthUserRepository _repo        = new();
+    private readonly FakeSecretHasher       _hasher      = new();
+    private readonly FakeTokenGenerator     _tokens      = new();
+    private readonly FakeClock              _clock       = new();
+
+    private Task<Result<LoginResult>> Handle(string email, string password)
+    {
+        var handler = HandlerFactory.CreateCommand<LoginCommand, Result<LoginResult>>(
+            _repo, _hasher, _tokens, _clock);
+        return handler.HandleAsync(new LoginCommand(email, password));
+    }
+
+    private async Task SeedEmailUser(string email, string password)
+    {
+        var user = AuthUser.CreateEmailPasswordUser(
+            id: _idGenerator.NextId(),
+            email: email,
+            passwordHash: _hasher.Hash(password),
+            _clock.UtcNow).Value;
+        await _repo.AddAsync(user);
+    }
+
+    [Fact]
+    public async Task ValidCredentials_ReturnsSuccessWithTokens()
+    {
+        await SeedEmailUser("user@example.com", "password123");
+
+        var result = await Handle("user@example.com", "password123");
+
+        Assert.True(result.Succeeded);
+        Assert.NotEmpty(result.Value.AccessToken);
+        Assert.NotEmpty(result.Value.RefreshToken);
+        Assert.Equal("fake-refresh-token", result.Value.RefreshToken);
+    }
+
+    [Fact]
+    public async Task ValidCredentials_RotatesRefreshToken()
+    {
+        await SeedEmailUser("user@example.com", "password123");
+
+        await Handle("user@example.com", "password123");
+
+        var user = _repo.Store.Values.Single();
+        Assert.NotNull(user.RefreshToken);
+        Assert.Equal("det:fake-refresh-token", user.RefreshToken.Hash);
+        Assert.True(user.RefreshToken.IsActive(_clock.UtcNow));
+    }
+
+    [Fact]
+    public async Task AccessToken_ContainsUserId()
+    {
+        await SeedEmailUser("user@example.com", "password123");
+
+        var result = await Handle("user@example.com", "password123");
+
+        var userId = _repo.Store.Values.Single().Id;
+        Assert.Equal($"access-token-{userId}", result.Value.AccessToken);
+    }
+
+    [Fact]
+    public async Task UnknownEmail_ReturnsInvalidCredentials()
+    {
+        var result = await Handle("nobody@example.com", "password123");
+
+        Assert.True(result.IsFailure);
+        Assert.Equal(AuthFailures.InvalidCredentials.Code, result.Error.Code);
+    }
+
+    [Fact]
+    public async Task WrongPassword_ReturnsInvalidCredentials()
+    {
+        await SeedEmailUser("user@example.com", "correct-password");
+
+        var result = await Handle("user@example.com", "wrong-password");
+
+        Assert.True(result.IsFailure);
+        Assert.Equal(AuthFailures.InvalidCredentials.Code, result.Error.Code);
+    }
+
+    [Fact]
+    public async Task SoftDeletedUser_ReturnsInvalidCredentials()
+    {
+        await SeedEmailUser("user@example.com", "password123");
+        var user = _repo.Store.Values.Single();
+        user.SoftDelete(_clock.UtcNow);
+        _repo.Update(user);
+
+        var result = await Handle("user@example.com", "password123");
+
+        Assert.True(result.IsFailure);
+        Assert.Equal(AuthFailures.InvalidCredentials.Code, result.Error.Code);
+    }
+
+    [Fact]
+    public async Task OAuthOnlyUser_ReturnsInvalidCredentials()
+    {
+        var oauthUser = AuthUser.CreateOAuthUser(
+            id: _idGenerator.NextId(),
+            oauthProvider: OAuthProvider.Github,
+            oauthId: "gh-123",
+            _clock.UtcNow).Value;
+        await _repo.AddAsync(oauthUser);
+
+        var result = await Handle("user@example.com", "password123");
+
+        Assert.True(result.IsFailure);
+        Assert.Equal(AuthFailures.InvalidCredentials.Code, result.Error.Code);
+    }
+}

--- a/services/auth/tests/Auth.UnitTests/Application/RefreshHandlerTests.cs
+++ b/services/auth/tests/Auth.UnitTests/Application/RefreshHandlerTests.cs
@@ -1,0 +1,131 @@
+using Auth.Application.Features.Refresh;
+using Auth.Domain.AuthUser;
+using Auth.Domain.Results;
+using Auth.UnitTests.Fakes;
+using Xunit;
+
+namespace Auth.UnitTests.Application;
+
+public sealed class RefreshHandlerTests
+{
+    private readonly FakeIdGenerator        _idGenerator = new();
+    private readonly FakeAuthUserRepository _repo        = new();
+    private readonly FakeSecretHasher       _hasher      = new();
+    private readonly FakeTokenGenerator     _tokens      = new();
+    private readonly FakeClock              _clock       = new();
+
+    private Task<Result<RefreshResult>> Handle(string rawToken)
+    {
+        var handler = HandlerFactory.CreateCommand<RefreshCommand, Result<RefreshResult>>(
+            _repo, _hasher, _tokens, _clock);
+        return handler.HandleAsync(new RefreshCommand(rawToken));
+    }
+
+    private async Task<AuthUser> SeedUserWithToken(
+        string rawToken,
+        DateTimeOffset? issuedAt  = null,
+        DateTimeOffset? expiresAt = null,
+        bool revoked = false)
+    {
+        var now  = _clock.UtcNow;
+        var user = AuthUser.CreateEmailPasswordUser(
+            id: _idGenerator.NextId(),
+            email: "user@example.com",
+            passwordHash: "hashed:pw",
+            now: now).Value;
+
+        user.SetRefreshToken(
+            _hasher.HashDeterministic(rawToken),
+            issuedAt  ?? now,
+            expiresAt ?? now.AddDays(7));
+
+        if (revoked)
+            user.RevokeRefreshToken(now);
+
+        await _repo.AddAsync(user);
+        return user;
+    }
+
+    [Fact]
+    public async Task ValidToken_ReturnsNewTokens()
+    {
+        await SeedUserWithToken("my-token");
+
+        var result = await Handle("my-token");
+
+        Assert.True(result.Succeeded);
+        Assert.NotEmpty(result.Value.AccessToken);
+        Assert.NotEmpty(result.Value.RefreshToken);
+    }
+
+    [Fact]
+    public async Task ValidToken_RotatesRefreshToken()
+    {
+        await SeedUserWithToken("my-token");
+
+        await Handle("my-token");
+
+        var user = _repo.Store.Values.Single();
+        Assert.NotNull(user.RefreshToken);
+        Assert.NotEqual("det:my-token", user.RefreshToken.Hash);
+        Assert.True(user.RefreshToken.IsActive(_clock.UtcNow));
+    }
+
+    [Fact]
+    public async Task ValidToken_AccessTokenContainsUserId()
+    {
+        await SeedUserWithToken("my-token");
+
+        var result = await Handle("my-token");
+
+        var userId = _repo.Store.Values.Single().Id;
+        Assert.Equal($"access-token-{userId}", result.Value.AccessToken);
+    }
+
+    [Fact]
+    public async Task UnknownToken_ReturnsInvalidRefreshToken()
+    {
+        await SeedUserWithToken("real-token");
+
+        var result = await Handle("wrong-token");
+
+        Assert.True(result.IsFailure);
+        Assert.Equal(AuthFailures.InvalidRefreshToken.Code, result.Error.Code);
+    }
+
+    [Fact]
+    public async Task ExpiredToken_ReturnsInvalidRefreshToken()
+    {
+        var past = _clock.UtcNow.AddDays(-8);
+        await SeedUserWithToken("my-token", issuedAt: past, expiresAt: past.AddDays(1));
+
+        var result = await Handle("my-token");
+
+        Assert.True(result.IsFailure);
+        Assert.Equal(AuthFailures.InvalidRefreshToken.Code, result.Error.Code);
+    }
+
+    [Fact]
+    public async Task RevokedToken_ReturnsInvalidRefreshToken()
+    {
+        await SeedUserWithToken("my-token", revoked: true);
+
+        var result = await Handle("my-token");
+
+        Assert.True(result.IsFailure);
+        Assert.Equal(AuthFailures.InvalidRefreshToken.Code, result.Error.Code);
+    }
+
+    [Fact]
+    public async Task SoftDeletedUser_ReturnsInvalidRefreshToken()
+    {
+        var user = await SeedUserWithToken("my-token");
+        user.SoftDelete(_clock.UtcNow);
+        _repo.Update(user);
+
+        var result = await Handle("my-token");
+
+        Assert.True(result.IsFailure);
+        Assert.Equal(AuthFailures.InvalidRefreshToken.Code, result.Error.Code);
+    }
+}


### PR DESCRIPTION
Add unit and functional tests for the **refresh** endpoint

- Unit tests for RefreshHandler: covers valid refresh, expired/revoked token, and missing cookie scenarios
- Functional tests for `POST /v1/refresh`: token rotation and error cases; adds required token helpers to AuthApiFactory

> - [x] Do not merge into main before #173 is merged