### PR TITLE
Feat/guild/join leave invites

### DIFF
--- a/services/guild/src/Guild.Application/Abstractions/IInviteCodeGenerator.cs
+++ b/services/guild/src/Guild.Application/Abstractions/IInviteCodeGenerator.cs
@@ -1,0 +1,10 @@
+namespace Guild.Application.Abstractions;
+
+public interface IInviteCodeGenerator
+{
+	/// <summary>
+	/// returns an opaque URL-safe invite code. callers must not parse the value
+	/// or rely on its format beyond "shorter than the schema column".
+	/// </summary>
+	string NextCode();
+}

--- a/services/guild/src/Guild.Application/Abstractions/Persistence/IGuildInviteRepository.cs
+++ b/services/guild/src/Guild.Application/Abstractions/Persistence/IGuildInviteRepository.cs
@@ -1,0 +1,16 @@
+using Guild.Domain.Guild;
+
+namespace Guild.Application.Abstractions.Persistence;
+
+public interface IGuildInviteRepository
+{
+	Task<GuildInvite?> GetByCodeAsync(string code, CancellationToken cancellationToken = default);
+
+	/// <summary>returns non-revoked invites for the guild. expired / exhausted entries are still returned so callers can decide whether to display them; <see cref="GuildInvite.IsActive"/> filters them out</summary>
+	Task<IReadOnlyList<GuildInvite>> ListByGuildAsync(long guildId, CancellationToken cancellationToken = default);
+
+	Task AddAsync(GuildInvite invite, CancellationToken cancellationToken = default);
+	void Update(GuildInvite invite);
+
+	Task SaveChangesAsync(CancellationToken cancellationToken = default);
+}

--- a/services/guild/src/Guild.Application/Abstractions/Users/IUserService.cs
+++ b/services/guild/src/Guild.Application/Abstractions/Users/IUserService.cs
@@ -1,0 +1,19 @@
+namespace Guild.Application.Abstractions.Users;
+
+/// <summary>
+/// thin client around the User Service docker-network endpoints (see
+/// <c>docs/contracts/user.md</c>). Implementations gracefully degrade on
+/// connect failure: callers receive <c>false</c> from <see cref="ExistsAsync"/>
+/// and <c>null</c> from <see cref="GetSummaryAsync"/>, never an exception.
+/// the join / invite flows treat existence as best-effort defence in depth
+/// (the JWT already proves the caller authenticated at Auth Service) so a
+/// User Service outage must not break joining.
+/// </summary>
+public interface IUserService
+{
+	Task<bool> ExistsAsync(long userId, CancellationToken cancellationToken = default);
+
+	Task<UserSummary?> GetSummaryAsync(long userId, CancellationToken cancellationToken = default);
+}
+
+public sealed record UserSummary(long Id, string Username);

--- a/services/guild/src/Guild.Application/Contracts/Events.cs
+++ b/services/guild/src/Guild.Application/Contracts/Events.cs
@@ -1,5 +1,5 @@
 namespace Guild.Application.Contracts;
 
-public sealed record GuildMemberJoined(long GuildId, long UserId);
+public sealed record GuildMemberJoined(long GuildId, string GuildName, long UserId);
 public sealed record GuildMemberLeft(long GuildId, long UserId);
 public sealed record GuildInviteCreated(long GuildId, string GuildName, long InvitedByUserId, long? InvitedUserId);

--- a/services/guild/src/Guild.Application/Features/Invites/Common/InviteDto.cs
+++ b/services/guild/src/Guild.Application/Features/Invites/Common/InviteDto.cs
@@ -1,0 +1,22 @@
+using Guild.Domain.Guild;
+
+namespace Guild.Application.Features.Invites.Common;
+
+public sealed record InviteDto(
+	string Code,
+	string GuildId,
+	string CreatedBy,
+	int? MaxUses,
+	int Uses,
+	DateTimeOffset? ExpiresAt,
+	DateTimeOffset CreatedAt)
+{
+	public static InviteDto FromEntity(GuildInvite invite) => new(
+		Code: invite.Code,
+		GuildId: invite.GuildId.ToString(),
+		CreatedBy: invite.CreatedBy.ToString(),
+		MaxUses: invite.MaxUses,
+		Uses: invite.Uses,
+		ExpiresAt: invite.ExpiresAt,
+		CreatedAt: invite.CreatedAt);
+}

--- a/services/guild/src/Guild.Application/Features/Invites/Common/InvitePreviewDto.cs
+++ b/services/guild/src/Guild.Application/Features/Invites/Common/InvitePreviewDto.cs
@@ -1,0 +1,17 @@
+namespace Guild.Application.Features.Invites.Common;
+
+public sealed record InvitePreviewGuildDto(
+	string Id,
+	string Name,
+	string? IconUrl,
+	int MemberCount);
+
+public sealed record InvitePreviewInviterDto(
+	string Id,
+	string Username);
+
+public sealed record InvitePreviewDto(
+	string Code,
+	InvitePreviewGuildDto Guild,
+	InvitePreviewInviterDto Inviter,
+	DateTimeOffset? ExpiresAt);

--- a/services/guild/src/Guild.Application/Features/Invites/CreateInvite/CreateInviteCommand.cs
+++ b/services/guild/src/Guild.Application/Features/Invites/CreateInvite/CreateInviteCommand.cs
@@ -1,0 +1,11 @@
+using Guild.Application.Abstractions.Messaging;
+using Guild.Application.Features.Invites.Common;
+using Guild.Domain.Results;
+
+namespace Guild.Application.Features.Invites.CreateInvite;
+
+public sealed record CreateInviteCommand(
+	long GuildId,
+	int? MaxUses,
+	int? ExpiresInHours)
+	: ICommand<Result<InviteDto>>;

--- a/services/guild/src/Guild.Application/Features/Invites/CreateInvite/CreateInviteHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Invites/CreateInvite/CreateInviteHandler.cs
@@ -1,0 +1,64 @@
+using Guild.Application.Abstractions;
+using Guild.Application.Abstractions.Messaging;
+using Guild.Application.Abstractions.Persistence;
+using Guild.Application.Abstractions.Security;
+using Guild.Application.Contracts;
+using Guild.Application.Features.Invites.Common;
+using Guild.Domain.Guild;
+using Guild.Domain.Results;
+
+namespace Guild.Application.Features.Invites.CreateInvite;
+
+internal sealed class CreateInviteHandler(
+	IGuildRepository guilds,
+	IGuildInviteRepository invites,
+	IInviteCodeGenerator codes,
+	IEventBus eventBus,
+	IClock clock,
+	ICurrentUser currentUser)
+	: ICommandHandler<CreateInviteCommand, Result<InviteDto>>
+{
+	public async Task<Result<InviteDto>> HandleAsync(
+		CreateInviteCommand command,
+		CancellationToken cancellationToken = default)
+	{
+		var guild = await guilds.GetByIdWithMembershipAsync(command.GuildId, cancellationToken);
+		if (guild is null)
+			return GuildFailures.GuildNotFound;
+
+		if (guild.Members.All(m => m.UserId != currentUser.Id))
+			return GuildFailures.NotAMember;
+
+		var mask = PermissionResolver.Resolve(
+			currentUser.Id, guild.OwnerId, guild.Roles, guild.MemberRoles);
+		if (!PermissionResolver.HasPermission(mask, Permission.CreateInvite))
+			return GuildFailures.MissingPermission;
+
+		var now = clock.UtcNow;
+		var expiresAt = command.ExpiresInHours is { } hours
+			? now.AddHours(hours)
+			: (DateTimeOffset?)null;
+
+		var inviteResult = GuildInvite.Create(
+			code: codes.NextCode(),
+			guildId: command.GuildId,
+			createdBy: currentUser.Id,
+			maxUses: command.MaxUses,
+			expiresAt: expiresAt,
+			now: now);
+		if (inviteResult.IsFailure)
+			return inviteResult.Error;
+
+		await invites.AddAsync(inviteResult.Value, cancellationToken);
+		await invites.SaveChangesAsync(cancellationToken);
+
+		// open-link invites have no specific target user, so InvitedUserId is null;
+		// targeted invites (a future endpoint) will set it so the consumer publishes
+		// a `guild_invite` notification only when there's a specific user to notify
+		await eventBus.PublishAsync(
+			new GuildInviteCreated(guild.Id, guild.Name, currentUser.Id, InvitedUserId: null),
+			cancellationToken);
+
+		return InviteDto.FromEntity(inviteResult.Value);
+	}
+}

