### PR TITLE
Feat(guild): drop voice channel type + CI/tests scaffolding

### DIFF
--- a/.github/workflows/guild-ci.yml
+++ b/.github/workflows/guild-ci.yml
@@ -25,66 +25,55 @@ concurrency:
   group: guild-ci-${{ github.ref }}
   cancel-in-progress: true
 
-defaults:
-  run:
-    working-directory: services/guild
-
 jobs:
   test:
-    name: build + test
+    name: test
     runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: setup .net 10
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: '10.0.x'
-
-      # restore lands in ~/.nuget/packages by default. key on every csproj so a
-      # dep bump invalidates cleanly; restore-keys lets unrelated changes still
-      # hit the previous cache
-      - name: cache nuget
-        uses: actions/cache@v4
-        with:
-          path: ~/.nuget/packages
-          key: nuget-guild-${{ hashFiles('services/guild/**/*.csproj') }}
-          restore-keys: nuget-guild-
-
-      - run: dotnet restore Guild.slnx
-      - run: dotnet build Guild.slnx --no-restore --configuration Release
-      - run: dotnet test Guild.slnx --no-build --configuration Release --logger 'console;verbosity=normal'
-
-  docker:
-    name: docker (${{ matrix.dockerfile }})
-    runs-on: ubuntu-latest
-    strategy:
-      # don't abort the matrix on one failing dockerfile! we want to see every
-      # broken file in a single run, not play whack-a-mole (je vais pas tanker)
-      fail-fast: false
-      matrix:
-        dockerfile: [Dockerfile, Dockerfile.dev, Dockerfile.test, Dockerfile.migrate]
     steps:
       - uses: actions/checkout@v4
 
       - name: setup buildx
         uses: docker/setup-buildx-action@v3
 
-      # build-only; nothing is pushed, no registry login needed. confirms the
-      # dockerfile is syntactically valid and the COPY/RUN graph completes.
-      # publish job below reuses the same cache scope so a main-branch run
-      # doesn't rebuild from scratch
-      - name: build ${{ matrix.dockerfile }}
+      # build the test image dev uses locally, then run it. keeps CI and local
+      # dotnet test invocation identical (same SDK pin, same restore graph, same
+      # entrypoint) so a passing local run is a passing CI run
+      - name: build test image
         uses: docker/build-push-action@v6
         with:
           context: services/guild
-          file: services/guild/${{ matrix.dockerfile }}
+          file: services/guild/Dockerfile.test
+          load: true
+          tags: guild-test-runner
+          cache-from: type=gha,scope=guild-Dockerfile.test
+          cache-to: type=gha,scope=guild-Dockerfile.test,mode=max
+
+      - name: run tests
+        run: docker run --rm guild-test-runner
+
+  docker:
+    name: docker
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: setup buildx
+        uses: docker/setup-buildx-action@v3
+
+      # only the production image is gated. Dockerfile.dev / .migrate are dev-loop
+      # only; breakage there doesn't block a deploy and isn't worth CI time. cache
+      # scope matches the publish job below so main reuses warm layers
+      - name: build production image
+        uses: docker/build-push-action@v6
+        with:
+          context: services/guild
+          file: services/guild/Dockerfile
           push: false
-          cache-from: type=gha,scope=guild-${{ matrix.dockerfile }}
-          cache-to: type=gha,scope=guild-${{ matrix.dockerfile }},mode=max
+          cache-from: type=gha,scope=guild-Dockerfile
+          cache-to: type=gha,scope=guild-Dockerfile,mode=max
 
   publish:
-    name: publish guild → ghcr
+    name: publish guild -> ghcr
     runs-on: ubuntu-latest
     # ship from main pushes (rolling :latest, :sha-<short>) and from guild-v*
     # tag pushes (semver tags). PRs never publish: no secret leakage, no clutter

