### PR TITLE
Test/auth/register

### DIFF
--- a/services/auth/tests/Auth.FunctionalTests/Endpoints/LoginEndpointTests.cs
+++ b/services/auth/tests/Auth.FunctionalTests/Endpoints/LoginEndpointTests.cs
@@ -1,0 +1,84 @@
+using System.Net;
+using Auth.FunctionalTests.Infrastructure;
+using Xunit;
+
+namespace Auth.FunctionalTests.Endpoints;
+
+public sealed class LoginEndpointTests(AuthApiFactory factory)
+    : IClassFixture<AuthApiFactory>
+{
+    private readonly HttpClient _client = factory.CreateClient(
+        new() { AllowAutoRedirect = false });
+
+    private static StringContent JsonBody(string email, string password) =>
+        new($$"""{"email":"{{email}}","password":"{{password}}"}""",
+            System.Text.Encoding.UTF8, "application/json");
+
+    private Task SeedUser(string email, string password) =>
+        factory.SeedEmailUserAsync(email, password);
+
+    [Fact]
+    public async Task ValidCredentials_Returns200_WithTokensAndCookie()
+    {
+        await SeedUser("login_valid@example.com", "password123");
+
+        var resp = await _client.PostAsync("/v1/login",
+            JsonBody("login_valid@example.com", "password123"));
+
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+
+        var json = await resp.ReadJsonAsync();
+        Assert.NotNull(json["user_id"]?.GetValue<long>());
+        Assert.NotEmpty(json["access_token"]!.GetValue<string>());
+
+        var setCookie = Assert.Single(
+            resp.Headers.GetValues("Set-Cookie"),
+            h => h.StartsWith("refresh_token=", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains("HttpOnly", setCookie, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ValidCredentials_RefreshToken_IsRotated()
+    {
+        await SeedUser("login_rotate@example.com", "password123");
+
+        var first  = await _client.PostAsync("/v1/login", JsonBody("login_rotate@example.com", "password123"));
+        var second = await _client.PostAsync("/v1/login", JsonBody("login_rotate@example.com", "password123"));
+
+        var cookie1 = first.Headers.GetValues("Set-Cookie")
+            .Single(h => h.StartsWith("refresh_token=", StringComparison.OrdinalIgnoreCase));
+        var cookie2 = second.Headers.GetValues("Set-Cookie")
+            .Single(h => h.StartsWith("refresh_token=", StringComparison.OrdinalIgnoreCase));
+
+        Assert.NotEqual(cookie1, cookie2);
+    }
+
+    [Fact]
+    public async Task WrongPassword_Returns401()
+    {
+        await SeedUser("login_wrongpw@example.com", "correct-password");
+
+        var resp = await _client.PostAsync("/v1/login",
+            JsonBody("login_wrongpw@example.com", "wrong-password"));
+
+        Assert.Equal(HttpStatusCode.Unauthorized, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task UnknownEmail_Returns401()
+    {
+        var resp = await _client.PostAsync("/v1/login",
+            JsonBody("nobody@example.com", "password123"));
+
+        Assert.Equal(HttpStatusCode.Unauthorized, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task MissingBody_Returns400()
+    {
+        var resp = await _client.PostAsync("/v1/login",
+            new StringContent("{}", System.Text.Encoding.UTF8, "application/json"));
+
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+}

--- a/services/auth/tests/Auth.FunctionalTests/Endpoints/RegisterEndpointTests.cs
+++ b/services/auth/tests/Auth.FunctionalTests/Endpoints/RegisterEndpointTests.cs
@@ -1,0 +1,77 @@
+using System.Net;
+using System.Net.Http.Json;
+using Auth.FunctionalTests.Infrastructure;
+using Xunit;
+
+namespace Auth.FunctionalTests.Endpoints;
+
+public sealed class RegisterEndpointTests(AuthApiFactory factory)
+    : IClassFixture<AuthApiFactory>
+{
+    private readonly HttpClient _client = factory.CreateClient(
+        new() { AllowAutoRedirect = false });
+
+    private static StringContent JsonBody(string email, string password) =>
+        new($$"""{"email":"{{email}}","password":"{{password}}"}""",
+            System.Text.Encoding.UTF8, "application/json");
+
+    [Fact]
+    public async Task ValidRequest_Returns201_WithTokensAndCookie()
+    {
+        var resp = await _client.PostAsync("/v1/register",
+            JsonBody("register_valid@example.com", "password123"));
+
+        Assert.Equal(HttpStatusCode.Created, resp.StatusCode);
+
+        var json = await resp.ReadJsonAsync();
+        Assert.NotNull(json["user_id"]?.GetValue<long>());
+        Assert.NotEmpty(json["access_token"]!.GetValue<string>());
+
+        var setCookie = Assert.Single(
+            resp.Headers.GetValues("Set-Cookie"),
+            h => h.StartsWith("refresh_token=", StringComparison.OrdinalIgnoreCase));
+        Assert.Contains("HttpOnly", setCookie, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ValidRequest_LocationHeader_PointsToUser()
+    {
+        var resp = await _client.PostAsync("/v1/register",
+            JsonBody("register_location@example.com", "password123"));
+
+        Assert.Equal(HttpStatusCode.Created, resp.StatusCode);
+
+        var userId = (await resp.ReadJsonAsync())["user_id"]!.GetValue<long>();
+        Assert.Equal($"/users/{userId}", resp.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task DuplicateEmail_Returns409()
+    {
+        await _client.PostAsync("/v1/register",
+            JsonBody("register_dup@example.com", "password123"));
+
+        var resp = await _client.PostAsync("/v1/register",
+            JsonBody("register_dup@example.com", "other-password"));
+
+        Assert.Equal(HttpStatusCode.Conflict, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task InvalidEmail_Returns400()
+    {
+        var resp = await _client.PostAsync("/v1/register",
+            JsonBody("not-an-email", "password123"));
+
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task MissingBody_Returns400()
+    {
+        var resp = await _client.PostAsync("/v1/register",
+            new StringContent("{}", System.Text.Encoding.UTF8, "application/json"));
+
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+}

--- a/services/auth/tests/Auth.UnitTests/Application/LoginHandlerTests.cs
+++ b/services/auth/tests/Auth.UnitTests/Application/LoginHandlerTests.cs
@@ -1,0 +1,120 @@
+using Auth.Application.Features.Login;
+using Auth.Domain.AuthUser;
+using Auth.Domain.Results;
+using Auth.UnitTests.Fakes;
+using Xunit;
+
+namespace Auth.UnitTests.Application;
+
+public sealed class LoginHandlerTests
+{
+    private readonly FakeIdGenerator        _idGenerator = new();
+    private readonly FakeAuthUserRepository _repo        = new();
+    private readonly FakeSecretHasher       _hasher      = new();
+    private readonly FakeTokenGenerator     _tokens      = new();
+    private readonly FakeClock              _clock       = new();
+
+    private Task<Result<LoginResult>> Handle(string email, string password)
+    {
+        var handler = HandlerFactory.CreateCommand<LoginCommand, Result<LoginResult>>(
+            _repo, _hasher, _tokens, _clock);
+        return handler.HandleAsync(new LoginCommand(email, password));
+    }
+
+    private async Task SeedEmailUser(string email, string password)
+    {
+        var user = AuthUser.CreateEmailPasswordUser(
+            id: _idGenerator.NextId(),
+            email: email,
+            passwordHash: _hasher.Hash(password),
+            _clock.UtcNow).Value;
+        await _repo.AddAsync(user);
+    }
+
+    [Fact]
+    public async Task ValidCredentials_ReturnsSuccessWithTokens()
+    {
+        await SeedEmailUser("user@example.com", "password123");
+
+        var result = await Handle("user@example.com", "password123");
+
+        Assert.True(result.Succeeded);
+        Assert.NotEmpty(result.Value.AccessToken);
+        Assert.NotEmpty(result.Value.RefreshToken);
+        Assert.Equal("fake-refresh-token", result.Value.RefreshToken);
+    }
+
+    [Fact]
+    public async Task ValidCredentials_RotatesRefreshToken()
+    {
+        await SeedEmailUser("user@example.com", "password123");
+
+        await Handle("user@example.com", "password123");
+
+        var user = _repo.Store.Values.Single();
+        Assert.NotNull(user.RefreshToken);
+        Assert.Equal("det:fake-refresh-token", user.RefreshToken.Hash);
+        Assert.True(user.RefreshToken.IsActive(_clock.UtcNow));
+    }
+
+    [Fact]
+    public async Task AccessToken_ContainsUserId()
+    {
+        await SeedEmailUser("user@example.com", "password123");
+
+        var result = await Handle("user@example.com", "password123");
+
+        var userId = _repo.Store.Values.Single().Id;
+        Assert.Equal($"access-token-{userId}", result.Value.AccessToken);
+    }
+
+    [Fact]
+    public async Task UnknownEmail_ReturnsInvalidCredentials()
+    {
+        var result = await Handle("nobody@example.com", "password123");
+
+        Assert.True(result.IsFailure);
+        Assert.Equal(AuthFailures.InvalidCredentials.Code, result.Error.Code);
+    }
+
+    [Fact]
+    public async Task WrongPassword_ReturnsInvalidCredentials()
+    {
+        await SeedEmailUser("user@example.com", "correct-password");
+
+        var result = await Handle("user@example.com", "wrong-password");
+
+        Assert.True(result.IsFailure);
+        Assert.Equal(AuthFailures.InvalidCredentials.Code, result.Error.Code);
+    }
+
+    [Fact]
+    public async Task SoftDeletedUser_ReturnsInvalidCredentials()
+    {
+        await SeedEmailUser("user@example.com", "password123");
+        var user = _repo.Store.Values.Single();
+        user.SoftDelete(_clock.UtcNow);
+        _repo.Update(user);
+
+        var result = await Handle("user@example.com", "password123");
+
+        Assert.True(result.IsFailure);
+        Assert.Equal(AuthFailures.InvalidCredentials.Code, result.Error.Code);
+    }
+
+    [Fact]
+    public async Task OAuthOnlyUser_ReturnsInvalidCredentials()
+    {
+        var oauthUser = AuthUser.CreateOAuthUser(
+            id: _idGenerator.NextId(),
+            oauthProvider: OAuthProvider.Github,
+            oauthId: "gh-123",
+            _clock.UtcNow).Value;
+        await _repo.AddAsync(oauthUser);
+
+        var result = await Handle("user@example.com", "password123");
+
+        Assert.True(result.IsFailure);
+        Assert.Equal(AuthFailures.InvalidCredentials.Code, result.Error.Code);
+    }
+}

--- a/services/auth/tests/Auth.UnitTests/Application/RegisterHandlerTests.cs
+++ b/services/auth/tests/Auth.UnitTests/Application/RegisterHandlerTests.cs
@@ -1,0 +1,96 @@
+using Auth.Application.Events;
+using Auth.Application.Features.Register;
+using Auth.Domain.Results;
+using Auth.UnitTests.Fakes;
+using Xunit;
+
+namespace Auth.UnitTests.Application;
+
+public sealed class RegisterHandlerTests
+{
+    private readonly FakeIdGenerator        _idGenerator = new();
+    private readonly FakeAuthUserRepository _repo        = new();
+    private readonly FakeTokenGenerator     _tokens      = new();
+    private readonly FakeSecretHasher       _hasher      = new();
+    private readonly FakeEventBus           _eventBus    = new();
+    private readonly FakeClock              _clock       = new();
+
+    private Task<Result<RegisterResult>> Handle(string email, string password)
+    {
+        var handler = HandlerFactory.CreateCommand<RegisterCommand, Result<RegisterResult>>(
+            _idGenerator, _repo, _tokens, _hasher, _eventBus, _clock);
+        return handler.HandleAsync(new RegisterCommand(email, password));
+    }
+
+    [Fact]
+    public async Task ValidRegistration_ReturnsSuccessWithTokens()
+    {
+        var result = await Handle("user@example.com", "password123");
+
+        Assert.True(result.Succeeded);
+        Assert.Equal($"access-token-{1_000_000_000_000_000_001L}", result.Value.AccessToken);
+        Assert.Equal("fake-refresh-token", result.Value.RefreshToken);
+        Assert.Equal(1_000_000_000_000_000_001L, result.Value.UserId);
+    }
+
+    [Fact]
+    public async Task ValidRegistration_StoresUserWithHashedPassword()
+    {
+        await Handle("user@example.com", "password123");
+
+        var user = Assert.Single(_repo.Store.Values);
+        Assert.Equal("user@example.com", user.Email!.Value);
+        Assert.Equal("hashed:password123", user.PasswordHash);
+    }
+
+    [Fact]
+    public async Task ValidRegistration_StoresDeterministicHashedRefreshToken()
+    {
+        await Handle("user@example.com", "password123");
+
+        var user = Assert.Single(_repo.Store.Values);
+        Assert.NotNull(user.RefreshToken);
+        Assert.Equal("det:fake-refresh-token", user.RefreshToken.Hash);
+        Assert.True(user.RefreshToken.IsActive(_clock.UtcNow));
+    }
+
+    [Fact]
+    public async Task ValidRegistration_PublishesUserRegisteredEvent()
+    {
+        await Handle("user@example.com", "password123");
+
+        var evt = Assert.Single(_eventBus.Published);
+        var registered = Assert.IsType<UserRegisteredEvent>(evt);
+        Assert.Equal(1_000_000_000_000_000_001L, registered.UserId);
+        Assert.Equal("user@example.com", registered.Email);
+    }
+
+    [Fact]
+    public async Task DuplicateEmail_ReturnsEmailAlreadyRegistered()
+    {
+        await Handle("user@example.com", "password123");
+
+        var result = await Handle("user@example.com", "other-password");
+
+        Assert.True(result.IsFailure);
+        Assert.Equal(AuthFailures.EmailAlreadyRegistered.Code, result.Error.Code);
+    }
+
+    [Fact]
+    public async Task DuplicateEmail_DoesNotPublishEvent()
+    {
+        await Handle("user@example.com", "password123");
+        await Handle("user@example.com", "other-password");
+
+        Assert.Single(_eventBus.Published);
+    }
+
+    [Fact]
+    public async Task InvalidEmail_ReturnsInvalidEmail()
+    {
+        var result = await Handle("not-an-email", "password123");
+
+        Assert.True(result.IsFailure);
+        Assert.Equal(AuthFailures.InvalidEmail.Code, result.Error.Code);
+    }
+}


### PR DESCRIPTION
Add unit and functional tests for the **register** endpoint

- Unit tests for `RegisterHandler`: covers successful registration, duplicate email, and validation error cases
- Functional tests for `POST /auth/register`: validates response shape, created user and tokens, error codes end-to-end
> - [x]  Do not merge into main before #173 is merged.