--- a/services/guild/src/Guild.Application/Features/Invites/CreateInvite/CreateInviteHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Invites/CreateInvite/CreateInviteHandler.cs
@@ -52,9 +52,6 @@ internal sealed class CreateInviteHandler(
 		await invites.AddAsync(inviteResult.Value, cancellationToken);
 		await invites.SaveChangesAsync(cancellationToken);
 
-		// open-link invites have no specific target user, so InvitedUserId is null;
-		// targeted invites (a future endpoint) will set it so the consumer publishes
-		// a `guild_invite` notification only when there's a specific user to notify
 		await eventBus.PublishAsync(
 			new GuildInviteCreated(guild.Id, guild.Name, currentUser.Id, InvitedUserId: null),
 			cancellationToken);

--- a/services/guild/src/Guild.Application/Features/Invites/DeleteInvite/DeleteInviteCommand.cs
+++ b/services/guild/src/Guild.Application/Features/Invites/DeleteInvite/DeleteInviteCommand.cs
@@ -1,0 +1,6 @@
+using Guild.Application.Abstractions.Messaging;
+using Guild.Domain.Results;
+
+namespace Guild.Application.Features.Invites.DeleteInvite;
+
+public sealed record DeleteInviteCommand(long GuildId, string Code) : ICommand<Result>;

--- a/services/guild/src/Guild.Application/Features/Invites/DeleteInvite/DeleteInviteHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Invites/DeleteInvite/DeleteInviteHandler.cs
@@ -1,0 +1,51 @@
+using Guild.Application.Abstractions.Messaging;
+using Guild.Application.Abstractions.Persistence;
+using Guild.Application.Abstractions.Security;
+using Guild.Domain.Guild;
+using Guild.Domain.Results;
+
+namespace Guild.Application.Features.Invites.DeleteInvite;
+
+internal sealed class DeleteInviteHandler(
+	IGuildRepository guilds,
+	IGuildInviteRepository invites,
+	ICurrentUser currentUser)
+	: ICommandHandler<DeleteInviteCommand, Result>
+{
+	public async Task<Result> HandleAsync(
+		DeleteInviteCommand command,
+		CancellationToken cancellationToken = default)
+	{
+		var invite = await invites.GetByCodeAsync(command.Code, cancellationToken);
+		if (invite is null || invite.IsRevoked)
+			return GuildFailures.InviteNotFound;
+
+		if (invite.GuildId != command.GuildId)
+			return GuildFailures.InviteGuildMismatch;
+
+		var guild = await guilds.GetByIdWithMembershipAsync(command.GuildId, cancellationToken);
+		if (guild is null)
+			return GuildFailures.GuildNotFound;
+
+		if (guild.Members.All(m => m.UserId != currentUser.Id))
+			return GuildFailures.NotAMember;
+
+		var isCreator = invite.CreatedBy == currentUser.Id;
+		if (!isCreator)
+		{
+			var mask = PermissionResolver.Resolve(
+				currentUser.Id, guild.OwnerId, guild.Roles, guild.MemberRoles);
+			if (!PermissionResolver.HasPermission(mask, Permission.ManageGuild))
+				return GuildFailures.MissingPermission;
+		}
+
+		var revokeResult = invite.Revoke();
+		if (revokeResult.IsFailure)
+			return revokeResult.Error;
+
+		invites.Update(invite);
+		await invites.SaveChangesAsync(cancellationToken);
+
+		return Result.Ok();
+	}
+}

--- a/services/guild/src/Guild.Application/Features/Invites/GetInvitePreview/GetInvitePreviewHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Invites/GetInvitePreview/GetInvitePreviewHandler.cs
@@ -1,0 +1,48 @@
+using Guild.Application.Abstractions;
+using Guild.Application.Abstractions.Messaging;
+using Guild.Application.Abstractions.Persistence;
+using Guild.Application.Abstractions.Users;
+using Guild.Application.Features.Invites.Common;
+using Guild.Domain.Results;
+
+namespace Guild.Application.Features.Invites.GetInvitePreview;
+
+internal sealed class GetInvitePreviewHandler(
+	IGuildRepository guilds,
+	IGuildInviteRepository invites,
+	IUserService users,
+	IClock clock)
+	: IQueryHandler<GetInvitePreviewQuery, Result<InvitePreviewDto>>
+{
+	public async Task<Result<InvitePreviewDto>> HandleAsync(
+		GetInvitePreviewQuery query,
+		CancellationToken cancellationToken = default)
+	{
+		var invite = await invites.GetByCodeAsync(query.Code, cancellationToken);
+		if (invite is null || !invite.IsActive(clock.UtcNow))
+			return GuildFailures.InviteNotFound;
+
+		var guild = await guilds.GetByIdAsync(invite.GuildId, cancellationToken);
+		if (guild is null)
+			return GuildFailures.InviteNotFound;
+
+		var memberCount = await guilds.CountMembersAsync(invite.GuildId, cancellationToken);
+
+		// inviter lookup is best-effort: if User Service is down or doesn't know
+		// the inviter, fall back to an empty username so the preview still renders
+		var inviter = await users.GetSummaryAsync(invite.CreatedBy, cancellationToken);
+		var inviterDto = new InvitePreviewInviterDto(
+			Id: invite.CreatedBy.ToString(),
+			Username: inviter?.Username ?? string.Empty);
+
+		return new InvitePreviewDto(
+			Code: invite.Code,
+			Guild: new InvitePreviewGuildDto(
+				Id: guild.Id.ToString(),
+				Name: guild.Name,
+				IconUrl: guild.IconUrl,
+				MemberCount: memberCount),
+			Inviter: inviterDto,
+			ExpiresAt: invite.ExpiresAt);
+	}
+}

--- a/services/guild/src/Guild.Application/Features/Invites/GetInvitePreview/GetInvitePreviewQuery.cs
+++ b/services/guild/src/Guild.Application/Features/Invites/GetInvitePreview/GetInvitePreviewQuery.cs
@@ -1,0 +1,7 @@
+using Guild.Application.Abstractions.Messaging;
+using Guild.Application.Features.Invites.Common;
+using Guild.Domain.Results;
+
+namespace Guild.Application.Features.Invites.GetInvitePreview;
+
+public sealed record GetInvitePreviewQuery(string Code) : IQuery<Result<InvitePreviewDto>>;

--- a/services/guild/src/Guild.Application/Features/Invites/ListInvites/ListInvitesHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Invites/ListInvites/ListInvitesHandler.cs
@@ -1,0 +1,36 @@
+using Guild.Application.Abstractions.Messaging;
+using Guild.Application.Abstractions.Persistence;
+using Guild.Application.Abstractions.Security;
+using Guild.Application.Features.Invites.Common;
+using Guild.Domain.Guild;
+using Guild.Domain.Results;
+
+namespace Guild.Application.Features.Invites.ListInvites;
+
+internal sealed class ListInvitesHandler(
+	IGuildRepository guilds,
+	IGuildInviteRepository invites,
+	ICurrentUser currentUser)
+	: IQueryHandler<ListInvitesQuery, Result<IReadOnlyList<InviteDto>>>
+{
+	public async Task<Result<IReadOnlyList<InviteDto>>> HandleAsync(
+		ListInvitesQuery query,
+		CancellationToken cancellationToken = default)
+	{
+		var guild = await guilds.GetByIdWithMembershipAsync(query.GuildId, cancellationToken);
+		if (guild is null)
+			return GuildFailures.GuildNotFound;
+
+		if (guild.Members.All(m => m.UserId != currentUser.Id))
+			return GuildFailures.NotAMember;
+
+		var mask = PermissionResolver.Resolve(
+			currentUser.Id, guild.OwnerId, guild.Roles, guild.MemberRoles);
+		if (!PermissionResolver.HasPermission(mask, Permission.ManageGuild))
+			return GuildFailures.MissingPermission;
+
+		var rows = await invites.ListByGuildAsync(query.GuildId, cancellationToken);
+		IReadOnlyList<InviteDto> dtos = rows.Select(InviteDto.FromEntity).ToList();
+		return Result.Ok(dtos);
+	}
+}

--- a/services/guild/src/Guild.Application/Features/Invites/ListInvites/ListInvitesQuery.cs
+++ b/services/guild/src/Guild.Application/Features/Invites/ListInvites/ListInvitesQuery.cs
@@ -1,0 +1,7 @@
+using Guild.Application.Abstractions.Messaging;
+using Guild.Application.Features.Invites.Common;
+using Guild.Domain.Results;
+
+namespace Guild.Application.Features.Invites.ListInvites;
+
+public sealed record ListInvitesQuery(long GuildId) : IQuery<Result<IReadOnlyList<InviteDto>>>;

--- a/services/guild/src/Guild.Application/Features/Membership/JoinByInviteCode/JoinByInviteCodeCommand.cs
+++ b/services/guild/src/Guild.Application/Features/Membership/JoinByInviteCode/JoinByInviteCodeCommand.cs
@@ -1,0 +1,13 @@
+using Guild.Application.Abstractions.Messaging;
+using Guild.Application.Features.Guilds.Common;
+using Guild.Domain.Results;
+
+namespace Guild.Application.Features.Membership.JoinByInviteCode;
+
+/// <summary>
+/// shared command behind <c>POST /guilds/{id}/join</c> and <c>POST /invites/{code}/join</c>.
+/// when <see cref="ExpectedGuildId"/> is set the handler rejects the invite if it
+/// belongs to a different guild (so the URL path stays authoritative).
+/// </summary>
+public sealed record JoinByInviteCodeCommand(string? Code, long? ExpectedGuildId)
+	: ICommand<Result<GuildDto>>;

--- a/services/guild/src/Guild.Application/Features/Membership/JoinByInviteCode/JoinByInviteCodeHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Membership/JoinByInviteCode/JoinByInviteCodeHandler.cs
@@ -32,6 +32,15 @@ internal sealed class JoinByInviteCodeHandler(
 		if (command.ExpectedGuildId is { } expected && invite.GuildId != expected)
 			return GuildFailures.InviteGuildMismatch;
 
+		var now = clock.UtcNow;
+
+		// fail fast before loading the guild aggregate: revoked / expired /
+		// exhausted invites get rejected without a second DB roundtrip, and the
+		// error ordering matches how a user thinks ("the code itself is bad",
+		// not "you're already a member of the guild this dead code points to")
+		if (!invite.IsActive(now))
+			return GuildFailures.InviteUnusable;
+
 		var guild = await guilds.GetByIdWithMembershipAsync(invite.GuildId, cancellationToken);
 		if (guild is null)
 			return GuildFailures.GuildNotFound;
@@ -39,7 +48,6 @@ internal sealed class JoinByInviteCodeHandler(
 		if (guild.Members.Any(m => m.UserId == currentUser.Id))
 			return GuildFailures.AlreadyMember;
 
-		var now = clock.UtcNow;
 		var consumeResult = invite.Consume(now);
 		if (consumeResult.IsFailure)
 			return consumeResult.Error;

--- a/services/guild/src/Guild.Application/Features/Membership/JoinByInviteCode/JoinByInviteCodeHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Membership/JoinByInviteCode/JoinByInviteCodeHandler.cs
@@ -1,0 +1,64 @@
+using Guild.Application.Abstractions;
+using Guild.Application.Abstractions.Messaging;
+using Guild.Application.Abstractions.Persistence;
+using Guild.Application.Abstractions.Security;
+using Guild.Application.Abstractions.Users;
+using Guild.Application.Contracts;
+using Guild.Application.Features.Guilds.Common;
+using Guild.Domain.Results;
+
+namespace Guild.Application.Features.Membership.JoinByInviteCode;
+
+internal sealed class JoinByInviteCodeHandler(
+	IGuildRepository guilds,
+	IGuildInviteRepository invites,
+	IEventBus eventBus,
+	IUserService users,
+	IClock clock,
+	ICurrentUser currentUser)
+	: ICommandHandler<JoinByInviteCodeCommand, Result<GuildDto>>
+{
+	public async Task<Result<GuildDto>> HandleAsync(
+		JoinByInviteCodeCommand command,
+		CancellationToken cancellationToken = default)
+	{
+		if (string.IsNullOrWhiteSpace(command.Code))
+			return GuildFailures.InviteCodeRequired;
+
+		var invite = await invites.GetByCodeAsync(command.Code, cancellationToken);
+		if (invite is null)
+			return GuildFailures.InviteNotFound;
+
+		if (command.ExpectedGuildId is { } expected && invite.GuildId != expected)
+			return GuildFailures.InviteGuildMismatch;
+
+		var guild = await guilds.GetByIdWithMembershipAsync(invite.GuildId, cancellationToken);
+		if (guild is null)
+			return GuildFailures.GuildNotFound;
+
+		if (guild.Members.Any(m => m.UserId == currentUser.Id))
+			return GuildFailures.AlreadyMember;
+
+		var now = clock.UtcNow;
+		var consumeResult = invite.Consume(now);
+		if (consumeResult.IsFailure)
+			return consumeResult.Error;
+
+		var addResult = guild.AddMember(currentUser.Id, now);
+		if (addResult.IsFailure)
+			return addResult.Error;
+
+		// best-effort existence check; logs internally on failure but does not block
+		await users.ExistsAsync(currentUser.Id, cancellationToken);
+
+		invites.Update(invite);
+		guilds.Update(guild);
+		await guilds.SaveChangesAsync(cancellationToken);
+
+		await eventBus.PublishAsync(
+			new GuildMemberJoined(guild.Id, guild.Name, currentUser.Id),
+			cancellationToken);
+
+		return GuildDto.FromEntity(guild);
+	}
+}

--- a/services/guild/src/Guild.Application/Features/Membership/LeaveGuild/LeaveGuildCommand.cs
+++ b/services/guild/src/Guild.Application/Features/Membership/LeaveGuild/LeaveGuildCommand.cs
@@ -1,0 +1,6 @@
+using Guild.Application.Abstractions.Messaging;
+using Guild.Domain.Results;
+
+namespace Guild.Application.Features.Membership.LeaveGuild;
+
+public sealed record LeaveGuildCommand(long GuildId) : ICommand<Result>;

--- a/services/guild/src/Guild.Application/Features/Membership/LeaveGuild/LeaveGuildHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Membership/LeaveGuild/LeaveGuildHandler.cs
@@ -1,0 +1,38 @@
+using Guild.Application.Abstractions;
+using Guild.Application.Abstractions.Messaging;
+using Guild.Application.Abstractions.Persistence;
+using Guild.Application.Abstractions.Security;
+using Guild.Application.Contracts;
+using Guild.Domain.Results;
+
+namespace Guild.Application.Features.Membership.LeaveGuild;
+
+internal sealed class LeaveGuildHandler(
+	IGuildRepository guilds,
+	IEventBus eventBus,
+	IClock clock,
+	ICurrentUser currentUser)
+	: ICommandHandler<LeaveGuildCommand, Result>
+{
+	public async Task<Result> HandleAsync(
+		LeaveGuildCommand command,
+		CancellationToken cancellationToken = default)
+	{
+		var guild = await guilds.GetByIdWithMembershipAsync(command.GuildId, cancellationToken);
+		if (guild is null)
+			return GuildFailures.GuildNotFound;
+
+		var removeResult = guild.RemoveMember(currentUser.Id, clock.UtcNow);
+		if (removeResult.IsFailure)
+			return removeResult.Error;
+
+		guilds.Update(guild);
+		await guilds.SaveChangesAsync(cancellationToken);
+
+		await eventBus.PublishAsync(
+			new GuildMemberLeft(guild.Id, currentUser.Id),
+			cancellationToken);
+
+		return Result.Ok();
+	}
+}

--- a/services/guild/src/Guild.Domain/Guild/Guild.cs
+++ b/services/guild/src/Guild.Domain/Guild/Guild.cs
@@ -123,6 +123,35 @@ public sealed class Guild
 		return Result.Ok();
 	}
 
+	public Result<GuildMember> AddMember(long userId, DateTimeOffset now)
+	{
+		if (_members.Any(m => m.UserId == userId))
+			return GuildFailures.AlreadyMember;
+
+		var memberResult = GuildMember.Create(Id, userId, now);
+		if (memberResult.IsFailure)
+			return memberResult.Error;
+
+		_members.Add(memberResult.Value);
+		UpdatedAt = now;
+		return memberResult.Value;
+	}
+
+	public Result RemoveMember(long userId, DateTimeOffset now)
+	{
+		if (userId == OwnerId)
+			return GuildFailures.OwnerCannotLeave;
+
+		var member = _members.FirstOrDefault(m => m.UserId == userId);
+		if (member is null)
+			return GuildFailures.NotAMember;
+
+		_members.Remove(member);
+		_memberRoles.RemoveAll(mr => mr.UserId == userId);
+		UpdatedAt = now;
+		return Result.Ok();
+	}
+
 	private static Result ValidateSettings(
 		string? name,
 		string? description,

--- a/services/guild/src/Guild.Domain/Guild/GuildInvite.cs
+++ b/services/guild/src/Guild.Domain/Guild/GuildInvite.cs
@@ -1,0 +1,91 @@
+using Guild.Domain.Results;
+
+namespace Guild.Domain.Guild;
+
+public sealed class GuildInvite
+{
+	public const int MaxCodeLen = 16;
+
+	// EF Core constructor
+	private GuildInvite() { }
+
+	private GuildInvite(
+		string code,
+		long guildId,
+		long createdBy,
+		int? maxUses,
+		DateTimeOffset? expiresAt,
+		DateTimeOffset createdAt)
+	{
+		Code = code;
+		GuildId = guildId;
+		CreatedBy = createdBy;
+		MaxUses = maxUses;
+		Uses = 0;
+		IsRevoked = false;
+		ExpiresAt = expiresAt;
+		CreatedAt = createdAt;
+	}
+
+	public string Code { get; private set; } = string.Empty;
+	public long GuildId { get; private set; }
+	public long CreatedBy { get; private set; }
+	public int? MaxUses { get; private set; }
+	public int Uses { get; private set; }
+	public bool IsRevoked { get; private set; }
+	public DateTimeOffset? ExpiresAt { get; private set; }
+	public DateTimeOffset CreatedAt { get; private set; }
+
+	public static Result<GuildInvite> Create(
+		string code,
+		long guildId,
+		long createdBy,
+		int? maxUses,
+		DateTimeOffset? expiresAt,
+		DateTimeOffset now)
+	{
+		if (string.IsNullOrEmpty(code) || code.Length > MaxCodeLen)
+			return GuildFailures.InviteCodeInvalid;
+		if (guildId <= 0 || createdBy <= 0)
+			return GuildFailures.InviteCodeInvalid;
+		if (maxUses is <= 0)
+			return GuildFailures.InviteMaxUsesInvalid;
+		if (expiresAt is { } exp && exp <= now)
+			return GuildFailures.InviteExpiresInPast;
+
+		return new GuildInvite(code, guildId, createdBy, maxUses, expiresAt, now);
+	}
+
+	/// <summary>
+	/// validates that the invite is still usable at <paramref name="now"/> and
+	/// increments <see cref="Uses"/>. callers must persist the invite afterwards
+	/// </summary>
+	public Result Consume(DateTimeOffset now)
+	{
+		if (IsRevoked)
+			return GuildFailures.InviteUnusable;
+		if (ExpiresAt is { } exp && exp <= now)
+			return GuildFailures.InviteUnusable;
+		if (MaxUses is { } cap && Uses >= cap)
+			return GuildFailures.InviteUnusable;
+
+		Uses += 1;
+		return Result.Ok();
+	}
+
+	public Result Revoke()
+	{
+		if (IsRevoked)
+			return GuildFailures.InviteAlreadyRevoked;
+		IsRevoked = true;
+		return Result.Ok();
+	}
+
+	public bool IsActive(DateTimeOffset now)
+	{
+		if (IsRevoked) return false;
+		if (ExpiresAt is { } exp && exp <= now) return false;
+		if (MaxUses is { } cap && Uses >= cap) return false;
+		return true;
+	}
+}

--- a/services/guild/src/Guild.Domain/Guild/GuildInvite.cs
+++ b/services/guild/src/Guild.Domain/Guild/GuildInvite.cs
@@ -62,11 +62,7 @@ public sealed class GuildInvite
 	/// </summary>
 	public Result Consume(DateTimeOffset now)
 	{
-		if (IsRevoked)
-			return GuildFailures.InviteUnusable;
-		if (ExpiresAt is { } exp && exp <= now)
-			return GuildFailures.InviteUnusable;
-		if (MaxUses is { } cap && Uses >= cap)
+		if (!IsActive(now))
 			return GuildFailures.InviteUnusable;
 
 		Uses += 1;

--- a/services/guild/src/Guild.Domain/Results/GuildFailures.cs
+++ b/services/guild/src/Guild.Domain/Results/GuildFailures.cs
@@ -82,4 +82,34 @@ public static class GuildFailures
 
 	public static readonly Failure OverwriteNotFound =
 		new("Guild.OverwriteNotFound", "Channel permission overwrite not found.");
+
+	public static readonly Failure AlreadyMember =
+		new("Guild.AlreadyMember", "User is already a member of this guild.");
+
+	public static readonly Failure OwnerCannotLeave =
+		new("Guild.OwnerCannotLeave", "Owner cannot leave. Transfer ownership or delete the guild first.");
+
+	public static readonly Failure InviteCodeRequired =
+		new("Guild.InviteCodeRequired", "Invite code is required.");
+
+	public static readonly Failure InviteCodeInvalid =
+		new("Guild.InviteCodeInvalid", "Invite code is invalid.");
+
+	public static readonly Failure InviteMaxUsesInvalid =
+		new("Guild.InviteMaxUsesInvalid", "Invite max_uses must be a positive integer.");
+
+	public static readonly Failure InviteExpiresInPast =
+		new("Guild.InviteExpiresInPast", "Invite expires_at must be in the future.");
+
+	public static readonly Failure InviteNotFound =
+		new("Guild.InviteNotFound", "Invite not found.");
+
+	public static readonly Failure InviteUnusable =
+		new("Guild.InviteUnusable", "Invite is revoked, expired, or has reached its max uses.");
+
+	public static readonly Failure InviteAlreadyRevoked =
+		new("Guild.InviteAlreadyRevoked", "Invite is already revoked.");
+
+	public static readonly Failure InviteGuildMismatch =
+		new("Guild.InviteGuildMismatch", "Invite code does not belong to this guild.");
 }

--- a/services/guild/src/Guild.Infrastructure/DependencyInjection.cs
+++ b/services/guild/src/Guild.Infrastructure/DependencyInjection.cs
@@ -1,10 +1,12 @@
 using System.Reflection;
 using Guild.Application.Abstractions;
 using Guild.Application.Abstractions.Security;
+using Guild.Application.Abstractions.Users;
 using Guild.Application.Contracts;
 using Guild.Infrastructure.Messaging;
 using Guild.Infrastructure.Options;
 using Guild.Infrastructure.Security;
+using Guild.Infrastructure.Users;
 using MassTransit;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
@@ -53,7 +55,15 @@ public static class DependencyInjection
 		services.AddScoped<IEventBus, EventBus>();
 		services.AddSingleton<IClock, SystemClock>();
 		services.AddSingleton<IIdGenerator, SnowflakeIdGenerator>();
+		services.AddSingleton<IInviteCodeGenerator, InviteCodeGenerator>();
 		services.AddScoped<ICurrentUser, CurrentUser>();
+
+		services.AddHttpClient<IUserService, UserServiceClient>((sp, client) =>
+		{
+			var opts = sp.GetRequiredService<IOptions<UserServiceOptions>>().Value;
+			client.BaseAddress = new Uri(opts.BaseUrl);
+			client.Timeout = TimeSpan.FromSeconds(2);
+		});
 
 		return services;
 	}

--- a/services/guild/src/Guild.Infrastructure/DependencyInjection.cs
+++ b/services/guild/src/Guild.Infrastructure/DependencyInjection.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using System.Text.Json;
 using Guild.Application.Abstractions;
 using Guild.Application.Abstractions.Security;
 using Guild.Application.Abstractions.Users;
@@ -40,6 +41,17 @@ public static class DependencyInjection
 				{
 					h.Username(options.Username);
 					h.Password(options.Password);
+				});
+
+				// the docs/contracts source of truth specify snake_case payloads.
+				// MassTransit defaults to camelCase via System.Text.Json, so override
+				// the property naming policy so the wire format matches the docs.
+				// every other service that publishes or consumes these events must
+				// apply the same policy or deserialisation will fail
+				cfg.ConfigureJsonSerializerOptions(opts =>
+				{
+					opts.PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower;
+					return opts;
 				});
 
 				cfg.Message<GuildMemberJoined>(m => m.SetEntityName("guild.member_joined"));

--- a/services/guild/src/Guild.Infrastructure/InviteCodeGenerator.cs
+++ b/services/guild/src/Guild.Infrastructure/InviteCodeGenerator.cs
@@ -1,0 +1,25 @@
+using System.Security.Cryptography;
+using Guild.Application.Abstractions;
+
+namespace Guild.Infrastructure;
+
+/// <summary>
+/// emits 10-char URL-safe codes drawn from a 56-symbol alphabet (no easily
+/// confused glyphs like 0/O/I/l/1). roughly 2^58 of entropy per code, well
+/// above what a casual brute force can scan against a guild_invites primary
+/// key with a non-existent code yielding a cheap 404
+/// </summary>
+internal sealed class InviteCodeGenerator : IInviteCodeGenerator
+{
+	private const string Alphabet = "abcdefghijkmnpqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ23456789";
+	private const int Length = 10;
+
+	public string NextCode()
+	{
+		var buffer = RandomNumberGenerator.GetBytes(Length);
+		var chars = new char[Length];
+		for (var i = 0; i < Length; i++)
+			chars[i] = Alphabet[buffer[i] % Alphabet.Length];
+		return new string(chars);
+	}
+}

--- a/services/guild/src/Guild.Infrastructure/Options/UserServiceOptions.cs
+++ b/services/guild/src/Guild.Infrastructure/Options/UserServiceOptions.cs
@@ -1,0 +1,10 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Guild.Infrastructure.Options;
+
+internal sealed class UserServiceOptions : IOptions
+{
+	static string IOptions.SectionName => "UserService";
+
+	[Required] public required string BaseUrl { get; init; }
+}

--- a/services/guild/src/Guild.Infrastructure/Users/UserServiceClient.cs
+++ b/services/guild/src/Guild.Infrastructure/Users/UserServiceClient.cs
@@ -28,14 +28,9 @@ internal sealed class UserServiceClient(HttpClient http, ILogger<UserServiceClie
 			response.EnsureSuccessStatusCode();
 			return true;
 		}
-		catch (HttpRequestException ex)
+		catch (Exception ex) when (ShouldSwallow(ex, cancellationToken))
 		{
-			logger.LogWarning(ex, "user service unreachable for ExistsAsync({UserId}); treating as best-effort", userId);
-			return true;
-		}
-		catch (TaskCanceledException ex) when (!cancellationToken.IsCancellationRequested)
-		{
-			logger.LogWarning(ex, "user service timed out for ExistsAsync({UserId}); treating as best-effort", userId);
+			logger.LogWarning(ex, "user service ExistsAsync({UserId}) failed; treating as best-effort", userId);
 			return true;
 		}
 	}