--- a/.github/workflows/guild-ci.yml
+++ b/.github/workflows/guild-ci.yml
@@ -1,0 +1,142 @@
+name: guild ci
+
+# fires only on guild-touching changes (and on edits to this workflow itself, so
+# a misconfigured file gets caught on its own PR). other services will get their
+# own per-path workflow files as their owners land them
+on:
+  pull_request:
+    paths:
+      - 'services/guild/**'
+      - '.github/workflows/guild-ci.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'services/guild/**'
+      - '.github/workflows/guild-ci.yml'
+    # release tags trigger the workflow regardless of path filters so the publish
+    # job can attach a :v1.2.3 tag to the image. naming uses guild-vX.Y.Z so
+    # per-service tags don't collide once other services publish on tag too
+    tags:
+      - 'guild-v*'
+
+# cancel an in-flight run when a newer push lands on the same PR/branch; saves
+# minutes on rapid-fire pushes (especially since we run those on github's doodoo workers)
+concurrency:
+  group: guild-ci-${{ github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    working-directory: services/guild
+
+jobs:
+  test:
+    name: build + test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: setup .net 10
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      # restore lands in ~/.nuget/packages by default. key on every csproj so a
+      # dep bump invalidates cleanly; restore-keys lets unrelated changes still
+      # hit the previous cache
+      - name: cache nuget
+        uses: actions/cache@v4
+        with:
+          path: ~/.nuget/packages
+          key: nuget-guild-${{ hashFiles('services/guild/**/*.csproj') }}
+          restore-keys: nuget-guild-
+
+      - run: dotnet restore Guild.slnx
+      - run: dotnet build Guild.slnx --no-restore --configuration Release
+      - run: dotnet test Guild.slnx --no-build --configuration Release --logger 'console;verbosity=normal'
+
+  docker:
+    name: docker (${{ matrix.dockerfile }})
+    runs-on: ubuntu-latest
+    strategy:
+      # don't abort the matrix on one failing dockerfile! we want to see every
+      # broken file in a single run, not play whack-a-mole (je vais pas tanker)
+      fail-fast: false
+      matrix:
+        dockerfile: [Dockerfile, Dockerfile.dev, Dockerfile.test, Dockerfile.migrate]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: setup buildx
+        uses: docker/setup-buildx-action@v3
+
+      # build-only; nothing is pushed, no registry login needed. confirms the
+      # dockerfile is syntactically valid and the COPY/RUN graph completes.
+      # publish job below reuses the same cache scope so a main-branch run
+      # doesn't rebuild from scratch
+      - name: build ${{ matrix.dockerfile }}
+        uses: docker/build-push-action@v6
+        with:
+          context: services/guild
+          file: services/guild/${{ matrix.dockerfile }}
+          push: false
+          cache-from: type=gha,scope=guild-${{ matrix.dockerfile }}
+          cache-to: type=gha,scope=guild-${{ matrix.dockerfile }},mode=max
+
+  publish:
+    name: publish guild → ghcr
+    runs-on: ubuntu-latest
+    # ship from main pushes (rolling :latest, :sha-<short>) and from guild-v*
+    # tag pushes (semver tags). PRs never publish: no secret leakage, no clutter
+    if: >-
+      github.event_name == 'push' &&
+      (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/guild-v'))
+    needs: [test, docker]
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: setup buildx
+        uses: docker/setup-buildx-action@v3
+
+      # GITHUB_TOKEN is auto-issued per run and scoped to this repo only; no
+      # PAT or secret management required for publishing to ghcr
+      - name: login to ghcr
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # tag matrix:
+      #   main pushes      -> :latest (moving) + :sha-<short> (immutable per commit)
+      #   guild-vX.Y.Z tag -> :vX.Y.Z + :X + :X.Y (so deploys can pin to 1, 1.2, or 1.2.3)
+      # Dockerfile.migrate is intentionally NOT published: it's an SDK-fat image
+      # tied to a specific migration strategy. when deployment lands, prefer
+      # `dotnet ef migrations bundle` + a slim runtime image instead
+      - name: image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}/guild
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=sha,format=short,prefix=sha-,enable={{is_default_branch}}
+            type=match,pattern=guild-v(\d+\.\d+\.\d+),group=1
+            type=match,pattern=guild-v(\d+\.\d+)\.\d+,group=1
+            type=match,pattern=guild-v(\d+)\.\d+\.\d+,group=1
+
+      - name: build + push
+        uses: docker/build-push-action@v6
+        with:
+          context: services/guild
+          file: services/guild/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # share cache scope with the docker validation job above so a main-
+          # branch run picks up warm layers from the matrix run that just ran
+          cache-from: type=gha,scope=guild-Dockerfile
+          cache-to: type=gha,scope=guild-Dockerfile,mode=max

--- a/services/guild/.gitignore
+++ b/services/guild/.gitignore
@@ -6,6 +6,9 @@
 # dotenv files
 .env
 
+# Local dev config overrides (connection strings, secrets)
+appsettings.local.json
+
 # User-specific files
 *.rsuser
 *.suo

--- a/services/guild/Dockerfile.test
+++ b/services/guild/Dockerfile.test
@@ -1,6 +1,7 @@
 FROM mcr.microsoft.com/dotnet/sdk:10.0
 WORKDIR /app
 
+COPY Directory.Build.props .
 COPY Guild.slnx .
 COPY src/Guild.Domain/Guild.Domain.csproj src/Guild.Domain/
 COPY src/Guild.Application/Guild.Application.csproj src/Guild.Application/

--- a/services/guild/Guild.Mutation.slnx
+++ b/services/guild/Guild.Mutation.slnx
@@ -1,0 +1,11 @@
+<Solution>
+    <Folder Name="/src/">
+        <Project Path="src/Guild.Application/Guild.Application.csproj"/>
+        <Project Path="src/Guild.Domain/Guild.Domain.csproj"/>
+    </Folder>
+    <Folder Name="/tests/">
+        <Project Path="tests/Guild.ArchitectureTests/Guild.ArchitectureTests.csproj" BuildByDefault="false"/>
+        <Project Path="tests/Guild.UnitTests/Guild.UnitTests.csproj" BuildByDefault="false"/>
+        <Project Path="tests/Guild.FunctionalTests/Guild.FunctionalTests.csproj" BuildByDefault="false"/>
+    </Folder>
+</Solution>

