### PR TITLE
Feat/chat/message history

### DIFF
--- a/services/chat/src/Chat.Application/Abstractions/Persistence/IMessageRepository.cs
+++ b/services/chat/src/Chat.Application/Abstractions/Persistence/IMessageRepository.cs
@@ -9,4 +9,5 @@ public interface IMessageRepository
 	Task<Message?> GetByIdAsync(long messageId, CancellationToken ct);
 	Task UpdateContentAsync(Message message, CancellationToken ct);
 	Task SoftDeleteAsync(Message message, CancellationToken ct);
+	Task<IReadOnlyList<Message>> GetChannelMessagesAsync(long channelId, DateTimeOffset beforeTime, int limit, CancellationToken ct);
 }

--- a/services/chat/src/Chat.Application/Features/Messages/GetChannelMessages/GetChannelMessagesHandler.cs
+++ b/services/chat/src/Chat.Application/Features/Messages/GetChannelMessages/GetChannelMessagesHandler.cs
@@ -1,0 +1,42 @@
+using Chat.Application.Abstractions;
+using Chat.Application.Abstractions.Authentication;
+using Chat.Application.Abstractions.Messaging;
+using Chat.Application.Abstractions.Persistence;
+using Chat.Application.Features.Messages.Common;
+using Chat.Domain.Results;
+
+namespace Chat.Application.Features.Messages.GetChannelMessages;
+
+internal sealed class GetChannelMessagesHandler(
+	ICurrentUser currentUser,
+	IGuildClient guildClient,
+	IMessageRepository repository,
+	IClock clock)
+	: IQueryHandler<GetChannelMessagesQuery, Result<IReadOnlyList<MessageResponse>>>
+{
+	private const long ReadMessages = 1L << 1;
+	private const long Administrator = 1L << 8;
+
+	public async Task<Result<IReadOnlyList<MessageResponse>>> HandleAsync(
+		GetChannelMessagesQuery query,
+		CancellationToken cancellationToken = default)
+	{
+		var userId = currentUser.UserId;
+		var membership = await guildClient.GetMembershipAsync(query.ChannelId, userId, cancellationToken);
+
+		if (membership is null)
+			return MessageFailures.ChannelNotFound;
+
+		if (!membership.IsMember)
+			return MessageFailures.NotAMember;
+
+		if ((membership.Permissions & (ReadMessages | Administrator)) == 0)
+			return MessageFailures.MissingReadPermission;
+
+		var beforeTime = query.BeforeTime ?? clock.UtcNow;
+		var messages = await repository.GetChannelMessagesAsync(query.ChannelId, beforeTime, query.Limit, cancellationToken);
+
+		return Result.Ok<IReadOnlyList<MessageResponse>>(
+			messages.Select(m => MessageResponse.From(m, null)).ToList());
+	}
+}

--- a/services/chat/src/Chat.Application/Features/Messages/GetChannelMessages/GetChannelMessagesQuery.cs
+++ b/services/chat/src/Chat.Application/Features/Messages/GetChannelMessages/GetChannelMessagesQuery.cs
@@ -1,0 +1,8 @@
+using Chat.Application.Abstractions.Messaging;
+using Chat.Application.Features.Messages.Common;
+using Chat.Domain.Results;
+
+namespace Chat.Application.Features.Messages.GetChannelMessages;
+
+public sealed record GetChannelMessagesQuery(long ChannelId, DateTimeOffset? BeforeTime, int Limit)
+	: IQuery<Result<IReadOnlyList<MessageResponse>>>;

--- a/services/chat/src/Chat.Domain/Results/MessageFailures.cs
+++ b/services/chat/src/Chat.Domain/Results/MessageFailures.cs
@@ -43,4 +43,7 @@ public static class MessageFailures
 
 	public static readonly Failure MissingManagePermission =
 		new("Message.MissingManagePermission", "Caller lacks MANAGE_MESSAGES permission on this channel.");
+
+	public static readonly Failure MissingReadPermission =
+		new("Message.MissingReadPermission", "Caller lacks READ_MESSAGES permission on this channel.");
 }