@@ -57,17 +52,19 @@ internal sealed class UserServiceClient(HttpClient http, ILogger<UserServiceClie
 				return null;
 			return new UserSummary(id, payload.Username ?? string.Empty);
 		}
-		catch (HttpRequestException ex)
+		catch (Exception ex) when (ShouldSwallow(ex, cancellationToken))
 		{
-			logger.LogWarning(ex, "user service unreachable for GetSummaryAsync({UserId})", userId);
-			return null;
-		}
-		catch (TaskCanceledException ex) when (!cancellationToken.IsCancellationRequested)
-		{
-			logger.LogWarning(ex, "user service timed out for GetSummaryAsync({UserId})", userId);
+			logger.LogWarning(ex, "user service GetSummaryAsync({UserId}) failed", userId);
 			return null;
 		}
 	}
+
+	// swallow anything except a real caller-initiated cancellation, which must
+	// propagate so the outer handler observes the cancellation contract. covers
+	// HttpRequestException (connect / DNS), TaskCanceledException (timeout),
+	// JsonException (malformed body), and any other transport / parsing fault
+	private static bool ShouldSwallow(Exception ex, CancellationToken ct) =>
+		ex is not OperationCanceledException || !ct.IsCancellationRequested;
 
 	private sealed record InternalUserPayload(string Id, string? Username);
 }

--- a/services/guild/src/Guild.Infrastructure/Users/UserServiceClient.cs
+++ b/services/guild/src/Guild.Infrastructure/Users/UserServiceClient.cs
@@ -1,0 +1,73 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Guild.Application.Abstractions.Users;
+using Microsoft.Extensions.Logging;
+
+namespace Guild.Infrastructure.Users;
+
+/// <summary>
+/// hits the User Service internal endpoints over the docker network. swallows
+/// connection failures and 404s with a warn log so the caller never sees a
+/// transport-level exception. see <see cref="IUserService"/> for the contract
+/// </summary>
+internal sealed class UserServiceClient(HttpClient http, ILogger<UserServiceClient> logger) : IUserService
+{
+	private static readonly JsonSerializerOptions JsonOptions = new()
+	{
+		PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+	};
+
+	public async Task<bool> ExistsAsync(long userId, CancellationToken cancellationToken = default)
+	{
+		try
+		{
+			using var response = await http.GetAsync($"/internal/users/{userId}", cancellationToken);
+			if (response.StatusCode == HttpStatusCode.NotFound)
+				return false;
+			response.EnsureSuccessStatusCode();
+			return true;
+		}
+		catch (HttpRequestException ex)
+		{
+			logger.LogWarning(ex, "user service unreachable for ExistsAsync({UserId}); treating as best-effort", userId);
+			return true;
+		}
+		catch (TaskCanceledException ex) when (!cancellationToken.IsCancellationRequested)
+		{
+			logger.LogWarning(ex, "user service timed out for ExistsAsync({UserId}); treating as best-effort", userId);
+			return true;
+		}
+	}
+
+	public async Task<UserSummary?> GetSummaryAsync(long userId, CancellationToken cancellationToken = default)
+	{
+		try
+		{
+			using var response = await http.GetAsync($"/internal/users/{userId}", cancellationToken);
+			if (response.StatusCode == HttpStatusCode.NotFound)
+				return null;
+			response.EnsureSuccessStatusCode();
+
+			var payload = await response.Content.ReadFromJsonAsync<InternalUserPayload>(
+				JsonOptions, cancellationToken);
+			if (payload is null || string.IsNullOrEmpty(payload.Id))
+				return null;
+			if (!long.TryParse(payload.Id, out var id))
+				return null;
+			return new UserSummary(id, payload.Username ?? string.Empty);
+		}
+		catch (HttpRequestException ex)
+		{
+			logger.LogWarning(ex, "user service unreachable for GetSummaryAsync({UserId})", userId);
+			return null;
+		}
+		catch (TaskCanceledException ex) when (!cancellationToken.IsCancellationRequested)
+		{
+			logger.LogWarning(ex, "user service timed out for GetSummaryAsync({UserId})", userId);
+			return null;
+		}
+	}
+
+	private sealed record InternalUserPayload(string Id, string? Username);
+}

--- a/services/guild/src/Guild.Persistence/Db/Configurations/GuildInviteConfig.cs
+++ b/services/guild/src/Guild.Persistence/Db/Configurations/GuildInviteConfig.cs
@@ -1,0 +1,57 @@
+using Guild.Domain.Guild;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using GuildEntity = Guild.Domain.Guild.Guild;
+
+namespace Guild.Persistence.Db.Configurations;
+
+internal sealed class GuildInviteConfig : IEntityTypeConfiguration<GuildInvite>
+{
+	public void Configure(EntityTypeBuilder<GuildInvite> builder)
+	{
+		builder.ToTable("guild_invites");
+
+		builder.HasKey(i => i.Code);
+
+		builder.Property(i => i.Code)
+			.HasColumnName("code")
+			.HasMaxLength(GuildInvite.MaxCodeLen)
+			.IsRequired();
+
+		builder.Property(i => i.GuildId).HasColumnName("guild_id").IsRequired();
+		builder.Property(i => i.CreatedBy).HasColumnName("created_by").IsRequired();
+
+		builder.Property(i => i.ExpiresAt).HasColumnName("expires_at");
+		builder.Property(i => i.MaxUses).HasColumnName("max_uses");
+
+		builder.Property(i => i.Uses)
+			.HasColumnName("uses")
+			.IsRequired()
+			.HasDefaultValue(0);
+
+		builder.Property(i => i.IsRevoked)
+			.HasColumnName("is_revoked")
+			.IsRequired()
+			.HasDefaultValue(false);
+
+		builder.Property(i => i.CreatedAt)
+			.HasColumnName("created_at")
+			.IsRequired()
+			.HasDefaultValueSql("NOW()");
+
+		// matches docs/schema/guild.sql: partial index on non-revoked invites only,
+		// since the listing endpoint omits revoked rows and revocation is the
+		// vastly more common state long-term
+		builder.HasIndex(i => i.GuildId)
+			.HasDatabaseName("idx_guild_invites_guild")
+			.HasFilter("is_revoked = FALSE");
+
+		// FK back to guilds with ON DELETE CASCADE matches docs/schema/guild.sql.
+		// no navigation either side: invites are owned by their own repository,
+		// not by the Guild aggregate, and the FK alone is enough for the cascade
+		builder.HasOne<GuildEntity>()
+			.WithMany()
+			.HasForeignKey(i => i.GuildId)
+			.OnDelete(DeleteBehavior.Cascade);
+	}
+}

--- a/services/guild/src/Guild.Persistence/Db/GuildDbContext.cs
+++ b/services/guild/src/Guild.Persistence/Db/GuildDbContext.cs
@@ -13,6 +13,7 @@ public sealed class GuildDbContext(DbContextOptions<GuildDbContext> options) : D
 	public DbSet<ChannelCategory> ChannelCategories => Set<ChannelCategory>();
 	public DbSet<Channel> Channels => Set<Channel>();
 	public DbSet<ChannelPermissionOverwrite> ChannelPermissionOverwrites => Set<ChannelPermissionOverwrite>();
+	public DbSet<GuildInvite> GuildInvites => Set<GuildInvite>();
 
 	protected override void OnModelCreating(ModelBuilder modelBuilder)
 	{

--- a/services/guild/src/Guild.Persistence/DependencyInjection.cs
+++ b/services/guild/src/Guild.Persistence/DependencyInjection.cs
@@ -25,6 +25,7 @@ public static class DependencyInjection
 		});
 
 		services.AddScoped<IGuildRepository, GuildRepository>();
+		services.AddScoped<IGuildInviteRepository, GuildInviteRepository>();
 		services.AddScoped<IChannelCategoryRepository, ChannelCategoryRepository>();
 		services.AddScoped<IChannelRepository, ChannelRepository>();
 		services.AddScoped<IChannelPermissionOverwriteRepository, ChannelPermissionOverwriteRepository>();

--- a/services/guild/src/Guild.Persistence/Migrations/20260604133333_AddGuildInvites.Designer.cs
+++ b/services/guild/src/Guild.Persistence/Migrations/20260604133333_AddGuildInvites.Designer.cs
@@ -4,6 +4,7 @@ using Guild.Domain.Guild;
 using Guild.Persistence.Db;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Guild.Persistence.Migrations
 {
     [DbContext(typeof(GuildDbContext))]
-    partial class GuildDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260604133333_AddGuildInvites")]
+    partial class AddGuildInvites
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/services/guild/src/Guild.Persistence/Migrations/20260604133333_AddGuildInvites.cs
+++ b/services/guild/src/Guild.Persistence/Migrations/20260604133333_AddGuildInvites.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Guild.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddGuildInvites : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "guild_invites",
+                columns: table => new
+                {
+                    code = table.Column<string>(type: "character varying(16)", maxLength: 16, nullable: false),
+                    guild_id = table.Column<long>(type: "bigint", nullable: false),
+                    created_by = table.Column<long>(type: "bigint", nullable: false),
+                    max_uses = table.Column<int>(type: "integer", nullable: true),
+                    uses = table.Column<int>(type: "integer", nullable: false, defaultValue: 0),
+                    is_revoked = table.Column<bool>(type: "boolean", nullable: false, defaultValue: false),
+                    expires_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    created_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false, defaultValueSql: "NOW()")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_guild_invites", x => x.code);
+                    table.ForeignKey(
+                        name: "FK_guild_invites_guilds_guild_id",
+                        column: x => x.guild_id,
+                        principalTable: "guilds",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "idx_guild_invites_guild",
+                table: "guild_invites",
+                column: "guild_id",
+                filter: "is_revoked = FALSE");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "guild_invites");
+        }
+    }
+}

--- a/services/guild/src/Guild.Persistence/Repositories/GuildInviteRepository.cs
+++ b/services/guild/src/Guild.Persistence/Repositories/GuildInviteRepository.cs
@@ -1,0 +1,38 @@
+using Guild.Application.Abstractions.Persistence;
+using Guild.Domain.Guild;
+using Guild.Persistence.Db;
+using Microsoft.EntityFrameworkCore;
+
+namespace Guild.Persistence.Repositories;
+
+internal sealed class GuildInviteRepository(GuildDbContext context) : IGuildInviteRepository
+{
+	public Task<GuildInvite?> GetByCodeAsync(string code, CancellationToken cancellationToken = default)
+	{
+		return context.GuildInvites
+			.FirstOrDefaultAsync(i => i.Code == code, cancellationToken);
+	}
+
+	public async Task<IReadOnlyList<GuildInvite>> ListByGuildAsync(long guildId, CancellationToken cancellationToken = default)
+	{
+		return await context.GuildInvites
+			.Where(i => i.GuildId == guildId && !i.IsRevoked)
+			.OrderByDescending(i => i.CreatedAt)
+			.ToListAsync(cancellationToken);
+	}
+
+	public async Task AddAsync(GuildInvite invite, CancellationToken cancellationToken = default)
+	{
+		await context.GuildInvites.AddAsync(invite, cancellationToken);
+	}
+
+	public void Update(GuildInvite invite)
+	{
+		context.GuildInvites.Update(invite);
+	}
+
+	public Task SaveChangesAsync(CancellationToken cancellationToken = default)
+	{
+		return context.SaveChangesAsync(cancellationToken);
+	}
+}

--- a/services/guild/src/Guild.Presentation/Endpoints/GuildInvitesEndpoint.cs
+++ b/services/guild/src/Guild.Presentation/Endpoints/GuildInvitesEndpoint.cs
@@ -1,0 +1,96 @@
+using Carter;
+using Guild.Application.Abstractions.Messaging;
+using Guild.Application.Features.Invites.Common;
+using Guild.Application.Features.Invites.CreateInvite;
+using Guild.Application.Features.Invites.DeleteInvite;
+using Guild.Application.Features.Invites.ListInvites;
+using Guild.Domain.Results;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+
+namespace Guild.Presentation.Endpoints;
+
+public sealed class GuildInvitesEndpoint : ICarterModule
+{
+	public void AddRoutes(IEndpointRouteBuilder endpoints)
+	{
+		var group = endpoints.MapGroup("/guilds/{id:long}/invites");
+		group.MapPost("/", CreateAsync);
+		group.MapGet("/", ListAsync);
+		group.MapDelete("/{code}", DeleteAsync);
+	}
+
+	private static async Task<Results<
+		Created<InviteDto>,
+		BadRequest<ErrorBody>,
+		NotFound<ErrorBody>,
+		JsonHttpResult<ErrorBody>>>
+	CreateAsync(
+		long id,
+		CreateInviteRequest request,
+		ICommandHandler<CreateInviteCommand, Result<InviteDto>> handler,
+		CancellationToken cancellationToken)
+	{
+		var result = await handler.HandleAsync(
+			new CreateInviteCommand(id, request.MaxUses, request.ExpiresInHours),
+			cancellationToken);
+
+		if (result.Succeeded)
+			return TypedResults.Created($"/v1/invites/{result.Value.Code}", result.Value);
+
+		return result.Error.Code switch
+		{
+			"Guild.GuildNotFound" => TypedResults.NotFound(new ErrorBody(result.Error.Message)),
+			"Guild.NotAMember" => TypedResults.Json(new ErrorBody(result.Error.Message), statusCode: StatusCodes.Status403Forbidden),
+			"Guild.MissingPermission" => TypedResults.Json(new ErrorBody(result.Error.Message), statusCode: StatusCodes.Status403Forbidden),
+			_ => TypedResults.BadRequest(new ErrorBody(result.Error.Message)),
+		};
+	}
+
+	private static async Task<Results<
+		Ok<IReadOnlyList<InviteDto>>,
+		NotFound<ErrorBody>,
+		JsonHttpResult<ErrorBody>>>
+	ListAsync(
+		long id,
+		IQueryHandler<ListInvitesQuery, Result<IReadOnlyList<InviteDto>>> handler,
+		CancellationToken cancellationToken)
+	{
+		var result = await handler.HandleAsync(new ListInvitesQuery(id), cancellationToken);
+
+		if (result.Succeeded)
+			return TypedResults.Ok(result.Value);
+
+		return result.Error.Code switch
+		{
+			"Guild.GuildNotFound" => TypedResults.NotFound(new ErrorBody(result.Error.Message)),
+			_ => TypedResults.Json(new ErrorBody(result.Error.Message), statusCode: StatusCodes.Status403Forbidden),
+		};
+	}
+
+	private static async Task<Results<
+		NoContent,
+		NotFound<ErrorBody>,
+		JsonHttpResult<ErrorBody>>>
+	DeleteAsync(
+		long id,
+		string code,
+		ICommandHandler<DeleteInviteCommand, Result> handler,
+		CancellationToken cancellationToken)
+	{
+		var result = await handler.HandleAsync(new DeleteInviteCommand(id, code), cancellationToken);
+
+		if (result.Succeeded)
+			return TypedResults.NoContent();
+
+		return result.Error.Code switch
+		{
+			"Guild.InviteNotFound" => TypedResults.NotFound(new ErrorBody(result.Error.Message)),
+			"Guild.InviteGuildMismatch" => TypedResults.NotFound(new ErrorBody(result.Error.Message)),
+			"Guild.GuildNotFound" => TypedResults.NotFound(new ErrorBody(result.Error.Message)),
+			_ => TypedResults.Json(new ErrorBody(result.Error.Message), statusCode: StatusCodes.Status403Forbidden),
+		};
+	}
+
+	private sealed record CreateInviteRequest(int? MaxUses, int? ExpiresInHours);
+}