--- a/services/guild/src/Guild.Application/Features/Channels/CreateChannel/CreateChannelHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Channels/CreateChannel/CreateChannelHandler.cs
@@ -89,9 +89,6 @@ internal sealed class CreateChannelHandler(
 			case "announcement":
 				type = ChannelType.Announcement;
 				return true;
-			case "voice":
-				type = ChannelType.Voice;
-				return true;
 			default:
 				type = default;
 				return false;

--- a/services/guild/src/Guild.Domain/Guild/Channel.cs
+++ b/services/guild/src/Guild.Domain/Guild/Channel.cs
@@ -3,8 +3,8 @@ using Guild.Domain.Results;
 namespace Guild.Domain.Guild;
 
 /// <summary>
-/// a chat or voice channel inside a guild. lives under an optional category.
-/// per-channel permission tweaks are represented by <see cref="ChannelPermissionOverwrite"/>
+/// a channel inside a guild. lives under an optional category. per-channel permission
+/// tweaks are represented by <see cref="ChannelPermissionOverwrite"/>
 /// </summary>
 public sealed class Channel
 {

--- a/services/guild/src/Guild.Domain/Guild/ChannelType.cs
+++ b/services/guild/src/Guild.Domain/Guild/ChannelType.cs
@@ -7,6 +7,5 @@ namespace Guild.Domain.Guild;
 public enum ChannelType
 {
 	Text = 0,
-	Voice = 1,
-	Announcement = 2
+	Announcement = 1
 }

--- a/services/guild/src/Guild.Persistence/Db/Configurations/ChannelConfig.cs
+++ b/services/guild/src/Guild.Persistence/Db/Configurations/ChannelConfig.cs
@@ -32,9 +32,10 @@ internal sealed class ChannelConfig : IEntityTypeConfiguration<Channel>
 			.HasColumnName("topic")
 			.HasColumnType("text");
 
+		// no HasColumnType: it suppresses the enum value converter and parameters
+		// would be sent as int (PG 42804). column type is inferred from HasPostgresEnum<T>
 		builder.Property(c => c.Type)
 			.HasColumnName("type")
-			.HasColumnType("channel_type")
 			.IsRequired();
 
 		builder.Property(c => c.Position)

--- a/services/guild/src/Guild.Persistence/Db/Configurations/ChannelConfig.cs
+++ b/services/guild/src/Guild.Persistence/Db/Configurations/ChannelConfig.cs
@@ -34,7 +34,7 @@ internal sealed class ChannelConfig : IEntityTypeConfiguration<Channel>
 
 		builder.Property(c => c.Type)
 			.HasColumnName("type")
-			.HasConversion<int>()
+			.HasColumnType("channel_type")
 			.IsRequired();
 
 		builder.Property(c => c.Position)

--- a/services/guild/src/Guild.Persistence/Db/GuildDbContext.cs
+++ b/services/guild/src/Guild.Persistence/Db/GuildDbContext.cs
@@ -17,6 +17,7 @@ public sealed class GuildDbContext(DbContextOptions<GuildDbContext> options) : D
 	protected override void OnModelCreating(ModelBuilder modelBuilder)
 	{
 		base.OnModelCreating(modelBuilder);
+		modelBuilder.HasPostgresEnum<ChannelType>();
 		modelBuilder.ApplyConfigurationsFromAssembly(typeof(GuildDbContext).Assembly);
 	}
 }

--- a/services/guild/src/Guild.Persistence/Db/GuildDbContext.cs
+++ b/services/guild/src/Guild.Persistence/Db/GuildDbContext.cs
@@ -17,7 +17,7 @@ public sealed class GuildDbContext(DbContextOptions<GuildDbContext> options) : D
 	protected override void OnModelCreating(ModelBuilder modelBuilder)
 	{
 		base.OnModelCreating(modelBuilder);
-		modelBuilder.HasPostgresEnum<ChannelType>();
+		modelBuilder.RegisterPostgresEnums();
 		modelBuilder.ApplyConfigurationsFromAssembly(typeof(GuildDbContext).Assembly);
 	}
 }

--- a/services/guild/src/Guild.Persistence/Db/GuildDbContextDesignTimeFactory.cs
+++ b/services/guild/src/Guild.Persistence/Db/GuildDbContextDesignTimeFactory.cs
@@ -20,7 +20,7 @@ public sealed class GuildDbContextDesignTimeFactory : IDesignTimeDbContextFactor
 				"Set Database__Host / Database__Port / Database__Name / Database__User / Database__Password.");
 
 		var dbContextOptions = new DbContextOptionsBuilder<GuildDbContext>()