--- a/services/chat/src/Chat.Persistence/Repositories/MessageRepository.cs
+++ b/services/chat/src/Chat.Persistence/Repositories/MessageRepository.cs
@@ -69,6 +69,31 @@ internal sealed class MessageRepository(ISession session, MessageStatements stat
 			message.Id));
 	}
 
+	public async Task<IReadOnlyList<Message>> GetChannelMessagesAsync(long channelId, DateTimeOffset beforeTime, int limit, CancellationToken ct)
+	{
+		var stmt = await statements.SelectChannelMessages.Value;
+		var rows = await session.ExecuteAsync(stmt.Bind(channelId, beforeTime.UtcDateTime, limit));
+
+		var messages = new List<Message>();
+		foreach (var row in rows)
+		{
+			var msg = Message.Reconstitute(
+				id: row.GetValue<long>("id"),
+				channelId: row.GetValue<long>("channel_id"),
+				authorId: row.GetValue<long>("author_id"),
+				content: row.GetValue<string>("content"),
+				replyToId: row.GetValue<long?>("reply_to_id"),
+				editedAt: row.GetValue<DateTime?>("edited_at"),
+				isDeleted: row.GetValue<bool>("is_deleted"),
+				createdAt: new DateTimeOffset(row.GetValue<DateTime>("created_at"), TimeSpan.Zero));
+
+			if (!msg.IsDeleted)
+				messages.Add(msg);
+		}
+
+		return messages;
+	}
+
 	public async Task<Message?> GetByIdAsync(long messageId, CancellationToken ct)
 	{
 		var selectLookup = await statements.SelectLookup.Value;

--- a/services/chat/src/Chat.Persistence/Repositories/MessageStatements.cs
+++ b/services/chat/src/Chat.Persistence/Repositories/MessageStatements.cs
@@ -34,4 +34,8 @@ internal sealed class MessageStatements(ISession session)
 	public Lazy<Task<PreparedStatement>> SoftDeleteMessage { get; } = new(() => session.PrepareAsync(
 		"UPDATE messages SET is_deleted = true " +
 		"WHERE channel_id = ? AND created_at = ? AND id = ?"));
+
+	public Lazy<Task<PreparedStatement>> SelectChannelMessages { get; } = new(() => session.PrepareAsync(
+		"SELECT channel_id, created_at, id, author_id, content, edited_at, is_deleted, reply_to_id " +
+		"FROM messages WHERE channel_id = ? AND created_at < ? LIMIT ?"));
 }

--- a/services/chat/src/Chat.Presentation/Endpoints/MessagesEndpoint.cs
+++ b/services/chat/src/Chat.Presentation/Endpoints/MessagesEndpoint.cs
@@ -3,6 +3,7 @@ using Chat.Application.Abstractions.Messaging;
 using Chat.Application.Features.Messages.Common;
 using Chat.Application.Features.Messages.DeleteMessage;
 using Chat.Application.Features.Messages.EditMessage;
+using Chat.Application.Features.Messages.GetChannelMessages;
 using Chat.Application.Features.Messages.SendMessage;
 using Chat.Domain.Results;
 using Microsoft.AspNetCore.Http.HttpResults;
@@ -14,11 +15,33 @@ public sealed class MessagesEndpoint : ICarterModule
 	public void AddRoutes(IEndpointRouteBuilder endpoints)
 	{
 		var channelGroup = endpoints.MapGroup("/channels/{channelId:long}/messages");
+		channelGroup.MapGet("/", GetChannelHistoryAsync);
 		channelGroup.MapPost("/", SendAsync);
 
 		var messageGroup = endpoints.MapGroup("/messages");
 		messageGroup.MapPatch("/{messageId:long}", EditAsync);
 		messageGroup.MapDelete("/{messageId:long}", DeleteAsync);
+	}
+
+	private static async Task<Results<
+		Ok<IReadOnlyList<MessageResponse>>,
+		JsonHttpResult<ErrorBody>,
+		NotFound<ErrorBody>>>
+	GetChannelHistoryAsync(
+		long channelId,
+		DateTimeOffset? before_time,
+		int? limit,
+		IQueryHandler<GetChannelMessagesQuery, Result<IReadOnlyList<MessageResponse>>> handler,
+		CancellationToken cancellationToken)
+	{
+		var clampedLimit = Math.Clamp(limit ?? 50, 1, 100);
+		var result = await handler.HandleAsync(
+			new GetChannelMessagesQuery(channelId, before_time, clampedLimit),
+			cancellationToken);
+
+		return result.Succeeded
+			? TypedResults.Ok(result.Value)
+			: MapGetChannelHistoryError(result.Error);
 	}
 
 	private static async Task<Results<