--- a/services/guild/src/Guild.Presentation/Endpoints/InvitesEndpoint.cs
+++ b/services/guild/src/Guild.Presentation/Endpoints/InvitesEndpoint.cs
@@ -1,0 +1,65 @@
+using Carter;
+using Guild.Application.Abstractions.Messaging;
+using Guild.Application.Features.Guilds.Common;
+using Guild.Application.Features.Invites.Common;
+using Guild.Application.Features.Invites.GetInvitePreview;
+using Guild.Application.Features.Membership.JoinByInviteCode;
+using Guild.Domain.Results;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+
+namespace Guild.Presentation.Endpoints;
+
+/// <summary>
+/// preview + accept flows for invite-link landings. these live outside
+/// <c>/guilds/{id}/...</c> because the client only knows the code, not the
+/// guild id, until preview returns it
+/// </summary>
+public sealed class InvitesEndpoint : ICarterModule
+{
+	public void AddRoutes(IEndpointRouteBuilder endpoints)
+	{
+		var group = endpoints.MapGroup("/invites/{code}");
+		group.MapGet("/", PreviewAsync);
+		group.MapPost("/join", JoinAsync);
+	}
+
+	private static async Task<Results<
+		Ok<InvitePreviewDto>,
+		NotFound<ErrorBody>>>
+	PreviewAsync(
+		string code,
+		IQueryHandler<GetInvitePreviewQuery, Result<InvitePreviewDto>> handler,
+		CancellationToken cancellationToken)
+	{
+		var result = await handler.HandleAsync(new GetInvitePreviewQuery(code), cancellationToken);
+
+		if (result.Succeeded)
+			return TypedResults.Ok(result.Value);
+
+		return TypedResults.NotFound(new ErrorBody(result.Error.Message));
+	}
+
+	private static async Task<Results<
+		Ok<GuildDto>,
+		NotFound<ErrorBody>,
+		Conflict<ErrorBody>>>
+	JoinAsync(
+		string code,
+		ICommandHandler<JoinByInviteCodeCommand, Result<GuildDto>> handler,
+		CancellationToken cancellationToken)
+	{
+		var result = await handler.HandleAsync(
+			new JoinByInviteCodeCommand(code, ExpectedGuildId: null),
+			cancellationToken);
+
+		if (result.Succeeded)
+			return TypedResults.Ok(result.Value);
+
+		return result.Error.Code switch
+		{
+			"Guild.AlreadyMember" => TypedResults.Conflict(new ErrorBody(result.Error.Message)),
+			_ => TypedResults.NotFound(new ErrorBody(result.Error.Message)),
+		};
+	}
+}

--- a/services/guild/src/Guild.Presentation/Endpoints/MembershipEndpoint.cs
+++ b/services/guild/src/Guild.Presentation/Endpoints/MembershipEndpoint.cs
@@ -1,0 +1,73 @@
+using Carter;
+using Guild.Application.Abstractions.Messaging;
+using Guild.Application.Features.Guilds.Common;
+using Guild.Application.Features.Membership.JoinByInviteCode;
+using Guild.Application.Features.Membership.LeaveGuild;
+using Guild.Domain.Results;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+
+namespace Guild.Presentation.Endpoints;
+
+public sealed class MembershipEndpoint : ICarterModule
+{
+	public void AddRoutes(IEndpointRouteBuilder endpoints)
+	{
+		var group = endpoints.MapGroup("/guilds/{id:long}");
+		group.MapPost("/join", JoinAsync);
+		group.MapPost("/leave", LeaveAsync);
+	}
+
+	private static async Task<Results<
+		Ok<GuildDto>,
+		BadRequest<ErrorBody>,
+		NotFound<ErrorBody>,
+		Conflict<ErrorBody>,
+		JsonHttpResult<ErrorBody>>>
+	JoinAsync(
+		long id,
+		JoinByPathRequest request,
+		ICommandHandler<JoinByInviteCodeCommand, Result<GuildDto>> handler,
+		CancellationToken cancellationToken)
+	{
+		var result = await handler.HandleAsync(
+			new JoinByInviteCodeCommand(request.InviteCode, ExpectedGuildId: id),
+			cancellationToken);
+
+		if (result.Succeeded)
+			return TypedResults.Ok(result.Value);
+
+		return result.Error.Code switch
+		{
+			"Guild.GuildNotFound" => TypedResults.NotFound(new ErrorBody(result.Error.Message)),
+			"Guild.AlreadyMember" => TypedResults.Conflict(new ErrorBody(result.Error.Message)),
+			_ => TypedResults.BadRequest(new ErrorBody(result.Error.Message)),
+		};
+	}
+
+	private static async Task<Results<
+		NoContent,
+		BadRequest<ErrorBody>,
+		NotFound<ErrorBody>,
+		JsonHttpResult<ErrorBody>>>
+	LeaveAsync(
+		long id,
+		ICommandHandler<LeaveGuildCommand, Result> handler,
+		CancellationToken cancellationToken)
+	{
+		var result = await handler.HandleAsync(new LeaveGuildCommand(id), cancellationToken);
+
+		if (result.Succeeded)
+			return TypedResults.NoContent();
+
+		return result.Error.Code switch
+		{
+			"Guild.GuildNotFound" => TypedResults.NotFound(new ErrorBody(result.Error.Message)),
+			"Guild.OwnerCannotLeave" => TypedResults.BadRequest(new ErrorBody(result.Error.Message)),
+			"Guild.NotAMember" => TypedResults.Json(new ErrorBody(result.Error.Message), statusCode: StatusCodes.Status403Forbidden),
+			_ => TypedResults.Json(new ErrorBody(result.Error.Message), statusCode: StatusCodes.Status403Forbidden),
+		};
+	}
+
+	private sealed record JoinByPathRequest(string? InviteCode);
+}

--- a/services/guild/src/Guild.Presentation/appsettings.json
+++ b/services/guild/src/Guild.Presentation/appsettings.json
@@ -9,5 +9,8 @@
   "RabbitMQ": {
     "Host": "localhost",
     "VirtualHost": "/"
+  },
+  "UserService": {
+    "BaseUrl": "http://user:8080"
   }
 }

--- a/services/guild/tests/Guild.FunctionalTests/Endpoints/CreateInviteTests.cs
+++ b/services/guild/tests/Guild.FunctionalTests/Endpoints/CreateInviteTests.cs
@@ -1,0 +1,78 @@
+using System.Net;
+using System.Net.Http.Json;
+using Guild.FunctionalTests.Infrastructure;
+using Xunit;
+
+namespace Guild.FunctionalTests.Endpoints;
+
+public sealed class CreateInviteTests(GuildApiFactory factory) : IClassFixture<GuildApiFactory>
+{
+	[Fact]
+	public async Task Without_Token_Returns_401()
+	{
+		var client = factory.CreateClient();
+		var resp = await client.PostAsJsonAsync(
+			"/v1/guilds/1/invites", new { }, JsonOptions.SnakeCase);
+		Assert.Equal(HttpStatusCode.Unauthorized, resp.StatusCode);
+	}
+
+	[Fact]
+	public async Task UnknownGuild_Returns_404()
+	{
+		var client = factory.CreateAuthenticatedClient(userId: 7301);
+		var resp = await client.PostAsJsonAsync(
+			"/v1/guilds/9999999/invites", new { }, JsonOptions.SnakeCase);
+		Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+	}
+
+	[Fact]
+	public async Task NotAMember_Returns_403()
+	{
+		var owner = factory.CreateAuthenticatedClient(userId: 7302);
+		var guild = await owner.CreateGuildAsync("g");
+		var id = guild.GetProperty("id").GetString()!;
+
+		var stranger = factory.CreateAuthenticatedClient(userId: 7303);
+		var resp = await stranger.PostAsJsonAsync(
+			$"/v1/guilds/{id}/invites", new { }, JsonOptions.SnakeCase);
+
+		Assert.Equal(HttpStatusCode.Forbidden, resp.StatusCode);
+	}
+
+	[Fact]
+	public async Task OwnerHappyPath_Returns_201_WithCode()
+	{
+		var owner = factory.CreateAuthenticatedClient(userId: 7304);
+		var guild = await owner.CreateGuildAsync("g");
+		var id = guild.GetProperty("id").GetString()!;
+
+		var resp = await owner.PostAsJsonAsync(
+			$"/v1/guilds/{id}/invites",
+			new { max_uses = 10, expires_in_hours = 24 },
+			JsonOptions.SnakeCase);
+
+		Assert.Equal(HttpStatusCode.Created, resp.StatusCode);
+		var body = await resp.ReadJsonAsync();
+		var code = body.GetProperty("code").GetString();
+		Assert.False(string.IsNullOrEmpty(code));
+		Assert.Equal(id, body.GetProperty("guild_id").GetString());
+		Assert.Equal(10, body.GetProperty("max_uses").GetInt32());
+		Assert.Equal(0, body.GetProperty("uses").GetInt32());
+	}
+
+	[Fact]
+	public async Task NoMaxUses_NoExpiry_ReturnsNullValues()
+	{
+		var owner = factory.CreateAuthenticatedClient(userId: 7305);
+		var guild = await owner.CreateGuildAsync("g");
+		var id = guild.GetProperty("id").GetString()!;
+
+		var resp = await owner.PostAsJsonAsync(
+			$"/v1/guilds/{id}/invites", new { }, JsonOptions.SnakeCase);
+
+		Assert.Equal(HttpStatusCode.Created, resp.StatusCode);
+		var body = await resp.ReadJsonAsync();
+		Assert.Equal(System.Text.Json.JsonValueKind.Null, body.GetProperty("max_uses").ValueKind);
+		Assert.Equal(System.Text.Json.JsonValueKind.Null, body.GetProperty("expires_at").ValueKind);
+	}
+}

--- a/services/guild/tests/Guild.FunctionalTests/Endpoints/DeleteInviteTests.cs
+++ b/services/guild/tests/Guild.FunctionalTests/Endpoints/DeleteInviteTests.cs
@@ -1,0 +1,84 @@
+using System.Net;
+using Guild.FunctionalTests.Infrastructure;
+using Xunit;
+
+namespace Guild.FunctionalTests.Endpoints;
+
+public sealed class DeleteInviteTests(GuildApiFactory factory) : IClassFixture<GuildApiFactory>
+{
+	[Fact]
+	public async Task Without_Token_Returns_401()
+	{
+		var client = factory.CreateClient();
+		var resp = await client.DeleteAsync("/v1/guilds/1/invites/code");
+		Assert.Equal(HttpStatusCode.Unauthorized, resp.StatusCode);
+	}
+
+	[Fact]
+	public async Task UnknownCode_Returns_404()
+	{
+		var owner = factory.CreateAuthenticatedClient(userId: 7501);
+		var guild = await owner.CreateGuildAsync("g");
+		var id = guild.GetProperty("id").GetString()!;
+
+		var resp = await owner.DeleteAsync($"/v1/guilds/{id}/invites/no-such-code");
+		Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+	}
+
+	[Fact]
+	public async Task CodeFromDifferentGuild_Returns_404()
+	{
+		var owner = factory.CreateAuthenticatedClient(userId: 7502);
+		var g1 = await owner.CreateGuildAsync("g1");
+		var g2 = await owner.CreateGuildAsync("g2");
+		var g1Id = long.Parse(g1.GetProperty("id").GetString()!);
+		var g2Id = long.Parse(g2.GetProperty("id").GetString()!);
+		await factory.AddInviteAsync(g1Id, "g1-code", createdBy: 7502);
+
+		var resp = await owner.DeleteAsync($"/v1/guilds/{g2Id}/invites/g1-code");
+		Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+	}
+
+	[Fact]
+	public async Task NonMember_Returns_403()
+	{
+		var owner = factory.CreateAuthenticatedClient(userId: 7503);
+		var guild = await owner.CreateGuildAsync("g");
+		var id = long.Parse(guild.GetProperty("id").GetString()!);
+		await factory.AddInviteAsync(id, "stranger-attempt", createdBy: 7503);
+
+		var stranger = factory.CreateAuthenticatedClient(userId: 7504);
+		var resp = await stranger.DeleteAsync($"/v1/guilds/{id}/invites/stranger-attempt");
+		Assert.Equal(HttpStatusCode.Forbidden, resp.StatusCode);
+	}
+
+	[Fact]
+	public async Task NonCreatorWithoutManageGuild_Returns_403()
+	{
+		var owner = factory.CreateAuthenticatedClient(userId: 7505);
+		var guild = await owner.CreateGuildAsync("g");
+		var id = long.Parse(guild.GetProperty("id").GetString()!);
+		await factory.AddBareMemberAsync(id, userId: 7506);
+		await factory.AddInviteAsync(id, "owner-made", createdBy: 7505);
+
+		var member = factory.CreateAuthenticatedClient(userId: 7506);
+		var resp = await member.DeleteAsync($"/v1/guilds/{id}/invites/owner-made");
+		Assert.Equal(HttpStatusCode.Forbidden, resp.StatusCode);
+	}
+
+	[Fact]
+	public async Task Owner_Returns_204_AndExcludesFromList()
+	{
+		var owner = factory.CreateAuthenticatedClient(userId: 7507);
+		var guild = await owner.CreateGuildAsync("g");
+		var id = long.Parse(guild.GetProperty("id").GetString()!);
+		await factory.AddInviteAsync(id, "to-revoke", createdBy: 7507);
+
+		var resp = await owner.DeleteAsync($"/v1/guilds/{id}/invites/to-revoke");
+		Assert.Equal(HttpStatusCode.NoContent, resp.StatusCode);
+
+		// second delete sees the invite as revoked, returns 404
+		var resp2 = await owner.DeleteAsync($"/v1/guilds/{id}/invites/to-revoke");
+		Assert.Equal(HttpStatusCode.NotFound, resp2.StatusCode);
+	}
+}

--- a/services/guild/tests/Guild.FunctionalTests/Endpoints/GetInvitePreviewTests.cs
+++ b/services/guild/tests/Guild.FunctionalTests/Endpoints/GetInvitePreviewTests.cs
@@ -1,0 +1,50 @@
+using System.Net;
+using Guild.FunctionalTests.Infrastructure;
+using Xunit;
+
+namespace Guild.FunctionalTests.Endpoints;
+
+public sealed class GetInvitePreviewTests(GuildApiFactory factory) : IClassFixture<GuildApiFactory>
+{
+	[Fact]
+	public async Task Without_Token_Returns_401()
+	{
+		var client = factory.CreateClient();
+		var resp = await client.GetAsync("/v1/invites/some-code");
+		Assert.Equal(HttpStatusCode.Unauthorized, resp.StatusCode);
+	}
+
+	[Fact]
+	public async Task UnknownCode_Returns_404()
+	{
+		var client = factory.CreateAuthenticatedClient(userId: 7601);
+		var resp = await client.GetAsync("/v1/invites/no-such-code");
+		Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+	}
+
+	[Fact]
+	public async Task HappyPath_ReturnsPreviewWithGuildAndInviter()
+	{
+		var owner = factory.CreateAuthenticatedClient(userId: 7602);
+		var guild = await owner.CreateGuildAsync("My Guild");
+		var id = long.Parse(guild.GetProperty("id").GetString()!);
+		await factory.AddInviteAsync(id, "preview-me", createdBy: 7602);
+
+		var client = factory.CreateAuthenticatedClient(userId: 7603);
+		var resp = await client.GetAsync("/v1/invites/preview-me");
+		Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+
+		var body = await resp.ReadJsonAsync();
+		Assert.Equal("preview-me", body.GetProperty("code").GetString());
+
+		var guildObj = body.GetProperty("guild");
+		Assert.Equal(id.ToString(), guildObj.GetProperty("id").GetString());
+		Assert.Equal("My Guild", guildObj.GetProperty("name").GetString());
+		Assert.Equal(1, guildObj.GetProperty("member_count").GetInt32());
+
+		var inviter = body.GetProperty("inviter");
+		Assert.Equal("7602", inviter.GetProperty("id").GetString());
+		// NoopUserService returns deterministic "user{id}" summaries
+		Assert.Equal("user7602", inviter.GetProperty("username").GetString());
+	}
+}

--- a/services/guild/tests/Guild.FunctionalTests/Endpoints/JoinByCodeTests.cs
+++ b/services/guild/tests/Guild.FunctionalTests/Endpoints/JoinByCodeTests.cs
@@ -1,0 +1,52 @@
+using System.Net;
+using Guild.FunctionalTests.Infrastructure;
+using Xunit;
+
+namespace Guild.FunctionalTests.Endpoints;
+
+public sealed class JoinByCodeTests(GuildApiFactory factory) : IClassFixture<GuildApiFactory>
+{
+	[Fact]
+	public async Task Without_Token_Returns_401()
+	{
+		var client = factory.CreateClient();
+		var resp = await client.PostAsync("/v1/invites/code/join", content: null);
+		Assert.Equal(HttpStatusCode.Unauthorized, resp.StatusCode);
+	}
+
+	[Fact]
+	public async Task UnknownCode_Returns_404()
+	{
+		var client = factory.CreateAuthenticatedClient(userId: 7701);
+		var resp = await client.PostAsync("/v1/invites/no-such-code/join", content: null);
+		Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+	}
+
+	[Fact]
+	public async Task HappyPath_Returns_200_WithGuildBody()
+	{
+		var owner = factory.CreateAuthenticatedClient(userId: 7702);
+		var guild = await owner.CreateGuildAsync("g");
+		var id = long.Parse(guild.GetProperty("id").GetString()!);
+		await factory.AddInviteAsync(id, "join-by-code", createdBy: 7702);
+
+		var stranger = factory.CreateAuthenticatedClient(userId: 7703);
+		var resp = await stranger.PostAsync("/v1/invites/join-by-code/join", content: null);
+
+		Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+		var body = await resp.ReadJsonAsync();
+		Assert.Equal(id.ToString(), body.GetProperty("id").GetString());
+	}
+
+	[Fact]
+	public async Task AlreadyMember_Returns_409()
+	{
+		var owner = factory.CreateAuthenticatedClient(userId: 7704);
+		var guild = await owner.CreateGuildAsync("g");
+		var id = long.Parse(guild.GetProperty("id").GetString()!);
+		await factory.AddInviteAsync(id, "already-in", createdBy: 7704);
+
+		var resp = await owner.PostAsync("/v1/invites/already-in/join", content: null);
+		Assert.Equal(HttpStatusCode.Conflict, resp.StatusCode);
+	}
+}