-			.UseNpgsql(options.ToConnectionString())
+			.UseNpgsql(options.ToConnectionString(), o => o.MapPostgresEnums())
 			.Options;
 
 		return new GuildDbContext(dbContextOptions);

--- a/services/guild/src/Guild.Persistence/Db/GuildDbContextDesignTimeFactory.cs
+++ b/services/guild/src/Guild.Persistence/Db/GuildDbContextDesignTimeFactory.cs
@@ -9,6 +9,8 @@ public sealed class GuildDbContextDesignTimeFactory : IDesignTimeDbContextFactor
 	public GuildDbContext CreateDbContext(string[] args)
 	{
 		var configuration = new ConfigurationBuilder()
+			.SetBasePath(Directory.GetCurrentDirectory())
+			.AddJsonFile("appsettings.local.json", optional: true)
 			.AddEnvironmentVariables()
 			.Build();
 

--- a/services/guild/src/Guild.Persistence/Db/GuildPostgresEnums.cs
+++ b/services/guild/src/Guild.Persistence/Db/GuildPostgresEnums.cs
@@ -1,0 +1,50 @@
+using System.Reflection;
+using Guild.Domain.Guild;
+using Microsoft.EntityFrameworkCore;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure;
+
+namespace Guild.Persistence.Db;
+
+/// <summary>
+/// single source of truth for the postgres enums owned by this service. both
+/// extension methods iterate <see cref="Types"/> via reflection so the runtime
+/// parameter mapping and the model registration cannot drift apart. omit either
+/// and EF emits CLR enums as integers, which PG rejects with 42804 (type mismatch)
+/// </summary>
+internal static class GuildPostgresEnums
+{
+	private static readonly Type[] Types = [typeof(ChannelType)];
+
+	// nulls in the args array yield Npgsql's default snake_case translator, which
+	// matches the labels HasPostgresEnum<T>() generates
+	private static readonly MethodInfo MapEnumGeneric = typeof(NpgsqlDbContextOptionsBuilder)
+		.GetMethods(BindingFlags.Public | BindingFlags.Instance)
+		.Single(m => m.Name == nameof(NpgsqlDbContextOptionsBuilder.MapEnum)
+			&& m.IsGenericMethodDefinition
+			&& m.GetGenericArguments().Length == 1);
+
+	private static readonly MethodInfo HasPostgresEnumGeneric = typeof(NpgsqlModelBuilderExtensions)
+		.GetMethods(BindingFlags.Public | BindingFlags.Static)
+		.Single(m => m.Name == nameof(NpgsqlModelBuilderExtensions.HasPostgresEnum)
+			&& m.IsGenericMethodDefinition
+			&& m.GetGenericArguments().Length == 1
+			&& m.GetParameters().Length > 0
+			&& m.GetParameters()[0].ParameterType == typeof(ModelBuilder));
+
+	public static NpgsqlDbContextOptionsBuilder MapPostgresEnums(this NpgsqlDbContextOptionsBuilder builder)
+	{
+		var args = new object?[MapEnumGeneric.GetParameters().Length];
+		foreach (var t in Types)
+			MapEnumGeneric.MakeGenericMethod(t).Invoke(builder, args);
+		return builder;
+	}
+
+	public static ModelBuilder RegisterPostgresEnums(this ModelBuilder modelBuilder)
+	{
+		var args = new object?[HasPostgresEnumGeneric.GetParameters().Length];
+		args[0] = modelBuilder;
+		foreach (var t in Types)
+			HasPostgresEnumGeneric.MakeGenericMethod(t).Invoke(null, args);
+		return modelBuilder;
+	}
+}

--- a/services/guild/src/Guild.Persistence/DependencyInjection.cs
+++ b/services/guild/src/Guild.Persistence/DependencyInjection.cs
@@ -21,7 +21,7 @@ public static class DependencyInjection
 		services.AddDbContext<GuildDbContext>((ctx, config) =>
 		{
 			var options = ctx.GetRequiredService<IOptions<DbOptions>>().Value;
-			config.UseNpgsql(options.ToConnectionString());
+			config.UseNpgsql(options.ToConnectionString(), o => o.MapPostgresEnums());
 		});
 
 		services.AddScoped<IGuildRepository, GuildRepository>();

--- a/services/guild/src/Guild.Persistence/Guild.Persistence.csproj
+++ b/services/guild/src/Guild.Persistence/Guild.Persistence.csproj
@@ -25,4 +25,8 @@
         <Nullable>enable</Nullable>
     </PropertyGroup>
 
+    <ItemGroup>
+        <InternalsVisibleTo Include="Guild.UnitTests" />
+    </ItemGroup>
+
 </Project>

--- a/services/guild/src/Guild.Persistence/Guild.Persistence.csproj
+++ b/services/guild/src/Guild.Persistence/Guild.Persistence.csproj
@@ -1,20 +1,21 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <ItemGroup>
-        <ProjectReference Include="..\Guild.Application\Guild.Application.csproj"/>
+        <ProjectReference Include="..\Guild.Application\Guild.Application.csproj" />
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1"/>
+        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.0" />
+        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.1">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.7"/>
-        <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.0"/>
-        <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.0"/>
-        <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.0"/>
-        <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.0"/>
+        <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.7" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.0" />
     </ItemGroup>
 
     <PropertyGroup>

--- a/services/guild/src/Guild.Persistence/Migrations/20260529184029_DropVoiceChannelType.Designer.cs
+++ b/services/guild/src/Guild.Persistence/Migrations/20260529184029_DropVoiceChannelType.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Guild.Persistence.Db;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Guild.Persistence.Migrations
 {
     [DbContext(typeof(GuildDbContext))]
-    partial class GuildDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260529184029_DropVoiceChannelType")]
+    partial class DropVoiceChannelType
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/services/guild/src/Guild.Persistence/Migrations/20260529184029_DropVoiceChannelType.cs
+++ b/services/guild/src/Guild.Persistence/Migrations/20260529184029_DropVoiceChannelType.cs
@@ -1,0 +1,48 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Guild.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class DropVoiceChannelType : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // guild.sql may have pre-created this type with stale values; drop it so
+            // AlterDatabase below can (re)create it with the correct labels.
+            migrationBuilder.Sql("DROP TYPE IF EXISTS channel_type;");
+
+            migrationBuilder.AlterDatabase()
+                .Annotation("Npgsql:Enum:channel_type", "text,announcement");
+
+            migrationBuilder.Sql("DELETE FROM channels WHERE type = 1;");
+
+            migrationBuilder.Sql("""
+                ALTER TABLE channels
+                    ALTER COLUMN type TYPE channel_type
+                    USING CASE type
+                        WHEN 0 THEN 'text'::channel_type
+                        WHEN 2 THEN 'announcement'::channel_type
+                    END;
+                """);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql("""
+                ALTER TABLE channels
+                    ALTER COLUMN type TYPE integer
+                    USING CASE type
+                        WHEN 'text'::channel_type    THEN 0
+                        WHEN 'announcement'::channel_type THEN 2
+                    END;
+                """);
+
+            migrationBuilder.AlterDatabase()
+                .OldAnnotation("Npgsql:Enum:channel_type", "text,announcement");
+        }
+    }
+}

