### PR TITLE
Test/auth/logout

### DIFF
--- a/services/auth/src/Auth.Infrastructure/Security/TokenGenerator.cs
+++ b/services/auth/src/Auth.Infrastructure/Security/TokenGenerator.cs
@@ -34,7 +34,7 @@ internal sealed class TokenGenerator(
             issuer: _jwtOptions.Issuer,
             audience: _jwtOptions.Audience,
             claims: claims,
-            expires: clock.UtcNow.AddMinutes(_jwtOptions.AccessTokenTtlMinutes).DateTime,
+            expires: clock.UtcNow.AddMinutes(_jwtOptions.AccessTokenTtlMinutes).UtcDateTime,
             signingCredentials: credentials
         );
 

--- a/services/auth/tests/Auth.FunctionalTests/Endpoints/LogoutEndpointTests.cs
+++ b/services/auth/tests/Auth.FunctionalTests/Endpoints/LogoutEndpointTests.cs
@@ -1,0 +1,66 @@
+using System.Net;
+using System.Net.Http.Headers;
+using Auth.FunctionalTests.Infrastructure;
+using Xunit;
+
+namespace Auth.FunctionalTests.Endpoints;
+
+public sealed class LogoutEndpointTests(AuthApiFactory factory)
+    : IClassFixture<AuthApiFactory>
+{
+    private readonly HttpClient _client = factory.CreateClient(
+        new() { AllowAutoRedirect = false });
+
+    private Task<string> SeedUser(string email, string password) =>
+        factory.SeedUserWithAccessTokenAsync(email, password);
+
+    private HttpRequestMessage LogoutRequest(string? bearerToken)
+    {
+        var req = new HttpRequestMessage(HttpMethod.Post, "/v1/logout");
+        if (bearerToken is not null)
+            req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", bearerToken);
+        return req;
+    }
+
+    [Fact]
+    public async Task ValidToken_Returns204_AndDeletesCookie()
+    {
+        var accessToken = await SeedUser("logout_valid@example.com", "password123");
+
+        var resp = await _client.SendAsync(LogoutRequest(accessToken));
+
+        Assert.Equal(HttpStatusCode.NoContent, resp.StatusCode);
+
+        var setCookie = Assert.Single(
+            resp.Headers.GetValues("Set-Cookie"),
+            h => h.StartsWith("refresh_token=", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains("expires=", setCookie, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task MissingToken_Returns401()
+    {
+        var resp = await _client.SendAsync(LogoutRequest(bearerToken: null));
+
+        Assert.Equal(HttpStatusCode.Unauthorized, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task InvalidToken_Returns401()
+    {
+        var resp = await _client.SendAsync(LogoutRequest("this.is.not.a.valid.jwt"));
+
+        Assert.Equal(HttpStatusCode.Unauthorized, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task ValidToken_RevokesRefreshToken_InDatabase()
+    {
+        var (accessToken, userId) = await factory.SeedUserWithBothTokensAsync(
+            "logout_db@example.com", "password123");
+
+        await _client.SendAsync(LogoutRequest(accessToken));
+
+        Assert.True(await factory.IsRefreshTokenRevokedAsync(userId));
+    }
+}

--- a/services/auth/tests/Auth.FunctionalTests/Infrastructure/AuthApiFactory.cs
+++ b/services/auth/tests/Auth.FunctionalTests/Infrastructure/AuthApiFactory.cs
@@ -81,6 +81,67 @@ public sealed class AuthApiFactory : WebApplicationFactory<Program>
         return rawRefreshToken;
     }
 
+    public async Task<string> SeedUserWithAccessTokenAsync(string email, string rawPassword)
+    {
+        using var scope = Services.CreateScope();
+        var sp          = scope.ServiceProvider;
+        var repo        = sp.GetRequiredService<IAuthUserRepository>();
+        var hasher      = sp.GetRequiredService<ISecretHasher>();
+        var clock       = sp.GetRequiredService<IClock>();
+        var idGen       = sp.GetRequiredService<IIdGenerator>();
+        var tokenGen    = sp.GetRequiredService<ITokenGenerator>();
+
+        var user = AuthUser.CreateEmailPasswordUser(
+            id: idGen.NextId(),
+            email: email,
+            passwordHash: hasher.Hash(rawPassword),
+            now: clock.UtcNow).Value;
+
+        await repo.AddAsync(user);
+        await repo.SaveChangesAsync();
+
+        return tokenGen.GenerateAccessToken(user.Id);
+    }
+
+    public async Task<(string AccessToken, long UserId)> SeedUserWithBothTokensAsync(
+        string email, string rawPassword)
+    {
+        using var scope = Services.CreateScope();
+        var sp          = scope.ServiceProvider;
+        var repo        = sp.GetRequiredService<IAuthUserRepository>();
+        var hasher      = sp.GetRequiredService<ISecretHasher>();
+        var clock       = sp.GetRequiredService<IClock>();
+        var idGen       = sp.GetRequiredService<IIdGenerator>();
+        var tokenGen    = sp.GetRequiredService<ITokenGenerator>();
+
+        var rawRefreshToken = tokenGen.GenerateRefreshToken();
+        var now             = clock.UtcNow;
+
+        var user = AuthUser.CreateEmailPasswordUser(
+            id: idGen.NextId(),
+            email: email,
+            passwordHash: hasher.Hash(rawPassword),
+            now: now).Value;
+
+        user.SetRefreshToken(
+            hasher.HashDeterministic(rawRefreshToken),
+            now,
+            now.Add(tokenGen.GetRefreshTokenLifetime()));
+
+        await repo.AddAsync(user);
+        await repo.SaveChangesAsync();
+
+        return (tokenGen.GenerateAccessToken(user.Id), user.Id);
+    }
+
+    public async Task<bool> IsRefreshTokenRevokedAsync(long userId)
+    {
+        using var scope = Services.CreateScope();
+        var repo = scope.ServiceProvider.GetRequiredService<IAuthUserRepository>();
+        var user = await repo.GetByIdAsync(userId);
+        return user?.RefreshToken?.Revoked ?? false;
+    }
+
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
         builder.UseEnvironment("Testing");

--- a/services/auth/tests/Auth.UnitTests/Application/LogoutHandlerTests.cs
+++ b/services/auth/tests/Auth.UnitTests/Application/LogoutHandlerTests.cs
@@ -1,0 +1,102 @@
+using Auth.Application.Events;
+using Auth.Application.Features.Logout;
+using Auth.Domain.AuthUser;
+using Auth.Domain.Results;
+using Auth.UnitTests.Fakes;
+using Xunit;
+
+namespace Auth.UnitTests.Application;
+
+public sealed class LogoutHandlerTests
+{
+    private readonly FakeIdGenerator        _idGenerator = new();
+    private readonly FakeAuthUserRepository _repo        = new();
+    private readonly FakeEventBus           _eventBus    = new();
+    private readonly FakeClock              _clock       = new();
+
+    private Task<Result> Handle(long userId)
+    {
+        var handler = HandlerFactory.CreateCommand<LogoutCommand, Result>(
+            _repo, _eventBus, _clock);
+        return handler.HandleAsync(new LogoutCommand(userId));
+    }
+
+    private async Task<AuthUser> SeedUser()
+    {
+        var user = AuthUser.CreateEmailPasswordUser(
+            id: _idGenerator.NextId(),
+            email: "user@example.com",
+            passwordHash: "hashed:pw",
+            now: _clock.UtcNow).Value;
+
+        var now = _clock.UtcNow;
+        user.SetRefreshToken("det:some-token", now, now.AddDays(7));
+
+        await _repo.AddAsync(user);
+        return user;
+    }
+
+    [Fact]
+    public async Task ValidUser_ReturnsSuccess()
+    {
+        var user = await SeedUser();
+
+        var result = await Handle(user.Id);
+
+        Assert.True(result.Succeeded);
+    }
+
+    [Fact]
+    public async Task ValidUser_RevokesRefreshToken()
+    {
+        var user = await SeedUser();
+
+        await Handle(user.Id);
+
+        var stored = _repo.Store[user.Id];
+        Assert.NotNull(stored.RefreshToken);
+        Assert.True(stored.RefreshToken.Revoked);
+    }
+
+    [Fact]
+    public async Task ValidUser_PublishesUserLoggedOutEvent()
+    {
+        var user = await SeedUser();
+
+        await Handle(user.Id);
+
+        var evt = Assert.Single(_eventBus.Published);
+        var loggedOut = Assert.IsType<UserLoggedOutEvent>(evt);
+        Assert.Equal(user.Id, loggedOut.UserId);
+    }
+
+    [Fact]
+    public async Task UnknownUser_ReturnsFailure()
+    {
+        var result = await Handle(999L);
+
+        Assert.True(result.IsFailure);
+        Assert.Equal(AuthFailures.InvalidAccessToken.Code, result.Error.Code);
+    }
+
+    [Fact]
+    public async Task UnknownUser_DoesNotPublishEvent()
+    {
+        await Handle(999L);
+
+        Assert.Empty(_eventBus.Published);
+    }
+
+    [Fact]
+    public async Task SoftDeletedUser_ReturnsFailure()
+    {
+        var user = await SeedUser();
+        user.SoftDelete(_clock.UtcNow);
+        _repo.Update(user);
+
+        var result = await Handle(user.Id);
+
+        Assert.True(result.IsFailure);
+        Assert.Equal(AuthFailures.InvalidAccessToken.Code, result.Error.Code);
+    }
+}


### PR DESCRIPTION
Add unit and functional tests for the **logout** endpoint

- Unit tests for LogoutHandler: covers successful logout, unauthenticated request, and token-already-revoked cases
- Functional tests for `POST /v1/logout`: verifies cookie clearing and token revocation end-to-end
- Extends `AuthApiFactory` with `SeedUserWithAccessTokenAsync()`, `SeedUserWithBothTokensAsync()`, and `IsRefreshTokenRevokedAsync()` helpers

> - [x] Do not merge into main before #173 is merged.