### PR TITLE
Feat/chat/message mutation

### DIFF
--- a/services/chat/src/Chat.Application/Abstractions/IChannelBroadcaster.cs
+++ b/services/chat/src/Chat.Application/Abstractions/IChannelBroadcaster.cs
@@ -6,4 +6,5 @@ public interface IChannelBroadcaster
 {
 	Task BroadcastMessageAsync(long channelId, MessageResponse message, CancellationToken ct);
 	Task BroadcastMessageEditedAsync(long channelId, MessageEditedEvent evt, CancellationToken ct);
+	Task BroadcastMessageDeletedAsync(long channelId, long messageId, CancellationToken ct);
 }

--- a/services/chat/src/Chat.Application/Abstractions/IChannelBroadcaster.cs
+++ b/services/chat/src/Chat.Application/Abstractions/IChannelBroadcaster.cs
@@ -5,4 +5,5 @@ namespace Chat.Application.Abstractions;
 public interface IChannelBroadcaster
 {
 	Task BroadcastMessageAsync(long channelId, MessageResponse message, CancellationToken ct);
+	Task BroadcastMessageEditedAsync(long channelId, MessageEditedEvent evt, CancellationToken ct);
 }

--- a/services/chat/src/Chat.Application/Abstractions/Persistence/IMessageRepository.cs
+++ b/services/chat/src/Chat.Application/Abstractions/Persistence/IMessageRepository.cs
@@ -7,4 +7,6 @@ public interface IMessageRepository
 	Task AddAsync(Message message, string? nonce, CancellationToken ct);
 	Task<long?> FindNonceAsync(long authorId, long channelId, string nonce, CancellationToken ct);
 	Task<Message?> GetByIdAsync(long messageId, CancellationToken ct);
+	Task UpdateContentAsync(Message message, CancellationToken ct);
+	Task SoftDeleteAsync(Message message, CancellationToken ct);
 }

--- a/services/chat/src/Chat.Application/Features/Messages/Common/EditMessageResponse.cs
+++ b/services/chat/src/Chat.Application/Features/Messages/Common/EditMessageResponse.cs
@@ -1,0 +1,11 @@
+using Chat.Domain.Messages;
+
+namespace Chat.Application.Features.Messages.Common;
+
+public sealed record EditMessageResponse(string Id, string? Content, DateTimeOffset EditedAt)
+{
+	public static EditMessageResponse From(Message m) => new(
+		Id: m.Id.ToString(),
+		Content: m.Content,
+		EditedAt: m.EditedAt!.Value);
+}

--- a/services/chat/src/Chat.Application/Features/Messages/Common/MessageDeletedEvent.cs
+++ b/services/chat/src/Chat.Application/Features/Messages/Common/MessageDeletedEvent.cs
@@ -1,0 +1,3 @@
+namespace Chat.Application.Features.Messages.Common;
+
+public sealed record MessageDeletedEvent(string MessageId, string ChannelId);

--- a/services/chat/src/Chat.Application/Features/Messages/Common/MessageEditedEvent.cs
+++ b/services/chat/src/Chat.Application/Features/Messages/Common/MessageEditedEvent.cs
@@ -1,0 +1,12 @@
+using Chat.Domain.Messages;
+
+namespace Chat.Application.Features.Messages.Common;
+
+public sealed record MessageEditedEvent(string Id, string ChannelId, string? Content, DateTimeOffset EditedAt)
+{
+	public static MessageEditedEvent From(Message m) => new(
+		Id: m.Id.ToString(),
+		ChannelId: m.ChannelId.ToString(),
+		Content: m.Content,
+		EditedAt: m.EditedAt!.Value);
+}

--- a/services/chat/src/Chat.Application/Features/Messages/DeleteMessage/DeleteMessageCommand.cs
+++ b/services/chat/src/Chat.Application/Features/Messages/DeleteMessage/DeleteMessageCommand.cs
@@ -1,0 +1,6 @@
+using Chat.Application.Abstractions.Messaging;
+using Chat.Domain.Results;
+
+namespace Chat.Application.Features.Messages.DeleteMessage;
+
+public sealed record DeleteMessageCommand(long MessageId) : ICommand<Result>;

--- a/services/chat/src/Chat.Application/Features/Messages/DeleteMessage/DeleteMessageHandler.cs
+++ b/services/chat/src/Chat.Application/Features/Messages/DeleteMessage/DeleteMessageHandler.cs
@@ -1,0 +1,55 @@
+using Chat.Application.Abstractions;
+using Chat.Application.Abstractions.Authentication;
+using Chat.Application.Abstractions.Messaging;
+using Chat.Application.Abstractions.Persistence;
+using Chat.Domain.Results;
+
+namespace Chat.Application.Features.Messages.DeleteMessage;
+
+internal sealed class DeleteMessageHandler(
+	ICurrentUser currentUser,
+	IGuildClient guildClient,
+	IMessageRepository repository,
+	IChannelBroadcaster broadcaster)
+	: ICommandHandler<DeleteMessageCommand, Result>
+{
+	// permission bits mirror the Guild Service domain so this stays a pure
+	// bitmask check; see services/guild/src/Guild.Domain/Guild/Permission.cs
+	// for the source of truth on permission numbering
+	private const long ManageMessages = 1L << 2;
+	private const long Administrator = 1L << 8;
+
+	public async Task<Result> HandleAsync(
+		DeleteMessageCommand command,
+		CancellationToken cancellationToken = default)
+	{
+		var message = await repository.GetByIdAsync(command.MessageId, cancellationToken);
+		if (message is null || message.IsDeleted)
+			return MessageFailures.NotFound;
+
+		var userId = currentUser.UserId;
+
+		if (message.AuthorId != userId)
+		{
+			var membership = await guildClient.GetMembershipAsync(message.ChannelId, userId, cancellationToken);
+			if (membership is null || !membership.IsMember)
+				return MessageFailures.NotFound;
+
+			if ((membership.Permissions & (ManageMessages | Administrator)) == 0)
+				return MessageFailures.MissingManagePermission;
+		}
+
+		var deleteResult = message.Delete();
+		if (deleteResult.IsFailure)
+			return deleteResult.Error;
+
+		await repository.SoftDeleteAsync(message, cancellationToken);
+
+		await broadcaster.BroadcastMessageDeletedAsync(
+			message.ChannelId,
+			message.Id,
+			cancellationToken);
+
+		return Result.Ok();
+	}
+}

--- a/services/chat/src/Chat.Application/Features/Messages/EditMessage/EditMessageCommand.cs
+++ b/services/chat/src/Chat.Application/Features/Messages/EditMessage/EditMessageCommand.cs
@@ -1,0 +1,8 @@
+using Chat.Application.Abstractions.Messaging;
+using Chat.Application.Features.Messages.Common;
+using Chat.Domain.Results;
+
+namespace Chat.Application.Features.Messages.EditMessage;
+
+public sealed record EditMessageCommand(long MessageId, string? Content)
+	: ICommand<Result<EditMessageResponse>>;

--- a/services/chat/src/Chat.Application/Features/Messages/EditMessage/EditMessageHandler.cs
+++ b/services/chat/src/Chat.Application/Features/Messages/EditMessage/EditMessageHandler.cs
@@ -1,0 +1,39 @@
+using Chat.Application.Abstractions;
+using Chat.Application.Abstractions.Authentication;
+using Chat.Application.Abstractions.Messaging;
+using Chat.Application.Abstractions.Persistence;
+using Chat.Application.Features.Messages.Common;
+using Chat.Domain.Results;
+
+namespace Chat.Application.Features.Messages.EditMessage;
+
+internal sealed class EditMessageHandler(
+	ICurrentUser currentUser,
+	IMessageRepository repository,
+	IClock clock,
+	IChannelBroadcaster broadcaster)
+	: ICommandHandler<EditMessageCommand, Result<EditMessageResponse>>
+{
+	public async Task<Result<EditMessageResponse>> HandleAsync(
+		EditMessageCommand command,
+		CancellationToken cancellationToken = default)
+	{
+		var message = await repository.GetByIdAsync(command.MessageId, cancellationToken);
+		if (message is null || message.IsDeleted)
+			return MessageFailures.NotFound;
+
+		if (message.AuthorId != currentUser.UserId)
+			return MessageFailures.NotAuthor;
+
+		var editResult = message.Edit(command.Content, clock.UtcNow);
+		if (editResult.IsFailure)
+			return editResult.Error;
+
+		await repository.UpdateContentAsync(message, cancellationToken);
+
+		var evt = MessageEditedEvent.From(message);
+		await broadcaster.BroadcastMessageEditedAsync(message.ChannelId, evt, cancellationToken);
+
+		return EditMessageResponse.From(message);
+	}
+}