--- a/services/guild/tests/Guild.FunctionalTests/Endpoints/JoinGuildTests.cs
+++ b/services/guild/tests/Guild.FunctionalTests/Endpoints/JoinGuildTests.cs
@@ -1,0 +1,108 @@
+using System.Net;
+using System.Net.Http.Json;
+using Guild.FunctionalTests.Infrastructure;
+using Xunit;
+
+namespace Guild.FunctionalTests.Endpoints;
+
+public sealed class JoinGuildTests(GuildApiFactory factory) : IClassFixture<GuildApiFactory>
+{
+	[Fact]
+	public async Task Without_Token_Returns_401()
+	{
+		var client = factory.CreateClient();
+		var resp = await client.PostAsJsonAsync(
+			"/v1/guilds/1/join", new { invite_code = "x" }, JsonOptions.SnakeCase);
+		Assert.Equal(HttpStatusCode.Unauthorized, resp.StatusCode);
+	}
+
+	[Fact]
+	public async Task UnknownGuildAndUnknownCode_Returns_400()
+	{
+		// the contract lists only 400/409 for this endpoint; "unknown guild" is
+		// indistinguishable from "unknown code" since both reduce to "no usable
+		// invite". the join-by-code flow under /invites/{code}/join returns 404
+		// instead, see JoinByCodeTests
+		var client = factory.CreateAuthenticatedClient(userId: 7101);
+		var resp = await client.PostAsJsonAsync(
+			"/v1/guilds/9999999/join", new { invite_code = "x" }, JsonOptions.SnakeCase);
+		Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+	}
+
+	[Fact]
+	public async Task MissingInviteCode_Returns_400()
+	{
+		var owner = factory.CreateAuthenticatedClient(userId: 7102);
+		var guild = await owner.CreateGuildAsync("g");
+		var id = guild.GetProperty("id").GetString()!;
+
+		var stranger = factory.CreateAuthenticatedClient(userId: 7103);
+		var resp = await stranger.PostAsJsonAsync(
+			$"/v1/guilds/{id}/join", new { invite_code = (string?)null }, JsonOptions.SnakeCase);
+
+		Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+	}
+
+	[Fact]
+	public async Task UnknownCode_Returns_400()
+	{
+		var owner = factory.CreateAuthenticatedClient(userId: 7104);
+		var guild = await owner.CreateGuildAsync("g");
+		var id = guild.GetProperty("id").GetString()!;
+
+		var stranger = factory.CreateAuthenticatedClient(userId: 7105);
+		var resp = await stranger.PostAsJsonAsync(
+			$"/v1/guilds/{id}/join", new { invite_code = "no-such-code" }, JsonOptions.SnakeCase);
+
+		Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+	}
+
+	[Fact]
+	public async Task CodeFromDifferentGuild_Returns_400()
+	{
+		var owner = factory.CreateAuthenticatedClient(userId: 7106);
+		var g1 = await owner.CreateGuildAsync("g1");
+		var g2 = await owner.CreateGuildAsync("g2");
+		var g1Id = long.Parse(g1.GetProperty("id").GetString()!);
+		var g2Id = long.Parse(g2.GetProperty("id").GetString()!);
+
+		await factory.AddInviteAsync(g1Id, "code-from-g1", createdBy: 7106);
+
+		var stranger = factory.CreateAuthenticatedClient(userId: 7107);
+		var resp = await stranger.PostAsJsonAsync(
+			$"/v1/guilds/{g2Id}/join", new { invite_code = "code-from-g1" }, JsonOptions.SnakeCase);
+
+		Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+	}
+
+	[Fact]
+	public async Task AlreadyMember_Returns_409()
+	{
+		var owner = factory.CreateAuthenticatedClient(userId: 7108);
+		var guild = await owner.CreateGuildAsync("g");
+		var id = long.Parse(guild.GetProperty("id").GetString()!);
+		await factory.AddInviteAsync(id, "owner-code", createdBy: 7108);
+
+		var resp = await owner.PostAsJsonAsync(
+			$"/v1/guilds/{id}/join", new { invite_code = "owner-code" }, JsonOptions.SnakeCase);
+
+		Assert.Equal(HttpStatusCode.Conflict, resp.StatusCode);
+	}
+
+	[Fact]
+	public async Task HappyPath_Returns_200_WithGuildBody()
+	{
+		var owner = factory.CreateAuthenticatedClient(userId: 7109);
+		var guild = await owner.CreateGuildAsync("g");
+		var id = long.Parse(guild.GetProperty("id").GetString()!);
+		await factory.AddInviteAsync(id, "join-me", createdBy: 7109);
+
+		var stranger = factory.CreateAuthenticatedClient(userId: 7110);
+		var resp = await stranger.PostAsJsonAsync(
+			$"/v1/guilds/{id}/join", new { invite_code = "join-me" }, JsonOptions.SnakeCase);
+
+		Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+		var body = await resp.ReadJsonAsync();
+		Assert.Equal(id.ToString(), body.GetProperty("id").GetString());
+	}
+}

--- a/services/guild/tests/Guild.FunctionalTests/Endpoints/LeaveGuildTests.cs
+++ b/services/guild/tests/Guild.FunctionalTests/Endpoints/LeaveGuildTests.cs
@@ -1,0 +1,67 @@
+using System.Net;
+using System.Net.Http.Json;
+using Guild.FunctionalTests.Infrastructure;
+using Xunit;
+
+namespace Guild.FunctionalTests.Endpoints;
+
+public sealed class LeaveGuildTests(GuildApiFactory factory) : IClassFixture<GuildApiFactory>
+{
+	[Fact]
+	public async Task Without_Token_Returns_401()
+	{
+		var client = factory.CreateClient();
+		var resp = await client.PostAsync("/v1/guilds/1/leave", content: null);
+		Assert.Equal(HttpStatusCode.Unauthorized, resp.StatusCode);
+	}
+
+	[Fact]
+	public async Task UnknownGuild_Returns_404()
+	{
+		var client = factory.CreateAuthenticatedClient(userId: 7201);
+		var resp = await client.PostAsync("/v1/guilds/9999999/leave", content: null);
+		Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+	}
+
+	[Fact]
+	public async Task Owner_Returns_400()
+	{
+		var owner = factory.CreateAuthenticatedClient(userId: 7202);
+		var guild = await owner.CreateGuildAsync("g");
+		var id = guild.GetProperty("id").GetString()!;
+
+		var resp = await owner.PostAsync($"/v1/guilds/{id}/leave", content: null);
+		Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+	}
+
+	[Fact]
+	public async Task NotAMember_Returns_403()
+	{
+		var owner = factory.CreateAuthenticatedClient(userId: 7203);
+		var guild = await owner.CreateGuildAsync("g");
+		var id = guild.GetProperty("id").GetString()!;
+
+		var stranger = factory.CreateAuthenticatedClient(userId: 7204);
+		var resp = await stranger.PostAsync($"/v1/guilds/{id}/leave", content: null);
+
+		Assert.Equal(HttpStatusCode.Forbidden, resp.StatusCode);
+	}
+
+	[Fact]
+	public async Task HappyPath_Returns_204()
+	{
+		var owner = factory.CreateAuthenticatedClient(userId: 7205);
+		var guild = await owner.CreateGuildAsync("g");
+		var id = long.Parse(guild.GetProperty("id").GetString()!);
+		await factory.AddBareMemberAsync(id, userId: 7206);
+
+		var member = factory.CreateAuthenticatedClient(userId: 7206);
+		var resp = await member.PostAsync($"/v1/guilds/{id}/leave", content: null);
+
+		Assert.Equal(HttpStatusCode.NoContent, resp.StatusCode);
+
+		// confirm idempotence: a second leave fails with 403 (not a member)
+		var resp2 = await member.PostAsync($"/v1/guilds/{id}/leave", content: null);
+		Assert.Equal(HttpStatusCode.Forbidden, resp2.StatusCode);
+	}
+}

--- a/services/guild/tests/Guild.FunctionalTests/Endpoints/LeaveGuildTests.cs
+++ b/services/guild/tests/Guild.FunctionalTests/Endpoints/LeaveGuildTests.cs
@@ -60,7 +60,6 @@ public sealed class LeaveGuildTests(GuildApiFactory factory) : IClassFixture<Gui
 
 		Assert.Equal(HttpStatusCode.NoContent, resp.StatusCode);
 
-		// confirm idempotence: a second leave fails with 403 (not a member)
 		var resp2 = await member.PostAsync($"/v1/guilds/{id}/leave", content: null);
 		Assert.Equal(HttpStatusCode.Forbidden, resp2.StatusCode);
 	}

--- a/services/guild/tests/Guild.FunctionalTests/Endpoints/ListInvitesTests.cs
+++ b/services/guild/tests/Guild.FunctionalTests/Endpoints/ListInvitesTests.cs
@@ -1,0 +1,76 @@
+using System.Net;
+using Guild.FunctionalTests.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Guild.FunctionalTests.Endpoints;
+
+public sealed class ListInvitesTests(GuildApiFactory factory) : IClassFixture<GuildApiFactory>
+{
+	[Fact]
+	public async Task Without_Token_Returns_401()
+	{
+		var client = factory.CreateClient();
+		var resp = await client.GetAsync("/v1/guilds/1/invites");
+		Assert.Equal(HttpStatusCode.Unauthorized, resp.StatusCode);
+	}
+
+	[Fact]
+	public async Task NonMember_Returns_403()
+	{
+		var owner = factory.CreateAuthenticatedClient(userId: 7401);
+		var guild = await owner.CreateGuildAsync("g");
+		var id = guild.GetProperty("id").GetString()!;
+
+		var stranger = factory.CreateAuthenticatedClient(userId: 7402);
+		var resp = await stranger.GetAsync($"/v1/guilds/{id}/invites");
+
+		Assert.Equal(HttpStatusCode.Forbidden, resp.StatusCode);
+	}
+
+	[Fact]
+	public async Task Member_Without_ManageGuild_Returns_403()
+	{
+		var owner = factory.CreateAuthenticatedClient(userId: 7403);
+		var guild = await owner.CreateGuildAsync("g");
+		var id = long.Parse(guild.GetProperty("id").GetString()!);
+		await factory.AddBareMemberAsync(id, userId: 7404);
+
+		var member = factory.CreateAuthenticatedClient(userId: 7404);
+		var resp = await member.GetAsync($"/v1/guilds/{id}/invites");
+
+		Assert.Equal(HttpStatusCode.Forbidden, resp.StatusCode);
+	}
+
+	[Fact]
+	public async Task OwnerHappyPath_ExcludesRevoked()
+	{
+		var owner = factory.CreateAuthenticatedClient(userId: 7405);
+		var guild = await owner.CreateGuildAsync("g");
+		var id = long.Parse(guild.GetProperty("id").GetString()!);
+
+		await factory.AddInviteAsync(id, "active1", createdBy: 7405);
+		await factory.AddInviteAsync(id, "active2", createdBy: 7405);
+		await factory.AddInviteAsync(id, "revoked", createdBy: 7405);
+		await RevokeAsync(id, "revoked");
+
+		var resp = await owner.GetAsync($"/v1/guilds/{id}/invites");
+		Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+
+		var body = await resp.ReadJsonAsync();
+		var codes = body.EnumerateArray().Select(e => e.GetProperty("code").GetString()).ToHashSet();
+		Assert.Contains("active1", codes);
+		Assert.Contains("active2", codes);
+		Assert.DoesNotContain("revoked", codes);
+	}
+
+	private async Task RevokeAsync(long guildId, string code)
+	{
+		using var scope = factory.Services.CreateScope();
+		var db = scope.ServiceProvider.GetRequiredService<Guild.Persistence.Db.GuildDbContext>();
+		var invite = await Microsoft.EntityFrameworkCore.EntityFrameworkQueryableExtensions
+			.FirstAsync(db.GuildInvites, i => i.Code == code);
+		invite.Revoke();
+		await db.SaveChangesAsync();
+	}
+}

--- a/services/guild/tests/Guild.FunctionalTests/Infrastructure/GuildApiFactory.cs
+++ b/services/guild/tests/Guild.FunctionalTests/Infrastructure/GuildApiFactory.cs
@@ -1,6 +1,7 @@
 using System.Net.Http.Headers;
 using System.Reflection;
 using Guild.Application.Abstractions;
+using Guild.Application.Abstractions.Users;
 using Guild.Persistence.Db;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
@@ -67,6 +68,8 @@ public sealed class GuildApiFactory : WebApplicationFactory<Program>
 
 				["BackendConfiguration:BaseUrl"] = "http://localhost",
 				["BackendConfiguration:BaseApiUrl"] = "http://localhost/api",
+
+				["UserService:BaseUrl"] = "http://user.test",
 			});
 		});
 
@@ -75,10 +78,16 @@ public sealed class GuildApiFactory : WebApplicationFactory<Program>
 			ReplaceDbContext(services);
 			StripMassTransit(services);
 
-			// re-register IEventBus with a no-op - none of the #54 endpoints
-			// publish, but handlers receive it via DI so the binding must exist
+			// re-register IEventBus with a no-op - handlers receive it via DI so
+			// the binding must exist even when nothing observes the published events
 			services.RemoveAll<IEventBus>();
 			services.AddSingleton<IEventBus, NoopEventBus>();
+
+			// User Service is mocked: the real client would try to dial over the
+			// docker network. NoopUserService treats every user as existing and
+			// returns a deterministic summary, matching graceful-degrade behaviour
+			services.RemoveAll<IUserService>();
+			services.AddSingleton<IUserService, NoopUserService>();
 		});
 	}
 
@@ -271,9 +280,39 @@ public sealed class GuildApiFactory : WebApplicationFactory<Program>
 		await db.SaveChangesAsync();
 	}
 
+	/// <summary>
+	/// seeds an active <c>GuildInvite</c> with no expiry directly through the scoped
+	/// DbContext. used by join / invite tests that need an exact code to hit
+	/// </summary>
+	public async Task AddInviteAsync(long guildId, string code, long createdBy, int? maxUses = null)
+	{
+		using var scope = Services.CreateScope();
+		var db = scope.ServiceProvider.GetRequiredService<GuildDbContext>();
+		var inviteResult = Guild.Domain.Guild.GuildInvite.Create(
+			code: code,
+			guildId: guildId,
+			createdBy: createdBy,
+			maxUses: maxUses,
+			expiresAt: null,
+			now: DateTimeOffset.UtcNow);
+		if (inviteResult.IsFailure)
+			throw new InvalidOperationException(inviteResult.Error.Message);
+		db.GuildInvites.Add(inviteResult.Value);
+		await db.SaveChangesAsync();
+	}
+
 	private sealed class NoopEventBus : IEventBus
 	{
 		public Task PublishAsync<T>(T message, CancellationToken cancellationToken = default)
 			where T : class => Task.CompletedTask;
+	}
+
+	private sealed class NoopUserService : IUserService
+	{
+		public Task<bool> ExistsAsync(long userId, CancellationToken cancellationToken = default)
+			=> Task.FromResult(true);
+
+		public Task<UserSummary?> GetSummaryAsync(long userId, CancellationToken cancellationToken = default)
+			=> Task.FromResult<UserSummary?>(new UserSummary(userId, $"user{userId}"));
 	}
 }

