### PR TITLE
Fix/auth/oauth

### DIFF
--- a/services/auth/.env.example
+++ b/services/auth/.env.example
@@ -30,3 +30,17 @@ POSTGRES_PASSWORD=
 POSTGRES_DB=
 POSTGRES_HOST=
 POSTGRES_PORT=
+
+#    ╭─────────────────────────────────────────────────────────────────────╮
+#    │                     OAuth configuration.                            │
+#    │         ───── FortyTwo, Google and GitHub credentials ─────         │
+#    ╰─────────────────────────────────────────────────────────────────────╯
+
+OAuth__FortyTwo__ClientId=
+OAuth__FortyTwo__ClientSecret=
+
+OAuth__Google__ClientId=
+OAuth__Google__ClientSecret=
+
+OAuth__Github__ClientId=
+OAuth__Github__ClientSecret=

--- a/services/auth/src/Auth.Application/Abstractions/Persistence/IAuthUserRepository.cs
+++ b/services/auth/src/Auth.Application/Abstractions/Persistence/IAuthUserRepository.cs
@@ -2,8 +2,6 @@ using Auth.Domain.AuthUser;
 
 namespace Auth.Application.Abstractions.Persistence;
 
-#nullable enable
-
 public interface IAuthUserRepository
 {
     Task<AuthUser?> GetByIdAsync(long id, CancellationToken cancellationToken = default);

--- a/services/auth/src/Auth.Application/Features/OAuth/OAuthCallbackHandler.cs
+++ b/services/auth/src/Auth.Application/Features/OAuth/OAuthCallbackHandler.cs
@@ -73,7 +73,6 @@ internal sealed class OAuthCallbackHandler(
         return new OAuthCallbackResult(accessToken, rawRefreshToken, isNewUser);
     }
 
-#nullable enable
     private static void UpdateOAuthUser(DateTimeOffset now, AuthUser existing, string ?email, bool verified)
     {
         if (!string.IsNullOrWhiteSpace(email) && (existing.Email is null || existing.Email.Value != email))
@@ -82,7 +81,6 @@ internal sealed class OAuthCallbackHandler(
         if (existing.Email is not null && !existing.Email.IsVerified && verified)
             existing.VerifyEmail(now);
     }
-#nullable disable
 
     private async Task<Result<AuthUser>> CreateOAuthUser(DateTimeOffset now, OAuthProvider provider, OAuthUserInfo userInfo, CancellationToken ct)
     {

--- a/services/auth/src/Auth.Application/Features/OAuth/OAuthCallbackHandler.cs
+++ b/services/auth/src/Auth.Application/Features/OAuth/OAuthCallbackHandler.cs
@@ -58,7 +58,7 @@ internal sealed class OAuthCallbackHandler(
 
         var rawRefreshToken = tokenGenerator.GenerateRefreshToken();
         var setTokenResult = user.SetRefreshToken(
-            hasher.Hash(rawRefreshToken),
+            hasher.HashDeterministic(rawRefreshToken),
             now,
             now.Add(tokenGenerator.GetRefreshTokenLifetime()));
         if (setTokenResult.IsFailure)

--- a/services/auth/src/Auth.Application/Features/OAuth/OAuthCallbackHandler.cs
+++ b/services/auth/src/Auth.Application/Features/OAuth/OAuthCallbackHandler.cs
@@ -42,18 +42,17 @@ internal sealed class OAuthCallbackHandler(
 
         if (existingUser is not null)
         {
+            UpdateOAuthUser(now, existingUser, userInfo.Email, userInfo.EmailVerified == true);
             user = existingUser;
             isNewUser = false;
         }
         else
         {
-            var id = idGenerator.NextId();
-            var createResult = AuthUser.CreateOAuthUser(id, command.Provider, userInfo.ProviderId, now);
-            if (createResult.IsFailure)
-                return createResult.Error;
+            var newUserResult = await CreateOAuthUser(now, command.Provider, userInfo, cancellationToken);
+            if (newUserResult.IsFailure)
+                return newUserResult.Error;
 
-            user = createResult.Value;
-            await repository.AddAsync(user, cancellationToken);
+            user = newUserResult.Value;
             isNewUser = true;
         }
 
@@ -72,5 +71,29 @@ internal sealed class OAuthCallbackHandler(
 
         var accessToken = tokenGenerator.GenerateAccessToken(user.Id);
         return new OAuthCallbackResult(accessToken, rawRefreshToken, isNewUser);
+    }
+
+#nullable enable
+    private static void UpdateOAuthUser(DateTimeOffset now, AuthUser existing, string ?email, bool verified)
+    {
+        if (!string.IsNullOrWhiteSpace(email) && (existing.Email is null || existing.Email.Value != email))
+            existing.SetEmail(now, email, verified);
+
+        if (existing.Email is not null && !existing.Email.IsVerified && verified)
+            existing.VerifyEmail(now);
+    }
+#nullable disable
+
+    private async Task<Result<AuthUser>> CreateOAuthUser(DateTimeOffset now, OAuthProvider provider, OAuthUserInfo userInfo, CancellationToken ct)
+    {
+        var id = idGenerator.NextId();
+        var createResult = AuthUser.CreateOAuthUser(id, provider, userInfo.ProviderId, now);
+        if (createResult.IsFailure)
+            return createResult.Error;
+
+        var user = createResult.Value;
+        await repository.AddAsync(user, ct);
+        UpdateOAuthUser(now, user, userInfo.Email, userInfo.EmailVerified == true);
+        return user;
     }
 }

--- a/services/auth/src/Auth.Domain/AuthUser/AuthUser.cs
+++ b/services/auth/src/Auth.Domain/AuthUser/AuthUser.cs
@@ -126,6 +126,26 @@ public sealed class AuthUser
         UpdatedAt = now;
     }
 
+    public void VerifyEmail(DateTimeOffset now)
+    {
+        if (Email is not null)
+            Email = Email.Verify();
+
+        UpdatedAt = now;
+    }
+
+    public Result SetEmail(DateTimeOffset now, string email, bool ?verified = null)
+    {
+        var emailResult = Email.Create(email);
+        if (emailResult.IsFailure)
+            return emailResult.Error;
+
+        Email = verified == true ? emailResult.Value.Verify() : emailResult.Value;
+        UpdatedAt = now;
+
+        return Result.Ok();
+    }
+
     public void SoftDelete(DateTimeOffset now)
     {
         DeletedAt = now;

--- a/services/auth/src/Auth.Domain/AuthUser/AuthUser.cs
+++ b/services/auth/src/Auth.Domain/AuthUser/AuthUser.cs
@@ -2,8 +2,6 @@ using Auth.Domain.Results;
 
 namespace Auth.Domain.AuthUser;
 
-#nullable enable
-
 public sealed class AuthUser
 {
     public AuthUser() {}

--- a/services/auth/src/Auth.Domain/AuthUser/Email.cs
+++ b/services/auth/src/Auth.Domain/AuthUser/Email.cs
@@ -15,7 +15,6 @@ public sealed record Email
     public string Value { get; }
     public bool   IsVerified { get; }
 
-#nullable enable
     public static Result<Email> Create(string? value)
     {
         if (string.IsNullOrWhiteSpace(value))
@@ -28,7 +27,6 @@ public sealed record Email
 
         return new Email(normalized, false);
     }
-#nullable disable
 
     public Email Verify() => new(Value, true);
 

--- a/services/auth/src/Auth.Domain/AuthUser/OAuthIdentity.cs
+++ b/services/auth/src/Auth.Domain/AuthUser/OAuthIdentity.cs
@@ -21,7 +21,6 @@ public sealed record OAuthIdentity
     public OAuthProvider Provider { get; }
     public string        Id { get; }
 
-#nullable enable
     public static Result<OAuthIdentity> Create(OAuthProvider? provider, string? oauthId)
     {
         if (provider is null)

--- a/services/auth/src/Auth.Domain/AuthUser/OAuthProviderExtensions.cs
+++ b/services/auth/src/Auth.Domain/AuthUser/OAuthProviderExtensions.cs
@@ -1,0 +1,23 @@
+namespace Auth.Domain.AuthUser;
+
+public static class OAuthProviderExtensions
+{
+    public static string ToSlug(this OAuthProvider provider) => provider switch
+    {
+        OAuthProvider.Github   => "github",
+        OAuthProvider.Google   => "google",
+        OAuthProvider.FortyTwo => "fortytwo",
+        _                      => provider.ToString().ToLowerInvariant()
+    };
+
+    public static bool TryFromSlug(string slug, out OAuthProvider provider)
+    {
+        switch (slug.ToLowerInvariant())
+        {
+            case "github":   provider = OAuthProvider.Github;   return true;
+            case "google":   provider = OAuthProvider.Google;   return true;
+            case "fortytwo": provider = OAuthProvider.FortyTwo; return true;
+            default:         provider = OAuthProvider.Unknown;  return false;
+        }
+    }
+}

--- a/services/auth/src/Auth.Domain/AuthUser/OAuthUserInfo.cs
+++ b/services/auth/src/Auth.Domain/AuthUser/OAuthUserInfo.cs
@@ -1,4 +1,3 @@
 namespace Auth.Domain.AuthUser;
 
-#nullable enable
 public sealed record OAuthUserInfo(string ProviderId, string? Email, bool? EmailVerified);

--- a/services/auth/src/Auth.Domain/AuthUser/StoredRefreshToken.cs
+++ b/services/auth/src/Auth.Domain/AuthUser/StoredRefreshToken.cs
@@ -23,8 +23,6 @@ public sealed record StoredRefreshToken
     public DateTimeOffset ExpiresAt { get; }
     public bool           Revoked { get; }
 
-#nullable enable
-
     public static Result<StoredRefreshToken> Create(
         string? hash,
         DateTimeOffset issuedAt,

--- a/services/auth/src/Auth.Domain/Results/Result.cs
+++ b/services/auth/src/Auth.Domain/Results/Result.cs
@@ -34,7 +34,6 @@ public sealed class Result<TValue>(bool isSuccess, TValue value, Failure error) 
     public static implicit operator Result<TValue>(TValue value) => Ok(value);
     public static implicit operator Result<TValue>(Failure failure) => Fail<TValue>(failure);
 
-#nullable enable
     public static implicit operator TValue?(Result<TValue> result) => result switch
     {
         { Succeeded: true, Value: var value } => value,

--- a/services/auth/src/Auth.Infrastructure/OAuth/FortyTwoOAuthProvider.cs
+++ b/services/auth/src/Auth.Infrastructure/OAuth/FortyTwoOAuthProvider.cs
@@ -57,7 +57,6 @@ internal sealed class FortyTwoOAuthProvider(
         [property: JsonPropertyName("expires_in")]   int ExpiresIn,
         [property: JsonPropertyName("created_at")]   long CreatedAt);
 
-#nullable enable
     private sealed record FortyTwoUserResp(
         [property: JsonPropertyName("id")]    long    Id,
         [property: JsonPropertyName("email")] string? Email);

--- a/services/auth/src/Auth.Infrastructure/OAuth/GithubOAuthProvider.cs
+++ b/services/auth/src/Auth.Infrastructure/OAuth/GithubOAuthProvider.cs
@@ -62,7 +62,6 @@ internal sealed class GithubOAuthProvider(
         return new OAuthUserInfo(user.Id.ToString(), email, verified);
     }
 
-#nullable enable
     private async Task<Result<(bool? Verified, string? Email)>> GetEmailFields(string accessToken, CancellationToken ct)
     {
         var result = await FetchAuthenticated<IReadOnlyList<GithubEmailResp>>(

--- a/services/auth/src/Auth.Infrastructure/OAuth/GoogleOAuthProvider.cs
+++ b/services/auth/src/Auth.Infrastructure/OAuth/GoogleOAuthProvider.cs
@@ -76,7 +76,6 @@ internal sealed class GoogleOAuthProvider(
         [property: JsonPropertyName("access_token")] string AccessToken,
         [property: JsonPropertyName("id_token")]     string IdToken);
 
-#nullable enable
     private sealed record GoogleIdTokenPayload(
         [property: JsonPropertyName("sub")]   string  Sub,
         [property: JsonPropertyName("email")] string? Email,

--- a/services/auth/src/Auth.Infrastructure/OAuth/OAuthProviderBase.cs
+++ b/services/auth/src/Auth.Infrastructure/OAuth/OAuthProviderBase.cs
@@ -38,7 +38,7 @@ internal abstract class OAuthProviderBase(HttpClient http) : IOAuthProviderClien
     protected async Task<Result<T>> Send<T>(HttpRequestMessage request, CancellationToken ct)
     {
         // ? Intentionnaly let the exception throw => 500
-        var response = await http.SendAsync(request, ct); 
+        using var response = await http.SendAsync(request, ct); 
 
         if (!response.IsSuccessStatusCode)
             return (int)response.StatusCode >= 500

--- a/services/auth/src/Auth.Infrastructure/Options/Oauth/GoogleOAuthOptions.cs
+++ b/services/auth/src/Auth.Infrastructure/Options/Oauth/GoogleOAuthOptions.cs
@@ -5,7 +5,7 @@ public sealed class GoogleOAuthOptions : OAuthProviderOptions, IOptions
     public static string SectionName => "OAuth:Google";
 
     public override required string AuthorizationEndpoint
-        { get; init; } = "https://accounts.google.com/o/oauth2/v2/auth";
+        { get; init; } = "https://accounts.google.com/o/oauth2/auth";
 
     public override required string TokenEndpoint
         { get; init; } = "https://oauth2.googleapis.com/token";

--- a/services/auth/src/Auth.Infrastructure/Options/RefreshTokenOptions.cs
+++ b/services/auth/src/Auth.Infrastructure/Options/RefreshTokenOptions.cs
@@ -2,8 +2,6 @@ using System.ComponentModel.DataAnnotations;
 
 namespace Auth.Infrastructure.Options;
 
-#nullable enable
-
 [Serializable]
 [AttributeUsage(AttributeTargets.Property, AllowMultiple = false, Inherited = true)]
 public class EvenNumberAttribute : ValidationAttribute

--- a/services/auth/src/Auth.Persistence/Repositories/AuthUserRepository.cs
+++ b/services/auth/src/Auth.Persistence/Repositories/AuthUserRepository.cs
@@ -5,8 +5,6 @@ using Microsoft.EntityFrameworkCore;
 
 namespace Auth.Persistence.Repositories;
 
-#nullable enable
-
 internal sealed class AuthUserRepository(AuthDbContext context) : IAuthUserRepository
 {
     public async Task<AuthUser?> GetByIdAsync(long id, CancellationToken cancellationToken = default)

--- a/services/auth/src/Auth.Presentation/Endpoints/LogoutEndpoint.cs
+++ b/services/auth/src/Auth.Presentation/Endpoints/LogoutEndpoint.cs
@@ -1,5 +1,4 @@
 using Carter;
-using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.Extensions.Options;
 using Auth.Application.Abstractions.Messaging;
 using Auth.Application.Abstractions.Security;
@@ -36,16 +35,14 @@ public sealed class LogoutEndpoint : ICarterModule
         var command = new LogoutCommand(currentUser.Id);
         var result = await handler.HandleAsync(command, ctx.RequestAborted);
 
+
+        ctx.Response.Cookies.Delete(options.CookieName, new CookieOptions
+        {
+            Secure   = options.Secure,
+            SameSite = SameSiteMode.Strict,
+        });
         return result.Match<LogoutEndpointHttpResults>(
-            () =>
-            {
-                ctx.Response.Cookies.Delete(options.CookieName, new CookieOptions
-                {
-                    Secure   = options.Secure,
-                    SameSite = SameSiteMode.Strict,
-                });
-                return TypedResults.NoContent();
-            },
+            () => TypedResults.NoContent(),
             _ => TypedResults.Unauthorized()
         );
     }

--- a/services/auth/src/Auth.Presentation/Endpoints/OAuthEndpoint.cs
+++ b/services/auth/src/Auth.Presentation/Endpoints/OAuthEndpoint.cs
@@ -1,4 +1,3 @@
-using System.Collections.Frozen;
 using Auth.Application.Abstractions;
 using Auth.Application.Abstractions.Messaging;
 using Auth.Application.Features.OAuth;
@@ -24,13 +23,6 @@ namespace Auth.Presentation.Endpoints;
 
 public sealed class OAuthEndpoint : ICarterModule
 {
-    private static readonly FrozenDictionary<string, OAuthProvider> ProviderMap =
-        new Dictionary<string, OAuthProvider>
-        {
-            ["fortytwo"] = OAuthProvider.FortyTwo,
-            ["google"]   = OAuthProvider.Google,
-            ["github"]   = OAuthProvider.Github,
-        }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
 
     public void AddRoutes(IEndpointRouteBuilder app)
     {
@@ -62,7 +54,7 @@ public sealed class OAuthEndpoint : ICarterModule
         OAuthStateCookieOptions stateOpts,
         HttpResponse resp)
     {
-        if (!ProviderMap.TryGetValue(provider, out var oauthProvider))
+        if (!OAuthProviderExtensions.TryFromSlug(provider, out var oauthProvider))
             return TypedResults.BadRequest(new ErrorResponse(AuthFailures.InvalidOAuthProvider.Message));
 
         var result = await handler.HandleAsync(new OAuthLoginCommand(oauthProvider));
@@ -94,7 +86,7 @@ public sealed class OAuthEndpoint : ICarterModule
         AppOptions appOpts,
         HttpContext ctx)
     {
-        if (!ProviderMap.TryGetValue(provider, out var oauthProvider))
+        if (!OAuthProviderExtensions.TryFromSlug(provider, out var oauthProvider))
             return TypedResults.BadRequest(new ErrorResponse(AuthFailures.InvalidOAuthProvider.Message));
 
         var storedState = ctx.Request.Cookies[stateOpts.CookieName];

--- a/services/auth/src/Auth.Presentation/Filters/RequiredFieldsFilter.cs
+++ b/services/auth/src/Auth.Presentation/Filters/RequiredFieldsFilter.cs
@@ -2,8 +2,6 @@ using Auth.Presentation.Contracts;
 
 namespace Auth.Presentation.Filters;
 
-#nullable enable
-
 public sealed class RequiredFieldsFilter<T> : IEndpointFilter
 {
     public async ValueTask<object?> InvokeAsync(

--- a/services/auth/src/Auth.Presentation/Middleware/ExceptionHandlingMiddleware.cs
+++ b/services/auth/src/Auth.Presentation/Middleware/ExceptionHandlingMiddleware.cs
@@ -10,6 +10,21 @@ public sealed class ExceptionHandlingMiddleware(RequestDelegate next, ILogger<Ex
         {
             await next(ctx);
         }
+        catch (BadHttpRequestException ex)
+        {
+            // model binding failures (missing/invalid query params, malformed body)
+            // surface as 400 with the binder's own message, not 500
+            logger.LogWarning(ex, "Bad request on {Method} {Path}", ctx.Request.Method, ctx.Request.Path);
+
+            // try retrieve error message from oauth provider (passed as query param)
+            // fallback to excpetion message
+            var queryErr = ctx.Request.Query["error"].ToString();
+            var errResp = new ErrorResponse((!string.IsNullOrWhiteSpace(queryErr)) ? queryErr : ex.Message);
+
+            ctx.Response.StatusCode = ex.StatusCode;
+            ctx.Response.ContentType = "application/json";
+            await ctx.Response.WriteAsJsonAsync(errResp);
+        }
         catch (Exception ex)
         {
             logger.LogError(ex, "Unhandled exception on {Method} {Path}", ctx.Request.Method, ctx.Request.Path);


### PR DESCRIPTION
  Fix **OAuth** callback email handling and error classification

  - Add `VerifyEmail()` and `UpdateEmail()` methods on `AuthUser` domain entity
  - Fix `OAuthCallbackHandler` to correctly set or update the email field
  - Document OAuth provider credentials in .env.example
  - Restore @vantavoids fix on `ExceptionHandlingMiddleware` to properly distinguish malformed requests (400) from actual internal errors (500)

>  My bad I missunderstand what was causing the `BadHttpRequestException` exception: 
If a malformed request is received, and **dotnet** cannot provide endpoint's arguments, it **throws** this exception and our endpoint will never be reached.