--- a/services/chat/src/Chat.Domain/Messages/Message.cs
+++ b/services/chat/src/Chat.Domain/Messages/Message.cs
@@ -49,6 +49,31 @@ public sealed class Message
 		DateTimeOffset createdAt)
 		=> new(id, channelId, authorId, content, replyToId, editedAt, isDeleted, createdAt);
 
+	public Result<Message> Edit(string? content, DateTimeOffset now)
+	{
+		if (IsDeleted)
+			return MessageFailures.AlreadyDeleted;
+
+		if (string.IsNullOrWhiteSpace(content))
+			return MessageFailures.ContentRequired;
+
+		if (content.Length > MaxContentLen)
+			return MessageFailures.ContentTooLong;
+
+		Content = content;
+		EditedAt = now;
+		return this;
+	}
+
+	public Result<Message> Delete()
+	{
+		if (IsDeleted)
+			return MessageFailures.AlreadyDeleted;
+
+		IsDeleted = true;
+		return this;
+	}
+
 	public static Result<Message> Create(
 		long id,
 		long channelId,

--- a/services/chat/src/Chat.Domain/Results/MessageFailures.cs
+++ b/services/chat/src/Chat.Domain/Results/MessageFailures.cs
@@ -31,4 +31,16 @@ public static class MessageFailures
 
 	public static readonly Failure NonceTooLong =
 		new("Message.NonceTooLong", "Nonce must be 64 characters or fewer.");
+
+	public static readonly Failure NotFound =
+		new("Message.NotFound", "Message not found.");
+
+	public static readonly Failure NotAuthor =
+		new("Message.NotAuthor", "Caller is not the author of this message.");
+
+	public static readonly Failure AlreadyDeleted =
+		new("Message.AlreadyDeleted", "Message has already been deleted.");
+
+	public static readonly Failure MissingManagePermission =
+		new("Message.MissingManagePermission", "Caller lacks MANAGE_MESSAGES permission on this channel.");
 }

--- a/services/chat/src/Chat.Persistence/Repositories/MessageRepository.cs
+++ b/services/chat/src/Chat.Persistence/Repositories/MessageRepository.cs
@@ -49,6 +49,26 @@ internal sealed class MessageRepository(ISession session, MessageStatements stat
 		return first?.GetValue<long>("message_id");
 	}
 
+	public async Task UpdateContentAsync(Message message, CancellationToken ct)
+	{
+		var stmt = await statements.UpdateContent.Value;
+		await session.ExecuteAsync(stmt.Bind(
+			message.Content,
+			message.EditedAt!.Value.UtcDateTime,
+			message.ChannelId,
+			message.CreatedAt.UtcDateTime,
+			message.Id));
+	}
+
+	public async Task SoftDeleteAsync(Message message, CancellationToken ct)
+	{
+		var stmt = await statements.SoftDeleteMessage.Value;
+		await session.ExecuteAsync(stmt.Bind(
+			message.ChannelId,
+			message.CreatedAt.UtcDateTime,
+			message.Id));
+	}
+
 	public async Task<Message?> GetByIdAsync(long messageId, CancellationToken ct)
 	{
 		var selectLookup = await statements.SelectLookup.Value;

--- a/services/chat/src/Chat.Persistence/Repositories/MessageStatements.cs
+++ b/services/chat/src/Chat.Persistence/Repositories/MessageStatements.cs
@@ -26,4 +26,12 @@ internal sealed class MessageStatements(ISession session)
 	public Lazy<Task<PreparedStatement>> SelectMessage { get; } = new(() => session.PrepareAsync(
 		"SELECT channel_id, created_at, id, author_id, content, edited_at, is_deleted, reply_to_id " +
 		"FROM messages WHERE channel_id = ? AND created_at = ? AND id = ?"));
+
+	public Lazy<Task<PreparedStatement>> UpdateContent { get; } = new(() => session.PrepareAsync(
+		"UPDATE messages SET content = ?, edited_at = ? " +
+		"WHERE channel_id = ? AND created_at = ? AND id = ?"));
+
+	public Lazy<Task<PreparedStatement>> SoftDeleteMessage { get; } = new(() => session.PrepareAsync(
+		"UPDATE messages SET is_deleted = true " +
+		"WHERE channel_id = ? AND created_at = ? AND id = ?"));
 }

--- a/services/chat/src/Chat.Presentation/Endpoints/MessagesEndpoint.cs
+++ b/services/chat/src/Chat.Presentation/Endpoints/MessagesEndpoint.cs
@@ -1,9 +1,10 @@
 using Carter;
 using Chat.Application.Abstractions.Messaging;
 using Chat.Application.Features.Messages.Common;
+using Chat.Application.Features.Messages.DeleteMessage;
+using Chat.Application.Features.Messages.EditMessage;
 using Chat.Application.Features.Messages.SendMessage;
 using Chat.Domain.Results;
-using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 
 namespace Chat.Presentation.Endpoints;
@@ -12,8 +13,12 @@ public sealed class MessagesEndpoint : ICarterModule
 {
 	public void AddRoutes(IEndpointRouteBuilder endpoints)
 	{
-		var group = endpoints.MapGroup("/channels/{channelId:long}/messages");
-		group.MapPost("/", SendAsync);
+		var channelGroup = endpoints.MapGroup("/channels/{channelId:long}/messages");
+		channelGroup.MapPost("/", SendAsync);
+
+		var messageGroup = endpoints.MapGroup("/messages");
+		messageGroup.MapPatch("/{messageId:long}", EditAsync);
+		messageGroup.MapDelete("/{messageId:long}", DeleteAsync);
 	}
 
 	private static async Task<Results<
@@ -33,11 +38,49 @@ public sealed class MessagesEndpoint : ICarterModule
 
 		return result.Succeeded
 			? TypedResults.Created($"/channels/{channelId}/messages/{result.Value.Id}", result.Value)
-			: MapError(result.Error);
+			: MapSendError(result.Error);
+	}
+
+	private static async Task<Results<
+		Ok<EditMessageResponse>,
+		BadRequest<ErrorBody>,
+		JsonHttpResult<ErrorBody>,
+		NotFound<ErrorBody>>>
+	EditAsync(
+		long messageId,
+		EditMessageRequest request,
+		ICommandHandler<EditMessageCommand, Result<EditMessageResponse>> handler,
+		CancellationToken cancellationToken)
+	{
+		var result = await handler.HandleAsync(
+			new EditMessageCommand(messageId, request.Content),
+			cancellationToken);
+
+		return result.Succeeded
+			? TypedResults.Ok(result.Value)
+			: MapEditError(result.Error);
+	}
+
+	private static async Task<Results<
+		NoContent,
+		JsonHttpResult<ErrorBody>,
+		NotFound<ErrorBody>>>
+	DeleteAsync(
+		long messageId,
+		ICommandHandler<DeleteMessageCommand, Result> handler,
+		CancellationToken cancellationToken)
+	{
+		var result = await handler.HandleAsync(
+			new DeleteMessageCommand(messageId),
+			cancellationToken);
+
+		return result.Succeeded
+			? TypedResults.NoContent()
+			: MapDeleteError(result.Error);
 	}
 
 	private static Results<Created<MessageResponse>, BadRequest<ErrorBody>, JsonHttpResult<ErrorBody>, NotFound<ErrorBody>>
