### PR TITLE
Feat/chat/guild member joined consumer

### DIFF
--- a/services/chat/src/Chat.Application/Abstractions/IUserBroadcaster.cs
+++ b/services/chat/src/Chat.Application/Abstractions/IUserBroadcaster.cs
@@ -1,0 +1,11 @@
+namespace Chat.Application.Abstractions;
+
+/// <summary>
+/// pushes per-user real-time notifications over SignalR. impl lives in the
+/// Presentation layer because <c>IHubContext</c> is an ASP.NET abstraction
+/// that must not leak into Infrastructure
+/// </summary>
+public interface IUserBroadcaster
+{
+	Task BroadcastGuildJoinedAsync(long userId, long guildId, string guildName, CancellationToken ct);
+}

--- a/services/chat/src/Chat.Application/Contracts/Events.cs
+++ b/services/chat/src/Chat.Application/Contracts/Events.cs
@@ -1,10 +1,12 @@
 namespace Chat.Application.Contracts;
 
+// own-source events published by Chat. consumers in other services bind to
+// these URNs via [MessageUrn("Chat.Application.Contracts:...")] on their side
 public sealed record ChatMessageSent(long ChannelId, long GuildId, long AuthorId, long MessageId, string Content, long[] Mentions);
 public sealed record CallIncoming(long CallId, long CallerId, long CalleeId, string CallType);
 public sealed record UserOnline(long UserId);
 public sealed record UserOffline(long UserId);
 
-public sealed record GuildMemberJoined(long GuildId, long UserId);
-public sealed record GuildMemberLeft(long GuildId, long UserId);
-public sealed record UserLoggedOut(long UserId);
+// cross-service inbound events live in Chat.Infrastructure.Messaging.Contracts
+// so the [MessageUrn] attribute (which carries a MassTransit dependency) stays
+// out of the Application layer. see InboundEvents.cs

--- a/services/chat/src/Chat.Infrastructure/DependencyInjection.cs
+++ b/services/chat/src/Chat.Infrastructure/DependencyInjection.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Chat.Application.Abstractions;
 using Chat.Application.Abstractions.Authentication;
 using Chat.Application.Contracts;
@@ -5,6 +6,7 @@ using Chat.Infrastructure.Authentication;
 using Chat.Infrastructure.Http;
 using Chat.Infrastructure.Messaging;
 using Chat.Infrastructure.Messaging.Consumers;
+using Chat.Infrastructure.Messaging.Contracts;
 using Chat.Infrastructure.Options;
 using MassTransit;
 using Microsoft.Extensions.DependencyInjection;
@@ -49,6 +51,15 @@ public static class DependencyInjection
 				{
 					h.Username(options.Username);
 					h.Password(options.Password);
+				});
+
+				// docs/contracts are the source of truth and document snake_case
+				// payloads. MassTransit defaults to camelCase via System.Text.Json,
+				// so override the property naming policy to match
+				cfg.ConfigureJsonSerializerOptions(opts =>
+				{
+					opts.PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower;
+					return opts;
 				});
 
 				cfg.Message<ChatMessageSent>(m => m.SetEntityName("chat.message_sent"));

--- a/services/chat/src/Chat.Infrastructure/Messaging/Consumers/MembershipConsumers.cs
+++ b/services/chat/src/Chat.Infrastructure/Messaging/Consumers/MembershipConsumers.cs
@@ -1,4 +1,4 @@
-using Chat.Application.Contracts;
+using Chat.Infrastructure.Messaging.Contracts;
 using MassTransit;
 
 namespace Chat.Infrastructure.Messaging.Consumers;

--- a/services/chat/src/Chat.Infrastructure/Messaging/Consumers/MembershipConsumers.cs
+++ b/services/chat/src/Chat.Infrastructure/Messaging/Consumers/MembershipConsumers.cs
@@ -1,19 +1,51 @@
+using Chat.Application.Abstractions;
 using Chat.Infrastructure.Messaging.Contracts;
 using MassTransit;
+using Microsoft.Extensions.Logging;
 
 namespace Chat.Infrastructure.Messaging.Consumers;
 