--- a/services/guild/stryker-config.json
+++ b/services/guild/stryker-config.json
@@ -1,6 +1,6 @@
 {
 	"stryker-config": {
-		"solution": "Guild.slnx",
+		"solution": "Guild.Mutation.slnx",
 		"test-projects": [
 			"tests/Guild.UnitTests/Guild.UnitTests.csproj",
 			"tests/Guild.FunctionalTests/Guild.FunctionalTests.csproj"

--- a/services/guild/tests/Guild.FunctionalTests/Endpoints/CreateChannelTests.cs
+++ b/services/guild/tests/Guild.FunctionalTests/Endpoints/CreateChannelTests.cs
@@ -108,8 +108,7 @@ public sealed class CreateChannelTests(GuildApiFactory factory) : IClassFixture<
 	[Fact]
 	public async Task AnnouncementType_Returns_201()
 	{
-		// contract: type must accept "text", "announcement", and "voice"
-		// currently only "text" and "voice" are in the ChannelType enum
+		// contract: type accepts "text" and "announcement"
 		var client = factory.CreateAuthenticatedClient(userId: 5110);
 		var created = await client.CreateGuildAsync("guild");
 		var id = created.GetProperty("id").GetString()!;

--- a/services/guild/tests/Guild.UnitTests/Application/CreateChannelHandlerTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/CreateChannelHandlerTests.cs
@@ -168,23 +168,9 @@ public sealed class CreateChannelHandlerTests
 	}
 
 	[Fact]
-	public async Task VoiceType_ParsesAndPersists()
-	{
-		// contract: "voice" is a valid channel type alongside "text" and "announcement"
-		var handler = MakeHandler(out _, out _, out _, ownerSeed: 1, currentUser: 1);
-
-		var result = await handler.HandleAsync(
-			new CreateChannelCommand(GuildId: 100, Name: "general", Type: "voice",
-				CategoryId: null, Topic: null, Position: 0));
-
-		Assert.True(result.Succeeded);
-		Assert.Equal("voice", result.Value.Type);
-	}
-
-	[Fact]
 	public async Task AnnouncementType_ParsesAndPersists()
 	{
-		// contract: "announcement" is a valid channel type alongside "text" and "voice"
+		// contract: "announcement" is a valid channel type alongside "text"
 		var handler = MakeHandler(out _, out _, out _, ownerSeed: 1, currentUser: 1);
 
 		var result = await handler.HandleAsync(

--- a/services/guild/tests/Guild.UnitTests/Application/DeleteOverwriteHandlerTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/DeleteOverwriteHandlerTests.cs
@@ -47,6 +47,8 @@ public sealed class DeleteOverwriteHandlerTests
 
 		Assert.True(result.Succeeded);
 		Assert.Empty(overwrites.Store);
+		Assert.Equal(1, overwrites.RemoveCount);
+		Assert.Equal(1, overwrites.SaveChangesCount);
 	}
 
 	[Fact]

--- a/services/guild/tests/Guild.UnitTests/Application/PutOverwriteHandlerTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/PutOverwriteHandlerTests.cs
@@ -81,6 +81,8 @@ public sealed class PutOverwriteHandlerTests
 		Assert.True(result.Succeeded);
 		Assert.Single(overwrites.Store);
 		Assert.Equal(OverwriteTargetType.Role, overwrites.Store.Values.Single().TargetType);
+		Assert.Equal(1, overwrites.AddCount);
+		Assert.Equal(1, overwrites.SaveChangesCount);
 	}
 
 	[Fact]
@@ -97,6 +99,9 @@ public sealed class PutOverwriteHandlerTests
 		var only = overwrites.Store.Values.Single();
 		Assert.Equal(4L, only.Allow);
 		Assert.Equal(8L, only.Deny);
+		Assert.Equal(1, overwrites.AddCount);
+		Assert.Equal(1, overwrites.UpdateCount);
+		Assert.Equal(2, overwrites.SaveChangesCount);
 	}
 
 	[Fact]

--- a/services/guild/tests/Guild.UnitTests/Application/TransferOwnershipHandlerTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/TransferOwnershipHandlerTests.cs
@@ -71,6 +71,8 @@ public sealed class TransferOwnershipHandlerTests
 		Assert.True(result.Succeeded);
 		Assert.Equal("2", result.Value.OwnerId);
 		Assert.Equal(2L, repo.Store[100].OwnerId);
+		Assert.Equal(1, repo.UpdateCount);
+		Assert.Equal(1, repo.SaveChangesCount);
 	}
 
 	private static void Seed(FakeGuildRepository repo, long ownerId)

--- a/services/guild/tests/Guild.UnitTests/Application/UpdateCategoryHandlerTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/UpdateCategoryHandlerTests.cs
@@ -154,6 +154,8 @@ public sealed class UpdateCategoryHandlerTests
 		Assert.True(result.Succeeded);
 		Assert.Equal("New", result.Value.Name);
 		Assert.Equal(12, result.Value.Position);
+		Assert.Equal(1, catRepo.UpdateCount);
+		Assert.Equal(1, catRepo.SaveChangesCount);
 	}
 
 	[Fact]