@@ -94,6 +117,13 @@ public sealed class MessagesEndpoint : ICarterModule
 			"Message.NotFound" or "Message.AlreadyDeleted" => TypedResults.NotFound(new ErrorBody(failure.Message)),
 			"Message.NotAuthor" => TypedResults.Json(new ErrorBody(failure.Message), statusCode: StatusCodes.Status403Forbidden),
 			_ => TypedResults.BadRequest(new ErrorBody(failure.Message)),
+		};
+
+	private static Results<Ok<IReadOnlyList<MessageResponse>>, JsonHttpResult<ErrorBody>, NotFound<ErrorBody>>
+		MapGetChannelHistoryError(Failure failure) => failure.Code switch
+		{
+			"Message.ChannelNotFound" => TypedResults.NotFound(new ErrorBody(failure.Message)),
+			_ => TypedResults.Json(new ErrorBody(failure.Message), statusCode: StatusCodes.Status403Forbidden),
 		};
 
 	private static Results<NoContent, JsonHttpResult<ErrorBody>, NotFound<ErrorBody>>

--- a/services/chat/tests/Chat.FunctionalTests/Endpoints/GetChannelMessagesEndpointTests.cs
+++ b/services/chat/tests/Chat.FunctionalTests/Endpoints/GetChannelMessagesEndpointTests.cs
@@ -1,0 +1,136 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Chat.Application.Features.Messages.Common;
+using Chat.Domain.Messages;
+using Chat.FunctionalTests.Infrastructure;
+using Xunit;
+
+namespace Chat.FunctionalTests.Endpoints;
+
+public sealed class GetChannelMessagesEndpointTests(ChatApiFactory factory)
+	: IClassFixture<ChatApiFactory>, IAsyncLifetime
+{
+	private const long ReadMessagesPermission = 1L << 1;
+
+	private static readonly JsonSerializerOptions JsonOptions = new()
+	{
+		PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+		PropertyNameCaseInsensitive = true,
+	};
+
+	// all seeded messages use a date well before FakeClock's 2026-01-01 anchor
+	private static readonly DateTimeOffset PastDate =
+		new(2025, 6, 1, 12, 0, 0, TimeSpan.Zero);
+
+	public Task InitializeAsync()
+	{
+		factory.GuildClient.Result = null;
+		factory.MessageRepository.Reset();
+		factory.Broadcaster.Reset();
+		return Task.CompletedTask;
+	}
+
+	public Task DisposeAsync() => Task.CompletedTask;
+
+	private HttpClient BuildClient(long userId)
+	{
+		var client = factory.CreateClient();
+		var token = TestTokens.Issue(ChatApiFactory.JwtSecret, userId: userId);
+		client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+		return client;
+	}
+
+	private static void SeedMessage(ChatApiFactory f, long id, long channelId, DateTimeOffset? createdAt = null, bool isDeleted = false)
+	{
+		var message = Message.Reconstitute(
+			id: id, channelId: channelId, authorId: 99,
+			content: "hello", replyToId: null, editedAt: null,
+			isDeleted: isDeleted, createdAt: createdAt ?? PastDate);
+		f.MessageRepository.Seed(message);
+	}
+
+	[Fact]
+	public async Task Get_WithoutToken_Returns401()
+	{
+		var response = await factory.CreateClient().GetAsync("/v1/channels/100/messages");
+
+		Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+	}
+
+	[Fact]
+	public async Task Get_ChannelNotFound_Returns404()
+	{
+		factory.GuildClient.Result = null;
+		var client = BuildClient(userId: 42);
+
+		var response = await client.GetAsync("/v1/channels/100/messages");
+
+		Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+	}
+
+	[Fact]
+	public async Task Get_NotAMember_Returns403()
+	{
+		factory.GuildClient.Result = new Chat.Application.Abstractions.ChannelMembership(
+			IsMember: false, GuildId: 5, Permissions: ReadMessagesPermission);
+		var client = BuildClient(userId: 42);
+
+		var response = await client.GetAsync("/v1/channels/100/messages");
+
+		Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+	}
+
+	[Fact]
+	public async Task Get_MissingReadPermission_Returns403()
+	{
+		factory.GuildClient.Result = new Chat.Application.Abstractions.ChannelMembership(
+			IsMember: true, GuildId: 5, Permissions: 0);
+		var client = BuildClient(userId: 42);
+
+		var response = await client.GetAsync("/v1/channels/100/messages");
+
+		Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+	}
+
+	[Fact]
+	public async Task Get_HappyPath_Returns200WithMessages()
+	{
+		factory.GuildClient.Result = new Chat.Application.Abstractions.ChannelMembership(
+			IsMember: true, GuildId: 5, Permissions: ReadMessagesPermission);
+		SeedMessage(factory, id: 1, channelId: 100, createdAt: PastDate.AddMinutes(-10));
+		SeedMessage(factory, id: 2, channelId: 100, createdAt: PastDate.AddMinutes(-5));
+		SeedMessage(factory, id: 3, channelId: 100, createdAt: PastDate.AddMinutes(-1), isDeleted: true);
+		var client = BuildClient(userId: 42);
+
+		var response = await client.GetAsync("/v1/channels/100/messages");
+
+		Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+		var messages = await response.Content.ReadFromJsonAsync<List<MessageResponse>>(JsonOptions);
+		Assert.NotNull(messages);
+		Assert.Equal(2, messages.Count);
+		Assert.DoesNotContain(messages, m => m.Id == "3");
+	}
+
+	[Fact]
+	public async Task Get_WithBeforeTime_ReturnsOnlyOlderMessages()
+	{
+		factory.GuildClient.Result = new Chat.Application.Abstractions.ChannelMembership(
+			IsMember: true, GuildId: 5, Permissions: ReadMessagesPermission);
+		var cursor = PastDate;
+		SeedMessage(factory, id: 1, channelId: 100, createdAt: cursor.AddMinutes(-20));
+		SeedMessage(factory, id: 2, channelId: 100, createdAt: cursor.AddMinutes(-10));
+		SeedMessage(factory, id: 3, channelId: 100, createdAt: cursor.AddMinutes(5));
+		var client = BuildClient(userId: 42);
+
+		var beforeTimeStr = Uri.EscapeDataString(cursor.ToString("O"));
+		var response = await client.GetAsync($"/v1/channels/100/messages?before_time={beforeTimeStr}");
+
+		Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+		var messages = await response.Content.ReadFromJsonAsync<List<MessageResponse>>(JsonOptions);
+		Assert.NotNull(messages);
+		Assert.Equal(2, messages.Count);
+		Assert.DoesNotContain(messages, m => m.Id == "3");
+	}
+}