-		MapError(Failure failure) => failure.Code switch
+		MapSendError(Failure failure) => failure.Code switch
 		{
 			"Message.ChannelNotFound" => TypedResults.NotFound(new ErrorBody(failure.Message)),
 			"Message.NotAMember" => TypedResults.Json(new ErrorBody(failure.Message), statusCode: StatusCodes.Status403Forbidden),
@@ -45,8 +88,22 @@ public sealed class MessagesEndpoint : ICarterModule
 			_ => TypedResults.BadRequest(new ErrorBody(failure.Message)),
 		};
 
-	private sealed record SendMessageRequest(
-		string? Content,
-		long? ReplyToId,
-		string? Nonce);
+	private static Results<Ok<EditMessageResponse>, BadRequest<ErrorBody>, JsonHttpResult<ErrorBody>, NotFound<ErrorBody>>
+		MapEditError(Failure failure) => failure.Code switch
+		{
+			"Message.NotFound" or "Message.AlreadyDeleted" => TypedResults.NotFound(new ErrorBody(failure.Message)),
+			"Message.NotAuthor" => TypedResults.Json(new ErrorBody(failure.Message), statusCode: StatusCodes.Status403Forbidden),
+			_ => TypedResults.BadRequest(new ErrorBody(failure.Message)),
+		};
+
+	private static Results<NoContent, JsonHttpResult<ErrorBody>, NotFound<ErrorBody>>
+		MapDeleteError(Failure failure) => failure.Code switch
+		{
+			"Message.NotFound" => TypedResults.NotFound(new ErrorBody(failure.Message)),
+			"Message.MissingManagePermission" => TypedResults.Json(new ErrorBody(failure.Message), statusCode: StatusCodes.Status403Forbidden),
+			_ => TypedResults.NotFound(new ErrorBody(failure.Message)),
+		};
+
+	private sealed record SendMessageRequest(string? Content, long? ReplyToId, string? Nonce);
+	private sealed record EditMessageRequest(string? Content);
 }

--- a/services/chat/src/Chat.Presentation/Hubs/IChatClient.cs
+++ b/services/chat/src/Chat.Presentation/Hubs/IChatClient.cs
@@ -5,6 +5,7 @@ namespace Chat.Presentation.Hubs;
 public interface IChatClient
 {
 	Task ReceiveMessage(MessageResponse message);
+	Task MessageEdited(MessageEditedEvent evt);
 	Task GuildJoined(string guildId, string guildName);
 	Task Error(string code, string message);
 }

--- a/services/chat/src/Chat.Presentation/Hubs/IChatClient.cs
+++ b/services/chat/src/Chat.Presentation/Hubs/IChatClient.cs
@@ -6,6 +6,7 @@ public interface IChatClient
 {
 	Task ReceiveMessage(MessageResponse message);
 	Task MessageEdited(MessageEditedEvent evt);
+	Task MessageDeleted(MessageDeletedEvent evt);
 	Task GuildJoined(string guildId, string guildName);
 	Task Error(string code, string message);
 }

--- a/services/chat/src/Chat.Presentation/Hubs/SignalRChannelBroadcaster.cs
+++ b/services/chat/src/Chat.Presentation/Hubs/SignalRChannelBroadcaster.cs
@@ -4,18 +4,12 @@ using Microsoft.AspNetCore.SignalR;
 
 namespace Chat.Presentation.Hubs;
 
-/// <summary>
-/// fans out <see cref="MessageResponse"/> to every connection subscribed to a
-/// channel group. lives in Presentation because <c>IHubContext</c> is a SignalR
-/// abstraction and <c>Chat.Infrastructure</c> must stay free of ASP.NET deps
-///
-/// note: users are not yet auto-joined to channel groups on connect (issue
-/// #66). until that lands, broadcasts are effectively a no-op in dev. the
-/// call site is correct so it light up the moment group membership wires up
-/// </summary>
 internal sealed class SignalRChannelBroadcaster(IHubContext<ChatHub, IChatClient> hub)
 	: IChannelBroadcaster
 {
 	public Task BroadcastMessageAsync(long channelId, MessageResponse message, CancellationToken ct) =>
 		hub.Clients.Group($"channel:{channelId}").ReceiveMessage(message);
+
+	public Task BroadcastMessageEditedAsync(long channelId, MessageEditedEvent evt, CancellationToken ct) =>
+		hub.Clients.Group($"channel:{channelId}").MessageEdited(evt);
 }

--- a/services/chat/src/Chat.Presentation/Hubs/SignalRChannelBroadcaster.cs
+++ b/services/chat/src/Chat.Presentation/Hubs/SignalRChannelBroadcaster.cs
@@ -12,4 +12,9 @@ internal sealed class SignalRChannelBroadcaster(IHubContext<ChatHub, IChatClient
 
 	public Task BroadcastMessageEditedAsync(long channelId, MessageEditedEvent evt, CancellationToken ct) =>
 		hub.Clients.Group($"channel:{channelId}").MessageEdited(evt);
+
+	public Task BroadcastMessageDeletedAsync(long channelId, long messageId, CancellationToken ct) =>
+		hub.Clients.Group($"channel:{channelId}").MessageDeleted(new MessageDeletedEvent(
+			MessageId: messageId.ToString(),
+			ChannelId: channelId.ToString()));
 }

--- a/services/chat/tests/Chat.FunctionalTests/Endpoints/DeleteMessageEndpointTests.cs
+++ b/services/chat/tests/Chat.FunctionalTests/Endpoints/DeleteMessageEndpointTests.cs
@@ -1,0 +1,113 @@
+using System.Net;
+using System.Net.Http.Headers;
+using Chat.Application.Abstractions;
+using Chat.Domain.Messages;
+using Chat.FunctionalTests.Infrastructure;
+using Xunit;
+
+namespace Chat.FunctionalTests.Endpoints;
+
+public sealed class DeleteMessageEndpointTests(ChatApiFactory factory)
+	: IClassFixture<ChatApiFactory>, IAsyncLifetime
+{
+	private const long ManageMessagesPermission = 1L << 2;
+
+	public Task InitializeAsync()
+	{
+		factory.GuildClient.Result = null;
+		factory.MessageRepository.Reset();
+		factory.Broadcaster.Reset();
+		return Task.CompletedTask;
+	}
+
+	public Task DisposeAsync() => Task.CompletedTask;
+
+	private HttpClient BuildClient(long userId)
+	{
+		var client = factory.CreateClient();
+		var token = TestTokens.Issue(ChatApiFactory.JwtSecret, userId: userId);
+		client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+		return client;
+	}
+
+	private static void SeedMessage(ChatApiFactory f, long id, long channelId, long authorId)
+	{
+		var message = Message.Reconstitute(
+			id: id, channelId: channelId, authorId: authorId,
+			content: "hello", replyToId: null, editedAt: null,
+			isDeleted: false, createdAt: DateTimeOffset.UtcNow);
+		f.MessageRepository.Seed(message);
+	}
+
+	[Fact]
+	public async Task Delete_WithoutToken_Returns401()
+	{
+		var response = await factory.CreateClient().DeleteAsync("/v1/messages/1");
+
+		Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+	}
+
+	[Fact]
+	public async Task Delete_Author_Returns204AndBroadcasts()
+	{
+		SeedMessage(factory, id: 1, channelId: 100, authorId: 42);
+		var client = BuildClient(userId: 42);
+
+		var response = await client.DeleteAsync("/v1/messages/1");
+
+		Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+
+		var (channel, messageId) = Assert.Single(factory.Broadcaster.DeletedBroadcasts);
+		Assert.Equal(100L, channel);
+		Assert.Equal(1L, messageId);
+	}
+
+	[Fact]
+	public async Task Delete_MessageNotFound_Returns404()
+	{
+		var client = BuildClient(userId: 42);
+
+		var response = await client.DeleteAsync("/v1/messages/999");
+
+		Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+	}
+
+	[Fact]
+	public async Task Delete_NonMember_Returns404()
+	{
+		SeedMessage(factory, id: 1, channelId: 100, authorId: 99);
+		factory.GuildClient.Result = new ChannelMembership(IsMember: false, GuildId: 5, Permissions: 0);
+		var client = BuildClient(userId: 42);
+
+		var response = await client.DeleteAsync("/v1/messages/1");
+
+		Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+		Assert.Empty(factory.Broadcaster.DeletedBroadcasts);
+	}
+
+	[Fact]
+	public async Task Delete_MemberWithoutManageMessages_Returns403()
+	{
+		SeedMessage(factory, id: 1, channelId: 100, authorId: 99);
+		factory.GuildClient.Result = new ChannelMembership(IsMember: true, GuildId: 5, Permissions: 0);
+		var client = BuildClient(userId: 42);
+
+		var response = await client.DeleteAsync("/v1/messages/1");
+
+		Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+		Assert.Empty(factory.Broadcaster.DeletedBroadcasts);
+	}
+
+	[Fact]
+	public async Task Delete_MemberWithManageMessages_Returns204()
+	{
+		SeedMessage(factory, id: 1, channelId: 100, authorId: 99);
+		factory.GuildClient.Result = new ChannelMembership(IsMember: true, GuildId: 5, Permissions: ManageMessagesPermission);
+		var client = BuildClient(userId: 42);
+
+		var response = await client.DeleteAsync("/v1/messages/1");
+
+		Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+		Assert.Single(factory.Broadcaster.DeletedBroadcasts);
+	}
+}