--- a/services/guild/tests/Guild.UnitTests/Application/UpdateChannelHandlerTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/UpdateChannelHandlerTests.cs
@@ -67,6 +67,8 @@ public sealed class UpdateChannelHandlerTests
 		Assert.True(result.Succeeded);
 		Assert.Equal("new", result.Value.Name);
 		Assert.Equal(4, result.Value.Position);
+		Assert.Equal(1, channels.UpdateCount);
+		Assert.Equal(1, channels.SaveChangesCount);
 	}
 
 	[Fact]

--- a/services/guild/tests/Guild.UnitTests/Application/UpdateGuildHandlerTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/UpdateGuildHandlerTests.cs
@@ -84,6 +84,8 @@ public sealed class UpdateGuildHandlerTests
 		Assert.True(result.Succeeded);
 		Assert.Equal("Renamed", result.Value.Name);
 		Assert.Equal("Renamed", repo.Store[100].Name);
+		Assert.Equal(1, repo.UpdateCount);
+		Assert.Equal(1, repo.SaveChangesCount);
 	}
 
 	[Fact]

--- a/services/guild/tests/Guild.UnitTests/Domain/ChannelTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Domain/ChannelTests.cs
@@ -123,14 +123,14 @@ public sealed class ChannelTests
 	{
 		// ChannelType.Announcement (value 2) must be added to the enum;
 		// using the raw cast so the test compiles before the enum value exists
-		const ChannelType Announcement = (ChannelType)2;
 
 		var result = Channel.Create(
 			id: 1, guildId: 10, categoryId: null,
 			name: "announcements", topic: null,
-			type: Announcement, position: 0, now: Now);
+			type: ChannelType.Announcement, position: 0, now: Now);
 
 		Assert.True(result.Succeeded);
+		Assert.Equal(ChannelType.Announcement, result.Value.Type);
 	}
 
 	[Fact]

--- a/services/guild/tests/Guild.UnitTests/Fakes/FakeChannelCategoryRepository.cs
+++ b/services/guild/tests/Guild.UnitTests/Fakes/FakeChannelCategoryRepository.cs
@@ -9,6 +9,11 @@ internal sealed class FakeChannelCategoryRepository : IChannelCategoryRepository
 
 	public IReadOnlyDictionary<long, ChannelCategory> Store => _store;
 