--- a/services/chat/tests/Chat.FunctionalTests/Endpoints/GetChannelMessagesEndpointTests.cs
+++ b/services/chat/tests/Chat.FunctionalTests/Endpoints/GetChannelMessagesEndpointTests.cs
@@ -133,4 +133,176 @@ public sealed class GetChannelMessagesEndpointTests(ChatApiFactory factory)
 		Assert.Equal(2, messages.Count);
 		Assert.DoesNotContain(messages, m => m.Id == "3");
 	}
+
+	// T3.14b — ADMINISTRATOR bit grants read access without explicit READ_MESSAGES
+	[Fact]
+	public async Task Get_AdministratorPermission_Returns200()
+	{
+		const long administrator = 1L << 8;
+		factory.GuildClient.Result = new Chat.Application.Abstractions.ChannelMembership(
+			IsMember: true, GuildId: 5, Permissions: administrator);
+		var client = BuildClient(userId: 42);
+
+		var response = await client.GetAsync("/v1/channels/100/messages");
+
+		Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+	}
+
+	// T3.11 — channel with no messages returns empty array
+	[Fact]
+	public async Task Get_EmptyChannel_ReturnsEmptyArray()
+	{
+		factory.GuildClient.Result = new Chat.Application.Abstractions.ChannelMembership(
+			IsMember: true, GuildId: 5, Permissions: ReadMessagesPermission);
+		var client = BuildClient(userId: 42);
+
+		var response = await client.GetAsync("/v1/channels/100/messages");
+
+		Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+		var messages = await response.Content.ReadFromJsonAsync<List<MessageResponse>>(JsonOptions);
+		Assert.Empty(messages!);
+	}
+
+	// T3.02 — default limit is 50 when more messages exist
+	[Fact]
+	public async Task Get_DefaultLimit_Returns50Messages()
+	{
+		factory.GuildClient.Result = new Chat.Application.Abstractions.ChannelMembership(
+			IsMember: true, GuildId: 5, Permissions: ReadMessagesPermission);
+		for (var i = 1; i <= 60; i++)
+			SeedMessage(factory, id: i, channelId: 100, createdAt: PastDate.AddMinutes(-i));
+		var client = BuildClient(userId: 42);
+
+		var response = await client.GetAsync("/v1/channels/100/messages");
+
+		Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+		var messages = await response.Content.ReadFromJsonAsync<List<MessageResponse>>(JsonOptions);
+		Assert.Equal(50, messages!.Count);
+	}
+
+	// T3.03 — explicit limit=10 returns exactly 10 messages
+	[Fact]
+	public async Task Get_ExplicitLimit_ReturnsExactCount()
+	{
+		factory.GuildClient.Result = new Chat.Application.Abstractions.ChannelMembership(
+			IsMember: true, GuildId: 5, Permissions: ReadMessagesPermission);
+		for (var i = 1; i <= 20; i++)
+			SeedMessage(factory, id: i, channelId: 100, createdAt: PastDate.AddMinutes(-i));
+		var client = BuildClient(userId: 42);
+
+		var response = await client.GetAsync("/v1/channels/100/messages?limit=10");
+
+		var messages = await response.Content.ReadFromJsonAsync<List<MessageResponse>>(JsonOptions);
+		Assert.Equal(10, messages!.Count);
+	}
+
+	// T3.04 & T3.06 — limit below 1 is clamped to 1
+	[Theory]
+	[InlineData(0)]
+	[InlineData(-5)]
+	public async Task Get_LimitBelowMin_IsClampedToOne(int limitValue)
+	{
+		factory.GuildClient.Result = new Chat.Application.Abstractions.ChannelMembership(
+			IsMember: true, GuildId: 5, Permissions: ReadMessagesPermission);
+		for (var i = 1; i <= 5; i++)
+			SeedMessage(factory, id: i, channelId: 100, createdAt: PastDate.AddMinutes(-i));
+		var client = BuildClient(userId: 42);
+
+		var response = await client.GetAsync($"/v1/channels/100/messages?limit={limitValue}");
+
+		Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+		var messages = await response.Content.ReadFromJsonAsync<List<MessageResponse>>(JsonOptions);
+		Assert.Single(messages!);
+	}
+
+	// T3.05 — limit above 100 is clamped to 100
+	[Fact]
+	public async Task Get_LimitAboveMax_IsClampedTo100()
+	{
+		factory.GuildClient.Result = new Chat.Application.Abstractions.ChannelMembership(
+			IsMember: true, GuildId: 5, Permissions: ReadMessagesPermission);
+		for (var i = 1; i <= 150; i++)
+			SeedMessage(factory, id: i, channelId: 100, createdAt: PastDate.AddMinutes(-i));
+		var client = BuildClient(userId: 42);
+
+		var response = await client.GetAsync("/v1/channels/100/messages?limit=200");
+
+		Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+		var messages = await response.Content.ReadFromJsonAsync<List<MessageResponse>>(JsonOptions);
+		Assert.Equal(100, messages!.Count);
+	}
+
+	// T3.08 — before_time far in the past returns empty array
+	[Fact]
+	public async Task Get_BeforeTimeFarInPast_ReturnsEmpty()
+	{
+		factory.GuildClient.Result = new Chat.Application.Abstractions.ChannelMembership(
+			IsMember: true, GuildId: 5, Permissions: ReadMessagesPermission);
+		SeedMessage(factory, id: 1, channelId: 100);
+		var client = BuildClient(userId: 42);
+
+		var farPast = Uri.EscapeDataString(
+			new DateTimeOffset(2000, 1, 1, 0, 0, 0, TimeSpan.Zero).ToString("O"));
+		var response = await client.GetAsync($"/v1/channels/100/messages?before_time={farPast}");
+
+		Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+		var messages = await response.Content.ReadFromJsonAsync<List<MessageResponse>>(JsonOptions);
+		Assert.Empty(messages!);
+	}
+
+	// T3.16 — messages are ordered by created_at DESC (newest first)
+	[Fact]
+	public async Task Get_Messages_AreReturnedNewestFirst()
+	{
+		factory.GuildClient.Result = new Chat.Application.Abstractions.ChannelMembership(
+			IsMember: true, GuildId: 5, Permissions: ReadMessagesPermission);
+		SeedMessage(factory, id: 1, channelId: 100, createdAt: PastDate.AddMinutes(-30));
+		SeedMessage(factory, id: 2, channelId: 100, createdAt: PastDate.AddMinutes(-20));
+		SeedMessage(factory, id: 3, channelId: 100, createdAt: PastDate.AddMinutes(-10));
+		var client = BuildClient(userId: 42);
+
+		var response = await client.GetAsync("/v1/channels/100/messages");
+
+		var messages = await response.Content.ReadFromJsonAsync<List<MessageResponse>>(JsonOptions);
+		Assert.Equal(3, messages!.Count);
+		Assert.Equal("3", messages[0].Id);
+		Assert.Equal("2", messages[1].Id);
+		Assert.Equal("1", messages[2].Id);
+	}
+
+	// T3.17 — editedAt is populated for edited messages
+	[Fact]
+	public async Task Get_EditedMessage_HasEditedAtPopulated()
+	{
+		factory.GuildClient.Result = new Chat.Application.Abstractions.ChannelMembership(
+			IsMember: true, GuildId: 5, Permissions: ReadMessagesPermission);
+		var edited = Message.Reconstitute(
+			id: 1, channelId: 100, authorId: 99,
+			content: "edited", replyToId: null,
+			editedAt: PastDate.AddMinutes(-5),
+			isDeleted: false, createdAt: PastDate.AddMinutes(-10));
+		factory.MessageRepository.Seed(edited);
+		var client = BuildClient(userId: 42);
+
+		var response = await client.GetAsync("/v1/channels/100/messages");
+
+		var messages = await response.Content.ReadFromJsonAsync<List<MessageResponse>>(JsonOptions);
+		var msg = Assert.Single(messages!);
+		Assert.NotNull(msg.EditedAt);
+	}
+
+	// T3.18 — nonce is always null in history responses
+	[Fact]
+	public async Task Get_Messages_NonceIsAlwaysNull()
+	{
+		factory.GuildClient.Result = new Chat.Application.Abstractions.ChannelMembership(
+			IsMember: true, GuildId: 5, Permissions: ReadMessagesPermission);
+		SeedMessage(factory, id: 1, channelId: 100);
+		var client = BuildClient(userId: 42);
+
+		var response = await client.GetAsync("/v1/channels/100/messages");
+
+		var messages = await response.Content.ReadFromJsonAsync<List<MessageResponse>>(JsonOptions);
+		Assert.All(messages!, m => Assert.Null(m.Nonce));
+	}
 }