--- a/services/chat/tests/Chat.FunctionalTests/Endpoints/DeleteMessageEndpointTests.cs
+++ b/services/chat/tests/Chat.FunctionalTests/Endpoints/DeleteMessageEndpointTests.cs
@@ -110,4 +110,34 @@ public sealed class DeleteMessageEndpointTests(ChatApiFactory factory)
 		Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
 		Assert.Single(factory.Broadcaster.DeletedBroadcasts);
 	}
+
+	[Fact]
+	public async Task Delete_MemberWithAdministrator_Returns204()
+	{
+		const long administratorPermission = 1L << 8;
+		SeedMessage(factory, id: 1, channelId: 100, authorId: 99);
+		factory.GuildClient.Result = new ChannelMembership(IsMember: true, GuildId: 5, Permissions: administratorPermission);
+		var client = BuildClient(userId: 42);
+
+		var response = await client.DeleteAsync("/v1/messages/1");
+
+		Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+		Assert.Single(factory.Broadcaster.DeletedBroadcasts);
+	}
+
+	[Fact]
+	public async Task Delete_AlreadyDeletedMessage_Returns404()
+	{
+		var deleted = Message.Reconstitute(
+			id: 1, channelId: 100, authorId: 42,
+			content: null, replyToId: null, editedAt: null,
+			isDeleted: true, createdAt: DateTimeOffset.UtcNow);
+		factory.MessageRepository.Seed(deleted);
+		var client = BuildClient(userId: 42);
+
+		var response = await client.DeleteAsync("/v1/messages/1");
+
+		Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+		Assert.Empty(factory.Broadcaster.DeletedBroadcasts);
+	}
 }

--- a/services/chat/tests/Chat.FunctionalTests/Endpoints/EditMessageEndpointTests.cs
+++ b/services/chat/tests/Chat.FunctionalTests/Endpoints/EditMessageEndpointTests.cs
@@ -1,0 +1,118 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Chat.Domain.Messages;
+using Chat.FunctionalTests.Infrastructure;
+using Xunit;
+
+namespace Chat.FunctionalTests.Endpoints;
+
+public sealed class EditMessageEndpointTests(ChatApiFactory factory)
+	: IClassFixture<ChatApiFactory>, IAsyncLifetime
+{
+	private static readonly JsonSerializerOptions JsonOptions = new()
+	{
+		PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+		PropertyNameCaseInsensitive = true,
+	};
+
+	public Task InitializeAsync()
+	{
+		factory.GuildClient.Result = null;
+		factory.MessageRepository.Reset();
+		factory.Broadcaster.Reset();
+		return Task.CompletedTask;
+	}
+
+	public Task DisposeAsync() => Task.CompletedTask;
+
+	private HttpClient BuildClient(long userId)
+	{
+		var client = factory.CreateClient();
+		var token = TestTokens.Issue(ChatApiFactory.JwtSecret, userId: userId);
+		client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+		return client;
+	}
+
+	private static Message SeedMessage(ChatApiFactory f, long id, long channelId, long authorId)
+	{
+		var message = Message.Reconstitute(
+			id: id, channelId: channelId, authorId: authorId,
+			content: "original", replyToId: null, editedAt: null,
+			isDeleted: false, createdAt: DateTimeOffset.UtcNow);
+		f.MessageRepository.Seed(message);
+		return message;
+	}
+
+	[Fact]
+	public async Task Patch_WithoutToken_Returns401()
+	{
+		var response = await factory.CreateClient().PatchAsJsonAsync("/v1/messages/1",
+			new { content = "hi" });
+
+		Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+	}
+
+	[Fact]
+	public async Task Patch_HappyPath_Returns200WithEditedResponse()
+	{
+		SeedMessage(factory, id: 1, channelId: 100, authorId: 42);
+		var client = BuildClient(userId: 42);
+
+		var response = await client.PatchAsJsonAsync("/v1/messages/1",
+			new { content = "updated content" });
+
+		Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+		var body = await response.Content.ReadFromJsonAsync<EditBody>(JsonOptions);
+		Assert.NotNull(body);
+		Assert.Equal("1", body.Id);
+		Assert.Equal("updated content", body.Content);
+		Assert.NotNull(body.EditedAt);
+
+		var (channel, evt) = Assert.Single(factory.Broadcaster.EditedBroadcasts);
+		Assert.Equal(100L, channel);
+		Assert.Equal("1", evt.Id);
+		Assert.Equal("updated content", evt.Content);
+	}
+
+	[Fact]
+	public async Task Patch_MessageNotFound_Returns404()
+	{
+		var client = BuildClient(userId: 42);
+
+		var response = await client.PatchAsJsonAsync("/v1/messages/999",
+			new { content = "hi" });
+
+		Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+	}
+
+	[Fact]
+	public async Task Patch_NotAuthor_Returns403()
+	{
+		SeedMessage(factory, id: 1, channelId: 100, authorId: 99);
+		var client = BuildClient(userId: 42);
+
+		var response = await client.PatchAsJsonAsync("/v1/messages/1",
+			new { content = "hi" });
+
+		Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+		Assert.Empty(factory.Broadcaster.EditedBroadcasts);
+	}
+
+	[Fact]
+	public async Task Patch_EmptyContent_Returns400()
+	{
+		SeedMessage(factory, id: 1, channelId: 100, authorId: 42);
+		var client = BuildClient(userId: 42);
+
+		var response = await client.PatchAsJsonAsync("/v1/messages/1",
+			new { content = "   " });
+
+		Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+		Assert.Empty(factory.Broadcaster.EditedBroadcasts);
+	}
+
+	private sealed record EditBody(string Id, string? Content, DateTimeOffset? EditedAt);
+}

--- a/services/chat/tests/Chat.FunctionalTests/Endpoints/EditMessageEndpointTests.cs
+++ b/services/chat/tests/Chat.FunctionalTests/Endpoints/EditMessageEndpointTests.cs
@@ -114,5 +114,64 @@ public sealed class EditMessageEndpointTests(ChatApiFactory factory)
 		Assert.Empty(factory.Broadcaster.EditedBroadcasts);
 	}
 