--- a/services/guild/tests/Guild.UnitTests/Application/CreateInviteHandlerTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/CreateInviteHandlerTests.cs
@@ -1,0 +1,144 @@
+using System.Reflection;
+using Guild.Application.Abstractions.Messaging;
+using Guild.Application.Contracts;
+using Guild.Application.Features.Invites.Common;
+using Guild.Application.Features.Invites.CreateInvite;
+using Guild.Domain.Guild;
+using Guild.Domain.Results;
+using Guild.UnitTests.Fakes;
+using Xunit;
+using GuildEntity = Guild.Domain.Guild.Guild;
+
+namespace Guild.UnitTests.Application;
+
+public sealed class CreateInviteHandlerTests
+{
+	private static readonly DateTimeOffset Now =
+		new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+	[Fact]
+	public async Task UnknownGuild_Returns404()
+	{
+		var (g, i, b) = NewFakes();
+		var handler = NewHandler(g, i, b, callerId: 1);
+
+		var result = await handler.HandleAsync(new CreateInviteCommand(GuildId: 9999, MaxUses: null, ExpiresInHours: null));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal("Guild.GuildNotFound", result.Error.Code);
+		Assert.Equal(0, i.AddCount);
+		Assert.Empty(b.Published);
+	}
+
+	[Fact]
+	public async Task NonMember_ReturnsNotAMember()
+	{
+		var (g, i, b) = NewFakes();
+		var guild = Seed(g, ownerId: 1);
+		var handler = NewHandler(g, i, b, callerId: 99);
+
+		var result = await handler.HandleAsync(new CreateInviteCommand(GuildId: guild.Id, MaxUses: null, ExpiresInHours: null));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal("Guild.NotAMember", result.Error.Code);
+	}
+
+	[Fact]
+	public async Task MemberWithoutCreateInvite_Returns403()
+	{
+		var (g, i, b) = NewFakes();
+		var guild = Seed(g, ownerId: 1);
+		DomainSeed.AddMember(guild, userId: 99, joinedAt: Now);
+		// strip @everyone of CREATE_INVITE so the member cannot create invites
+		var everyone = guild.Roles.Single(r => r.IsDefault);
+		DomainSeed.SetRolePermissions(everyone, 0);
+		var handler = NewHandler(g, i, b, callerId: 99);
+
+		var result = await handler.HandleAsync(new CreateInviteCommand(GuildId: guild.Id, MaxUses: null, ExpiresInHours: null));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal("Guild.MissingPermission", result.Error.Code);
+		Assert.Equal(0, i.AddCount);
+	}
+
+	[Fact]
+	public async Task HappyPath_CreatesInviteAndPublishesEvent()
+	{
+		var (g, i, b) = NewFakes();
+		var guild = Seed(g, ownerId: 1);
+		var handler = NewHandler(g, i, b, callerId: 1, codeSeed: "abcdef");
+
+		var result = await handler.HandleAsync(
+			new CreateInviteCommand(GuildId: guild.Id, MaxUses: 10, ExpiresInHours: 24));
+
+		Assert.True(result.Succeeded);
+		Assert.Equal("abcdef01", result.Value.Code);
+		Assert.Equal(guild.Id.ToString(), result.Value.GuildId);
+		Assert.Equal("1", result.Value.CreatedBy);
+		Assert.Equal(10, result.Value.MaxUses);
+		Assert.NotNull(result.Value.ExpiresAt);
+
+		Assert.Equal(1, i.AddCount);
+		Assert.Equal(1, i.SaveChangesCount);
+
+		var evt = b.Single<GuildInviteCreated>();
+		Assert.Equal(guild.Id, evt.GuildId);
+		Assert.Equal("Test", evt.GuildName);
+		Assert.Equal(1L, evt.InvitedByUserId);
+		Assert.Null(evt.InvitedUserId);
+	}
+
+	[Fact]
+	public async Task NoExpiry_NullExpiresAt()
+	{
+		var (g, i, b) = NewFakes();
+		var guild = Seed(g, ownerId: 1);
+		var handler = NewHandler(g, i, b, callerId: 1);
+
+		var result = await handler.HandleAsync(
+			new CreateInviteCommand(GuildId: guild.Id, MaxUses: null, ExpiresInHours: null));
+
+		Assert.True(result.Succeeded);
+		Assert.Null(result.Value.ExpiresAt);
+		Assert.Null(result.Value.MaxUses);
+	}
+
+	[Fact]
+	public async Task NegativeMaxUses_PropagatesDomainFailure()
+	{
+		var (g, i, b) = NewFakes();
+		var guild = Seed(g, ownerId: 1);
+		var handler = NewHandler(g, i, b, callerId: 1);
+
+		var result = await handler.HandleAsync(
+			new CreateInviteCommand(GuildId: guild.Id, MaxUses: -5, ExpiresInHours: null));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal("Guild.InviteMaxUsesInvalid", result.Error.Code);
+		Assert.Equal(0, i.AddCount);
+	}
+
+	private static (FakeGuildRepository, FakeGuildInviteRepository, FakeEventBus) NewFakes()
+		=> (new FakeGuildRepository(), new FakeGuildInviteRepository(), new FakeEventBus());
+
+	private static ICommandHandler<CreateInviteCommand, Result<InviteDto>> NewHandler(
+		FakeGuildRepository guilds,
+		FakeGuildInviteRepository invites,
+		FakeEventBus bus,
+		long callerId,
+		string codeSeed = "abcdef")
+	{
+		return HandlerFactory.CreateCommand<CreateInviteCommand, Result<InviteDto>>(
+			guilds, invites, new FakeInviteCodeGenerator(codeSeed), bus,
+			new FakeClock(), new FakeCurrentUser { Id = callerId });
+	}
+
+	private static GuildEntity Seed(FakeGuildRepository repo, long ownerId)
+	{
+		var guild = GuildEntity.Create(
+			id: 100, name: "Test", description: null, iconUrl: null, bannerUrl: null,
+			ownerId: ownerId, everyoneRoleId: 101, adminRoleId: 102, now: Now).Value;
+		repo.AddAsync(guild).GetAwaiter().GetResult();
+		return guild;
+	}
+}

--- a/services/guild/tests/Guild.UnitTests/Application/DeleteInviteHandlerTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/DeleteInviteHandlerTests.cs
@@ -1,0 +1,143 @@
+using Guild.Application.Abstractions.Messaging;
+using Guild.Application.Features.Invites.DeleteInvite;
+using Guild.Domain.Guild;
+using Guild.Domain.Results;
+using Guild.UnitTests.Fakes;
+using Xunit;
+using GuildEntity = Guild.Domain.Guild.Guild;
+
+namespace Guild.UnitTests.Application;
+
+public sealed class DeleteInviteHandlerTests
+{
+	private static readonly DateTimeOffset Now =
+		new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+	[Fact]
+	public async Task UnknownCode_Returns404()
+	{
+		var (g, i) = NewFakes();
+		var handler = NewHandler(g, i, callerId: 1);
+
+		var result = await handler.HandleAsync(new DeleteInviteCommand(GuildId: 1, Code: "ghost"));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal("Guild.InviteNotFound", result.Error.Code);
+	}
+
+	[Fact]
+	public async Task AlreadyRevoked_Returns404()
+	{
+		var (g, i) = NewFakes();
+		var guild = SeedGuild(g, ownerId: 1);
+		var invite = SeedInvite(i, guild.Id, creator: 1);
+		invite.Revoke();
+		var handler = NewHandler(g, i, callerId: 1);
+
+		var result = await handler.HandleAsync(new DeleteInviteCommand(guild.Id, invite.Code));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal("Guild.InviteNotFound", result.Error.Code);
+	}
+
+	[Fact]
+	public async Task GuildIdMismatch_Returns404()
+	{
+		var (g, i) = NewFakes();
+		var guild = SeedGuild(g, ownerId: 1);
+		var invite = SeedInvite(i, guild.Id, creator: 1);
+		var handler = NewHandler(g, i, callerId: 1);
+
+		var result = await handler.HandleAsync(new DeleteInviteCommand(GuildId: guild.Id + 1, Code: invite.Code));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal("Guild.InviteGuildMismatch", result.Error.Code);
+	}
+
+	[Fact]
+	public async Task NonMember_Returns403()
+	{
+		var (g, i) = NewFakes();
+		var guild = SeedGuild(g, ownerId: 1);
+		var invite = SeedInvite(i, guild.Id, creator: 1);
+		var handler = NewHandler(g, i, callerId: 99);
+
+		var result = await handler.HandleAsync(new DeleteInviteCommand(guild.Id, invite.Code));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal("Guild.NotAMember", result.Error.Code);
+	}
+
+	[Fact]
+	public async Task CreatorWithoutManageGuild_CanRevoke()
+	{
+		var (g, i) = NewFakes();
+		var guild = SeedGuild(g, ownerId: 1);
+		DomainSeed.AddMember(guild, userId: 99, joinedAt: Now);
+		var invite = SeedInvite(i, guild.Id, creator: 99);
+
+		var handler = NewHandler(g, i, callerId: 99);
+		var result = await handler.HandleAsync(new DeleteInviteCommand(guild.Id, invite.Code));
+
+		Assert.True(result.Succeeded);
+		Assert.True(invite.IsRevoked);
+		Assert.Equal(1, i.UpdateCount);
+		Assert.Equal(1, i.SaveChangesCount);
+	}
+
+	[Fact]
+	public async Task NonCreatorWithoutManageGuild_Returns403()
+	{
+		var (g, i) = NewFakes();
+		var guild = SeedGuild(g, ownerId: 1);
+		DomainSeed.AddMember(guild, userId: 99, joinedAt: Now);
+		var invite = SeedInvite(i, guild.Id, creator: 1);
+		var handler = NewHandler(g, i, callerId: 99);
+
+		var result = await handler.HandleAsync(new DeleteInviteCommand(guild.Id, invite.Code));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal("Guild.MissingPermission", result.Error.Code);
+		Assert.False(invite.IsRevoked);
+	}
+
+	[Fact]
+	public async Task OwnerCanRevoke()
+	{
+		var (g, i) = NewFakes();
+		var guild = SeedGuild(g, ownerId: 1);
+		var invite = SeedInvite(i, guild.Id, creator: 42);
+		var handler = NewHandler(g, i, callerId: 1);
+
+		var result = await handler.HandleAsync(new DeleteInviteCommand(guild.Id, invite.Code));
+
+		Assert.True(result.Succeeded);
+		Assert.True(invite.IsRevoked);
+	}
+
+	private static (FakeGuildRepository, FakeGuildInviteRepository) NewFakes()
+		=> (new FakeGuildRepository(), new FakeGuildInviteRepository());
+
+	private static ICommandHandler<DeleteInviteCommand, Result> NewHandler(
+		FakeGuildRepository guilds, FakeGuildInviteRepository invites, long callerId)
+	{
+		return HandlerFactory.CreateCommand<DeleteInviteCommand, Result>(
+			guilds, invites, new FakeCurrentUser { Id = callerId });
+	}
+
+	private static GuildEntity SeedGuild(FakeGuildRepository repo, long ownerId)
+	{
+		var guild = GuildEntity.Create(
+			id: 100, name: "Test", description: null, iconUrl: null, bannerUrl: null,
+			ownerId: ownerId, everyoneRoleId: 101, adminRoleId: 102, now: Now).Value;
+		repo.AddAsync(guild).GetAwaiter().GetResult();
+		return guild;
+	}
+
+	private static GuildInvite SeedInvite(FakeGuildInviteRepository repo, long guildId, long creator)
+	{
+		var invite = GuildInvite.Create("abc123", guildId, creator, null, null, Now).Value;
+		repo.Seed(invite);
+		return invite;
+	}
+}

--- a/services/guild/tests/Guild.UnitTests/Application/GetInvitePreviewHandlerTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/GetInvitePreviewHandlerTests.cs
@@ -1,0 +1,138 @@
+using Guild.Application.Abstractions.Messaging;
+using Guild.Application.Features.Invites.Common;
+using Guild.Application.Features.Invites.GetInvitePreview;
+using Guild.Domain.Guild;
+using Guild.Domain.Results;
+using Guild.UnitTests.Fakes;
+using Xunit;
+using GuildEntity = Guild.Domain.Guild.Guild;
+
+namespace Guild.UnitTests.Application;
+
+public sealed class GetInvitePreviewHandlerTests
+{
+	private static readonly DateTimeOffset Now =
+		new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+	[Fact]
+	public async Task UnknownCode_Returns404()
+	{
+		var (g, i, u) = NewFakes();
+		var handler = NewHandler(g, i, u);
+
+		var result = await handler.HandleAsync(new GetInvitePreviewQuery("ghost"));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal("Guild.InviteNotFound", result.Error.Code);
+	}
+
+	[Fact]
+	public async Task RevokedInvite_Returns404()
+	{
+		var (g, i, u) = NewFakes();
+		var guild = SeedGuild(g);
+		var invite = SeedInvite(i, guildId: guild.Id, creator: 1);
+		invite.Revoke();
+		var handler = NewHandler(g, i, u);
+
+		var result = await handler.HandleAsync(new GetInvitePreviewQuery(invite.Code));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal("Guild.InviteNotFound", result.Error.Code);
+	}
+
+	[Fact]
+	public async Task ExpiredInvite_Returns404()
+	{
+		var (g, i, u) = NewFakes();
+		var guild = SeedGuild(g);
+		var invite = GuildInvite.Create("abc", guild.Id, 1, null, Now.AddHours(1), Now).Value;
+		i.Seed(invite);
+
+		var handler = HandlerFactory.CreateQuery<GetInvitePreviewQuery, Result<InvitePreviewDto>>(
+			g, i, u, new FakeClock(Now.AddHours(2)));
+
+		var result = await handler.HandleAsync(new GetInvitePreviewQuery(invite.Code));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal("Guild.InviteNotFound", result.Error.Code);
+	}
+
+	[Fact]
+	public async Task HappyPath_ReturnsPreview_WithInviterFromUserService()
+	{
+		var (g, i, u) = NewFakes();
+		var guild = SeedGuild(g);
+		var invite = SeedInvite(i, guildId: guild.Id, creator: 42, expiresAt: Now.AddHours(1));
+		u.RegisterSummary(42, "yandry");
+
+		var handler = NewHandler(g, i, u);
+		var result = await handler.HandleAsync(new GetInvitePreviewQuery(invite.Code));
+
+		Assert.True(result.Succeeded);
+		var dto = result.Value;
+		Assert.Equal("abc123", dto.Code);
+		Assert.Equal(guild.Id.ToString(), dto.Guild.Id);
+		Assert.Equal("Test", dto.Guild.Name);
+		Assert.Equal(1, dto.Guild.MemberCount);
+		Assert.Equal("42", dto.Inviter.Id);
+		Assert.Equal("yandry", dto.Inviter.Username);
+		Assert.NotNull(dto.ExpiresAt);
+		Assert.Equal(1, u.GetSummaryCallCount);
+	}
+
+	[Fact]
+	public async Task UserServiceMisses_FallsBackToEmptyUsername()
+	{
+		var (g, i, u) = NewFakes();
+		var guild = SeedGuild(g);
+		var invite = SeedInvite(i, guildId: guild.Id, creator: 42);
+
+		var handler = NewHandler(g, i, u);
+		var result = await handler.HandleAsync(new GetInvitePreviewQuery(invite.Code));
+
+		Assert.True(result.Succeeded);
+		Assert.Equal("42", result.Value.Inviter.Id);
+		Assert.Equal(string.Empty, result.Value.Inviter.Username);
+	}
+
+	[Fact]
+	public async Task GuildMissing_Returns404()
+	{
+		var (g, i, u) = NewFakes();
+		var invite = SeedInvite(i, guildId: 9999, creator: 1);
+		var handler = NewHandler(g, i, u);
+
+		var result = await handler.HandleAsync(new GetInvitePreviewQuery(invite.Code));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal("Guild.InviteNotFound", result.Error.Code);
+	}
+
+	private static (FakeGuildRepository, FakeGuildInviteRepository, FakeUserService) NewFakes()
+		=> (new FakeGuildRepository(), new FakeGuildInviteRepository(), new FakeUserService());
+
+	private static IQueryHandler<GetInvitePreviewQuery, Result<InvitePreviewDto>> NewHandler(
+		FakeGuildRepository guilds, FakeGuildInviteRepository invites, FakeUserService users)
+	{
+		return HandlerFactory.CreateQuery<GetInvitePreviewQuery, Result<InvitePreviewDto>>(
+			guilds, invites, users, new FakeClock());
+	}
+
+	private static GuildEntity SeedGuild(FakeGuildRepository repo)
+	{
+		var guild = GuildEntity.Create(
+			id: 100, name: "Test", description: null, iconUrl: null, bannerUrl: null,
+			ownerId: 1, everyoneRoleId: 101, adminRoleId: 102, now: Now).Value;
+		repo.AddAsync(guild).GetAwaiter().GetResult();
+		return guild;
+	}
+
+	private static GuildInvite SeedInvite(
+		FakeGuildInviteRepository repo, long guildId, long creator, DateTimeOffset? expiresAt = null)
+	{
+		var invite = GuildInvite.Create("abc123", guildId, creator, null, expiresAt, Now).Value;
+		repo.Seed(invite);
+		return invite;
+	}
+}

--- a/services/guild/tests/Guild.UnitTests/Application/JoinByInviteCodeHandlerTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/JoinByInviteCodeHandlerTests.cs
@@ -98,6 +98,39 @@ public sealed class JoinByInviteCodeHandlerTests
 	}
 
 	[Fact]
