### PR TITLE
Test/auth/oauth

### DIFF
--- a/services/auth/src/Auth.Infrastructure/Auth.Infrastructure.csproj
+++ b/services/auth/src/Auth.Infrastructure/Auth.Infrastructure.csproj
@@ -21,4 +21,10 @@
         <Nullable>enable</Nullable>
     </PropertyGroup>
 
+    <ItemGroup>
+        <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+            <_Parameter1>Auth.UnitTests</_Parameter1>
+        </AssemblyAttribute>
+    </ItemGroup>
+
 </Project>

--- a/services/auth/tests/Auth.FunctionalTests/Endpoints/OAuthCallbackTests.cs
+++ b/services/auth/tests/Auth.FunctionalTests/Endpoints/OAuthCallbackTests.cs
@@ -104,6 +104,16 @@ public sealed class OAuthCallbackTests(AuthApiFactory factory) : IClassFixture<A
     }
 
     [Fact]
+    public async Task UpstreamError_Returns502()
+    {
+        factory.OAuthClient.SetupFailure(AuthFailures.OAuthUpstreamError);
+
+        var resp = await DoFullCallback();
+
+        Assert.Equal(HttpStatusCode.BadGateway, resp.StatusCode);
+    }
+
+    [Fact]
     public async Task UnknownProvider_Returns400()
     {
         var client = CreateClient();

--- a/services/auth/tests/Auth.FunctionalTests/Endpoints/OAuthCallbackTests.cs
+++ b/services/auth/tests/Auth.FunctionalTests/Endpoints/OAuthCallbackTests.cs
@@ -1,0 +1,118 @@
+using System.Net;
+using Auth.Domain.AuthUser;
+using Auth.Domain.Results;
+using Auth.FunctionalTests.Infrastructure;
+using Xunit;
+
+namespace Auth.FunctionalTests.Endpoints;
+
+public sealed class OAuthCallbackTests(AuthApiFactory factory) : IClassFixture<AuthApiFactory>
+{
+    private HttpClient CreateClient() =>
+        factory.CreateClient(new() { AllowAutoRedirect = false });
+
+    private async Task<HttpResponseMessage> DoFullCallback(string provider = "fortytwo", string code = "code-xyz")
+    {
+        var client = CreateClient();
+
+        var initResp = await client.GetAsync($"/v1/oauth/{provider}");
+        var stateCookie = initResp.Headers
+            .GetValues("Set-Cookie")
+            .First(c => c.StartsWith("oauth_state="));
+
+        var stateValue = stateCookie.Split(';')[0].Split('=', 2)[1];
+
+        // 2. callback avec le même cookie et le même state
+        var req = new HttpRequestMessage(HttpMethod.Get,
+            $"/v1/oauth/{provider}/callback?code={code}&state={stateValue}");
+        req.Headers.Add("Cookie", $"oauth_state={stateValue}");
+
+        return await client.SendAsync(req);
+    }
+
+    [Fact]
+    public async Task ValidCallback_Returns302_WithAccessTokenAndRefreshCookie()
+    {
+        var resp = await DoFullCallback();
+
+        Assert.Equal(HttpStatusCode.Redirect, resp.StatusCode);
+
+        var location = resp.Headers.Location!.ToString();
+        Assert.Contains("access_token=", location);
+
+        var refreshCookie = resp.Headers.GetValues("Set-Cookie")
+            .FirstOrDefault(c => c.StartsWith("refresh_token="));
+        Assert.NotNull(refreshCookie);
+        Assert.Contains("HttpOnly", refreshCookie, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task NewUser_RedirectContainsNewUserFlag()
+    {
+        factory.OAuthClient.SetupSuccess(new OAuthUserInfo("new-user-42", "newuser@example.com", true));
+
+        var resp = await DoFullCallback();
+
+        Assert.Equal(HttpStatusCode.Redirect, resp.StatusCode);
+        Assert.Contains("new_user=true", resp.Headers.Location!.ToString());
+    }
+
+    [Fact]
+    public async Task ExistingUser_RedirectDoesNotContainNewUserFlag()
+    {
+        factory.OAuthClient.SetupSuccess(new OAuthUserInfo("existing-42", "existing@example.com", true));
+        await DoFullCallback();
+
+        var resp = await DoFullCallback();
+        Assert.Equal(HttpStatusCode.Redirect, resp.StatusCode);
+        Assert.DoesNotContain("new_user=true", resp.Headers.Location!.ToString());
+    }
+
+    [Fact]
+    public async Task StateMismatch_Returns400()
+    {
+        var client = CreateClient();
+
+        var req = new HttpRequestMessage(HttpMethod.Get,
+            "/v1/oauth/fortytwo/callback?code=xyz&state=wrong-state");
+        req.Headers.Add("Cookie", "oauth_state=correct-state");
+
+        var resp = await client.SendAsync(req);
+
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task MissingStateCookie_Returns400()
+    {
+        var client = CreateClient();
+
+        var resp = await client.GetAsync(
+            "/v1/oauth/fortytwo/callback?code=xyz&state=any-state");
+
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task ProviderError_Returns400()
+    {
+        factory.OAuthClient.SetupFailure(AuthFailures.OAuthProviderError);
+
+        var resp = await DoFullCallback();
+
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task UnknownProvider_Returns400()
+    {
+        var client = CreateClient();
+        var req = new HttpRequestMessage(HttpMethod.Get,
+            "/v1/oauth/twitter/callback?code=xyz&state=state");
+        req.Headers.Add("Cookie", "oauth_state=state");
+
+        var resp = await client.SendAsync(req);
+
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+}

--- a/services/auth/tests/Auth.FunctionalTests/Endpoints/OAuthLoginTests.cs
+++ b/services/auth/tests/Auth.FunctionalTests/Endpoints/OAuthLoginTests.cs
@@ -1,0 +1,37 @@
+using System.Net;
+using Auth.FunctionalTests.Infrastructure;
+using Xunit;
+
+namespace Auth.FunctionalTests.Endpoints;
+
+public sealed class OAuthLoginTests(AuthApiFactory factory) : IClassFixture<AuthApiFactory>
+{
+    [Theory]
+    [InlineData("fortytwo")]
+    [InlineData("google")]
+    [InlineData("github")]
+    public async Task ValidProvider_Returns302_WithLocationAndStateCookie(string provider)
+    {
+        var client = factory.CreateClient(new() { AllowAutoRedirect = false });
+
+        var resp = await client.GetAsync($"/v1/oauth/{provider}");
+
+        Assert.Equal(HttpStatusCode.Redirect, resp.StatusCode);
+        Assert.NotNull(resp.Headers.Location);
+        Assert.Contains("state=", resp.Headers.Location!.Query);
+
+        var setCookie = resp.Headers.GetValues("Set-Cookie").FirstOrDefault(c => c.StartsWith("oauth_state="));
+        Assert.NotNull(setCookie);
+        Assert.Contains("HttpOnly", setCookie, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task UnknownProvider_Returns400()
+    {
+        var client = factory.CreateClient(new() { AllowAutoRedirect = false });
+
+        var resp = await client.GetAsync("/v1/oauth/twitter");
+
+        Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+    }
+}

--- a/services/auth/tests/Auth.FunctionalTests/Infrastructure/AuthApiFactory.cs
+++ b/services/auth/tests/Auth.FunctionalTests/Infrastructure/AuthApiFactory.cs
@@ -1,5 +1,6 @@
 using Auth.Application.Abstractions;
 using Auth.Application.Abstractions.Events;
+using Auth.Application.Abstractions.OAuth;
 using Auth.Application.Abstractions.Persistence;
 using Auth.Application.Abstractions.Security;
 using Auth.Domain.AuthUser;
@@ -28,6 +29,8 @@ public sealed class AuthApiFactory : WebApplicationFactory<Program>
     }
 
     private readonly string _dbName = "auth-tests-" + Guid.NewGuid();
+
+    public FakeOAuthProviderClient OAuthClient { get; } = new();
 
     public async Task SeedEmailUserAsync(string email, string rawPassword)
     {
@@ -86,7 +89,7 @@ public sealed class AuthApiFactory : WebApplicationFactory<Program>
         {
             config.AddInMemoryCollection(new Dictionary<string, string?>
             {
-                ["App:BaseUrl"]       = "https://localhost:1443",
+                ["App:BaseUrl"] = "https://app.test",
 
                 ["Database:Host"]     = "test",
                 ["Database:Port"]     = "5432",
@@ -107,17 +110,18 @@ public sealed class AuthApiFactory : WebApplicationFactory<Program>
                 ["RefreshToken:ByteLength"] = "64",
                 ["RefreshToken:CookieName"] = "refresh_token",
 
-                ["OAuth:FortyTwo:ClientId"]     = "test",
-                ["OAuth:FortyTwo:ClientSecret"] = "test",
-                ["OAuth:FortyTwo:RedirectUri"]  = "https://localhost:1443/auth/callback/42",
+                ["OAuthStateCookie:CookieName"] = "oauth_state",
+                ["OAuthStateCookie:TtlMinutes"] = "10",
 
-                ["OAuth:Github:ClientId"]     = "test",
-                ["OAuth:Github:ClientSecret"] = "test",
-                ["OAuth:Github:RedirectUri"]  = "https://localhost:1443/auth/callback/github",
-
-                ["OAuth:Google:ClientId"]     = "test",
-                ["OAuth:Google:ClientSecret"] = "test",
-                ["OAuth:Google:RedirectUri"]  = "https://localhost:1443/auth/callback/google",
+                ["OAuth:FortyTwo:ClientId"]     = "test-client-id",
+                ["OAuth:FortyTwo:ClientSecret"] = "test-client-secret",
+                ["OAuth:FortyTwo:RedirectUri"]  = "https://app.test/callback",
+                ["OAuth:Google:ClientId"]       = "test-client-id",
+                ["OAuth:Google:ClientSecret"]   = "test-client-secret",
+                ["OAuth:Google:RedirectUri"]    = "https://app.test/callback",
+                ["OAuth:Github:ClientId"]       = "test-client-id",
+                ["OAuth:Github:ClientSecret"]   = "test-client-secret",
+                ["OAuth:Github:RedirectUri"]    = "https://app.test/callback",
             });
         });
 
@@ -128,6 +132,9 @@ public sealed class AuthApiFactory : WebApplicationFactory<Program>
 
             services.RemoveAll<IEventBus>();
             services.AddSingleton<IEventBus, NoopEventBus>();
+
+            foreach (var provider in new[] { OAuthProvider.FortyTwo, OAuthProvider.Google, OAuthProvider.Github })
+                services.AddKeyedSingleton<IOAuthProviderClient>(provider, OAuthClient);
         });
     }
 
@@ -169,4 +176,21 @@ public sealed class AuthApiFactory : WebApplicationFactory<Program>
         public Task PublishAsync<T>(T message, CancellationToken cancellationToken = default)
             where T : class, IEvent => Task.CompletedTask;
     }
+}
+
+public sealed class FakeOAuthProviderClient : IOAuthProviderClient
+{
+    private Result<OAuthUserInfo> _exchangeResult =
+        new OAuthUserInfo("fake-provider-id", "fake@example.com", true);
+
+    public Uri BuildAuthorizationUrl(string state)
+        => new($"https://fake-provider.example.com/oauth/authorize?state={state}");
+
+    public Task<Result<OAuthUserInfo>> ExchangeCodeAsync(
+        string code, string state, CancellationToken cancellationToken = default)
+        => Task.FromResult(_exchangeResult);
+
+    public void SetupSuccess(OAuthUserInfo info) => _exchangeResult = info;
+
+    public void SetupFailure(Failure failure) => _exchangeResult = failure;
 }

--- a/services/auth/tests/Auth.UnitTests/Application/OAuthCallbackHandlerTests.cs
+++ b/services/auth/tests/Auth.UnitTests/Application/OAuthCallbackHandlerTests.cs
@@ -94,6 +94,20 @@ public sealed class OAuthCallbackHandlerTests
     }
 
     [Fact]
+    public async Task UpstreamError_PropagatesFailure()
+    {
+        var (sp, client) = BuildServiceProvider();
+        client.SetupFailure(AuthFailures.OAuthUpstreamError);
+        var handler = BuildHandler(sp);
+
+        var result = await handler.HandleAsync(
+            new OAuthCallbackCommand(OAuthProvider.FortyTwo, "code", "state"));
+
+        Assert.True(result.IsFailure);
+        Assert.Equal(AuthFailures.OAuthUpstreamError.Code, result.Error.Code);
+    }
+
+    [Fact]
     public async Task UnknownProvider_ReturnsFailure()
     {
         var sp = new ServiceCollection().BuildServiceProvider();

--- a/services/auth/tests/Auth.UnitTests/Application/OAuthCallbackHandlerTests.cs
+++ b/services/auth/tests/Auth.UnitTests/Application/OAuthCallbackHandlerTests.cs
@@ -1,0 +1,123 @@
+using Auth.Application.Abstractions.Messaging;
+using Auth.Application.Events;
+using Auth.Application.Features.OAuth;
+using Auth.Domain.AuthUser;
+using Auth.Domain.Results;
+using Auth.UnitTests.Fakes;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Auth.UnitTests.Application;
+
+public sealed class OAuthCallbackHandlerTests
+{
+    private static (IServiceProvider sp, FakeOAuthProviderClient client) BuildServiceProvider()
+    {
+        var client = new FakeOAuthProviderClient();
+        var services = new ServiceCollection();
+        services.AddKeyedSingleton<Auth.Application.Abstractions.OAuth.IOAuthProviderClient>(
+            OAuthProvider.FortyTwo, client);
+        return (services.BuildServiceProvider(), client);
+    }
+
+    private static ICommandHandler<OAuthCallbackCommand, Result<OAuthCallbackResult>> BuildHandler(
+        IServiceProvider sp,
+        FakeAuthUserRepository? repo = null,
+        FakeEventBus? eventBus = null)
+    {
+        return HandlerFactory.CreateCommand<OAuthCallbackCommand, Result<OAuthCallbackResult>>(
+            sp,
+            repo ?? new FakeAuthUserRepository(),
+            new FakeTokenGenerator(),
+            new FakeSecretHasher(),
+            new FakeIdGenerator(),
+            new FakeClock(),
+            eventBus ?? new FakeEventBus());
+    }
+
+    [Fact]
+    public async Task NewUser_CreatesUserAndPublishesRegisteredEvent()
+    {
+        var (sp, _) = BuildServiceProvider();
+        var repo = new FakeAuthUserRepository();
+        var eventBus = new FakeEventBus();
+        var handler = BuildHandler(sp, repo, eventBus);
+
+        var result = await handler.HandleAsync(
+            new OAuthCallbackCommand(OAuthProvider.FortyTwo, "code-xyz", "state-abc"));
+
+        Assert.True(result.Succeeded);
+        Assert.True(result.Value.IsNewUser);
+        Assert.Single(repo.Store);
+        Assert.Single(eventBus.Published);
+        Assert.IsType<UserRegisteredEvent>(eventBus.Published[0]);
+    }
+
+    [Fact]
+    public async Task ExistingUser_ReturnsTokensAndDoesNotPublishEvent()
+    {
+        var (sp, _) = BuildServiceProvider();
+        var repo = new FakeAuthUserRepository();
+        var eventBus = new FakeEventBus();
+        var idGen = new FakeIdGenerator();
+
+        var existingUser = AuthUser.CreateOAuthUser(
+            idGen.NextId(),
+            OAuthProvider.FortyTwo,
+            "fake-provider-id",
+            DateTimeOffset.UtcNow).Value;
+        await repo.AddAsync(existingUser);
+
+        var handler = BuildHandler(sp, repo, eventBus);
+
+        var result = await handler.HandleAsync(
+            new OAuthCallbackCommand(OAuthProvider.FortyTwo, "code-xyz", "state-abc"));
+
+        Assert.True(result.Succeeded);
+        Assert.False(result.Value.IsNewUser);
+        Assert.Single(repo.Store);
+        Assert.Empty(eventBus.Published);
+    }
+
+    [Fact]
+    public async Task ProviderError_ReturnsFailure()
+    {
+        var (sp, client) = BuildServiceProvider();
+        client.SetupFailure(AuthFailures.OAuthProviderError);
+        var handler = BuildHandler(sp);
+
+        var result = await handler.HandleAsync(
+            new OAuthCallbackCommand(OAuthProvider.FortyTwo, "bad-code", "state"));
+
+        Assert.True(result.IsFailure);
+        Assert.Equal(AuthFailures.OAuthProviderError.Code, result.Error.Code);
+    }
+
+    [Fact]
+    public async Task UnknownProvider_ReturnsFailure()
+    {
+        var sp = new ServiceCollection().BuildServiceProvider();
+        var handler = BuildHandler(sp);
+
+        var result = await handler.HandleAsync(
+            new OAuthCallbackCommand(OAuthProvider.Unknown, "code", "state"));
+
+        Assert.True(result.IsFailure);
+        Assert.Equal(AuthFailures.InvalidOAuthProvider.Code, result.Error.Code);
+    }
+
+    [Fact]
+    public async Task AccessToken_ContainsUserId()
+    {
+        var (sp, _) = BuildServiceProvider();
+        var repo = new FakeAuthUserRepository();
+        var handler = BuildHandler(sp, repo);
+
+        var result = await handler.HandleAsync(
+            new OAuthCallbackCommand(OAuthProvider.FortyTwo, "code", "state"));
+
+        Assert.True(result.Succeeded);
+        var userId = repo.Store.Keys.Single();
+        Assert.Equal($"access-token-{userId}", result.Value.AccessToken);
+    }
+}

--- a/services/auth/tests/Auth.UnitTests/Application/OAuthLoginHandlerTests.cs
+++ b/services/auth/tests/Auth.UnitTests/Application/OAuthLoginHandlerTests.cs
@@ -1,0 +1,73 @@
+using Auth.Application.Features.OAuth;
+using Auth.Domain.AuthUser;
+using Auth.Domain.Results;
+using Auth.UnitTests.Fakes;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Auth.UnitTests.Application;
+
+public sealed class OAuthLoginHandlerTests
+{
+    private static IServiceProvider BuildServiceProvider(
+        OAuthProvider provider, FakeOAuthProviderClient client)
+    {
+        var services = new ServiceCollection();
+        services.AddKeyedSingleton<Auth.Application.Abstractions.OAuth.IOAuthProviderClient>(provider, client);
+        return services.BuildServiceProvider();
+    }
+
+    [Fact]
+    public async Task ValidProvider_ReturnsRedirectUriAndState()
+    {
+        var fakeClient = new FakeOAuthProviderClient();
+        var sp = BuildServiceProvider(OAuthProvider.FortyTwo, fakeClient);
+        var handler = HandlerFactory.CreateCommand<OAuthLoginCommand, Result<OAuthLoginResult>>(sp);
+
+        var result = await handler.HandleAsync(new OAuthLoginCommand(OAuthProvider.FortyTwo));
+
+        Assert.True(result.Succeeded);
+        Assert.NotNull(result.Value.RedirectUri);
+        Assert.False(string.IsNullOrEmpty(result.Value.State));
+    }
+
+    [Fact]
+    public async Task UnknownProvider_ReturnsFailure()
+    {
+        var sp = new ServiceCollection().BuildServiceProvider();
+        var handler = HandlerFactory.CreateCommand<OAuthLoginCommand, Result<OAuthLoginResult>>(sp);
+
+        var result = await handler.HandleAsync(new OAuthLoginCommand(OAuthProvider.Unknown));
+
+        Assert.True(result.IsFailure);
+        Assert.Equal(AuthFailures.InvalidOAuthProvider.Code, result.Error.Code);
+    }
+
+    [Fact]
+    public async Task UnregisteredProvider_ReturnsFailure()
+    {
+        // ? Valid provider but not registered in DI
+        var sp = new ServiceCollection().BuildServiceProvider();
+        var handler = HandlerFactory.CreateCommand<OAuthLoginCommand, Result<OAuthLoginResult>>(sp);
+
+        var result = await handler.HandleAsync(new OAuthLoginCommand(OAuthProvider.Github));
+
+        Assert.True(result.IsFailure);
+        Assert.Equal(AuthFailures.InvalidOAuthProvider.Code, result.Error.Code);
+    }
+
+    [Fact]
+    public async Task TwoConsecutiveCalls_ProduceDifferentStates()
+    {
+        var fakeClient = new FakeOAuthProviderClient();
+        var sp = BuildServiceProvider(OAuthProvider.Google, fakeClient);
+        var handler = HandlerFactory.CreateCommand<OAuthLoginCommand, Result<OAuthLoginResult>>(sp);
+
+        var r1 = await handler.HandleAsync(new OAuthLoginCommand(OAuthProvider.Google));
+        var r2 = await handler.HandleAsync(new OAuthLoginCommand(OAuthProvider.Google));
+
+        Assert.True(r1.Succeeded);
+        Assert.True(r2.Succeeded);
+        Assert.NotEqual(r1.Value.State, r2.Value.State);
+    }
+}

--- a/services/auth/tests/Auth.UnitTests/Fakes/FakeOAuthProviderClient.cs
+++ b/services/auth/tests/Auth.UnitTests/Fakes/FakeOAuthProviderClient.cs
@@ -1,0 +1,22 @@
+using Auth.Application.Abstractions.OAuth;
+using Auth.Domain.AuthUser;
+using Auth.Domain.Results;
+
+namespace Auth.UnitTests.Fakes;
+
+internal sealed class FakeOAuthProviderClient : IOAuthProviderClient
+{
+    private Result<OAuthUserInfo> _exchangeResult =
+        new OAuthUserInfo("fake-provider-id", "fake@example.com", true);
+
+    public Uri BuildAuthorizationUrl(string state)
+        => new($"https://fake-provider.example.com/oauth/authorize?state={state}");
+
+    public Task<Result<OAuthUserInfo>> ExchangeCodeAsync(
+        string code, string state, CancellationToken cancellationToken = default)
+        => Task.FromResult(_exchangeResult);
+
+    public void SetupSuccess(OAuthUserInfo info) => _exchangeResult = info;
+
+    public void SetupFailure(Failure failure) => _exchangeResult = failure;
+}

--- a/services/auth/tests/Auth.UnitTests/Infrastructure/FakeHttpMessageHandler.cs
+++ b/services/auth/tests/Auth.UnitTests/Infrastructure/FakeHttpMessageHandler.cs
@@ -1,0 +1,8 @@
+namespace Auth.UnitTests.Infrastructure;
+
+internal sealed class FakeHttpMessageHandler(HttpResponseMessage response) : HttpMessageHandler
+{
+    protected override Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request, CancellationToken cancellationToken)
+        => Task.FromResult(response);
+}

--- a/services/auth/tests/Auth.UnitTests/Infrastructure/GoogleOAuthProviderTests.cs
+++ b/services/auth/tests/Auth.UnitTests/Infrastructure/GoogleOAuthProviderTests.cs
@@ -1,0 +1,100 @@
+using System.Net;
+using System.Text;
+using Auth.Domain.Results;
+using Auth.Infrastructure.OAuth;
+using Auth.Infrastructure.Options.OAuth;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Auth.UnitTests.Infrastructure;
+
+public sealed class GoogleOAuthProviderTests
+{
+    private static GoogleOAuthProvider BuildProvider(string idToken)
+    {
+        var json = $$"""{"access_token":"tok","id_token":"{{idToken}}"}""";
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        };
+        var opts = Options.Create(new GoogleOAuthOptions
+        {
+            ClientId              = "id",
+            ClientSecret          = "secret",
+            RedirectUri           = "https://test.example.com/cb",
+            TokenEndpoint         = "https://oauth.test/token",
+            AuthorizationEndpoint = "https://oauth.test/auth",
+            UserEndpoint          = "null",
+        });
+        return new GoogleOAuthProvider(new HttpClient(new FakeHttpMessageHandler(response)), opts);
+    }
+
+    private static string Base64UrlEncode(string json)
+    {
+        var bytes = Encoding.UTF8.GetBytes(json);
+        return Convert.ToBase64String(bytes).TrimEnd('=').Replace('+', '-').Replace('/', '_');
+    }
+
+    private static string BuildIdToken(string payloadJson)
+        => $"{Base64UrlEncode("{\"alg\":\"RS256\"}")}.{Base64UrlEncode(payloadJson)}.fakesig";
+
+    [Fact]
+    public async Task ExchangeCode_ValidToken_ReturnsUserInfo()
+    {
+        var idToken = BuildIdToken("{\"sub\":\"99\",\"email\":\"u@test.com\",\"email_verified\":true}");
+        var provider = BuildProvider(idToken);
+
+        var result = await provider.ExchangeCodeAsync("code", "state");
+
+        Assert.True(result.Succeeded);
+        Assert.Equal("99", result.Value.ProviderId);
+        Assert.Equal("u@test.com", result.Value.Email);
+        Assert.True(result.Value.EmailVerified);
+    }
+
+    [Fact]
+    public async Task ExchangeCode_IdTokenWithoutDots_ReturnsUpstreamError()
+    {
+        var provider = BuildProvider("not-a-jwt");
+
+        var result = await provider.ExchangeCodeAsync("code", "state");
+
+        Assert.True(result.IsFailure);
+        Assert.Equal(AuthFailures.OAuthUpstreamError.Code, result.Error.Code);
+    }
+
+    [Fact]
+    public async Task ExchangeCode_InvalidBase64InPayload_ReturnsUpstreamError()
+    {
+        var provider = BuildProvider("header.!!!invalid!!!.sig");
+
+        var result = await provider.ExchangeCodeAsync("code", "state");
+
+        Assert.True(result.IsFailure);
+        Assert.Equal(AuthFailures.OAuthUpstreamError.Code, result.Error.Code);
+    }
+
+    [Fact]
+    public async Task ExchangeCode_EmptySub_ReturnsUpstreamError()
+    {
+        var idToken = BuildIdToken("{\"sub\":\"\",\"email\":\"u@test.com\",\"email_verified\":true}");
+        var provider = BuildProvider(idToken);
+
+        var result = await provider.ExchangeCodeAsync("code", "state");
+
+        Assert.True(result.IsFailure);
+        Assert.Equal(AuthFailures.OAuthUpstreamError.Code, result.Error.Code);
+    }
+
+    [Fact]
+    public async Task ExchangeCode_NullPayload_ReturnsUpstreamError()
+    {
+        var idToken = $"{Base64UrlEncode("{\"alg\":\"RS256\"}")}.{Base64UrlEncode("null")}.sig";
+        var provider = BuildProvider(idToken);
+
+        var result = await provider.ExchangeCodeAsync("code", "state");
+
+        Assert.True(result.IsFailure);
+        Assert.Equal(AuthFailures.OAuthUpstreamError.Code, result.Error.Code);
+    }
+}