+	[Fact]
+	public async Task Patch_Content4000Chars_Returns200()
+	{
+		SeedMessage(factory, id: 1, channelId: 100, authorId: 42);
+		var client = BuildClient(userId: 42);
+
+		var response = await client.PatchAsJsonAsync("/v1/messages/1",
+			new { content = new string('a', 4000) });
+
+		Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+	}
+
+	[Fact]
+	public async Task Patch_ContentOver4000Chars_Returns400()
+	{
+		SeedMessage(factory, id: 1, channelId: 100, authorId: 42);
+		var client = BuildClient(userId: 42);
+
+		var response = await client.PatchAsJsonAsync("/v1/messages/1",
+			new { content = new string('a', 4001) });
+
+		Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+		Assert.Empty(factory.Broadcaster.EditedBroadcasts);
+	}
+
+	[Fact]
+	public async Task Patch_AlreadyDeletedMessage_Returns404()
+	{
+		var deleted = Message.Reconstitute(
+			id: 1, channelId: 100, authorId: 42,
+			content: null, replyToId: null, editedAt: null,
+			isDeleted: true, createdAt: DateTimeOffset.UtcNow);
+		factory.MessageRepository.Seed(deleted);
+		var client = BuildClient(userId: 42);
+
+		var response = await client.PatchAsJsonAsync("/v1/messages/1",
+			new { content = "new content" });
+
+		Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+		Assert.Empty(factory.Broadcaster.EditedBroadcasts);
+	}
+
+	[Fact]
+	public async Task Patch_EditTwice_Returns200WithUpdatedEditedAt()
+	{
+		SeedMessage(factory, id: 1, channelId: 100, authorId: 42);
+		var client = BuildClient(userId: 42);
+
+		var first  = await client.PatchAsJsonAsync("/v1/messages/1", new { content = "v1" });
+		var second = await client.PatchAsJsonAsync("/v1/messages/1", new { content = "v2" });
+
+		Assert.Equal(HttpStatusCode.OK, first.StatusCode);
+		Assert.Equal(HttpStatusCode.OK, second.StatusCode);
+
+		var body = await second.Content.ReadFromJsonAsync<EditBody>(JsonOptions);
+		Assert.Equal("v2", body!.Content);
+		Assert.Equal(2, factory.Broadcaster.EditedBroadcasts.Count);
+	}
+
 	private sealed record EditBody(string Id, string? Content, DateTimeOffset? EditedAt);
 }

--- a/services/chat/tests/Chat.FunctionalTests/Endpoints/SendMessageHubTests.cs
+++ b/services/chat/tests/Chat.FunctionalTests/Endpoints/SendMessageHubTests.cs
@@ -1,5 +1,4 @@
 using Chat.FunctionalTests.Infrastructure;
-using Microsoft.AspNetCore.Http.Connections;
 using Microsoft.AspNetCore.SignalR.Client;
 using Xunit;
 