+	public async Task ExpiredInvite_ReturnsInviteUnusable_DoesNotLoadGuild()
+	{
+		var (g, i, b, u) = NewFakes();
+		var invite = GuildInvite.Create("abc123", guildId: 100, createdBy: 1,
+			maxUses: null, expiresAt: Now.AddHours(1), now: Now).Value;
+		i.Seed(invite);
+		// guild is intentionally not seeded; the fail-fast must reject the invite
+		// without ever reaching the guild repository
+		var handler = HandlerFactory.CreateCommand<JoinByInviteCodeCommand, Result<GuildDto>>(
+			g, i, b, u, new FakeClock(Now.AddHours(2)), new FakeCurrentUser { Id = 99 });
+
+		var result = await handler.HandleAsync(new JoinByInviteCodeCommand(invite.Code, ExpectedGuildId: null));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal("Guild.InviteUnusable", result.Error.Code);
+	}
+
+	[Fact]
+	public async Task ExhaustedInvite_ReturnsInviteUnusable()
+	{
+		var (g, i, b, u) = NewFakes();
+		var guild = SeedGuild(g, ownerId: 1);
+		var invite = SeedInvite(i, guildId: guild.Id, creator: 1, maxUses: 1);
+		invite.Consume(Now);
+		var handler = NewHandler(g, i, b, u, callerId: 99);
+
+		var result = await handler.HandleAsync(new JoinByInviteCodeCommand(invite.Code, ExpectedGuildId: null));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal("Guild.InviteUnusable", result.Error.Code);
+	}
+
+	[Fact]
 	public async Task HappyPath_AddsMember_ConsumesInvite_PublishesEvent_HitsUserService()
 	{
 		var (g, i, b, u) = NewFakes();

--- a/services/guild/tests/Guild.UnitTests/Application/JoinByInviteCodeHandlerTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/JoinByInviteCodeHandlerTests.cs
@@ -1,0 +1,173 @@
+using Guild.Application.Abstractions.Messaging;
+using Guild.Application.Contracts;
+using Guild.Application.Features.Guilds.Common;
+using Guild.Application.Features.Membership.JoinByInviteCode;
+using Guild.Domain.Guild;
+using Guild.Domain.Results;
+using Guild.UnitTests.Fakes;
+using Xunit;
+using GuildEntity = Guild.Domain.Guild.Guild;
+
+namespace Guild.UnitTests.Application;
+
+public sealed class JoinByInviteCodeHandlerTests
+{
+	private static readonly DateTimeOffset Now =
+		new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+	[Fact]
+	public async Task EmptyCode_ReturnsInviteCodeRequired()
+	{
+		var (g, i, b, u) = NewFakes();
+		var handler = NewHandler(g, i, b, u, callerId: 99);
+
+		var result = await handler.HandleAsync(new JoinByInviteCodeCommand(Code: null, ExpectedGuildId: null));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal("Guild.InviteCodeRequired", result.Error.Code);
+	}
+
+	[Fact]
+	public async Task UnknownCode_ReturnsInviteNotFound()
+	{
+		var (g, i, b, u) = NewFakes();
+		var handler = NewHandler(g, i, b, u, callerId: 99);
+
+		var result = await handler.HandleAsync(new JoinByInviteCodeCommand(Code: "ghost", ExpectedGuildId: null));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal("Guild.InviteNotFound", result.Error.Code);
+	}
+
+	[Fact]
+	public async Task ExpectedGuildMismatch_ReturnsInviteGuildMismatch()
+	{
+		var (g, i, b, u) = NewFakes();
+		var guild = SeedGuild(g, ownerId: 1);
+		var invite = SeedInvite(i, guildId: guild.Id, creator: 1);
+		var handler = NewHandler(g, i, b, u, callerId: 99);
+
+		var result = await handler.HandleAsync(
+			new JoinByInviteCodeCommand(invite.Code, ExpectedGuildId: guild.Id + 1));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal("Guild.InviteGuildMismatch", result.Error.Code);
+	}
+
+	[Fact]
+	public async Task GuildMissing_ReturnsGuildNotFound()
+	{
+		var (g, i, b, u) = NewFakes();
+		// invite exists pointing at a guild that does not (data drift / cascade lag)
+		var invite = SeedInvite(i, guildId: 12345, creator: 1);
+		var handler = NewHandler(g, i, b, u, callerId: 99);
+
+		var result = await handler.HandleAsync(new JoinByInviteCodeCommand(invite.Code, ExpectedGuildId: null));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal("Guild.GuildNotFound", result.Error.Code);
+	}
+
+	[Fact]
+	public async Task AlreadyMember_ReturnsAlreadyMember()
+	{
+		var (g, i, b, u) = NewFakes();
+		var guild = SeedGuild(g, ownerId: 1);
+		var invite = SeedInvite(i, guildId: guild.Id, creator: 1);
+		var handler = NewHandler(g, i, b, u, callerId: 1);
+
+		var result = await handler.HandleAsync(new JoinByInviteCodeCommand(invite.Code, ExpectedGuildId: null));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal("Guild.AlreadyMember", result.Error.Code);
+	}
+
+	[Fact]
+	public async Task RevokedInvite_ReturnsInviteUnusable()
+	{
+		var (g, i, b, u) = NewFakes();
+		var guild = SeedGuild(g, ownerId: 1);
+		var invite = SeedInvite(i, guildId: guild.Id, creator: 1);
+		invite.Revoke();
+		var handler = NewHandler(g, i, b, u, callerId: 99);
+
+		var result = await handler.HandleAsync(new JoinByInviteCodeCommand(invite.Code, ExpectedGuildId: null));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal("Guild.InviteUnusable", result.Error.Code);
+	}
+
+	[Fact]
+	public async Task HappyPath_AddsMember_ConsumesInvite_PublishesEvent_HitsUserService()
+	{
+		var (g, i, b, u) = NewFakes();
+		var guild = SeedGuild(g, ownerId: 1);
+		var invite = SeedInvite(i, guildId: guild.Id, creator: 1, maxUses: 3);
+		var handler = NewHandler(g, i, b, u, callerId: 99);
+
+		var result = await handler.HandleAsync(new JoinByInviteCodeCommand(invite.Code, ExpectedGuildId: guild.Id));
+
+		Assert.True(result.Succeeded);
+		Assert.Equal(guild.Id.ToString(), result.Value.Id);
+		Assert.Contains(guild.Members, m => m.UserId == 99);
+		Assert.Equal(1, invite.Uses);
+		Assert.Equal(1, i.UpdateCount);
+		Assert.Equal(1, g.UpdateCount);
+		Assert.Equal(1, g.SaveChangesCount);
+		Assert.Equal(1, u.ExistsCallCount);
+
+		var evt = b.Single<GuildMemberJoined>();
+		Assert.Equal(guild.Id, evt.GuildId);
+		Assert.Equal("Test", evt.GuildName);
+		Assert.Equal(99L, evt.UserId);
+	}
+
+	[Fact]
+	public async Task UserServiceUnavailable_StillJoins()
+	{
+		var (g, i, b, u) = NewFakes();
+		u.Exists = false;
+		var guild = SeedGuild(g, ownerId: 1);
+		var invite = SeedInvite(i, guildId: guild.Id, creator: 1);
+		var handler = NewHandler(g, i, b, u, callerId: 99);
+
+		var result = await handler.HandleAsync(new JoinByInviteCodeCommand(invite.Code, ExpectedGuildId: null));
+
+		Assert.True(result.Succeeded);
+		Assert.Contains(guild.Members, m => m.UserId == 99);
+		Assert.True(b.Has<GuildMemberJoined>());
+	}
+
+	private static (FakeGuildRepository, FakeGuildInviteRepository, FakeEventBus, FakeUserService) NewFakes()
+		=> (new FakeGuildRepository(), new FakeGuildInviteRepository(), new FakeEventBus(), new FakeUserService());
+
+	private static ICommandHandler<JoinByInviteCodeCommand, Result<GuildDto>> NewHandler(
+		FakeGuildRepository guilds,
+		FakeGuildInviteRepository invites,
+		FakeEventBus bus,
+		FakeUserService users,
+		long callerId)
+	{
+		return HandlerFactory.CreateCommand<JoinByInviteCodeCommand, Result<GuildDto>>(
+			guilds, invites, bus, users, new FakeClock(), new FakeCurrentUser { Id = callerId });
+	}
+
+	private static GuildEntity SeedGuild(FakeGuildRepository repo, long ownerId)
+	{
+		var guild = GuildEntity.Create(
+			id: 100, name: "Test", description: null, iconUrl: null, bannerUrl: null,
+			ownerId: ownerId, everyoneRoleId: 101, adminRoleId: 102, now: Now).Value;
+		repo.AddAsync(guild).GetAwaiter().GetResult();
+		return guild;
+	}
+
+	private static GuildInvite SeedInvite(
+		FakeGuildInviteRepository repo, long guildId, long creator, int? maxUses = null)
+	{
+		var invite = GuildInvite.Create(
+			code: "abc123", guildId: guildId, createdBy: creator,
+			maxUses: maxUses, expiresAt: null, now: Now).Value;
+		repo.Seed(invite);
+		return invite;
+	}
+}

--- a/services/guild/tests/Guild.UnitTests/Application/LeaveGuildHandlerTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/LeaveGuildHandlerTests.cs
@@ -1,0 +1,89 @@
+using Guild.Application.Contracts;
+using Guild.Application.Features.Membership.LeaveGuild;
+using Guild.Domain.Results;
+using Guild.UnitTests.Fakes;
+using Xunit;
+using GuildEntity = Guild.Domain.Guild.Guild;
+
+namespace Guild.UnitTests.Application;
+
+public sealed class LeaveGuildHandlerTests
+{
+	private static readonly DateTimeOffset Now =
+		new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+	[Fact]
+	public async Task UnknownGuild_Returns404()
+	{
+		var (repo, bus) = (new FakeGuildRepository(), new FakeEventBus());
+		var handler = HandlerFactory.CreateCommand<LeaveGuildCommand, Result>(
+			repo, bus, new FakeClock(), new FakeCurrentUser { Id = 1 });
+
+		var result = await handler.HandleAsync(new LeaveGuildCommand(GuildId: 999));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal("Guild.GuildNotFound", result.Error.Code);
+		Assert.Empty(bus.Published);
+	}
+
+	[Fact]
+	public async Task OwnerCannotLeave()
+	{
+		var (repo, bus) = (new FakeGuildRepository(), new FakeEventBus());
+		var guild = Seed(repo, ownerId: 1);
+		var handler = HandlerFactory.CreateCommand<LeaveGuildCommand, Result>(
+			repo, bus, new FakeClock(), new FakeCurrentUser { Id = 1 });
+
+		var result = await handler.HandleAsync(new LeaveGuildCommand(GuildId: guild.Id));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal("Guild.OwnerCannotLeave", result.Error.Code);
+		Assert.Empty(bus.Published);
+		Assert.Equal(0, repo.SaveChangesCount);
+	}
+
+	[Fact]
+	public async Task NotAMember_ReturnsNotAMember()
+	{
+		var (repo, bus) = (new FakeGuildRepository(), new FakeEventBus());
+		var guild = Seed(repo, ownerId: 1);
+		var handler = HandlerFactory.CreateCommand<LeaveGuildCommand, Result>(
+			repo, bus, new FakeClock(), new FakeCurrentUser { Id = 99 });
+
+		var result = await handler.HandleAsync(new LeaveGuildCommand(GuildId: guild.Id));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal("Guild.NotAMember", result.Error.Code);
+		Assert.Empty(bus.Published);
+	}
+
+	[Fact]
+	public async Task HappyPath_RemovesMemberAndPublishesEvent()
+	{
+		var (repo, bus) = (new FakeGuildRepository(), new FakeEventBus());
+		var guild = Seed(repo, ownerId: 1);
+		DomainSeed.AddMember(guild, userId: 99, joinedAt: Now);
+		var handler = HandlerFactory.CreateCommand<LeaveGuildCommand, Result>(
+			repo, bus, new FakeClock(), new FakeCurrentUser { Id = 99 });
+
+		var result = await handler.HandleAsync(new LeaveGuildCommand(GuildId: guild.Id));
+
+		Assert.True(result.Succeeded);
+		Assert.DoesNotContain(guild.Members, m => m.UserId == 99);
+		Assert.Equal(1, repo.UpdateCount);
+		Assert.Equal(1, repo.SaveChangesCount);
+
+		var evt = bus.Single<GuildMemberLeft>();
+		Assert.Equal(guild.Id, evt.GuildId);
+		Assert.Equal(99L, evt.UserId);
+	}
+
+	private static GuildEntity Seed(FakeGuildRepository repo, long ownerId)
+	{
+		var guild = GuildEntity.Create(
+			id: 100, name: "Test", description: null, iconUrl: null, bannerUrl: null,
+			ownerId: ownerId, everyoneRoleId: 101, adminRoleId: 102, now: Now).Value;
+		repo.AddAsync(guild).GetAwaiter().GetResult();
+		return guild;
+	}
+}

--- a/services/guild/tests/Guild.UnitTests/Application/ListInvitesHandlerTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/ListInvitesHandlerTests.cs
@@ -1,0 +1,105 @@
+using Guild.Application.Abstractions.Messaging;
+using Guild.Application.Features.Invites.Common;
+using Guild.Application.Features.Invites.ListInvites;
+using Guild.Domain.Guild;
+using Guild.Domain.Results;
+using Guild.UnitTests.Fakes;
+using Xunit;
+using GuildEntity = Guild.Domain.Guild.Guild;
+
+namespace Guild.UnitTests.Application;
+
+public sealed class ListInvitesHandlerTests
+{
+	private static readonly DateTimeOffset Now =
+		new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+	[Fact]
+	public async Task UnknownGuild_Returns404()
+	{
+		var (g, i) = (new FakeGuildRepository(), new FakeGuildInviteRepository());
+		var handler = NewHandler(g, i, callerId: 1);
+
+		var result = await handler.HandleAsync(new ListInvitesQuery(GuildId: 9999));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal("Guild.GuildNotFound", result.Error.Code);
+	}
+
+	[Fact]
+	public async Task NonMember_ReturnsNotAMember()
+	{
+		var (g, i) = (new FakeGuildRepository(), new FakeGuildInviteRepository());
+		var guild = SeedGuild(g, ownerId: 1);
+		var handler = NewHandler(g, i, callerId: 99);
+
+		var result = await handler.HandleAsync(new ListInvitesQuery(guild.Id));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal("Guild.NotAMember", result.Error.Code);
+	}
+
+	[Fact]
+	public async Task MemberWithoutManageGuild_ReturnsMissingPermission()
+	{
+		var (g, i) = (new FakeGuildRepository(), new FakeGuildInviteRepository());
+		var guild = SeedGuild(g, ownerId: 1);
+		DomainSeed.AddMember(guild, userId: 99, joinedAt: Now);
+		var handler = NewHandler(g, i, callerId: 99);
+
+		var result = await handler.HandleAsync(new ListInvitesQuery(guild.Id));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal("Guild.MissingPermission", result.Error.Code);
+	}
+
+	[Fact]
+	public async Task HappyPath_ReturnsActiveInvites_NewestFirst()
+	{
+		var (g, i) = (new FakeGuildRepository(), new FakeGuildInviteRepository());
+		var guild = SeedGuild(g, ownerId: 1);
+
+		i.Seed(GuildInvite.Create("old", guild.Id, 1, null, null, Now).Value);
+		i.Seed(GuildInvite.Create("new", guild.Id, 1, null, null, Now.AddMinutes(1)).Value);
+		var revoked = GuildInvite.Create("revoked", guild.Id, 1, null, null, Now.AddSeconds(30)).Value;
+		revoked.Revoke();
+		i.Seed(revoked);
+
+		var handler = NewHandler(g, i, callerId: 1);
+		var result = await handler.HandleAsync(new ListInvitesQuery(guild.Id));
+
+		Assert.True(result.Succeeded);
+		Assert.Equal(2, result.Value.Count);
+		Assert.Equal("new", result.Value[0].Code);
+		Assert.Equal("old", result.Value[1].Code);
+	}
+
+	[Fact]
+	public async Task EmptyList_ReturnsEmpty()
+	{
+		var (g, i) = (new FakeGuildRepository(), new FakeGuildInviteRepository());
+		var guild = SeedGuild(g, ownerId: 1);
+		var handler = NewHandler(g, i, callerId: 1);
+
+		var result = await handler.HandleAsync(new ListInvitesQuery(guild.Id));
+
+		Assert.True(result.Succeeded);
+		Assert.Empty(result.Value);
+	}
+
+	private static IQueryHandler<ListInvitesQuery, Result<IReadOnlyList<InviteDto>>> NewHandler(
+		FakeGuildRepository guilds, FakeGuildInviteRepository invites, long callerId)
+	{
+		return HandlerFactory.CreateQuery<ListInvitesQuery, Result<IReadOnlyList<InviteDto>>>(
+			guilds, invites, new FakeCurrentUser { Id = callerId });
+	}
+
+	private static GuildEntity SeedGuild(FakeGuildRepository repo, long ownerId)
+	{
+		var guild = GuildEntity.Create(
+			id: 100, name: "Test", description: null, iconUrl: null, bannerUrl: null,
+			ownerId: ownerId, everyoneRoleId: 101, adminRoleId: 102, now: Now).Value;
+		repo.AddAsync(guild).GetAwaiter().GetResult();
+		return guild;
+	}
+}

--- a/services/guild/tests/Guild.UnitTests/Domain/GuildInviteTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Domain/GuildInviteTests.cs
@@ -1,0 +1,254 @@
+using Guild.Domain.Guild;
+using Guild.Domain.Results;
+using Xunit;
+
+namespace Guild.UnitTests.Domain;
+
+public sealed class GuildInviteTests
+{
+	private static readonly DateTimeOffset Now =
+		new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+	[Fact]
+	public void Create_HappyPath()
+	{
+		var result = GuildInvite.Create(
+			code: "abc123",
+			guildId: 10,
+			createdBy: 42,
+			maxUses: 5,
+			expiresAt: Now.AddHours(1),
+			now: Now);
+
+		Assert.True(result.Succeeded);
+		var invite = result.Value;
+		Assert.Equal("abc123", invite.Code);
+		Assert.Equal(10L, invite.GuildId);
+		Assert.Equal(42L, invite.CreatedBy);
+		Assert.Equal(5, invite.MaxUses);
+		Assert.Equal(0, invite.Uses);
+		Assert.False(invite.IsRevoked);
+		Assert.Equal(Now.AddHours(1), invite.ExpiresAt);
+	}
+
+	[Fact]
+	public void Create_NullMaxUses_AllowsUnlimitedUses()
+	{
+		var result = GuildInvite.Create(
+			code: "abc", guildId: 1, createdBy: 1, maxUses: null, expiresAt: null, now: Now);
+
+		Assert.True(result.Succeeded);
+		Assert.Null(result.Value.MaxUses);
+	}
+
+	[Fact]
+	public void Create_EmptyCode_Fails()
+	{
+		var result = GuildInvite.Create(
+			code: "", guildId: 1, createdBy: 1, maxUses: null, expiresAt: null, now: Now);
+
+		Assert.True(result.IsFailure);
+		Assert.Equal(GuildFailures.InviteCodeInvalid, result.Error);
+	}
+
+	[Fact]
+	public void Create_CodeTooLong_Fails()
+	{
+		var code = new string('a', GuildInvite.MaxCodeLen + 1);
+
+		var result = GuildInvite.Create(
+			code: code, guildId: 1, createdBy: 1, maxUses: null, expiresAt: null, now: Now);
+
+		Assert.True(result.IsFailure);
+		Assert.Equal(GuildFailures.InviteCodeInvalid, result.Error);
+	}
+
+	[Fact]
+	public void Create_ZeroGuildId_Fails()
+	{
+		var result = GuildInvite.Create(
+			code: "abc", guildId: 0, createdBy: 1, maxUses: null, expiresAt: null, now: Now);
+
+		Assert.True(result.IsFailure);
+		Assert.Equal(GuildFailures.InviteCodeInvalid, result.Error);
+	}
+
+	[Fact]
+	public void Create_ZeroCreatedBy_Fails()
+	{
+		var result = GuildInvite.Create(
+			code: "abc", guildId: 1, createdBy: 0, maxUses: null, expiresAt: null, now: Now);
+
+		Assert.True(result.IsFailure);
+		Assert.Equal(GuildFailures.InviteCodeInvalid, result.Error);
+	}
+
+	[Fact]
+	public void Create_ZeroMaxUses_Fails()
+	{
+		var result = GuildInvite.Create(
+			code: "abc", guildId: 1, createdBy: 1, maxUses: 0, expiresAt: null, now: Now);
+
+		Assert.True(result.IsFailure);
+		Assert.Equal(GuildFailures.InviteMaxUsesInvalid, result.Error);
+	}
+
+	[Fact]
+	public void Create_NegativeMaxUses_Fails()
+	{
+		var result = GuildInvite.Create(
+			code: "abc", guildId: 1, createdBy: 1, maxUses: -1, expiresAt: null, now: Now);
+
+		Assert.True(result.IsFailure);
+		Assert.Equal(GuildFailures.InviteMaxUsesInvalid, result.Error);
+	}
+
+	[Fact]
+	public void Create_ExpiresInPast_Fails()
+	{
+		var result = GuildInvite.Create(
+			code: "abc", guildId: 1, createdBy: 1, maxUses: null,
+			expiresAt: Now.AddHours(-1), now: Now);
+
+		Assert.True(result.IsFailure);
+		Assert.Equal(GuildFailures.InviteExpiresInPast, result.Error);
+	}
+
+	[Fact]
+	public void Create_ExpiresExactlyNow_Fails()
+	{
+		var result = GuildInvite.Create(
+			code: "abc", guildId: 1, createdBy: 1, maxUses: null, expiresAt: Now, now: Now);
+
+		Assert.True(result.IsFailure);
+		Assert.Equal(GuildFailures.InviteExpiresInPast, result.Error);
+	}
+
+	[Fact]
+	public void Consume_IncrementsUses()
+	{
+		var invite = CreateValid(maxUses: 5);
+
+		var result = invite.Consume(Now);
+
+		Assert.True(result.Succeeded);
+		Assert.Equal(1, invite.Uses);
+	}
+
+	[Fact]
+	public void Consume_AtMaxUses_Fails()
+	{
+		var invite = CreateValid(maxUses: 1);
+		invite.Consume(Now);
+
+		var result = invite.Consume(Now);
+
+		Assert.True(result.IsFailure);
+		Assert.Equal(GuildFailures.InviteUnusable, result.Error);
+		Assert.Equal(1, invite.Uses);
+	}
+
+	[Fact]
+	public void Consume_Revoked_Fails()
+	{
+		var invite = CreateValid();
+		invite.Revoke();
+
+		var result = invite.Consume(Now);
+
+		Assert.True(result.IsFailure);
+		Assert.Equal(GuildFailures.InviteUnusable, result.Error);
+		Assert.Equal(0, invite.Uses);
+	}
+
+	[Fact]
+	public void Consume_Expired_Fails()
+	{
+		var invite = CreateValid(expiresAt: Now.AddHours(1));
+
+		var result = invite.Consume(Now.AddHours(2));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal(GuildFailures.InviteUnusable, result.Error);
+	}
+
+	[Fact]
+	public void Consume_UnlimitedUses_NeverFailsOnCount()
+	{
+		var invite = CreateValid(maxUses: null);
+		for (var i = 0; i < 100; i++)
+		{
+			var result = invite.Consume(Now);
+			Assert.True(result.Succeeded);
+		}
+		Assert.Equal(100, invite.Uses);
+	}
+
+	[Fact]
+	public void Revoke_FlagsInvite()
+	{
+		var invite = CreateValid();
+
+		var result = invite.Revoke();
+
+		Assert.True(result.Succeeded);
+		Assert.True(invite.IsRevoked);
+	}
+
+	[Fact]
+	public void Revoke_AlreadyRevoked_Fails()
+	{
+		var invite = CreateValid();
+		invite.Revoke();
+
+		var result = invite.Revoke();
+
+		Assert.True(result.IsFailure);
+		Assert.Equal(GuildFailures.InviteAlreadyRevoked, result.Error);
+	}
+
+	[Fact]
+	public void IsActive_RevokedFalse()
+	{
+		var invite = CreateValid();
+		invite.Revoke();
+
+		Assert.False(invite.IsActive(Now));
+	}
+
+	[Fact]
+	public void IsActive_ExpiredFalse()
+	{
+		var invite = CreateValid(expiresAt: Now.AddHours(1));
+
+		Assert.False(invite.IsActive(Now.AddHours(2)));
+	}
+
+	[Fact]
+	public void IsActive_ExhaustedFalse()
+	{
+		var invite = CreateValid(maxUses: 1);
+		invite.Consume(Now);
+
+		Assert.False(invite.IsActive(Now));
+	}
+
+	[Fact]
+	public void IsActive_FreshTrue()
+	{
+		var invite = CreateValid(maxUses: 5, expiresAt: Now.AddHours(1));
+
+		Assert.True(invite.IsActive(Now));
+	}
+
+	private static GuildInvite CreateValid(
+		int? maxUses = null,
+		DateTimeOffset? expiresAt = null) =>
+		GuildInvite.Create(
+			code: "abc",
+			guildId: 1,
+			createdBy: 1,
+			maxUses: maxUses,
+			expiresAt: expiresAt,
+			now: Now).Value;
+}

--- a/services/guild/tests/Guild.UnitTests/Domain/GuildTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Domain/GuildTests.cs
@@ -340,6 +340,82 @@ public sealed class GuildTests
 		Assert.Equal(later, guild.UpdatedAt);
 	}
 