--- a/services/auth/tests/Auth.UnitTests/Infrastructure/OAuthProviderBaseTests.cs
+++ b/services/auth/tests/Auth.UnitTests/Infrastructure/OAuthProviderBaseTests.cs
@@ -1,0 +1,97 @@
+using System.Net;
+using Auth.Domain.AuthUser;
+using Auth.Domain.Results;
+using Auth.Infrastructure.OAuth;
+using Xunit;
+
+namespace Auth.UnitTests.Infrastructure;
+
+// Minimal concrete subclass that exposes Send<T> for testing.
+sealed class TestableOAuthProvider(HttpClient http) : OAuthProviderBase(http)
+{
+    public override Uri BuildAuthorizationUrl(string state) => new("https://test.example.com");
+
+    public override Task<Result<OAuthUserInfo>> ExchangeCodeAsync(
+        string code, string state, CancellationToken ct = default)
+        => throw new NotImplementedException();
+
+    public Task<Result<T>> CallSend<T>(HttpRequestMessage request, CancellationToken ct = default)
+        => Send<T>(request, ct);
+}
+
+public sealed class OAuthProviderBaseTests
+{
+    private sealed record Payload(string Name);
+
+    private static TestableOAuthProvider BuildProvider(HttpStatusCode status, string? body = null)
+    {
+        var response = new HttpResponseMessage(status);
+        if (body is not null)
+            response.Content = new StringContent(body, System.Text.Encoding.UTF8, "application/json");
+        return new TestableOAuthProvider(new HttpClient(new FakeHttpMessageHandler(response)));
+    }
+
+    [Fact]
+    public async Task Provider4xxResponse_ReturnsOAuthProviderError()
+    {
+        var provider = BuildProvider(HttpStatusCode.BadRequest);
+        using var req = new HttpRequestMessage(HttpMethod.Get, "https://p.test/api");
+
+        var result = await provider.CallSend<Payload>(req);
+
+        Assert.True(result.IsFailure);
+        Assert.Equal(AuthFailures.OAuthProviderError.Code, result.Error.Code);
+    }
+
+    [Theory]
+    [InlineData(500)]
+    [InlineData(502)]
+    [InlineData(503)]
+    [InlineData(504)]
+    public async Task Provider5xxResponse_ReturnsOAuthUpstreamError(int statusCode)
+    {
+        var provider = BuildProvider((HttpStatusCode)statusCode);
+        using var req = new HttpRequestMessage(HttpMethod.Get, "https://p.test/api");
+
+        var result = await provider.CallSend<Payload>(req);
+
+        Assert.True(result.IsFailure);
+        Assert.Equal(AuthFailures.OAuthUpstreamError.Code, result.Error.Code);
+    }
+
+    [Fact]
+    public async Task MalformedJsonResponse_ReturnsOAuthUpstreamError()
+    {
+        var provider = BuildProvider(HttpStatusCode.OK, "not json {{{{");
+        using var req = new HttpRequestMessage(HttpMethod.Get, "https://p.test/api");
+
+        var result = await provider.CallSend<Payload>(req);
+
+        Assert.True(result.IsFailure);
+        Assert.Equal(AuthFailures.OAuthUpstreamError.Code, result.Error.Code);
+    }
+
+    [Fact]
+    public async Task NullJsonResponse_ReturnsOAuthUpstreamError()
+    {
+        var provider = BuildProvider(HttpStatusCode.OK, "null");
+        using var req = new HttpRequestMessage(HttpMethod.Get, "https://p.test/api");
+
+        var result = await provider.CallSend<Payload>(req);
+
+        Assert.True(result.IsFailure);
+        Assert.Equal(AuthFailures.OAuthUpstreamError.Code, result.Error.Code);
+    }
+
+    [Fact]
+    public async Task ValidJsonResponse_ReturnsDeserializedData()
+    {
+        var provider = BuildProvider(HttpStatusCode.OK, "{\"name\":\"hello\"}");
+        using var req = new HttpRequestMessage(HttpMethod.Get, "https://p.test/api");
+
+        var result = await provider.CallSend<Payload>(req);
+
+        Assert.True(result.Succeeded);
+        Assert.Equal("hello", result.Value.Name);
+    }
+}


### PR DESCRIPTION
Add unit and functional tests for the **OAuth** endpoints

- Extends `AuthApiFactory` with `FakeOAuthProviderClient` in both unit and functional assemblies
- Unit tests for `OAuthLoginHandler` and `OAuthCallbackHandler`: covers happy path, unknown user, and provider error cases
- Functional tests for `GET /auth/oauth/{provider}` and `GET /auth/oauth/{provider}/callback`: redirect behavior, cookie issuance, and error responses
- Additional tests for 400 vs 502 error classification in `OAuthProviderBase` and `GoogleOAuthProvider`, using a `FakeHttpMessageHandler` to simulate provider responses

> - [x] Do not merge into main before #173 is merged.