-public sealed class GuildMemberJoinedConsumer : IConsumer<GuildMemberJoined>
+public sealed class GuildMemberJoinedConsumer(
+	IUserBroadcaster broadcaster,
+	ILogger<GuildMemberJoinedConsumer> logger)
+	: IConsumer<GuildMemberJoined>
 {
-	public Task Consume(ConsumeContext<GuildMemberJoined> context) => Task.CompletedTask;
+	public async Task Consume(ConsumeContext<GuildMemberJoined> context)
+	{
+		var msg = context.Message;
+
+		await broadcaster.BroadcastGuildJoinedAsync(
+			userId: msg.UserId,
+			guildId: msg.GuildId,
+			guildName: msg.GuildName,
+			ct: context.CancellationToken);
+
+		logger.LogDebug(
+			"guild.member_joined consumed: guild_id={GuildId} guild_name={GuildName} user_id={UserId}",
+			msg.GuildId, msg.GuildName, msg.UserId);
+	}
 }
 
-public sealed class GuildMemberLeftConsumer : IConsumer<GuildMemberLeft>
+public sealed class GuildMemberLeftConsumer(ILogger<GuildMemberLeftConsumer> logger)
+	: IConsumer<GuildMemberLeft>
 {
-	public Task Consume(ConsumeContext<GuildMemberLeft> context) => Task.CompletedTask;
+	public Task Consume(ConsumeContext<GuildMemberLeft> context)
+	{
+		var msg = context.Message;
+		logger.LogDebug(
+			"guild.member_left consumed: guild_id={GuildId} user_id={UserId}",
+			msg.GuildId, msg.UserId);
+		return Task.CompletedTask;
+	}
 }
 
-public sealed class UserLoggedOutConsumer : IConsumer<UserLoggedOut>
+public sealed class UserLoggedOutConsumer(ILogger<UserLoggedOutConsumer> logger)
+	: IConsumer<UserLoggedOut>
 {
-	public Task Consume(ConsumeContext<UserLoggedOut> context) => Task.CompletedTask;
+	public Task Consume(ConsumeContext<UserLoggedOut> context)
+	{
+		var msg = context.Message;
+		logger.LogDebug("user.logged_out consumed: user_id={UserId}", msg.UserId);
+		return Task.CompletedTask;
+	}
 }

--- a/services/chat/src/Chat.Infrastructure/Messaging/Contracts/InboundEvents.cs
+++ b/services/chat/src/Chat.Infrastructure/Messaging/Contracts/InboundEvents.cs
@@ -1,0 +1,19 @@
+using MassTransit;
+
+namespace Chat.Infrastructure.Messaging.Contracts;
+
+// cross-service events Chat *consumes* but does not publish. each carries a
+// [MessageUrn] override so MassTransit binds the local consumer to the URN
+// the publisher actually sends on the wire. without the override the URN
+// would default to "Chat.Infrastructure.Messaging.Contracts:...", which
+// would never match the publisher's "{PubAssembly}.Application.Contracts:..."
+// and every message would land in the *_skipped queue
+
+[MessageUrn("Guild.Application.Contracts:GuildMemberJoined")]
+public sealed record GuildMemberJoined(long GuildId, string GuildName, long UserId);
+
+[MessageUrn("Guild.Application.Contracts:GuildMemberLeft")]
+public sealed record GuildMemberLeft(long GuildId, long UserId);
+
+[MessageUrn("Auth.Application.Contracts:UserLoggedOut")]
+public sealed record UserLoggedOut(long UserId);

--- a/services/chat/src/Chat.Presentation/Hubs/IChatClient.cs
+++ b/services/chat/src/Chat.Presentation/Hubs/IChatClient.cs
@@ -5,5 +5,6 @@ namespace Chat.Presentation.Hubs;
 public interface IChatClient
 {
 	Task ReceiveMessage(MessageResponse message);
+	Task GuildJoined(string guildId, string guildName);
 	Task Error(string code, string message);
 }

--- a/services/chat/src/Chat.Presentation/Hubs/SignalRUserBroadcaster.cs
+++ b/services/chat/src/Chat.Presentation/Hubs/SignalRUserBroadcaster.cs
@@ -1,0 +1,18 @@
+using Chat.Application.Abstractions;
+using Microsoft.AspNetCore.SignalR;
+
+namespace Chat.Presentation.Hubs;
+
+/// <summary>
+/// routes per-user payloads to every connection the user has open using
+/// SignalR's built-in user routing. resolution goes through
+/// <c>DefaultUserIdProvider</c>, which reads <c>ClaimTypes.NameIdentifier</c>
+/// off the JWT-authenticated identity (the user's snowflake string, since the
+/// JwtBearer middleware auto-maps the <c>sub</c> claim to it)
+/// </summary>
+internal sealed class SignalRUserBroadcaster(IHubContext<ChatHub, IChatClient> hub)
+	: IUserBroadcaster
+{
+	public Task BroadcastGuildJoinedAsync(long userId, long guildId, string guildName, CancellationToken ct) =>
+		hub.Clients.User(userId.ToString()).GuildJoined(guildId.ToString(), guildName);
+}