+	[Fact]
+	public void AddMember_HappyPath_AppendsAndAdvancesUpdatedAt()
+	{
+		var guild = CreateValid();
+		var later = Now.AddMinutes(10);
+		var before = guild.Members.Count;
+
+		var result = guild.AddMember(userId: 99, now: later);
+
+		Assert.True(result.Succeeded);
+		Assert.Equal(before + 1, guild.Members.Count);
+		Assert.Contains(guild.Members, m => m.UserId == 99);
+		Assert.Equal(later, guild.UpdatedAt);
+	}
+
+	[Fact]
+	public void AddMember_AlreadyMember_Fails()
+	{
+		var guild = CreateValid();
+
+		var result = guild.AddMember(userId: guild.OwnerId, now: Now);
+
+		Assert.True(result.IsFailure);
+		Assert.Equal(GuildFailures.AlreadyMember, result.Error);
+	}
+
+	[Fact]
+	public void AddMember_PropagatesGuildMemberCreateFailure()
+	{
+		var guild = CreateValid();
+
+		var result = guild.AddMember(userId: 0, now: Now);
+
+		Assert.True(result.IsFailure);
+		Assert.Equal(GuildFailures.TargetNotAMember, result.Error);
+	}
+
+	[Fact]
+	public void RemoveMember_HappyPath_RemovesMemberAndRoles()
+	{
+		var guild = CreateValid();
+		guild.AddMember(userId: 99, now: Now);
+		Guild.UnitTests.Fakes.DomainSeed.AssignRole(
+			guild, userId: 99, roleId: guild.Roles.First(r => r.IsDefault).Id, now: Now);
+
+		var later = Now.AddMinutes(5);
+		var result = guild.RemoveMember(userId: 99, now: later);
+
+		Assert.True(result.Succeeded);
+		Assert.DoesNotContain(guild.Members, m => m.UserId == 99);
+		Assert.DoesNotContain(guild.MemberRoles, mr => mr.UserId == 99);
+		Assert.Equal(later, guild.UpdatedAt);
+	}
+
+	[Fact]
+	public void RemoveMember_Owner_Fails()
+	{
+		var guild = CreateValid();
+
+		var result = guild.RemoveMember(userId: guild.OwnerId, now: Now);
+
+		Assert.True(result.IsFailure);
+		Assert.Equal(GuildFailures.OwnerCannotLeave, result.Error);
+	}
+
+	[Fact]
+	public void RemoveMember_NotAMember_Fails()
+	{
+		var guild = CreateValid();
+
+		var result = guild.RemoveMember(userId: 9999, now: Now);
+
+		Assert.True(result.IsFailure);
+		Assert.Equal(GuildFailures.NotAMember, result.Error);
+	}
+
 	private static GuildEntity CreateValid(
 		string? description = null,
 		string? iconUrl = null,

--- a/services/guild/tests/Guild.UnitTests/Fakes/DomainSeed.cs
+++ b/services/guild/tests/Guild.UnitTests/Fakes/DomainSeed.cs
@@ -73,6 +73,11 @@ internal static class DomainSeed
 		return role;
 	}
 
+	internal static void SetRolePermissions(Role role, long permissions)
+	{
+		typeof(Role).GetProperty(nameof(Role.Permissions), AnyInstance)!.SetValue(role, permissions);
+	}
+
 	internal static MemberRole AssignRole(GuildEntity guild, long userId, long roleId, DateTimeOffset now)
 	{
 		var memberRole = (MemberRole)Activator.CreateInstance(

--- a/services/guild/tests/Guild.UnitTests/Fakes/FakeEventBus.cs
+++ b/services/guild/tests/Guild.UnitTests/Fakes/FakeEventBus.cs
@@ -1,0 +1,26 @@
+using Guild.Application.Abstractions;
+
+namespace Guild.UnitTests.Fakes;
+
+internal sealed class FakeEventBus : IEventBus
+{
+	private readonly List<object> _published = [];
+
+	public IReadOnlyList<object> Published => _published;
+
+	public Task PublishAsync<T>(T message, CancellationToken cancellationToken = default) where T : class
+	{
+		_published.Add(message);
+		return Task.CompletedTask;
+	}
+
+	public T Single<T>() where T : class
+	{
+		return _published.OfType<T>().Single();
+	}
+
+	public bool Has<T>() where T : class
+	{
+		return _published.OfType<T>().Any();
+	}
+}

--- a/services/guild/tests/Guild.UnitTests/Fakes/FakeGuildInviteRepository.cs
+++ b/services/guild/tests/Guild.UnitTests/Fakes/FakeGuildInviteRepository.cs
@@ -1,0 +1,51 @@
+using Guild.Application.Abstractions.Persistence;
+using Guild.Domain.Guild;
+
+namespace Guild.UnitTests.Fakes;
+
+internal sealed class FakeGuildInviteRepository : IGuildInviteRepository
+{
+	private readonly Dictionary<string, GuildInvite> _store = new();
+
+	public IReadOnlyDictionary<string, GuildInvite> Store => _store;
+
+	public int AddCount { get; private set; }
+	public int UpdateCount { get; private set; }
+	public int SaveChangesCount { get; private set; }
+
+	public Task<GuildInvite?> GetByCodeAsync(string code, CancellationToken cancellationToken = default)
+	{
+		_store.TryGetValue(code, out var invite);
+		return Task.FromResult(invite);
+	}
+
+	public Task<IReadOnlyList<GuildInvite>> ListByGuildAsync(long guildId, CancellationToken cancellationToken = default)
+	{
+		IReadOnlyList<GuildInvite> rows = _store.Values
+			.Where(i => i.GuildId == guildId && !i.IsRevoked)
+			.OrderByDescending(i => i.CreatedAt)
+			.ToList();
+		return Task.FromResult(rows);
+	}
+
+	public Task AddAsync(GuildInvite invite, CancellationToken cancellationToken = default)
+	{
+		_store[invite.Code] = invite;
+		AddCount++;
+		return Task.CompletedTask;
+	}
+
+	public void Update(GuildInvite invite)
+	{
+		_store[invite.Code] = invite;
+		UpdateCount++;
+	}
+
+	public Task SaveChangesAsync(CancellationToken cancellationToken = default)
+	{
+		SaveChangesCount++;
+		return Task.CompletedTask;
+	}
+
+	internal void Seed(GuildInvite invite) => _store[invite.Code] = invite;
+}

--- a/services/guild/tests/Guild.UnitTests/Fakes/FakeInviteCodeGenerator.cs
+++ b/services/guild/tests/Guild.UnitTests/Fakes/FakeInviteCodeGenerator.cs
@@ -1,0 +1,10 @@
+using Guild.Application.Abstractions;
+
+namespace Guild.UnitTests.Fakes;
+
+internal sealed class FakeInviteCodeGenerator(string seed = "seed00") : IInviteCodeGenerator
+{
+	private int _counter;
+
+	public string NextCode() => $"{seed}{++_counter:D2}";
+}

--- a/services/guild/tests/Guild.UnitTests/Fakes/FakeUserService.cs
+++ b/services/guild/tests/Guild.UnitTests/Fakes/FakeUserService.cs
@@ -1,0 +1,28 @@
+using Guild.Application.Abstractions.Users;
+
+namespace Guild.UnitTests.Fakes;
+
+internal sealed class FakeUserService : IUserService
+{
+	private readonly Dictionary<long, UserSummary> _summaries = new();
+
+	public bool Exists { get; set; } = true;
+	public int ExistsCallCount { get; private set; }
+	public int GetSummaryCallCount { get; private set; }
+
+	public void RegisterSummary(long userId, string username)
+		=> _summaries[userId] = new UserSummary(userId, username);
+
+	public Task<bool> ExistsAsync(long userId, CancellationToken cancellationToken = default)
+	{
+		ExistsCallCount++;
+		return Task.FromResult(Exists);
+	}
+
+	public Task<UserSummary?> GetSummaryAsync(long userId, CancellationToken cancellationToken = default)
+	{
+		GetSummaryCallCount++;
+		_summaries.TryGetValue(userId, out var summary);
+		return Task.FromResult<UserSummary?>(summary);
+	}
+}


### PR DESCRIPTION
Resolves #57 
Resolves #59
Resolves #65

## Summary

- **Join/leave**: `POST /guilds/{id}/join`, `POST /guilds/{id}/leave`. Owner cannot leave. Join publishes `guild.member_joined` (payload now carries `guild_name` per #65 so consumers don't need an HTTP callback).
- **Invites**: `POST/GET /guilds/{id}/invites`, `DELETE /guilds/{id}/invites/{code}` (creator OR `MANAGE_GUILD`), `GET /invites/{code}` preview, `POST /invites/{code}/join`. Codes are 10-char URL-safe from a 56-symbol alphabet.
- **`IUserService`**: typed HttpClient against User Service `/internal/users/{id}`. Used for the contract-spec'd existence check on join and the inviter username on preview. Swallows any non-cancellation fault so a User Service outage never breaks a join.
- **RabbitMQ serializer**: configured to `JsonNamingPolicy.SnakeCaseLower` so the wire format matches `docs/contracts/guild.md`. Auth and Chat will need the same block.

## Fun little things (🥲)
  
Remember when I mentionned how debugging events was an absolute bliss that makes me all warm and fuzzy inside?
Yeah so basically when a publisher and a consumer live in different services with their own contract assemblies, MassTransit binds by URN. The default URN derives from the type's namespace. Cross-service (that rely on MT) consumers MUST add `[MessageUrn("PublisherNs:TypeName")]` (in a layer that can reference MassTransit, not Application) or every message silently lands in the `*_skipped` queue with no error :D
<img width="800" height="604" alt="image" src="https://github.com/user-attachments/assets/b1532b43-8630-4855-8cef-298cac25dc3d" />
