### PR TITLE
feat(chat): lazy channel subscription via JoinChannel/LeaveChannel

### DIFF
--- a/docs/contracts/chat.md
+++ b/docs/contracts/chat.md
@@ -511,18 +511,55 @@ Remove the caller's own reaction. Removing a reaction the caller did not place i
 
 Connect with the access token:
 ```
-wss://<host>/hubs/chat?access_token=<jwt>
+wss://<host>/api/chat/v1/hubs/chat?access_token=<jwt>
 ```
 
 On connect, the server:
-1. Adds the client to all SignalR groups for their guild channels, plus a personal group for DMs.
+1. Publishes `user.online` to RabbitMQ. No SignalR groups are joined automatically — the client subscribes to channels on demand via `JoinChannel` (see below).
 2. Checks for a pending incoming call (caller sent `CallOffer` while this user was offline) - if one exists, immediately relays `IncomingCall` to the client so they can answer.
 
 ---
 
 ### Client → Server (Invocations)
 
-Sending messages is REST-only (`POST /channels/{channel_id}/messages`, `POST /dms/{user_id}/messages`). The hub carries one chat invocation (`Typing`, below) plus the WebRTC signaling methods documented further down.
+Sending messages is REST-only (`POST /channels/{channel_id}/messages`, `POST /dms/{user_id}/messages`). The hub carries three chat invocations (`JoinChannel`, `LeaveChannel`, `Typing`) plus the WebRTC signaling methods documented further down.
+
+#### JoinChannel
+
+Subscribe the current connection to a channel's real-time message stream. Must be called before `ReceiveMessage` broadcasts for that channel reach the client. Clients call this when the user navigates to a channel.
+
+```json
+{
+  "target": "JoinChannel",
+  "arguments": ["<snowflake>"]
+}
+```
+
+The single argument is the channel ID. Server actions:
+1. Calls Guild Service `GET /internal/channels/{channel_id}/membership?user_id={caller}` to verify membership and permissions.
+2. On success: adds the connection to the `channel:{id}` SignalR group.
+3. On failure: sends `Error` to the caller.
+
+**Errors** (via `Error` event):
+| Code | Reason |
+|------|--------|
+| `Channel.NotFound` | Channel not found or caller is not a member |
+| `Channel.MissingReadPermission` | Caller lacks `READ_MESSAGES` permission |
+
+---
+
+#### LeaveChannel
+
+Unsubscribe the current connection from a channel's real-time stream. Clients call this when navigating away from a channel. No permission check — a connection can always leave a group.
+
+```json
+{
+  "target": "LeaveChannel",
+  "arguments": ["<snowflake>"]
+}
+```
+
+---
 
 #### Typing
 
@@ -720,6 +757,53 @@ Sent to the caller's personal SignalR group after `PUT /dms/{user_id}/read` so o
 
 ---
 
+#### GuildJoined
+
+Sent to all connections of a user when they join a guild (triggered by consuming `guild.member_joined` from RabbitMQ). The client should update its guild list in the sidebar. If the user navigates to a channel in the new guild, it then calls `JoinChannel`.
+
+```json
+{
+  "target": "GuildJoined",
+  "arguments": [{
+    "guild_id": "<snowflake>",
+    "guild_name": "ft_transcendence"
+  }]
+}
+```
+
+---
+
+#### GuildLeft
+
+Sent to all connections of a user when they leave a guild (triggered by consuming `guild.member_left` from RabbitMQ). The client should remove the guild from its sidebar and call `LeaveChannel` for any channel of that guild it is currently subscribed to.
+
+```json
+{
+  "target": "GuildLeft",
+  "arguments": [{
+    "guild_id": "<snowflake>"
+  }]
+}
+```
+
+---
+
+#### Error
+
+Sent to the caller when a hub invocation fails validation.
+
+```json
+{
+  "target": "Error",
+  "arguments": [{
+    "code": "<error_code>",
+    "message": "<human_readable_description>"
+  }]
+}
+```
+
+---
+
 #### UserPresence
 
 Broadcast when a user's presence changes (connect, disconnect, or `PATCH /users/me` status update). Fanned out to every connection that could see the user in a sidebar:
@@ -741,7 +825,6 @@ Broadcast when a user's presence changes (connect, disconnect, or `PATCH /users/
 `status` is `online`, `idle`, `dnd`, or `offline`, matching the values of `users_profile.status` in the User Service. `idle` and `dnd` only ever arrive via an explicit `PATCH /users/me` from the user; connect/disconnect transitions only produce `online` / `offline`.
 
 ---
-
 ## WebRTC Signaling (via SignalR Hub)
 
 Voice and video calls are **1-on-1, peer-to-peer via WebRTC**. The Chat Service hub acts as the signaling server - it relays SDP offers/answers and ICE candidates between the two peers. No media ever touches the server.
@@ -1001,7 +1084,7 @@ Relayed verbatim from the remote peer.
 
 | Event | Action |
 |-------|--------|
-| `guild.member_joined` | Add user to SignalR groups for all channels in that guild |
-| `guild.member_left` | Remove user from SignalR groups for that guild |
+| `guild.member_joined` | Broadcast `GuildJoined` to all connections of the user; clients call `JoinChannel` themselves when navigating to a channel in that guild |
+| `guild.member_left` | Broadcast `GuildLeft` to all connections of the user; clients call `LeaveChannel` for any open subscription in that guild |
 | `user.logged_out` | Force-disconnect any active WebSocket for that user |
 | `user.deleted` | Force-disconnect any active WebSocket; delete the user's `user_conversations`, `channel_read_states`, and `dm_unread_counts` rows. Messages stay - the user's profile becomes unresolvable in User Service, so the frontend renders them as "Deleted User". |