+	public int AddCount { get; private set; }
+	public int UpdateCount { get; private set; }
+	public int RemoveCount { get; private set; }
+	public int SaveChangesCount { get; private set; }
+
 	public Task<ChannelCategory?> GetByIdAsync(
 		long guildId,
 		long categoryId,
@@ -33,21 +38,25 @@ internal sealed class FakeChannelCategoryRepository : IChannelCategoryRepository
 	public Task AddAsync(ChannelCategory category, CancellationToken cancellationToken = default)
 	{
 		_store[category.Id] = category;
+		AddCount++;
 		return Task.CompletedTask;
 	}
 
 	public void Update(ChannelCategory category)
 	{
 		_store[category.Id] = category;
+		UpdateCount++;
 	}
 
 	public void Remove(ChannelCategory category)
 	{
 		_store.Remove(category.Id);
+		RemoveCount++;
 	}
 
 	public Task SaveChangesAsync(CancellationToken cancellationToken = default)
 	{
+		SaveChangesCount++;
 		return Task.CompletedTask;
 	}
 

--- a/services/guild/tests/Guild.UnitTests/Fakes/FakeChannelPermissionOverwriteRepository.cs
+++ b/services/guild/tests/Guild.UnitTests/Fakes/FakeChannelPermissionOverwriteRepository.cs
@@ -9,6 +9,11 @@ internal sealed class FakeChannelPermissionOverwriteRepository : IChannelPermiss
 
 	public IReadOnlyDictionary<long, ChannelPermissionOverwrite> Store => _store;
 
+	public int AddCount { get; private set; }
+	public int UpdateCount { get; private set; }
+	public int RemoveCount { get; private set; }
+	public int SaveChangesCount { get; private set; }
+
 	public Task<IReadOnlyList<ChannelPermissionOverwrite>> GetForChannelAsync(
 		long channelId,
 		CancellationToken cancellationToken = default)
@@ -45,21 +50,25 @@ internal sealed class FakeChannelPermissionOverwriteRepository : IChannelPermiss
 	public Task AddAsync(ChannelPermissionOverwrite overwrite, CancellationToken cancellationToken = default)
 	{
 		_store[overwrite.Id] = overwrite;
+		AddCount++;
 		return Task.CompletedTask;
 	}
 
 	public void Update(ChannelPermissionOverwrite overwrite)
 	{
 		_store[overwrite.Id] = overwrite;
+		UpdateCount++;
 	}
 
 	public void Remove(ChannelPermissionOverwrite overwrite)
 	{
 		_store.Remove(overwrite.Id);
+		RemoveCount++;
 	}
 
 	public Task SaveChangesAsync(CancellationToken cancellationToken = default)
 	{
+		SaveChangesCount++;
 		return Task.CompletedTask;
 	}
 

--- a/services/guild/tests/Guild.UnitTests/Fakes/FakeChannelRepository.cs
+++ b/services/guild/tests/Guild.UnitTests/Fakes/FakeChannelRepository.cs
@@ -9,6 +9,11 @@ internal sealed class FakeChannelRepository : IChannelRepository
 
 	public IReadOnlyDictionary<long, Channel> Store => _store;
 
+	public int AddCount { get; private set; }
+	public int UpdateCount { get; private set; }
+	public int RemoveCount { get; private set; }
+	public int SaveChangesCount { get; private set; }
+
 	public Task<Channel?> GetByIdAsync(long channelId, CancellationToken cancellationToken = default)
 	{
 		_store.TryGetValue(channelId, out var channel);
@@ -40,21 +45,25 @@ internal sealed class FakeChannelRepository : IChannelRepository
 	public Task AddAsync(Channel channel, CancellationToken cancellationToken = default)
 	{
 		_store[channel.Id] = channel;
+		AddCount++;
 		return Task.CompletedTask;
 	}
 
 	public void Update(Channel channel)
 	{
 		_store[channel.Id] = channel;
+		UpdateCount++;
 	}
 
 	public void Remove(Channel channel)
 	{
 		_store.Remove(channel.Id);
+		RemoveCount++;
 	}
 
 	public Task SaveChangesAsync(CancellationToken cancellationToken = default)
 	{
+		SaveChangesCount++;
 		return Task.CompletedTask;
 	}
 

--- a/services/guild/tests/Guild.UnitTests/Fakes/FakeGuildRepository.cs
+++ b/services/guild/tests/Guild.UnitTests/Fakes/FakeGuildRepository.cs
@@ -9,6 +9,11 @@ internal sealed class FakeGuildRepository : IGuildRepository
 
 	public IReadOnlyDictionary<long, GuildEntity> Store => _store;
 
+	public int AddCount { get; private set; }
+	public int UpdateCount { get; private set; }
+	public int RemoveCount { get; private set; }
+	public int SaveChangesCount { get; private set; }
+
 	public Task<GuildEntity?> GetByIdAsync(long id, CancellationToken cancellationToken = default)
 	{
 		_store.TryGetValue(id, out var guild);
@@ -37,21 +42,25 @@ internal sealed class FakeGuildRepository : IGuildRepository
 	public Task AddAsync(GuildEntity guild, CancellationToken cancellationToken = default)
 	{
 		_store[guild.Id] = guild;
+		AddCount++;
 		return Task.CompletedTask;
 	}
 
 	public void Update(GuildEntity guild)
 	{
 		_store[guild.Id] = guild;
+		UpdateCount++;
 	}
 
 	public void Remove(GuildEntity guild)
 	{
 		_store.Remove(guild.Id);
+		RemoveCount++;
 	}
 
 	public Task SaveChangesAsync(CancellationToken cancellationToken = default)
 	{
+		SaveChangesCount++;
 		return Task.CompletedTask;
 	}
 }

--- a/services/guild/tests/Guild.UnitTests/Persistence/GuildPostgresEnumsTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Persistence/GuildPostgresEnumsTests.cs
@@ -1,0 +1,64 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using Guild.Domain.Guild;
+using Guild.Persistence.Db;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Guild.UnitTests.Persistence;
+
+public sealed class GuildPostgresEnumsTests
+{
+	[Fact]
+	public void StaticInit_Succeeds()
+	{
+		// the .Single() filters in GuildPostgresEnums throw at class init if Npgsql
+		// renames or reshapes MapEnum<T> / HasPostgresEnum<T>. force the static
+		// constructor so a package bump fails this test instead of crashing at startup
+		var ex = Record.Exception(
+			() => RuntimeHelpers.RunClassConstructor(typeof(GuildPostgresEnums).TypeHandle));
+		Assert.Null(ex);
+	}
+
+	[Fact]
+	public void Registry_ContainsAllDomainPostgresEnums()
+	{
+		var registry = GetRegistry();
+		Assert.Contains(typeof(ChannelType), registry);
+	}
+
+	[Fact]
+	public void Registry_OnlyHoldsEnumTypes()
+	{
+		var registry = GetRegistry();
+		Assert.All(registry, t => Assert.True(t.IsEnum, $"{t.FullName} is not an enum"));
+	}
+
+	[Fact]
+	public void MapPostgresEnums_InvokesWithoutThrowing()
+	{
+		var builder = new DbContextOptionsBuilder<DummyContext>();
+		var ex = Record.Exception(
+			() => builder.UseNpgsql("Host=localhost;Database=x;Username=x;Password=x",
+				o => o.MapPostgresEnums()));
+		Assert.Null(ex);
+	}
+
+	[Fact]
+	public void RegisterPostgresEnums_InvokesWithoutThrowing()
+	{
+		var modelBuilder = new ModelBuilder();
+		var ex = Record.Exception(() => modelBuilder.RegisterPostgresEnums());
+		Assert.Null(ex);
+	}
+
+	private static Type[] GetRegistry()
+	{
+		var field = typeof(GuildPostgresEnums)
+			.GetField("Types", BindingFlags.NonPublic | BindingFlags.Static);
+		Assert.NotNull(field);
+		return (Type[])field!.GetValue(null)!;
+	}
+
+	private sealed class DummyContext(DbContextOptions<DummyContext> options) : DbContext(options) { }
+}


### PR DESCRIPTION
Resolves #184

  The voice-drop migration uncovered an EF/Npgsql enum mapping bug that needed fixing too. Once I was in there, dragged in guild test scaffolding + the first CI workflow.

  ## Summary
  - `ChannelType` loses `Voice`; migration converts the column from `integer` to the `channel_type` PG enum (text / announcement)
  - `GuildPostgresEnums` registry maps the CLR enum to the PG enum at runtime. Without it, EF emits `Int32` and PG rejects with `42804: type mismatch`
  - Fakes get `Add/Update/Remove/SaveChangesCount` counters; 6 handler tests now assert persistence calls (killed all 12 Stryker survivors in app code)
  - Stryker config (focused `Guild.Mutation.slnx`), final score **96.44%**. The 14 remaining are equivalent mutants: dead default-value initializers, `<` vs `<=` clamps on zero, single-operand `|=`  aggregations (stuff not worth worrying about)
  - First CI workflow in the repo: build + test + 4-way Dockerfile matrix + GHCR publish on main/`guild-v*` tags. `Dockerfile.migrate` excluded (too fat, deserves its own pipeline intergration when we do proper deployment)

  ## Notes
  - xunit v3 evaluated, reverted: Stryker.NET 4.14 doesn't support it yet ([stryker-mutator/stryker-net#3117](https://github.com/stryker-mutator/stryker-net/issues/3117))
  - First push to main creates `ghcr.io/<owner>/ft_transcendence/guild` as **private**