@@ -11,43 +10,10 @@ namespace Chat.FunctionalTests.Endpoints;
 /// </summary>
 public sealed class ChatHubTests(ChatApiFactory factory) : IClassFixture<ChatApiFactory>
 {
-	private HubConnection BuildHubConnection(string? token)
-	{
-		var server = factory.Server;
-		var hubUri = new UriBuilder(server.BaseAddress) { Path = "/v1/hubs/chat" }.Uri;
-
-		return new HubConnectionBuilder()
-			.WithUrl(hubUri, options =>
-			{
-				options.Transports = HttpTransportType.WebSockets;
-				options.SkipNegotiation = true;
-				options.HttpMessageHandlerFactory = _ => server.CreateHandler();
-				options.WebSocketFactory = async (context, ct) =>
-				{
-					var wsClient = server.CreateWebSocketClient();
-					wsClient.ConfigureRequest = req =>
-					{
-						if (token is not null)
-							req.Headers["Authorization"] = $"Bearer {token}";
-					};
-
-					var uri = context.Uri;
-					if (token is not null)
-					{
-						var separator = string.IsNullOrEmpty(uri.Query) ? "?" : "&";
-						uri = new Uri(uri + separator + "access_token=" + token);
-					}
-
-					return await wsClient.ConnectAsync(uri, ct);
-				};
-			})
-			.Build();
-	}
-
 	[Fact]
 	public async Task Connect_WithoutToken_IsRejected()
 	{
-		var connection = BuildHubConnection(token: null);
+		var connection = HubConnectionHelper.Build(factory, token: null);
 
 		await Assert.ThrowsAnyAsync<Exception>(() => connection.StartAsync());
 		Assert.NotEqual(HubConnectionState.Connected, connection.State);
@@ -59,12 +25,10 @@ public sealed class ChatHubTests(ChatApiFactory factory) : IClassFixture<ChatApi
 	public async Task Connect_WithToken_SucceedsAndConnects()
 	{
 		var token = TestTokens.Issue(ChatApiFactory.JwtSecret, userId: 42);
-		var connection = BuildHubConnection(token);
+		await using var connection = HubConnectionHelper.Build(factory, token);
 
 		await connection.StartAsync();
 
 		Assert.Equal(HubConnectionState.Connected, connection.State);
-
-		await connection.DisposeAsync();
 	}
 }

--- a/services/chat/tests/Chat.FunctionalTests/Features/MessageMutationTests.cs
+++ b/services/chat/tests/Chat.FunctionalTests/Features/MessageMutationTests.cs
@@ -1,0 +1,172 @@
+using Chat.Application.Features.Messages.Common;
+using Chat.FunctionalTests.Infrastructure;
+using Microsoft.AspNetCore.SignalR.Client;
+using Xunit;
+
+namespace Chat.FunctionalTests.Features;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Hub broadcast reception — MessageEdited
+//
+// FakeChannelBroadcaster replaces SignalRChannelBroadcaster in the factory, so
+// PATCH via REST never reaches the real SignalR group. These tests use
+// SimulateMessageEditedAsync to push the event directly into the hub group and
+// verify that connected subscribers receive the right invocation.
+// ─────────────────────────────────────────────────────────────────────────────
+
+public sealed class EditMessageBroadcastTests(ChatApiFactory factory)
+	: IClassFixture<ChatApiFactory>, IAsyncLifetime
+{
+	private const long ReadMessages = 1L << 1;
+	private const long GuildId      = 999;
+	private const long ChannelId    = 100;
+
+	private const long UserSubscriber    = 5_001;
+	private const long UserNonSubscriber = 5_002;
+	private const long UserSender        = 5_003;
+
+	public Task InitializeAsync()
+	{
+		factory.GuildClient.Result = null;
+		factory.MessageRepository.Reset();
+		factory.Broadcaster.Reset();
+		return Task.CompletedTask;
+	}
+
+	public Task DisposeAsync() => Task.CompletedTask;
+
+	// T2.11 & T2.12 — subscriber get MessageEdited with right payload
+	[Fact]
+	public async Task MessageEdited_SubscriberInGroup_ReceivesEventWithCorrectPayload()
+	{
+		factory.WithMembershipFor(ChannelId, UserSubscriber, GuildId, ReadMessages);
+		var token = TestTokens.Issue(ChatApiFactory.JwtSecret, UserSubscriber);
+		await using var conn = HubConnectionHelper.Build(factory, token);
+
+		var tcs = new TaskCompletionSource<MessageEditedEvent>();
+		conn.On<MessageEditedEvent>("MessageEdited", evt => tcs.TrySetResult(evt));
+
+		await conn.StartAsync();
+		await conn.InvokeAsync("JoinChannel", ChannelId);
+
+		var sentEvt = new MessageEditedEvent(
+			Id: "42",
+			ChannelId: ChannelId.ToString(),
+			Content: "edited content",
+			EditedAt: DateTimeOffset.UtcNow);
+
+		await factory.SimulateMessageEditedAsync(ChannelId, sentEvt);
+
+		var received = await tcs.Task.WaitAsync(TimeSpan.FromSeconds(3));
+		Assert.Equal("42", received.Id);
+		Assert.Equal(ChannelId.ToString(), received.ChannelId);
+		Assert.Equal("edited content", received.Content);
+		Assert.NotEqual(default, received.EditedAt);
+	}
+
+	// T2.13 — broadcast Group SignalR : everyone receive (sender too)
+	[Fact]
+	public async Task MessageEdited_BroadcastIsToFullGroup_SenderAlsoReceives()
+	{
+		factory.WithMembershipFor(ChannelId, UserSender, GuildId, ReadMessages);
+		var token = TestTokens.Issue(ChatApiFactory.JwtSecret, UserSender);
+		await using var conn = HubConnectionHelper.Build(factory, token);
+
+		var received = false;
+		conn.On<MessageEditedEvent>("MessageEdited", _ => received = true);
+
+		await conn.StartAsync();
+		await conn.InvokeAsync("JoinChannel", ChannelId);
+
+		await factory.SimulateMessageEditedAsync(ChannelId,
+			new MessageEditedEvent("1", ChannelId.ToString(), "x", DateTimeOffset.UtcNow));
+
+		await Task.Delay(300);
+		Assert.True(received);
+	}
+
+	// T2.14 — user not in Group → doesn't get MessageEdited
+	[Fact]
+	public async Task MessageEdited_NonSubscriber_DoesNotReceive()
+	{
+		var token = TestTokens.Issue(ChatApiFactory.JwtSecret, UserNonSubscriber);
+		await using var conn = HubConnectionHelper.Build(factory, token);
+
+		var received = false;
+		conn.On<MessageEditedEvent>("MessageEdited", _ => received = true);
+
+		await conn.StartAsync();
+		// intentionally no JoinChannel
+
+		await factory.SimulateMessageEditedAsync(ChannelId,
+			new MessageEditedEvent("1", ChannelId.ToString(), "x", DateTimeOffset.UtcNow));
+
+		await Task.Delay(300);
+		Assert.False(received);
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Hub broadcast reception — MessageDeleted
+// ─────────────────────────────────────────────────────────────────────────────
+
+public sealed class DeleteMessageBroadcastTests(ChatApiFactory factory)
+	: IClassFixture<ChatApiFactory>, IAsyncLifetime
+{
+	private const long ReadMessages = 1L << 1;
+	private const long GuildId      = 999;
+	private const long ChannelId    = 200;
+
+	private const long UserSubscriber    = 6_001;
+	private const long UserNonSubscriber = 6_002;
+
+	public Task InitializeAsync()
+	{
+		factory.GuildClient.Result = null;
+		factory.MessageRepository.Reset();
+		factory.Broadcaster.Reset();
+		return Task.CompletedTask;
+	}
+
+	public Task DisposeAsync() => Task.CompletedTask;
+
+	// T2.22 & T2.23 — subscriber get MessageDeleted with right payload
+	[Fact]
+	public async Task MessageDeleted_SubscriberInGroup_ReceivesEventWithCorrectPayload()
+	{
+		factory.WithMembershipFor(ChannelId, UserSubscriber, GuildId, ReadMessages);
+		var token = TestTokens.Issue(ChatApiFactory.JwtSecret, UserSubscriber);
+		await using var conn = HubConnectionHelper.Build(factory, token);
+
+		var tcs = new TaskCompletionSource<MessageDeletedEvent>();
+		conn.On<MessageDeletedEvent>("MessageDeleted", evt => tcs.TrySetResult(evt));
+
+		await conn.StartAsync();
+		await conn.InvokeAsync("JoinChannel", ChannelId);
+
+		await factory.SimulateMessageDeletedAsync(ChannelId, messageId: 99);
+
+		var received = await tcs.Task.WaitAsync(TimeSpan.FromSeconds(3));
+		Assert.Equal("99", received.MessageId);
+		Assert.Equal(ChannelId.ToString(), received.ChannelId);
+	}
+
+	// T2.23b — user not in Group → doesn't get MessageDeleted
+	[Fact]
+	public async Task MessageDeleted_NonSubscriber_DoesNotReceive()
+	{
+		var token = TestTokens.Issue(ChatApiFactory.JwtSecret, UserNonSubscriber);
+		await using var conn = HubConnectionHelper.Build(factory, token);
+
+		var received = false;
+		conn.On<MessageDeletedEvent>("MessageDeleted", _ => received = true);
+
+		await conn.StartAsync();
+		// intentionally no JoinChannel
+
+		await factory.SimulateMessageDeletedAsync(ChannelId, messageId: 99);
+
+		await Task.Delay(300);
+		Assert.False(received);
+	}
+}

--- a/services/chat/tests/Chat.FunctionalTests/Infrastructure/ChatApiFactory.cs
+++ b/services/chat/tests/Chat.FunctionalTests/Infrastructure/ChatApiFactory.cs
@@ -1,9 +1,12 @@
 using Cassandra;
 using Chat.Application.Abstractions;
 using Chat.Application.Abstractions.Persistence;
+using Chat.Application.Features.Messages.Common;
+using Chat.Presentation.Hubs;
 using Chat.UnitTests.Fakes;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.SignalR;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -50,7 +53,29 @@ public sealed class ChatApiFactory : WebApplicationFactory<Program>
 		GuildClient.Result = new ChannelMembership(IsMember: true, GuildId: guildId, Permissions: permissions);
 	}
 
+	public void WithMembershipFor(long channelId, long userId, long guildId, long permissions)
+		=> GuildClient.Setup(channelId, userId, new ChannelMembership(IsMember: true, GuildId: guildId, Permissions: permissions));
+
+	public void WithoutMembershipFor(long channelId, long userId)
+		=> GuildClient.Setup(channelId, userId, null);
+
 	public void WithoutMembership() => GuildClient.Result = null;
+
+	// Bypasses FakeChannelBroadcaster (which is a no-op for SignalR) and pushes
+	// events directly into the hub group via IHubContext. Use to verify that a
+	// subscriber in the group receives the correct hub invocation.
+	public async Task SimulateMessageEditedAsync(long channelId, MessageEditedEvent evt)
+	{
+		var hub = Server.Services.GetRequiredService<IHubContext<ChatHub, IChatClient>>();
+		await hub.Clients.Group($"channel:{channelId}").MessageEdited(evt);
+	}
+
+	public async Task SimulateMessageDeletedAsync(long channelId, long messageId)
+	{
+		var hub = Server.Services.GetRequiredService<IHubContext<ChatHub, IChatClient>>();
+		await hub.Clients.Group($"channel:{channelId}").MessageDeleted(
+			new MessageDeletedEvent(messageId.ToString(), channelId.ToString()));
+	}
 
 	protected override void ConfigureWebHost(IWebHostBuilder builder)
 	{

--- a/services/chat/tests/Chat.FunctionalTests/Infrastructure/HubConnectionHelper.cs
+++ b/services/chat/tests/Chat.FunctionalTests/Infrastructure/HubConnectionHelper.cs
@@ -1,0 +1,40 @@
+using Microsoft.AspNetCore.Http.Connections;
+using Microsoft.AspNetCore.SignalR.Client;
+
+namespace Chat.FunctionalTests.Infrastructure;
+
+internal static class HubConnectionHelper
+{
+	public static HubConnection Build(ChatApiFactory factory, string? token)
+	{
+		var server = factory.Server;
+		var hubUri = new UriBuilder(server.BaseAddress) { Path = "/v1/hubs/chat" }.Uri;
+
+		return new HubConnectionBuilder()
+			.WithUrl(hubUri, options =>
+			{
+				options.Transports = HttpTransportType.WebSockets;
+				options.SkipNegotiation = true;
+				options.HttpMessageHandlerFactory = _ => server.CreateHandler();
+				options.WebSocketFactory = async (context, ct) =>
+				{
+					var wsClient = server.CreateWebSocketClient();
+					wsClient.ConfigureRequest = req =>
+					{
+						if (token is not null)
+							req.Headers["Authorization"] = $"Bearer {token}";
+					};
+
+					var uri = context.Uri;
+					if (token is not null)
+					{
+						var separator = string.IsNullOrEmpty(uri.Query) ? "?" : "&";
+						uri = new Uri(uri + separator + "access_token=" + token);
+					}
+
+					return await wsClient.ConnectAsync(uri, ct);
+				};
+			})
+			.Build();
+	}
+}

--- a/services/chat/tests/Chat.UnitTests/Application/DeleteMessageHandlerTests.cs
+++ b/services/chat/tests/Chat.UnitTests/Application/DeleteMessageHandlerTests.cs
@@ -1,0 +1,157 @@
+using Chat.Application.Abstractions;
+using Chat.Application.Abstractions.Messaging;
+using Chat.Application.Features.Messages.DeleteMessage;
+using Chat.Domain.Messages;
+using Chat.Domain.Results;
+using Chat.UnitTests.Fakes;
+using Xunit;
+
+namespace Chat.UnitTests.Application;
+
+public sealed class DeleteMessageHandlerTests
+{
+	private const long ManageMessagesPermission = 1L << 2;
+	private const long AdministratorPermission = 1L << 8;
+
+	private sealed record Harness(
+		FakeCurrentUser CurrentUser,
+		FakeGuildClient GuildClient,
+		FakeMessageRepository Repository,
+		FakeChannelBroadcaster Broadcaster);
+
+	private static (Harness Harness, ICommandHandler<DeleteMessageCommand, Result> Handler)
+		BuildHandler(long userId = 42)
+	{
+		var currentUser = new FakeCurrentUser { UserId = userId };
+		var guildClient = new FakeGuildClient();
+		var repository = new FakeMessageRepository();
+		var broadcaster = new FakeChannelBroadcaster();
+
+		var handler = HandlerFactory.CreateCommand<DeleteMessageCommand, Result>(
+			currentUser, guildClient, repository, broadcaster);
+
+		return (new Harness(currentUser, guildClient, repository, broadcaster), handler);
+	}
+
+	private static Message Seed(FakeMessageRepository repo, long id = 1, long channelId = 100, long authorId = 42, bool isDeleted = false)
+	{
+		var message = Message.Reconstitute(
+			id: id, channelId: channelId, authorId: authorId,
+			content: "hello", replyToId: null, editedAt: null,
+			isDeleted: isDeleted, createdAt: DateTimeOffset.UtcNow);
+		repo.Seed(message);
+		return message;
+	}
+
+	[Fact]
+	public async Task MessageNotFound_ReturnsNotFound_NoSideEffects()
+	{
+		var (h, handler) = BuildHandler();
+
+		var result = await handler.HandleAsync(new DeleteMessageCommand(MessageId: 999));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal(MessageFailures.NotFound, result.Error);
+		Assert.Empty(h.Repository.SoftDeleted);
+		Assert.Empty(h.Broadcaster.DeletedBroadcasts);
+	}
+
+	[Fact]
+	public async Task AlreadyDeleted_ReturnsNotFound_NoSideEffects()
+	{
+		var (h, handler) = BuildHandler(userId: 42);
+		Seed(h.Repository, authorId: 42, isDeleted: true);
+
+		var result = await handler.HandleAsync(new DeleteMessageCommand(MessageId: 1));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal(MessageFailures.NotFound, result.Error);
+		Assert.Empty(h.Repository.SoftDeleted);
+	}
+
+	[Fact]
+	public async Task Author_DeletesWithoutPermissionCheck()
+	{
+		var (h, handler) = BuildHandler(userId: 42);
+		Seed(h.Repository, authorId: 42);
+
+		var result = await handler.HandleAsync(new DeleteMessageCommand(MessageId: 1));
+
+		Assert.True(result.Succeeded);
+		Assert.Single(h.Repository.SoftDeleted);
+		Assert.Single(h.Broadcaster.DeletedBroadcasts);
+		Assert.Null(h.GuildClient.Result);
+	}
+
+	[Fact]
+	public async Task NonAuthor_NonMember_ReturnsNotFound()
+	{
+		var (h, handler) = BuildHandler(userId: 99);
+		Seed(h.Repository, authorId: 42);
+		h.GuildClient.Result = new ChannelMembership(IsMember: false, GuildId: 5, Permissions: 0);
+
+		var result = await handler.HandleAsync(new DeleteMessageCommand(MessageId: 1));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal(MessageFailures.NotFound, result.Error);
+		Assert.Empty(h.Repository.SoftDeleted);
+	}
+
+	[Fact]
+	public async Task NonAuthor_ChannelNotFound_ReturnsNotFound()
+	{
+		var (h, handler) = BuildHandler(userId: 99);
+		Seed(h.Repository, authorId: 42);
+		h.GuildClient.Result = null;
+
+		var result = await handler.HandleAsync(new DeleteMessageCommand(MessageId: 1));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal(MessageFailures.NotFound, result.Error);
+	}
+
+	[Fact]
+	public async Task NonAuthor_MemberWithoutManageMessages_ReturnsMissingManagePermission()
+	{
+		var (h, handler) = BuildHandler(userId: 99);
+		Seed(h.Repository, authorId: 42);
+		h.GuildClient.Result = new ChannelMembership(IsMember: true, GuildId: 5, Permissions: 0);
+
+		var result = await handler.HandleAsync(new DeleteMessageCommand(MessageId: 1));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal(MessageFailures.MissingManagePermission, result.Error);
+		Assert.Empty(h.Repository.SoftDeleted);
+	}
+
+	[Fact]
+	public async Task NonAuthor_WithManageMessages_DeletesAndBroadcasts()
+	{
+		var (h, handler) = BuildHandler(userId: 99);
+		Seed(h.Repository, id: 1, channelId: 100, authorId: 42);
+		h.GuildClient.Result = new ChannelMembership(IsMember: true, GuildId: 5, Permissions: ManageMessagesPermission);
+
+		var result = await handler.HandleAsync(new DeleteMessageCommand(MessageId: 1));
+
+		Assert.True(result.Succeeded);
+		Assert.Single(h.Repository.SoftDeleted);
+
+		var (broadcastChannel, broadcastMessageId) = Assert.Single(h.Broadcaster.DeletedBroadcasts);
+		Assert.Equal(100L, broadcastChannel);
+		Assert.Equal(1L, broadcastMessageId);
+	}
+
+	[Fact]
+	public async Task NonAuthor_Administrator_DeletesAndBroadcasts()
+	{
+		var (h, handler) = BuildHandler(userId: 99);
+		Seed(h.Repository, authorId: 42);
+		h.GuildClient.Result = new ChannelMembership(IsMember: true, GuildId: 5, Permissions: AdministratorPermission);
+
+		var result = await handler.HandleAsync(new DeleteMessageCommand(MessageId: 1));
+
+		Assert.True(result.Succeeded);
+		Assert.Single(h.Repository.SoftDeleted);
+		Assert.Single(h.Broadcaster.DeletedBroadcasts);
+	}
+}

--- a/services/chat/tests/Chat.UnitTests/Application/EditMessageHandlerTests.cs
+++ b/services/chat/tests/Chat.UnitTests/Application/EditMessageHandlerTests.cs
@@ -1,0 +1,142 @@
+using Chat.Application.Abstractions.Messaging;
+using Chat.Application.Features.Messages.Common;
+using Chat.Application.Features.Messages.EditMessage;
+using Chat.Domain.Messages;
+using Chat.Domain.Results;
+using Chat.UnitTests.Fakes;
+using Xunit;
+
+namespace Chat.UnitTests.Application;
+
+public sealed class EditMessageHandlerTests
+{
+	private sealed record Harness(
+		FakeCurrentUser CurrentUser,
+		FakeMessageRepository Repository,
+		FakeClock Clock,
+		FakeChannelBroadcaster Broadcaster);
+
+	private static (Harness Harness, ICommandHandler<EditMessageCommand, Result<EditMessageResponse>> Handler)
+		BuildHandler(long userId = 42)
+	{
+		var currentUser = new FakeCurrentUser { UserId = userId };
+		var repository = new FakeMessageRepository();
+		var clock = new FakeClock();
+		var broadcaster = new FakeChannelBroadcaster();
+
+		var handler = HandlerFactory.CreateCommand<EditMessageCommand, Result<EditMessageResponse>>(
+			currentUser, repository, clock, broadcaster);
+
+		return (new Harness(currentUser, repository, clock, broadcaster), handler);
+	}
+
+	private static Message SeedMessage(FakeMessageRepository repo, long id = 1, long channelId = 100, long authorId = 42) =>
+		SeedMessage(repo, id, channelId, authorId, isDeleted: false);
+
+	private static Message SeedMessage(FakeMessageRepository repo, long id, long channelId, long authorId, bool isDeleted)
+	{
+		var message = Message.Reconstitute(
+			id: id,
+			channelId: channelId,
+			authorId: authorId,
+			content: "original content",
+			replyToId: null,
+			editedAt: null,
+			isDeleted: isDeleted,
+			createdAt: DateTimeOffset.UtcNow);
+		repo.Seed(message);
+		return message;
+	}
+
+	[Fact]
+	public async Task MessageNotFound_ReturnsNotFound_NoSideEffects()
+	{
+		var (h, handler) = BuildHandler();
+
+		var result = await handler.HandleAsync(new EditMessageCommand(MessageId: 999, Content: "new content"));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal(MessageFailures.NotFound, result.Error);
+		Assert.Empty(h.Repository.Updated);
+		Assert.Empty(h.Broadcaster.EditedBroadcasts);
+	}
+
+	[Fact]
+	public async Task DeletedMessage_ReturnsNotFound_NoSideEffects()
+	{
+		var (h, handler) = BuildHandler(userId: 42);
+		SeedMessage(h.Repository, id: 1, channelId: 100, authorId: 42, isDeleted: true);
+
+		var result = await handler.HandleAsync(new EditMessageCommand(MessageId: 1, Content: "new content"));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal(MessageFailures.NotFound, result.Error);
+		Assert.Empty(h.Repository.Updated);
+	}
+
+	[Fact]
+	public async Task NotAuthor_ReturnsNotAuthor_NoSideEffects()
+	{
+		var (h, handler) = BuildHandler(userId: 42);
+		SeedMessage(h.Repository, id: 1, channelId: 100, authorId: 99);
+
+		var result = await handler.HandleAsync(new EditMessageCommand(MessageId: 1, Content: "new content"));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal(MessageFailures.NotAuthor, result.Error);
+		Assert.Empty(h.Repository.Updated);
+		Assert.Empty(h.Broadcaster.EditedBroadcasts);
+	}
+
+	[Fact]
+	public async Task EmptyContent_ReturnsContentRequired_NoSideEffects()
+	{
+		var (h, handler) = BuildHandler(userId: 42);
+		SeedMessage(h.Repository);
+
+		var result = await handler.HandleAsync(new EditMessageCommand(MessageId: 1, Content: "   "));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal(MessageFailures.ContentRequired, result.Error);
+		Assert.Empty(h.Repository.Updated);
+		Assert.Empty(h.Broadcaster.EditedBroadcasts);
+	}
+
+	[Fact]
+	public async Task ContentTooLong_ReturnsContentTooLong_NoSideEffects()
+	{
+		var (h, handler) = BuildHandler(userId: 42);
+		SeedMessage(h.Repository);
+
+		var result = await handler.HandleAsync(new EditMessageCommand(MessageId: 1, Content: new string('x', 4001)));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal(MessageFailures.ContentTooLong, result.Error);
+		Assert.Empty(h.Repository.Updated);
+	}
+
+	[Fact]
+	public async Task HappyPath_UpdatesRepo_Broadcasts_ReturnsResponse()
+	{
+		var (h, handler) = BuildHandler(userId: 42);
+		SeedMessage(h.Repository, id: 1, channelId: 100, authorId: 42);
+
+		var result = await handler.HandleAsync(new EditMessageCommand(MessageId: 1, Content: "updated content"));
+
+		Assert.True(result.Succeeded);
+		var response = result.Value;
+		Assert.Equal("1", response.Id);
+		Assert.Equal("updated content", response.Content);
+		Assert.True(response.EditedAt > DateTimeOffset.MinValue);
+
+		var updated = Assert.Single(h.Repository.Updated);
+		Assert.Equal(1L, updated.Id);
+		Assert.Equal("updated content", updated.Content);
+
+		var (broadcastChannel, evt) = Assert.Single(h.Broadcaster.EditedBroadcasts);
+		Assert.Equal(100L, broadcastChannel);
+		Assert.Equal("1", evt.Id);
+		Assert.Equal("100", evt.ChannelId);
+		Assert.Equal("updated content", evt.Content);
+	}
+}

--- a/services/chat/tests/Chat.UnitTests/Fakes/FakeChannelBroadcaster.cs
+++ b/services/chat/tests/Chat.UnitTests/Fakes/FakeChannelBroadcaster.cs
@@ -6,14 +6,35 @@ namespace Chat.UnitTests.Fakes;
 public sealed class FakeChannelBroadcaster : IChannelBroadcaster
 {
 	private readonly List<(long ChannelId, MessageResponse Message)> _broadcasts = [];
+	private readonly List<(long ChannelId, MessageEditedEvent Evt)> _editedBroadcasts = [];
+	private readonly List<(long ChannelId, long MessageId)> _deletedBroadcasts = [];
 
 	public IReadOnlyList<(long ChannelId, MessageResponse Message)> Broadcasts => _broadcasts;
+	public IReadOnlyList<(long ChannelId, MessageEditedEvent Evt)> EditedBroadcasts => _editedBroadcasts;
+	public IReadOnlyList<(long ChannelId, long MessageId)> DeletedBroadcasts => _deletedBroadcasts;
 
-	public void Reset() => _broadcasts.Clear();
+	public void Reset()
+	{
+		_broadcasts.Clear();
+		_editedBroadcasts.Clear();
+		_deletedBroadcasts.Clear();
+	}
 
 	public Task BroadcastMessageAsync(long channelId, MessageResponse message, CancellationToken ct)
 	{
 		_broadcasts.Add((channelId, message));
+		return Task.CompletedTask;
+	}
+
+	public Task BroadcastMessageEditedAsync(long channelId, MessageEditedEvent evt, CancellationToken ct)
+	{
+		_editedBroadcasts.Add((channelId, evt));
+		return Task.CompletedTask;
+	}
+
+	public Task BroadcastMessageDeletedAsync(long channelId, long messageId, CancellationToken ct)
+	{
+		_deletedBroadcasts.Add((channelId, messageId));
 		return Task.CompletedTask;
 	}
 }

--- a/services/chat/tests/Chat.UnitTests/Fakes/FakeGuildClient.cs
+++ b/services/chat/tests/Chat.UnitTests/Fakes/FakeGuildClient.cs
@@ -4,8 +4,14 @@ namespace Chat.UnitTests.Fakes;
 
 public sealed class FakeGuildClient : IGuildClient
 {
+	private readonly Dictionary<(long ChannelId, long UserId), ChannelMembership?> _map = new();
+
+	// fallback returned when no per-key entry is set
 	public ChannelMembership? Result { get; set; }
 
+	public void Setup(long channelId, long userId, ChannelMembership? membership)
+		=> _map[(channelId, userId)] = membership;
+
 	public Task<ChannelMembership?> GetMembershipAsync(long channelId, long userId, CancellationToken ct)
-		=> Task.FromResult(Result);
+		=> Task.FromResult(_map.TryGetValue((channelId, userId), out var m) ? m : Result);
 }

--- a/services/chat/tests/Chat.UnitTests/Fakes/FakeMessageRepository.cs
+++ b/services/chat/tests/Chat.UnitTests/Fakes/FakeMessageRepository.cs
@@ -35,4 +35,21 @@ public sealed class FakeMessageRepository : IMessageRepository
 		var message = _saved.FirstOrDefault(m => m.Id == messageId);
 		return Task.FromResult(message);
 	}
+
+	public Task UpdateContentAsync(Message message, CancellationToken ct)
+	{
+		Updated.Add(message);
+		return Task.CompletedTask;
+	}
+
+	public Task SoftDeleteAsync(Message message, CancellationToken ct)
+	{
+		SoftDeleted.Add(message);
+		return Task.CompletedTask;
+	}
+
+	public void Seed(Message message) => _saved.Add(message);
+
+	public List<Message> Updated { get; } = [];
+	public List<Message> SoftDeleted { get; } = [];
 }


### PR DESCRIPTION
Implement **edit** and **delete** messages features.

## This PR contains:

- `/messages/{messageId}` `PATCH` and `DELETE` endpoints with error mapping like `Guild` does
- command handler for message deletion (soft delete) and update
- update Domain to add `Edit()` and `Delete()` methods and dedicated `MessagesFailures`
- DB operations to **edit** and **delete** a message
- unit and functionnal tests

Close #69