--- a/services/chat/tests/Chat.UnitTests/Application/GetChannelMessagesHandlerTests.cs
+++ b/services/chat/tests/Chat.UnitTests/Application/GetChannelMessagesHandlerTests.cs
@@ -1,0 +1,128 @@
+using Chat.Application.Abstractions;
+using Chat.Application.Abstractions.Messaging;
+using Chat.Application.Features.Messages.Common;
+using Chat.Application.Features.Messages.GetChannelMessages;
+using Chat.Domain.Messages;
+using Chat.Domain.Results;
+using Chat.UnitTests.Fakes;
+using Xunit;
+
+namespace Chat.UnitTests.Application;
+
+public sealed class GetChannelMessagesHandlerTests
+{
+	private const long ReadMessagesPermission = 1L << 1;
+	private const long AdministratorPermission = 1L << 8;
+
+	private sealed record Harness(
+		FakeCurrentUser CurrentUser,
+		FakeGuildClient GuildClient,
+		FakeMessageRepository Repository,
+		FakeClock Clock);
+
+	private static (Harness Harness, IQueryHandler<GetChannelMessagesQuery, Result<IReadOnlyList<MessageResponse>>> Handler)
+		BuildHandler(long userId = 42)
+	{
+		var currentUser = new FakeCurrentUser { UserId = userId };
+		var guildClient = new FakeGuildClient();
+		var repository = new FakeMessageRepository();
+		var clock = new FakeClock();
+
+		var handler = HandlerFactory.CreateQuery<GetChannelMessagesQuery, Result<IReadOnlyList<MessageResponse>>>(
+			currentUser, guildClient, repository, clock);
+
+		return (new Harness(currentUser, guildClient, repository, clock), handler);
+	}
+
+	private static Message SeedMessage(FakeMessageRepository repo, long id, long channelId, DateTimeOffset createdAt, bool isDeleted = false)
+	{
+		var message = Message.Reconstitute(
+			id: id, channelId: channelId, authorId: 99,
+			content: "hello", replyToId: null, editedAt: null,
+			isDeleted: isDeleted, createdAt: createdAt);
+		repo.Seed(message);
+		return message;
+	}
+
+	[Fact]
+	public async Task ChannelNotFound_ReturnsChannelNotFound()
+	{
+		var (h, handler) = BuildHandler();
+		h.GuildClient.Result = null;
+
+		var result = await handler.HandleAsync(new GetChannelMessagesQuery(ChannelId: 100, BeforeTime: null, Limit: 50));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal(MessageFailures.ChannelNotFound, result.Error);
+	}
+
+	[Fact]
+	public async Task NotAMember_ReturnsNotAMember()
+	{
+		var (h, handler) = BuildHandler();
+		h.GuildClient.Result = new ChannelMembership(IsMember: false, GuildId: 5, Permissions: ReadMessagesPermission);
+
+		var result = await handler.HandleAsync(new GetChannelMessagesQuery(ChannelId: 100, BeforeTime: null, Limit: 50));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal(MessageFailures.NotAMember, result.Error);
+	}
+
+	[Fact]
+	public async Task MemberWithoutReadPermission_ReturnsMissingReadPermission()
+	{
+		var (h, handler) = BuildHandler();
+		h.GuildClient.Result = new ChannelMembership(IsMember: true, GuildId: 5, Permissions: 0);
+
+		var result = await handler.HandleAsync(new GetChannelMessagesQuery(ChannelId: 100, BeforeTime: null, Limit: 50));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal(MessageFailures.MissingReadPermission, result.Error);
+	}
+
+	[Fact]
+	public async Task HappyPath_ReturnsMessages_ExcludesDeleted()
+	{
+		var (h, handler) = BuildHandler();
+		h.GuildClient.Result = new ChannelMembership(IsMember: true, GuildId: 5, Permissions: ReadMessagesPermission);
+
+		var anchor = new DateTimeOffset(2026, 1, 1, 12, 0, 0, TimeSpan.Zero);
+		SeedMessage(h.Repository, id: 1, channelId: 100, createdAt: anchor.AddMinutes(-10));
+		SeedMessage(h.Repository, id: 2, channelId: 100, createdAt: anchor.AddMinutes(-5));
+		SeedMessage(h.Repository, id: 3, channelId: 100, createdAt: anchor.AddMinutes(-2), isDeleted: true);
+
+		var result = await handler.HandleAsync(new GetChannelMessagesQuery(ChannelId: 100, BeforeTime: anchor, Limit: 50));
+
+		Assert.True(result.Succeeded);
+		Assert.Equal(2, result.Value.Count);
+		Assert.DoesNotContain(result.Value, m => m.Id == "3");
+	}
+
+	[Fact]
+	public async Task NullBeforeTime_DefaultsToClockNow()
+	{
+		var (h, handler) = BuildHandler();
+		h.GuildClient.Result = new ChannelMembership(IsMember: true, GuildId: 5, Permissions: ReadMessagesPermission);
+
+		var now = new DateTimeOffset(2026, 1, 1, 12, 0, 0, TimeSpan.Zero);
+		h.Clock.Set(now);
+		SeedMessage(h.Repository, id: 1, channelId: 100, createdAt: now.AddMinutes(-1));
+
+		var result = await handler.HandleAsync(new GetChannelMessagesQuery(ChannelId: 100, BeforeTime: null, Limit: 50));
+
+		Assert.True(result.Succeeded);
+		Assert.Single(result.Value);
+	}
+
+	[Fact]
+	public async Task Administrator_BypassesReadPermissionCheck()
+	{
+		var (h, handler) = BuildHandler();
+		h.GuildClient.Result = new ChannelMembership(IsMember: true, GuildId: 5, Permissions: AdministratorPermission);
+		h.Clock.Set(new DateTimeOffset(2026, 1, 1, 12, 0, 0, TimeSpan.Zero));
+
+		var result = await handler.HandleAsync(new GetChannelMessagesQuery(ChannelId: 100, BeforeTime: null, Limit: 50));
+
+		Assert.True(result.Succeeded);
+	}
+}