--- a/services/chat/src/Chat.Application/Abstractions/IUserBroadcaster.cs
+++ b/services/chat/src/Chat.Application/Abstractions/IUserBroadcaster.cs
@@ -8,4 +8,5 @@ namespace Chat.Application.Abstractions;
 public interface IUserBroadcaster
 {
 	Task BroadcastGuildJoinedAsync(long userId, long guildId, string guildName, CancellationToken ct);
+	Task BroadcastGuildLeftAsync(long userId, long guildId, CancellationToken ct);
 }

--- a/services/chat/src/Chat.Infrastructure/Messaging/Consumers/MembershipConsumers.cs
+++ b/services/chat/src/Chat.Infrastructure/Messaging/Consumers/MembershipConsumers.cs
@@ -26,16 +26,23 @@ public sealed class GuildMemberJoinedConsumer(
 	}
 }
 
-public sealed class GuildMemberLeftConsumer(ILogger<GuildMemberLeftConsumer> logger)
+public sealed class GuildMemberLeftConsumer(
+	IUserBroadcaster broadcaster,
+	ILogger<GuildMemberLeftConsumer> logger)
 	: IConsumer<GuildMemberLeft>
 {
-	public Task Consume(ConsumeContext<GuildMemberLeft> context)
+	public async Task Consume(ConsumeContext<GuildMemberLeft> context)
 	{
 		var msg = context.Message;
+
+		await broadcaster.BroadcastGuildLeftAsync(
+			userId: msg.UserId,
+			guildId: msg.GuildId,
+			ct: context.CancellationToken);
+
 		logger.LogDebug(
 			"guild.member_left consumed: guild_id={GuildId} user_id={UserId}",
 			msg.GuildId, msg.UserId);
-		return Task.CompletedTask;
 	}
 }
 

--- a/services/chat/src/Chat.Presentation/Hubs/ChatHub.cs
+++ b/services/chat/src/Chat.Presentation/Hubs/ChatHub.cs
@@ -14,19 +14,13 @@ public sealed class ChatHub(IGuildClient guildClient, ICurrentUser currentUser, 
 
 	public override async Task OnConnectedAsync()
 	{
-		if (Context.UserIdentifier is not null)
-			await eventBus.PublishAsync(
-				new UserOnline(long.Parse(Context.UserIdentifier)),
-				Context.ConnectionAborted);
+		await eventBus.PublishAsync(new UserOnline(currentUser.UserId), CancellationToken.None);
 		await base.OnConnectedAsync();
 	}
 
 	public override async Task OnDisconnectedAsync(Exception? exception)
 	{
-		if (Context.UserIdentifier is not null)
-			await eventBus.PublishAsync(new UserOffline(
-				long.Parse(Context.UserIdentifier)),
-				Context.ConnectionAborted);
+		await eventBus.PublishAsync(new UserOffline(currentUser.UserId), CancellationToken.None);
 		await base.OnDisconnectedAsync(exception);
 	}
 

--- a/services/chat/src/Chat.Presentation/Hubs/ChatHub.cs
+++ b/services/chat/src/Chat.Presentation/Hubs/ChatHub.cs
@@ -48,4 +48,7 @@ public sealed class ChatHub(IGuildClient guildClient, ICurrentUser currentUser, 
 
 		await Groups.AddToGroupAsync(Context.ConnectionId, $"channel:{channelId}", Context.ConnectionAborted);
 	}
+
+	public Task LeaveChannel(long channelId) =>
+		Groups.RemoveFromGroupAsync(Context.ConnectionId, $"channel:{channelId}");
 }

--- a/services/chat/src/Chat.Presentation/Hubs/ChatHub.cs
+++ b/services/chat/src/Chat.Presentation/Hubs/ChatHub.cs
@@ -1,15 +1,34 @@
 using Chat.Application.Abstractions;
 using Chat.Application.Abstractions.Authentication;
+using Chat.Application.Contracts;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.SignalR;
 
 namespace Chat.Presentation.Hubs;
 
 [Authorize]