--- a/services/chat/src/Chat.Presentation/Program.cs
+++ b/services/chat/src/Chat.Presentation/Program.cs
@@ -27,6 +27,7 @@ builder.Services.AddApplication()
 	.AddInfrastructure()
 	.AddPersistence();
 builder.Services.AddScoped<IChannelBroadcaster, SignalRChannelBroadcaster>();
+builder.Services.AddScoped<IUserBroadcaster, SignalRUserBroadcaster>();
 builder.Services.AddCarter();
 
 var jwtSecret = builder.Configuration["Jwt:SecretKey"]

--- a/services/chat/tests/Chat.UnitTests/Fakes/FakeUserBroadcaster.cs
+++ b/services/chat/tests/Chat.UnitTests/Fakes/FakeUserBroadcaster.cs
@@ -1,0 +1,16 @@
+using Chat.Application.Abstractions;
+
+namespace Chat.UnitTests.Fakes;
+
+public sealed class FakeUserBroadcaster : IUserBroadcaster
+{
+	private readonly List<(long UserId, long GuildId, string GuildName)> _calls = [];
+
+	public IReadOnlyList<(long UserId, long GuildId, string GuildName)> Calls => _calls;
+
+	public Task BroadcastGuildJoinedAsync(long userId, long guildId, string guildName, CancellationToken ct)
+	{
+		_calls.Add((userId, guildId, guildName));
+		return Task.CompletedTask;
+	}
+}

--- a/services/chat/tests/Chat.UnitTests/Infrastructure/GuildMemberJoinedConsumerTests.cs
+++ b/services/chat/tests/Chat.UnitTests/Infrastructure/GuildMemberJoinedConsumerTests.cs
@@ -1,0 +1,36 @@
+using Chat.Application.Abstractions;
+using Chat.Infrastructure.Messaging.Consumers;
+using Chat.Infrastructure.Messaging.Contracts;
+using Chat.UnitTests.Fakes;
+using MassTransit;
+using MassTransit.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Chat.UnitTests.Infrastructure;
+
+public sealed class GuildMemberJoinedConsumerTests
+{
+	[Fact]
+	public async Task Consume_ForwardsMessageFieldsToBroadcaster()
+	{
+		var broadcaster = new FakeUserBroadcaster();
+		await using var provider = new ServiceCollection()
+			.AddSingleton<IUserBroadcaster>(broadcaster)
+			.AddMassTransitTestHarness(x => x.AddConsumer<GuildMemberJoinedConsumer>())
+			.BuildServiceProvider(true);
+
+		var harness = provider.GetRequiredService<ITestHarness>();
+		await harness.Start();
+
+		await harness.Bus.Publish(new GuildMemberJoined(
+			GuildId: 100, GuildName: "skafenings", UserId: 42));
+
+		Assert.True(await harness.Consumed.Any<GuildMemberJoined>());
+
+		var call = Assert.Single(broadcaster.Calls);
+		Assert.Equal(42L, call.UserId);
+		Assert.Equal(100L, call.GuildId);
+		Assert.Equal("skafenings", call.GuildName);
+	}
+}


### PR DESCRIPTION
Resolves #66 

## Summary
     
- **`guild.member_joined` consumer**: Chat now ingests the event Guild started publishing in #57/#65. On consume, pushes a `GuildJoined(guildId, guildName)` invocation over SignalR to every connection the joining user has open. Goes through a new `IUserBroadcaster` (impl in `Chat.Presentation/Hubs/SignalRUserBroadcaster.cs`) so the Application layer stays free of `IHubContext`. Routing relies on SignalR's `DefaultUserIdProvider` reading the JWT's `sub` claim, no manual group bookkeeping.
- **Wire format fixes** (paired with the Guild PR's matching block):
- `ConfigureJsonSerializerOptions` set to `JsonNamingPolicy.SnakeCaseLower` so MT deserialises the snake_case envelope Guild publishes.
- Cross-service contract records (`GuildMemberJoined`, `GuildMemberLeft`, `UserLoggedOut`) moved out of `Chat.Application.Contracts` into `Chat.Infrastructure.Messaging.Contracts.InboundEvents` and  tagged with `[MessageUrn("PublisherNs:TypeName")]` so MassTransit binds the consumer to the URN the publisher actually sends. Without this every cross-service message silently routes to `*_skipped`.


## Depends on
- #194  (snake_case + `guild_name` payload) needs to be merged before this becomes observable in shared environments. Makes it easier to test instead of having to figure out how to publish an event by hand (which is hell, you're welcome)