### PR TITLE
Feat/secretman author comments

### DIFF
--- a/tools/secretman/.sops.yaml
+++ b/tools/secretman/.sops.yaml
@@ -2,8 +2,13 @@ creation_rules:
   - path_regex: '^.*/infra/secretman/secrets/.*\.env\.crypt$'
     key_groups:
       - age:
+          # cartoone@fedora
           - age177x42mdywc7trn68g0nk35wy2306qstzsu2elgzp36f68cf5qe6s3jl7gu
+          # vanta@laptop
           - age1lnm7u2w4hzcjrjxzg2p5x3rgythc9lmfyj67pa03zt7mhfr9symqdxkn23
+          # um4s@laptop
           - age1gzenlllvttdf70xu3pr9y7pxfvu292e639eemczn5vuy3qcz69eqrzzgxa
+          # skydogzz@laptop
           - age13lcxl50t8t7jf8crxprty2xkfhra5fg43sm5kle53unnxc56c55s4m2r9p
+          # daaktar@laptop
           - age1h94z5det0mgtg4j62m6wndj8cl222avxxrjq90hzmzhwsglxc57qsspl8p

--- a/tools/secretman/ensure.go
+++ b/tools/secretman/ensure.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"os/user"
 	"strings"
 )
 
@@ -170,6 +171,15 @@ func fetchPublicKey() (string, error) {
 
 func addKeyToSopsYaml(publicKey string) error {
 
+	user, err := user.Current()
+	if err != nil {
+		return err
+	}
+	hostname, err := os.Hostname()
+	if err != nil {
+		return err
+	}
+	author := "          # " + user.Name + "@" + hostname + "\n"
 	line := "          - " + publicKey + "\n"
 
 	out, err := os.OpenFile(sopsYamlPath, os.O_APPEND|os.O_WRONLY, 0644)
@@ -178,6 +188,10 @@ func addKeyToSopsYaml(publicKey string) error {
 	}
 	defer out.Close()
 
+	_, err = out.WriteString(author)
+	if err != nil {
+		return err
+	}
 	_, err = out.WriteString(line)
 	if err != nil {
 		return err

--- a/tools/secretman/flags.go
+++ b/tools/secretman/flags.go
@@ -16,10 +16,10 @@ func flagSetup(setup *bool, refresh *bool, decrypt *bool, encrypt *bool) error {
 	flag.BoolVar(refresh, "refresh", false, "refresh all secret files")
 	flag.BoolVar(refresh, "r", false, "")
 
-	flag.BoolVar(decrypt, "decrypt-all", false, "decrypt all env files")
+	flag.BoolVar(decrypt, "decrypt", false, "decrypt env files")
 	flag.BoolVar(decrypt, "d", false, "")
 
-	flag.BoolVar(encrypt, "encrypt-all", false, "encrypt all env files")
+	flag.BoolVar(encrypt, "encrypt", false, "encrypt env files")
 	flag.BoolVar(encrypt, "e", false, "")
 
 	flag.Parse()
@@ -32,7 +32,7 @@ func flagSetup(setup *bool, refresh *bool, decrypt *bool, encrypt *bool) error {
 	}
 
 	if count > 1 {
-		return fmt.Errorf("❌ Error: use only one action flag at a time")
+		return fmt.Errorf("❌ Use only one action flag at a time")
 	}
 	return nil
 }

--- a/tools/secretman/main.go
+++ b/tools/secretman/main.go
@@ -7,10 +7,7 @@ import (
 
 func main() {
 
-	var setup bool
-	var refresh bool
-	var decrypt bool
-	var encrypt bool
+	var setup, refresh, decrypt, encrypt bool
 
 	err := flagSetup(&setup, &refresh, &decrypt, &encrypt)
 	if err != nil {
@@ -18,26 +15,24 @@ func main() {
 		os.Exit(1)
 	}
 
-	if setup {
-		err := bootstrap()
-		if err != nil {
-			fmt.Fprintln(os.Stderr, err)
-			os.Exit(1)
-		}
-	} else if refresh {
-		if err := refreshSecrets(); err != nil {
-			fmt.Fprintln(os.Stderr, err)
-			os.Exit(1)
-		}
-	} else if decrypt {
-		if err := decryptSecrets(); err != nil {
-			fmt.Fprintln(os.Stderr, err)
-			os.Exit(1)
-		}
-	} else if encrypt {
-		if err := encryptSecrets(); err != nil {
-			fmt.Fprintln(os.Stderr, err)
-			os.Exit(1)
-		}
+	var cmd func() error
+
+	switch {
+	case setup:
+		cmd = bootstrap
+	case refresh:
+		cmd = refreshSecrets
+	case encrypt:
+		cmd = encryptSecrets
+	case decrypt:
+		cmd = decryptSecrets
+	default:
+		fmt.Fprintln(os.Stderr, "❌ Error: expected at least one flag, use -h for help")
+		os.Exit(1)
+	}
+
+	if err := cmd(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
 	}
 }


### PR DESCRIPTION
Hello,

This PR adds author comments to the keys listed in `.sops.yaml`.

These comments are meant to identify which key belongs to which user and machine. The expected format is `username@hostname`. For now, existing team members are listed as `username@laptop` for simplicity, but they can change the username or hostname if needed.

During `secretman` setup, the username and hostname are now fetched, and a comment is added before the newly generated key in `.sops.yaml`.

This should make it easier to track which SOPS key belongs to which person and device.

---

This PR also includes a small cleanup of main.go and flags.go.