-public sealed class ChatHub(IGuildClient guildClient, ICurrentUser currentUser) : Hub<IChatClient>
+public sealed class ChatHub(IGuildClient guildClient, ICurrentUser currentUser, IEventBus eventBus) : Hub<IChatClient>
 {
 	private const long ReadMessages = 1L << 1;
 	private const long Administrator = 1L << 8;
+
+	public override async Task OnConnectedAsync()
+	{
+		if (Context.UserIdentifier is not null)
+			await eventBus.PublishAsync(
+				new UserOnline(long.Parse(Context.UserIdentifier)),
+				Context.ConnectionAborted);
+		await base.OnConnectedAsync();
+	}
+
+	public override async Task OnDisconnectedAsync(Exception? exception)
+	{
+		if (Context.UserIdentifier is not null)
+			await eventBus.PublishAsync(new UserOffline(
+				long.Parse(Context.UserIdentifier)),
+				Context.ConnectionAborted);
+		await base.OnDisconnectedAsync(exception);
+	}
 
 	public async Task JoinChannel(long channelId)
 	{

--- a/services/chat/src/Chat.Presentation/Hubs/ChatHub.cs
+++ b/services/chat/src/Chat.Presentation/Hubs/ChatHub.cs
@@ -7,20 +7,26 @@ using Microsoft.AspNetCore.SignalR;
 namespace Chat.Presentation.Hubs;
 
 [Authorize]
-public sealed class ChatHub(IGuildClient guildClient, ICurrentUser currentUser, IEventBus eventBus) : Hub<IChatClient>
+public sealed class ChatHub(
+	IGuildClient guildClient,
+	ICurrentUser currentUser,
+	IEventBus eventBus,
+	UserConnectionTracker connectionTracker) : Hub<IChatClient>
 {
 	private const long ReadMessages = 1L << 1;
 	private const long Administrator = 1L << 8;
 
 	public override async Task OnConnectedAsync()
 	{
-		await eventBus.PublishAsync(new UserOnline(currentUser.UserId), CancellationToken.None);
+		if (connectionTracker.TrackConnected(currentUser.UserId))
+			await eventBus.PublishAsync(new UserOnline(currentUser.UserId), CancellationToken.None);
 		await base.OnConnectedAsync();
 	}
 
 	public override async Task OnDisconnectedAsync(Exception? exception)
 	{
-		await eventBus.PublishAsync(new UserOffline(currentUser.UserId), CancellationToken.None);
+		if (connectionTracker.TrackDisconnected(currentUser.UserId))
+			await eventBus.PublishAsync(new UserOffline(currentUser.UserId), CancellationToken.None);
 		await base.OnDisconnectedAsync(exception);
 	}
 

--- a/services/chat/src/Chat.Presentation/Hubs/IChatClient.cs
+++ b/services/chat/src/Chat.Presentation/Hubs/IChatClient.cs
@@ -8,5 +8,6 @@ public interface IChatClient
 	Task MessageEdited(MessageEditedEvent evt);
 	Task MessageDeleted(MessageDeletedEvent evt);
 	Task GuildJoined(string guildId, string guildName);
+	Task GuildLeft(string guildId);
 	Task Error(string code, string message);
 }

--- a/services/chat/src/Chat.Presentation/Hubs/SignalRUserBroadcaster.cs
+++ b/services/chat/src/Chat.Presentation/Hubs/SignalRUserBroadcaster.cs
@@ -15,4 +15,7 @@ internal sealed class SignalRUserBroadcaster(IHubContext<ChatHub, IChatClient> h
 {
 	public Task BroadcastGuildJoinedAsync(long userId, long guildId, string guildName, CancellationToken ct) =>
 		hub.Clients.User(userId.ToString()).GuildJoined(guildId.ToString(), guildName);
+
+	public Task BroadcastGuildLeftAsync(long userId, long guildId, CancellationToken ct) =>
+		hub.Clients.User(userId.ToString()).GuildLeft(guildId.ToString());
 }

--- a/services/chat/src/Chat.Presentation/Hubs/UserConnectionTracker.cs
+++ b/services/chat/src/Chat.Presentation/Hubs/UserConnectionTracker.cs
@@ -1,0 +1,32 @@
+using System.Collections.Concurrent;
+
+namespace Chat.Presentation.Hubs;
+
+public sealed class UserConnectionTracker
+{
+	private readonly ConcurrentDictionary<long, int> _counts = new();
+
+	// Returns true if this is the user's first connection.
+	public bool TrackConnected(long userId)
+		=> _counts.AddOrUpdate(userId, 1, (_, c) => c + 1) == 1;
+
+	// Returns true if this was the user's last connection.
+	public bool TrackDisconnected(long userId)
+	{
+		while (true)
+		{
+			if (!_counts.TryGetValue(userId, out var count))
+				return true;
+			if (count <= 1)
+			{
+				if (_counts.TryRemove(new KeyValuePair<long, int>(userId, count)))
+					return true;
+			}
+			else
+			{
+				if (_counts.TryUpdate(userId, count - 1, count))
+					return false;
+			}
+		}
+	}
+}

--- a/services/chat/src/Chat.Presentation/Program.cs
+++ b/services/chat/src/Chat.Presentation/Program.cs
@@ -26,6 +26,7 @@ builder.Services.AddSignalR();
 builder.Services.AddApplication()
 	.AddInfrastructure()
 	.AddPersistence();
+builder.Services.AddSingleton<UserConnectionTracker>();
 builder.Services.AddScoped<IChannelBroadcaster, SignalRChannelBroadcaster>();
 builder.Services.AddScoped<IUserBroadcaster, SignalRUserBroadcaster>();
 builder.Services.AddCarter();

--- a/services/chat/src/Chat.Presentation/appsettings.Development.json
+++ b/services/chat/src/Chat.Presentation/appsettings.Development.json
@@ -1,1 +1,8 @@
-{}
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Debug",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/services/chat/tests/Chat.FunctionalTests/Features/ChannelLazySubscriptionTests.cs
+++ b/services/chat/tests/Chat.FunctionalTests/Features/ChannelLazySubscriptionTests.cs
@@ -1,0 +1,492 @@
+using Chat.Application.Abstractions;
+using Chat.Application.Contracts;
+using Chat.Application.Features.Messages.Common;
+using Chat.FunctionalTests.Infrastructure;
+using Microsoft.AspNetCore.SignalR.Client;
+using Xunit;
+
+namespace Chat.FunctionalTests.Features;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// T1.01 – T1.09 · Hub connection & user presence events
+// ─────────────────────────────────────────────────────────────────────────────
+public sealed class HubConnectionTests(ChatApiFactory factory)
+	: IClassFixture<ChatApiFactory>, IAsyncLifetime
+{
+	// Unique IDs per test — UserConnectionTracker is a singleton shared across
+	// all tests in this class, so each test must use a distinct userId to avoid
+	// cross-contamination.
+	private const long UserValidToken        = 1_001;
+	private const long UserExpiredToken      = 1_002;
+	private const long UserOnlineEvent       = 1_003;
+	private const long UserOfflineEvent      = 1_004;
+	private const long UserMultiConnOnline   = 1_005;
+	private const long UserMultiConnNoOff    = 1_006;
+	private const long UserMultiConnLastOff  = 1_007;
+
+	public Task InitializeAsync() { factory.EventBus.Reset(); return Task.CompletedTask; }
+	public Task DisposeAsync() => Task.CompletedTask;
+
+	// T1.01 — connection without token rejected
+	[Fact]
+	public async Task Connect_WithoutToken_IsRejected()
+	{
+		var conn = HubConnectionHelper.Build(factory, token: null);
+		await Assert.ThrowsAnyAsync<Exception>(() => conn.StartAsync());
+		Assert.NotEqual(HubConnectionState.Connected, conn.State);
+		await conn.DisposeAsync();
+	}
+
+	// T1.02 — connection with valid token succeeds
+	[Fact]
+	public async Task Connect_WithValidToken_Succeeds()
+	{
+		var token = TestTokens.Issue(ChatApiFactory.JwtSecret, UserValidToken);
+		await using var conn = HubConnectionHelper.Build(factory, token);
+		await conn.StartAsync();
+		Assert.Equal(HubConnectionState.Connected, conn.State);
+	}
+
+	// T1.03 — connection with expired token rejected
+
+	[Fact]
+	public async Task Connect_WithExpiredToken_IsRejected()
+	{
+		var token = TestTokens.Issue(ChatApiFactory.JwtSecret, UserExpiredToken,
+			expiresAt: DateTimeOffset.UtcNow.AddHours(-1));
+		var conn = HubConnectionHelper.Build(factory, token);
+		await Assert.ThrowsAnyAsync<Exception>(() => conn.StartAsync());
+		await conn.DisposeAsync();
+	}
+
+	// T1.04 — connection publish user.online
+	[Fact]
+	public async Task Connect_PublishesUserOnlineEvent()
+	{
+		var token = TestTokens.Issue(ChatApiFactory.JwtSecret, UserOnlineEvent);
+		await using var conn = HubConnectionHelper.Build(factory, token);
+
+		await conn.StartAsync();
+
+		Assert.Contains(factory.EventBus.PublishedOf<UserOnline>(), e => e.UserId == UserOnlineEvent);
+	}
+
+	// T1.05 — disconnection publish user.offline
+	[Fact]
+	public async Task Disconnect_PublishesUserOfflineEvent()
+	{
+		var token = TestTokens.Issue(ChatApiFactory.JwtSecret, UserOfflineEvent);
+		var conn = HubConnectionHelper.Build(factory, token);
+		await conn.StartAsync();
+		factory.EventBus.Reset();
+
+		await conn.DisposeAsync();
+		await Task.Delay(200);
+
+		Assert.Contains(factory.EventBus.PublishedOf<UserOffline>(), e => e.UserId == UserOfflineEvent);
+	}
+
+	// T1.07 — two connections for the same user → user.online published once
+	[Fact]
+	public async Task TwoConnections_SameUser_UserOnlinePublishedOnce()
+	{
+		var token = TestTokens.Issue(ChatApiFactory.JwtSecret, UserMultiConnOnline);
+		await using var conn1 = HubConnectionHelper.Build(factory, token);
+		await using var conn2 = HubConnectionHelper.Build(factory, token);
+
+		await conn1.StartAsync();
+		await conn2.StartAsync();
+
+		var events = factory.EventBus.PublishedOf<UserOnline>().Where(e => e.UserId == UserMultiConnOnline).ToList();
+		Assert.Single(events);
+	}
+
+	// T1.08 — one of thems disconnect (but the other stay) → user.offline not published
+	[Fact]
+	public async Task OneOfTwoDisconnects_UserOfflineNotPublished()
+	{
+		var token = TestTokens.Issue(ChatApiFactory.JwtSecret, UserMultiConnNoOff);
+		await using var conn1 = HubConnectionHelper.Build(factory, token);
+		var conn2 = HubConnectionHelper.Build(factory, token);
+		await conn1.StartAsync();
+		await conn2.StartAsync();
+		factory.EventBus.Reset();
+
+		await conn2.DisposeAsync();
+		await Task.Delay(200);
+
+		Assert.DoesNotContain(factory.EventBus.PublishedOf<UserOffline>(), e => e.UserId == UserMultiConnNoOff);
+	}
+
+	// T1.09 — last connection leave → user.offline published
+	[Fact]
+	public async Task LastConnectionDisconnects_UserOfflinePublished()
+	{
+		var token = TestTokens.Issue(ChatApiFactory.JwtSecret, UserMultiConnLastOff);
+		var conn1 = HubConnectionHelper.Build(factory, token);
+		var conn2 = HubConnectionHelper.Build(factory, token);
+		await conn1.StartAsync();
+		await conn2.StartAsync();
+		factory.EventBus.Reset();
+
+		await conn1.DisposeAsync();
+		await Task.Delay(150);
+		Assert.DoesNotContain(factory.EventBus.PublishedOf<UserOffline>(), e => e.UserId == UserMultiConnLastOff);
+
+		await conn2.DisposeAsync();
+		await Task.Delay(200);
+		Assert.Contains(factory.EventBus.PublishedOf<UserOffline>(), e => e.UserId == UserMultiConnLastOff);
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// T1.10 – T1.17 · JoinChannel
+// ─────────────────────────────────────────────────────────────────────────────
+
+public sealed class JoinChannelTests(ChatApiFactory factory)
+	: IClassFixture<ChatApiFactory>, IAsyncLifetime
+{
+	private const long ReadMessages  = 1L << 1;
+	private const long Administrator = 1L << 8;
+	private const long GuildId       = 999;
+	private const long ChannelId     = 100;
+
+	private const long UserMember        = 2_001;
+	private const long UserNotMember     = 2_002;
+	private const long UserNoPerm        = 2_003;
+	private const long UserAdmin         = 2_004;
+	private const long UserReceive       = 2_005;
+	private const long UserNoReceive     = 2_006;
+	private const long UserIdempotent    = 2_007;
+
+	public Task InitializeAsync() { factory.EventBus.Reset(); return Task.CompletedTask; }
+	public Task DisposeAsync() => Task.CompletedTask;
+
+	// T1.10 — valid member + READ_MESSAGES → succeed
+	[Fact]
+	public async Task JoinChannel_ValidMemberWithReadPerm_NoError()
+	{
+		factory.WithMembershipFor(ChannelId, UserMember, GuildId, ReadMessages);
+		var token = TestTokens.Issue(ChatApiFactory.JwtSecret, UserMember);
+		await using var conn = HubConnectionHelper.Build(factory, token);
+
+		var errorReceived = false;
+		conn.On<string, string>("Error", (_, _) => errorReceived = true);
+
+		await conn.StartAsync();
+		await conn.InvokeAsync("JoinChannel", ChannelId);
+		await Task.Delay(200);
+
+		Assert.False(errorReceived);
+	}
+
+	// T1.11 — membership null (unknow channel) → Error("Channel.NotFound")
+	[Fact]
+	public async Task JoinChannel_NullMembership_SendsChannelNotFoundError()
+	{
+		factory.WithoutMembershipFor(ChannelId, UserNotMember);
+		var token = TestTokens.Issue(ChatApiFactory.JwtSecret, UserNotMember);
+		await using var conn = HubConnectionHelper.Build(factory, token);
+
+		var errorTcs = new TaskCompletionSource<string>();
+		conn.On<string, string>("Error", (code, _) => errorTcs.TrySetResult(code));
+
+		await conn.StartAsync();
+		await conn.InvokeAsync("JoinChannel", ChannelId);
+
+		var code = await errorTcs.Task.WaitAsync(TimeSpan.FromSeconds(3));
+		Assert.Equal("Channel.NotFound", code);
+	}
+
+	// T1.12 — not a member → Error("Channel.NotFound")
+	[Fact]
+	public async Task JoinChannel_NotMember_SendsChannelNotFoundError()
+	{
+		factory.GuildClient.Setup(ChannelId, UserNotMember + 1,
+			new ChannelMembership(IsMember: false, GuildId: GuildId, Permissions: ReadMessages));
+		var token = TestTokens.Issue(ChatApiFactory.JwtSecret, UserNotMember + 1);
+		await using var conn = HubConnectionHelper.Build(factory, token);
+
+		var errorTcs = new TaskCompletionSource<string>();
+		conn.On<string, string>("Error", (code, _) => errorTcs.TrySetResult(code));
+
+		await conn.StartAsync();
+		await conn.InvokeAsync("JoinChannel", ChannelId);
+
+		var code = await errorTcs.Task.WaitAsync(TimeSpan.FromSeconds(3));
+		Assert.Equal("Channel.NotFound", code);
+	}
+
+	// T1.13 — valid member but no perms → Error("Channel.MissingReadPermission")
+	[Fact]
+	public async Task JoinChannel_MemberWithNoPermissions_SendsMissingReadPermError()
+	{
+		factory.GuildClient.Setup(ChannelId, UserNoPerm,
+			new ChannelMembership(IsMember: true, GuildId: GuildId, Permissions: 0));
+		var token = TestTokens.Issue(ChatApiFactory.JwtSecret, UserNoPerm);
+		await using var conn = HubConnectionHelper.Build(factory, token);
+
+		var errorTcs = new TaskCompletionSource<string>();
+		conn.On<string, string>("Error", (code, _) => errorTcs.TrySetResult(code));
+
+		await conn.StartAsync();
+		await conn.InvokeAsync("JoinChannel", ChannelId);
+
+		var code = await errorTcs.Task.WaitAsync(TimeSpan.FromSeconds(3));
+		Assert.Equal("Channel.MissingReadPermission", code);
+	}
+
+	// T1.14 — ADMINISTRATOR only (without READ_MESSAGES) → succeed
+	[Fact]
+	public async Task JoinChannel_AdministratorOnly_Succeeds()
+	{
+		factory.GuildClient.Setup(ChannelId, UserAdmin,
+			new ChannelMembership(IsMember: true, GuildId: GuildId, Permissions: Administrator));
+		var token = TestTokens.Issue(ChatApiFactory.JwtSecret, UserAdmin);
+		await using var conn = HubConnectionHelper.Build(factory, token);
+
+		var errorReceived = false;
+		conn.On<string, string>("Error", (_, _) => errorReceived = true);
+
+		await conn.StartAsync();
+		await conn.InvokeAsync("JoinChannel", ChannelId);
+		await Task.Delay(200);
+
+		Assert.False(errorReceived);
+	}
+
+	// T1.15 — after JoinChannel, when messages is sent → get ReceiveMessage
+	[Fact]
+	public async Task JoinChannel_ThenBroadcast_ClientReceivesMessage()
+	{
+		factory.WithMembershipFor(ChannelId, UserReceive, GuildId, ReadMessages);
+		var token = TestTokens.Issue(ChatApiFactory.JwtSecret, UserReceive);
+		await using var conn = HubConnectionHelper.Build(factory, token);
+
+		var messageTcs = new TaskCompletionSource<MessageResponse>();
+		conn.On<MessageResponse>("ReceiveMessage", msg => messageTcs.TrySetResult(msg));
+
+		await conn.StartAsync();
+		await conn.InvokeAsync("JoinChannel", ChannelId);
+
+		var testMessage = new MessageResponse(
+			Id: "42", ChannelId: ChannelId.ToString(), AuthorId: "1",
+			Content: "hello", ReplyToId: null, EditedAt: null,
+			CreatedAt: DateTimeOffset.UtcNow, Attachments: [], Reactions: [], Nonce: null);
+
+		await factory.SimulateChannelMessageAsync(ChannelId, testMessage);
+
+		var received = await messageTcs.Task.WaitAsync(TimeSpan.FromSeconds(3));
+		Assert.Equal("42", received.Id);
+		Assert.Equal("hello", received.Content);
+	}
+
+	// T1.16 — without JoinChannel, when messages is sent → doesn't get ReceiveMessage
+	[Fact]
+	public async Task WithoutJoinChannel_Broadcast_ClientDoesNotReceiveMessage()
+	{
+		var token = TestTokens.Issue(ChatApiFactory.JwtSecret, UserNoReceive);
+		await using var conn = HubConnectionHelper.Build(factory, token);
+
+		var received = false;
+		conn.On<MessageResponse>("ReceiveMessage", _ => received = true);
+
+		await conn.StartAsync();
+
+		var testMessage = new MessageResponse(
+			Id: "99", ChannelId: ChannelId.ToString(), AuthorId: "1",
+			Content: "ghost", ReplyToId: null, EditedAt: null,
+			CreatedAt: DateTimeOffset.UtcNow, Attachments: [], Reactions: [], Nonce: null);
+
+		await factory.SimulateChannelMessageAsync(ChannelId, testMessage);
+		await Task.Delay(300);
+
+		Assert.False(received);
+	}
+
+	// T1.17 — JoinChannel two time the same channel → idempotent, the second try is a no-op
+	[Fact]
+	public async Task JoinChannel_Twice_IsIdempotent()
+	{
+		factory.WithMembershipFor(ChannelId, UserIdempotent, GuildId, ReadMessages);
+		var token = TestTokens.Issue(ChatApiFactory.JwtSecret, UserIdempotent);
+		await using var conn = HubConnectionHelper.Build(factory, token);
+
+		var errorReceived = false;
+		conn.On<string, string>("Error", (_, _) => errorReceived = true);
+
+		await conn.StartAsync();
+		await conn.InvokeAsync("JoinChannel", ChannelId);
+		await conn.InvokeAsync("JoinChannel", ChannelId);
+		await Task.Delay(200);
+
+		Assert.False(errorReceived);
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// T1.18 – T1.20 · LeaveChannel
+// ─────────────────────────────────────────────────────────────────────────────
+
+public sealed class LeaveChannelTests(ChatApiFactory factory)
+	: IClassFixture<ChatApiFactory>, IAsyncLifetime
+{
+	private const long ReadMessages = 1L << 1;
+	private const long GuildId      = 999;
+	private const long ChannelId    = 200;
+
+	private const long UserLeaveAfterJoin  = 3_001;
+	private const long UserLeaveNoJoin     = 3_002;
+	private const long UserLeaveWrongId    = 3_003;
+
+	public Task InitializeAsync() { factory.EventBus.Reset(); return Task.CompletedTask; }
+	public Task DisposeAsync() => Task.CompletedTask;
+
+	// T1.18 — LeaveChannel after JoinChannel → doesn't get ReceiveMessage anymore
+	[Fact]
+	public async Task LeaveChannel_AfterJoin_StopsReceivingMessages()
+	{
+		factory.WithMembershipFor(ChannelId, UserLeaveAfterJoin, GuildId, ReadMessages);
+		var token = TestTokens.Issue(ChatApiFactory.JwtSecret, UserLeaveAfterJoin);
+		await using var conn = HubConnectionHelper.Build(factory, token);
+
+		var received = false;
+		conn.On<MessageResponse>("ReceiveMessage", _ => received = true);
+
+		await conn.StartAsync();
+		await conn.InvokeAsync("JoinChannel", ChannelId);
+		await conn.InvokeAsync("LeaveChannel", ChannelId);
+
+		var testMessage = new MessageResponse(
+			Id: "1", ChannelId: ChannelId.ToString(), AuthorId: "1",
+			Content: "after leave", ReplyToId: null, EditedAt: null,
+			CreatedAt: DateTimeOffset.UtcNow, Attachments: [], Reactions: [], Nonce: null);
+
+		await factory.SimulateChannelMessageAsync(ChannelId, testMessage);
+		await Task.Delay(300);
+
+		Assert.False(received);
+	}
+
+	// T1.19 — LeaveChannel without JoinChannel → no op, a connection can always leave a channel
+	[Fact]
+	public async Task LeaveChannel_WithoutPriorJoin_NoError()
+	{
+		var token = TestTokens.Issue(ChatApiFactory.JwtSecret, UserLeaveNoJoin);
+		await using var conn = HubConnectionHelper.Build(factory, token);
+
+		var errorReceived = false;
+		conn.On<string, string>("Error", (_, _) => errorReceived = true);
+
+		await conn.StartAsync();
+		await conn.InvokeAsync("LeaveChannel", ChannelId);
+		await Task.Delay(200);
+
+		Assert.False(errorReceived);
+		Assert.Equal(HubConnectionState.Connected, conn.State);
+	}
+
+	// T1.20 — LeaveChannel with unknow channelId → no op, for the same reason as above
+	[Fact]
+	public async Task LeaveChannel_NonExistentChannel_NoError()
+	{
+		var token = TestTokens.Issue(ChatApiFactory.JwtSecret, UserLeaveWrongId);
+		await using var conn = HubConnectionHelper.Build(factory, token);
+
+		var errorReceived = false;
+		conn.On<string, string>("Error", (_, _) => errorReceived = true);
+
+		await conn.StartAsync();
+		await conn.InvokeAsync("LeaveChannel", 999_999_999L);
+		await Task.Delay(200);
+
+		Assert.False(errorReceived);
+		Assert.Equal(HubConnectionState.Connected, conn.State);
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// T1.21 – T1.24 · Guild events (GuildJoined / GuildLeft)
+// ─────────────────────────────────────────────────────────────────────────────
+
+public sealed class GuildEventTests(ChatApiFactory factory)
+	: IClassFixture<ChatApiFactory>, IAsyncLifetime
+{
+	private const long GuildId     = 999;
+	private const string GuildName = "TestGuild";
+
+	private const long UserGuildJoined       = 4_001;
+	private const long UserGuildLeft         = 4_002;
+	private const long UserGuildJoinedOther  = 4_003;
+	private const long UserGuildLeftOther    = 4_004;
+
+	public Task InitializeAsync() { factory.EventBus.Reset(); return Task.CompletedTask; }
+	public Task DisposeAsync() => Task.CompletedTask;
+
+	// T1.21 — SimulateGuildJoined → client get GuildJoined(guildId, guildName)
+	[Fact]
+	public async Task GuildJoined_ConnectedUser_ReceivesGuildJoinedInvocation()
+	{
+		var token = TestTokens.Issue(ChatApiFactory.JwtSecret, UserGuildJoined);
+		await using var conn = HubConnectionHelper.Build(factory, token);
+
+		var tcs = new TaskCompletionSource<(string GuildId, string GuildName)>();
+		conn.On<string, string>("GuildJoined", (gId, gName) => tcs.TrySetResult((gId, gName)));
+
+		await conn.StartAsync();
+		await factory.SimulateGuildJoinedAsync(UserGuildJoined, GuildId, GuildName);
+
+		var result = await tcs.Task.WaitAsync(TimeSpan.FromSeconds(3));
+		Assert.Equal(GuildId.ToString(), result.GuildId);
+		Assert.Equal(GuildName, result.GuildName);
+	}
+
+	// T1.22 — SimulateGuildJoined for a unconnected user → no crash
+	[Fact]
+	public async Task GuildJoined_DisconnectedUser_NoException()
+	{
+		var exception = await Record.ExceptionAsync(
+			() => factory.SimulateGuildJoinedAsync(userId: 99_999, GuildId, GuildName));
+
+		Assert.Null(exception);
+	}
+
+	// T1.23 — SimulateGuildLeft → client get GuildLeft(guildId)
+	[Fact]
+	public async Task GuildLeft_ConnectedUser_ReceivesGuildLeftInvocation()
+	{
+		var token = TestTokens.Issue(ChatApiFactory.JwtSecret, UserGuildLeft);
+		await using var conn = HubConnectionHelper.Build(factory, token);
+
+		var tcs = new TaskCompletionSource<string>();
+		conn.On<string>("GuildLeft", gId => tcs.TrySetResult(gId));
+
+		await conn.StartAsync();
+		await factory.SimulateGuildLeftAsync(UserGuildLeft, GuildId);
+
+		var receivedGuildId = await tcs.Task.WaitAsync(TimeSpan.FromSeconds(3));
+		Assert.Equal(GuildId.ToString(), receivedGuildId);
+	}
+
+	// T1.24 — GuildJoined is broadcasted to only one user, the one who join the guild
+	[Fact]
+	public async Task GuildJoined_BroadcastedToTargetOnly_OtherUserDoesNotReceive()
+	{
+		var tokenA = TestTokens.Issue(ChatApiFactory.JwtSecret, UserGuildJoinedOther);
+		var tokenB = TestTokens.Issue(ChatApiFactory.JwtSecret, UserGuildLeftOther);
+
+		await using var connA = HubConnectionHelper.Build(factory, tokenA);
+		await using var connB = HubConnectionHelper.Build(factory, tokenB);
+
+		var bReceived = false;
+		connB.On<string, string>("GuildJoined", (_, _) => bReceived = true);
+
+		await connA.StartAsync();
+		await connB.StartAsync();
+
+		await factory.SimulateGuildJoinedAsync(UserGuildJoinedOther, GuildId, GuildName);
+		await Task.Delay(300);
+
+		Assert.False(bReceived);
+	}
+}

--- a/services/chat/tests/Chat.FunctionalTests/Infrastructure/ChatApiFactory.cs
+++ b/services/chat/tests/Chat.FunctionalTests/Infrastructure/ChatApiFactory.cs
@@ -77,6 +77,33 @@ public sealed class ChatApiFactory : WebApplicationFactory<Program>
 			new MessageDeletedEvent(messageId.ToString(), channelId.ToString()));
 	}
 
+	// Directly calls the real SignalRUserBroadcaster (not a fake) so that
+	// connected hub clients receive GuildJoined/GuildLeft invocations.
+	// MassTransit is stripped in tests, so consumers cannot be triggered via
+	// RabbitMQ — this method simulates the consumer side effect.
+	public async Task SimulateGuildJoinedAsync(long userId, long guildId, string guildName)
+	{
+		using var scope = Server.Services.CreateScope();
+		var broadcaster = scope.ServiceProvider.GetRequiredService<IUserBroadcaster>();
+		await broadcaster.BroadcastGuildJoinedAsync(userId, guildId, guildName, CancellationToken.None);
+	}
+
+	public async Task SimulateGuildLeftAsync(long userId, long guildId)
+	{
+		using var scope = Server.Services.CreateScope();
+		var broadcaster = scope.ServiceProvider.GetRequiredService<IUserBroadcaster>();
+		await broadcaster.BroadcastGuildLeftAsync(userId, guildId, CancellationToken.None);
+	}
+
+	// Bypasses IChannelBroadcaster (replaced by a fake) and pushes a message
+	// directly into the SignalR channel group. Use to verify that a connected
+	// client receives ReceiveMessage after JoinChannel.
+	public async Task SimulateChannelMessageAsync(long channelId, MessageResponse message)
+	{
+		var hub = Server.Services.GetRequiredService<IHubContext<ChatHub, IChatClient>>();
+		await hub.Clients.Group($"channel:{channelId}").ReceiveMessage(message);
+	}
+
 	protected override void ConfigureWebHost(IWebHostBuilder builder)
 	{
 		builder.UseEnvironment("Testing");

--- a/services/chat/tests/Chat.UnitTests/Fakes/FakeUserBroadcaster.cs
+++ b/services/chat/tests/Chat.UnitTests/Fakes/FakeUserBroadcaster.cs
@@ -4,13 +4,19 @@ namespace Chat.UnitTests.Fakes;
 
 public sealed class FakeUserBroadcaster : IUserBroadcaster
 {
-	private readonly List<(long UserId, long GuildId, string GuildName)> _calls = [];
+	private readonly List<(long UserId, long GuildId, string? GuildName)> _calls = [];
 
-	public IReadOnlyList<(long UserId, long GuildId, string GuildName)> Calls => _calls;
+	public IReadOnlyList<(long UserId, long GuildId, string? GuildName)> Calls => _calls;
 
 	public Task BroadcastGuildJoinedAsync(long userId, long guildId, string guildName, CancellationToken ct)
 	{
 		_calls.Add((userId, guildId, guildName));
+		return Task.CompletedTask;
+	}
+	
+	public Task BroadcastGuildLeftAsync(long userId, long guildId, CancellationToken ct)
+	{
+		_calls.Add((userId, guildId, null));
 		return Task.CompletedTask;
 	}
 }

--- a/services/chat/tests/Chat.UnitTests/Fakes/FakeUserBroadcaster.cs
+++ b/services/chat/tests/Chat.UnitTests/Fakes/FakeUserBroadcaster.cs
@@ -4,19 +4,21 @@ namespace Chat.UnitTests.Fakes;
 
 public sealed class FakeUserBroadcaster : IUserBroadcaster
 {
-	private readonly List<(long UserId, long GuildId, string? GuildName)> _calls = [];
+	private readonly List<(long UserId, long GuildId, string GuildName)> _joinCalls = [];
+	private readonly List<(long UserId, long GuildId)> _leftCalls = [];
 
-	public IReadOnlyList<(long UserId, long GuildId, string? GuildName)> Calls => _calls;
+	public IReadOnlyList<(long UserId, long GuildId, string GuildName)> JoinCalls => _joinCalls;
+	public IReadOnlyList<(long UserId, long GuildId)> LeftCalls => _leftCalls;
 
 	public Task BroadcastGuildJoinedAsync(long userId, long guildId, string guildName, CancellationToken ct)
 	{
-		_calls.Add((userId, guildId, guildName));
+		_joinCalls.Add((userId, guildId, guildName));
 		return Task.CompletedTask;
 	}
-	
+
 	public Task BroadcastGuildLeftAsync(long userId, long guildId, CancellationToken ct)
 	{
-		_calls.Add((userId, guildId, null));
+		_leftCalls.Add((userId, guildId));
 		return Task.CompletedTask;
 	}
 }

--- a/services/chat/tests/Chat.UnitTests/Infrastructure/GuildMemberJoinedConsumerTests.cs
+++ b/services/chat/tests/Chat.UnitTests/Infrastructure/GuildMemberJoinedConsumerTests.cs
@@ -28,7 +28,7 @@ public sealed class GuildMemberJoinedConsumerTests
 
 		Assert.True(await harness.Consumed.Any<GuildMemberJoined>());
 
-		var call = Assert.Single(broadcaster.Calls);
+		var call = Assert.Single(broadcaster.JoinCalls);
 		Assert.Equal(42L, call.UserId);
 		Assert.Equal(100L, call.GuildId);
 		Assert.Equal("skafenings", call.GuildName);

--- a/services/chat/tools/HubTester/Program.cs
+++ b/services/chat/tools/HubTester/Program.cs
@@ -25,6 +25,8 @@ app.AddCommand("listen", async (string url = DefaultChatHub, string? token = nul
 	conn.On<object>("MessageEdited",        m => Console.WriteLine($"<- MessageEdited: {m}"));
 	conn.On<object>("MessageDeleted",       m => Console.WriteLine($"<- MessageDeleted: {m}"));
 	conn.On<object>("UserPresence",         m => Console.WriteLine($"<- UserPresence: {m}"));
+	conn.On<object, object>("GuildJoined",  (id, name) => Console.WriteLine($"<- GuildJoined: {id} ({name})"));
+	conn.On<object>("GuildLeft",            id => Console.WriteLine($"<- GuildLeft: {id}"));
 	conn.On<string, string>("Error",        (code, msg) => Console.WriteLine($"<- Error: {code} — {msg}"));
 
 	await conn.StartAsync();


### PR DESCRIPTION
## Context

The previous design gave Chat Service full responsibility for SignalR group
membership: on connect it joined every **channel** of every **guild** the user belongs
to, and on `guild.member_joined` it auto-added the user to all **channels** of the
new **guild**. This created two problems:

- SignalR groups needs a connection ID, but in some case we juste have userId,
  so it would required an additionnal `userId -> connectionId` mapping to add
  user to a group without a client invocation.
- The frontend never opens more than one channel at a time, so broadcasting to
  all channel groups per user was unnecessary fan-out with no consumer.

## Changes

**Hub lifecycle simplified (`ChatHub`)**
- `OnConnectedAsync` now only publishes `user.online` to RabbitMQ.
- `OnDisconnectedAsync` publishes `user.offline`.
- No group membership is managed automatically.

**New client → server invocations**
- `LeaveChannel(channelId)` — removes the connection from `channel:{id}`.
  Called when navigating away.

**Guild membership events → client notifications**
- `guild.member_joined` consumer now broadcasts `GuildJoined(guildId, guildName)`
  to all connections of the user instead of silently adding them to groups.
  _The client updates its sidebar and calls `JoinChannel` itself if it navigates
  to a channel in the new guild._
- `guild.member_left` consumer broadcasts `GuildLeft(guildId)`. 
_The client removes the guild from its sidebar and calls `LeaveChannel` for any open
  subscription in that guild._

**Contract updated** (`docs/contracts/chat.md`)
- Hub WebSocket URL corrected to `/api/chat/v1/hubs/chat`.
- On-connect behaviour documented accurately.
- `JoinChannel` and `LeaveChannel` invocations formally documented.
- `GuildJoined`, `GuildLeft`, and `Error` added to Server → Client events.
- `UserPresence` removed (presence is, for now, served on-demand by User Service).
- Consumed events table updated to reflect the new broadcast-only semantics.

## Test plan

- [x] Connect to hub → verify `user.online` published on RabbitMQ, no group
  auto-join occurs
- [x] Call `JoinChannel` on a valid channel → verify `ReceiveMessage` arrives
  for messages sent to that channel
- [x] Call `JoinChannel` without `READ_MESSAGES` → verify `Error` event
  received with code `Channel.MissingReadPermission`
- [x] Call `LeaveChannel` → verify subsequent messages no longer arrive
- [x] Trigger `guild.member_joined` event → verify `GuildJoined` received on
  all connections of the user
- [x] Trigger `guild.member_left` event → verify `GuildLeft` received

differ #66
close #188 (removed)
