### PR TITLE
feat(secretman): install BetterLeaks hook during secretman setup

### DIFF
--- a/tools/secretman/archive.go
+++ b/tools/secretman/archive.go
@@ -6,16 +6,17 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 )
 
-func extractTarGz(tarGzPath string) error {
+func extractTarGz(tarGzPath string, target string) error {
 
 	tarPath, err := decompressGz(tarGzPath)
 	if err != nil {
 		return err
 	}
 
-	err = extractTar(tarPath)
+	err = extractTar(tarPath, target)
 	if err != nil {
 		return err
 	}
@@ -71,7 +72,7 @@ func decompressGz(filePath string) (string, error) {
 	return newPath, nil
 }
 
-func extractTar(filePath string) error {
+func extractTar(filePath string, target string) error {
 
 	file, err := os.Open(filePath)
 	if err != nil {
@@ -79,9 +80,7 @@ func extractTar(filePath string) error {
 	}
 	defer file.Close()
 
-	ageDir := "age/"
-	ageBin := "age-keygen"
-	binPath := toolsDir + ageBin
+	binPath := toolsDir + filepath.Base(target)
 	tmpPath := binPath + ".tmp"
 
 	// Open and iterate through the files in the archive.
@@ -95,7 +94,7 @@ func extractTar(filePath string) error {
 			return err
 		}
 
-		if hdr.Name == ageDir+ageBin {
+		if hdr.Name == target {
 			out, err := os.Create(tmpPath)
 			if err != nil {
 				return err
@@ -127,5 +126,5 @@ func extractTar(filePath string) error {
 		}
 	}
 
-	return fmt.Errorf("❌ AGE binary age-keygen not found in archive")
+	return fmt.Errorf("❌ %s binary not found in archive", target)
 }

--- a/tools/secretman/bootstrap.go
+++ b/tools/secretman/bootstrap.go
@@ -24,6 +24,9 @@ func bootstrap() error {
 	}
 
 	// check for git-hooks and install if missing
+	if err := ensureBetterLeaks(); err != nil {
+		return err
+	}
 
 	fmt.Printf("\n✅ Secretman setup finished successfully.\n")
 

--- a/tools/secretman/tools.go
+++ b/tools/secretman/tools.go
@@ -1,10 +1,14 @@
 package main
 
 import (
+	"bufio"
+	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"runtime"
+	"strings"
 )
 
 const userOS = runtime.GOOS
@@ -69,19 +73,19 @@ func resolveSOPSPath() (string, error) {
 		return globalPath, nil
 	}
 
-	projectPath := toolsDir + "sops"
+	localPath := toolsDir + "sops"
 
-	if fileExists(projectPath) {
+	if fileExists(localPath) {
 		fmt.Println("✅ SOPS binary found in secretman tools.")
-		return projectPath, nil
+		return localPath, nil
 	}
 
 	fmt.Println("⚠️ SOPS binary not found, downloading it.")
-	if err := installSOPS(userOS, userArch, projectPath); err != nil {
+	if err := installSOPS(userOS, userArch, localPath); err != nil {
 		return "", err
 	}
 
-	return projectPath, nil
+	return localPath, nil
 }
 
 func resolveAGEPath() (string, error) {
@@ -94,11 +98,11 @@ func resolveAGEPath() (string, error) {
 		return globalPath, nil
 	}
 
-	projectPath := toolsDir + "age-keygen"
+	localPath := toolsDir + "age-keygen"
 
-	if fileExists(projectPath) {
+	if fileExists(localPath) {
 		fmt.Println("✅ AGE binary found in secretman tools.")
-		return projectPath, nil
+		return localPath, nil
 	}
 
 	fmt.Println("⚠️ AGE binary not found, downloading it.")
@@ -106,7 +110,7 @@ func resolveAGEPath() (string, error) {
 		return "", err
 	}
 
-	return projectPath, nil
+	return localPath, nil
 }
 
 type toolAsset struct {
@@ -184,13 +188,188 @@ func installAGE(userOS string, userArch string, archive string) error {
 		return err
 	}
 
-	err = extractTarGz(archive)
+	err = extractTarGz(archive, "age/age-keygen")
 	if err != nil {
 		return err
 	}
 
 	err = changePerm(toolsDir+"age-keygen", 0755)
 	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+const gitPath string = rootPath + ".git/"
+
+func ensureBetterLeaks() error {
+
+	// check that .git/ exists
+	if !fileExists(gitPath) {
+		err := fmt.Errorf("❌ Missing .git in root directory, cannot add BetterLeaks hook")
+		return err
+	}
+
+	// check that betterleaks is installed or install it
+	binPath, err := resolveBetterLeaksToolPath()
+	if err != nil {
+		return err
+	}
+
+	// create .git/hooks/betterleaks & .git/hooks/pre-commit if missing
+	hooksDirPath := gitPath + "hooks/"
+	if err := ensureBetterLeaksHook(hooksDirPath, binPath); err != nil {
+		return err
+	}
+	if err := ensurePreCommitHook(hooksDirPath); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func resolveBetterLeaksToolPath() (string, error) {
+
+	fmt.Println()
+
+	globalPath, err := exec.LookPath("betterleaks")
+	if err == nil {
+		fmt.Println("✅ BetterLeaks binary found in global PATH.")
+		return globalPath, nil
+	}
+
+	localPath := toolsDir + "betterleaks"
+	if fileExists(localPath) {
+		fmt.Println("✅ BetterLeaks binary found in secretman tools.")
+		return localPath, nil
+	}
+
+	fmt.Println("⚠️ BetterLeaks binary not found, downloading it.")
+	if err := installBetterLeaks(userOS, userArch, toolsDir+"betterleaks.tar.gz"); err != nil {
+		return "", err
+	}
+
+	return localPath, nil
+}
+
+func installBetterLeaks(userOS string, userArch string, archive string) error {
+
+	ageAssets := map[string]toolAsset{
+		"linux-arm64": {
+			URL:    "https://github.com/betterleaks/betterleaks/releases/download/v1.5.0/betterleaks_1.5.0_linux_arm64.tar.gz",
+			SHA256: "f4e89eccde1cdf0cf048748876757e56705d21f122fa4284a4b84803da288608",
+		},
+		"linux-amd64": {
+			URL:    "https://github.com/betterleaks/betterleaks/releases/download/v1.5.0/betterleaks_1.5.0_linux_x64.tar.gz",
+			SHA256: "b883e8c61a3a14c90ff46a08c203cf88fe340ed88251d4c049db5530ec0ac54b",
+		},
+		"darwin-arm64": {
+			URL:    "https://github.com/betterleaks/betterleaks/releases/download/v1.5.0/betterleaks_1.5.0_darwin_arm64.tar.gz",
+			SHA256: "a341e534f152bd10fa8309d74e2ab7eadb634f16ddeb7c3f43ca54f8a016905b",
+		},
+		"darwin-amd64": {
+			URL:    "https://github.com/betterleaks/betterleaks/releases/download/v1.5.0/betterleaks_1.5.0_darwin_x64.tar.gz",
+			SHA256: "bbbbf362ddd0a0c5d37633707206be92501ba5f3291ea45af0c6ab3980ec693d",
+		},
+	}
+
+	key := userOS + "-" + userArch
+
+	url := ageAssets[key].URL
+	checksum := ageAssets[key].SHA256
+
+	err := downloadFile(url, archive, checksum)
+	if err != nil {
+		return err
+	}
+
+	target := "betterleaks"
+
+	err = extractTarGz(archive, target)
+	if err != nil {
+		return err
+	}
+
+	err = changePerm(toolsDir+target, 0755)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func ensureBetterLeaksHook(hooksDirPath string, binPath string) error {
+
+	if err := os.MkdirAll(hooksDirPath, 0755); err != nil {
+		return err
+	}
+
+	betterHookPath := hooksDirPath + "betterleaks"
+
+	betterHookFile, err := os.OpenFile(betterHookPath, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0755)
+	if err != nil {
+		if errors.Is(err, os.ErrExist) {
+			fmt.Println("✅ BetterLeaks hook found in .git directory.")
+			return nil
+		}
+		return err
+	}
+	defer betterHookFile.Close()
+
+	fmt.Println("⚠️ BetterLeaks hook not found in .git directory, adding it.")
+
+	hookContent := "#!/bin/sh\n\n" + binPath + " git . --pre-commit --staged -v"
+
+	if _, err := io.Copy(betterHookFile, strings.NewReader(hookContent)); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func ensurePreCommitHook(hooksDirPath string) error {
+
+	preCommitHookPath := hooksDirPath + "pre-commit"
+
+	if !fileExists(preCommitHookPath) {
+		shebang := []byte("#!/bin/sh\n")
+		if err := os.WriteFile(preCommitHookPath, shebang, 0755); err != nil {
+			return err
+		}
+	}
+
+	preCommitHookFile, err := os.OpenFile(preCommitHookPath, os.O_CREATE|os.O_RDWR, 0755)
+	if err != nil {
+		return err
+	}
+
+	scanner := bufio.NewScanner(preCommitHookFile)
+
+	for scanner.Scan() {
+		if strings.Contains(scanner.Text(), "# secretman betterleaks hook") {
+			fmt.Println("✅ BetterLeaks found in pre-commit hook.")
+			return nil
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return err
+	}
+
+	fmt.Println("⚠️ BetterLeaks not found in pre-commit hook, adding it.")
+
+	hookContent := `
+# secretman betterleaks hook
+
+repo_root="$(git rev-parse --show-toplevel)" || exit 1
+cd "$repo_root" || exit 1
+
+if [ -x ".git/hooks/betterleaks" ]; then
+	.git/hooks/betterleaks || exit $?
+fi
+`
+
+	if _, err := io.Copy(preCommitHookFile, strings.NewReader(hookContent)); err != nil {
 		return err
 	}
 

--- a/tools/secretman/tools.go
+++ b/tools/secretman/tools.go
@@ -319,7 +319,7 @@ func ensureBetterLeaksHook(hooksDirPath string, binPath string) error {
 
 	fmt.Println("⚠️ BetterLeaks hook not found in .git directory, adding it.")
 
-	hookContent := "#!/bin/sh\n\n" + binPath + " git . --pre-commit --staged -v"
+	hookContent := "#!/bin/sh\n\nexec \"" + binPath + "\" git . --pre-commit --staged -v\n"
 
 	if _, err := io.Copy(betterHookFile, strings.NewReader(hookContent)); err != nil {
 		return err
@@ -343,11 +343,13 @@ func ensurePreCommitHook(hooksDirPath string) error {
 	if err != nil {
 		return err
 	}
+	defer preCommitHookFile.Close()
 
 	scanner := bufio.NewScanner(preCommitHookFile)
 
 	for scanner.Scan() {
-		if strings.Contains(scanner.Text(), "# secretman betterleaks hook") {
+		line := scanner.Text()
+		if strings.Contains(line, "# secretman betterleaks hook") || strings.Contains(line, ".git/hooks/betterleaks") {
 			fmt.Println("✅ BetterLeaks found in pre-commit hook.")
 			return nil
 		}


### PR DESCRIPTION
Hello,

This PR adds [BetterLeaks](https://github.com/betterleaks/betterleaks) integration to the `secretman` setup flow.

![flex tape](https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExeTJrZnBhNjJpdHlnODU2bXVmam5mZWptZXdnaXlhZ2tnNmNkcWFzYSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/JGunlb6LbQlz2/giphy.gif)

During setup, `secretman` now:

* checks for the BetterLeaks binary in `PATH`
* falls back to the local tools cache if it is not found globally
* downloads and extracts BetterLeaks if needed
* creates the local Git hook file when it does not already exist
* checks the repository `pre-commit` hook for a call to the BetterLeaks hook
* appends the BetterLeaks hook call when it is missing

This ensures BetterLeaks is installed and wired into the local pre-commit flow when running `secretman` setup.

---

BetterLeaks is currently configured to scan only staged files. This avoids scanning the full repository or Git history on every commit. It also avoids relying on BetterLeaks ignore configuration, since BetterLeaks does not currently appear to provide a straightforward way to reuse the repository’s existing .gitignore. Related ignore support is being discussed in [BetterLeaks issue #150](https://github.com/betterleaks/betterleaks/issues/150).