--- a/services/chat/tests/Chat.UnitTests/Fakes/FakeMessageRepository.cs
+++ b/services/chat/tests/Chat.UnitTests/Fakes/FakeMessageRepository.cs
@@ -48,6 +48,16 @@ public sealed class FakeMessageRepository : IMessageRepository
 		return Task.CompletedTask;
 	}
 
+	public Task<IReadOnlyList<Message>> GetChannelMessagesAsync(long channelId, DateTimeOffset beforeTime, int limit, CancellationToken ct)
+	{
+		var result = _saved
+			.Where(m => m.ChannelId == channelId && m.CreatedAt < beforeTime && !m.IsDeleted)
+			.OrderByDescending(m => m.CreatedAt)
+			.Take(limit)
+			.ToList();
+		return Task.FromResult<IReadOnlyList<Message>>(result);
+	}
+
 	public void Seed(Message message) => _saved.Add(message);
 
 	public List<Message> Updated { get; } = [];

--- a/services/chat/tests/Chat.UnitTests/Fakes/HandlerFactory.cs
+++ b/services/chat/tests/Chat.UnitTests/Fakes/HandlerFactory.cs
@@ -25,6 +25,15 @@ internal static class HandlerFactory
 		return (ICommandHandler<TCommand, TResult>)Activator.CreateInstance(handlerType, ctorArgs)!;
 	}
 
+	internal static IQueryHandler<TQuery, TResult> CreateQuery<TQuery, TResult>(
+		params object[] ctorArgs)
+		where TQuery : class, IQuery<TResult>
+		where TResult : class
+	{
+		var handlerType = FindImplementer(typeof(IQueryHandler<,>).MakeGenericType(typeof(TQuery), typeof(TResult)));
+		return (IQueryHandler<TQuery, TResult>)Activator.CreateInstance(handlerType, ctorArgs)!;
+	}
+
 	private static Type FindImplementer(Type closedInterface)
 	{
 		return ApplicationAssembly.GetTypes()


### PR DESCRIPTION
Implement message **history** feature.

## This PR contains:
- GET `/channels/{channelId}/messages` endpoint with cursor-based pagination (before_time + limit clamped to 1–100, default 50)
- query handler returning messages ordered by created_at DESC, filtered on soft-deleted rows
- DB prepared statement and repository method for channel message history
- functional tests covering auth, authorization, pagination clamping, ordering, editedAt and nonce shape

> - [x]  Depends on #218 — must be merged first. This PR was based on `feat/chat/message-mutation` before the tests commits.

Close #68