### PR TITLE
Feat/chat/typing

### DIFF
--- a/services/chat/Tiltfile
+++ b/services/chat/Tiltfile
@@ -44,6 +44,7 @@ local_resource(
         '-e BackendConfiguration__BaseUrl=' + BASE_URL + ' ' +
         '-e BackendConfiguration__BaseApiUrl=' + BASE_API_URL + ' ' +
         '-e Services__GuildService=http://guild:8080 ' +
+        '-e Services__UserService=http://user:8080 ' +
         '-e DOTNET_USE_POLLING_FILE_WATCHER=1 ' +
         '-e Jwt__SecretKey=' + JWT_SECRET + ' ' +
         '-v $(pwd)/src:/app/src ' +

--- a/services/chat/compose.yaml
+++ b/services/chat/compose.yaml
@@ -44,6 +44,7 @@ services:
       BackendConfiguration__BaseUrl: ${BASE_URL}
       BackendConfiguration__BaseApiUrl: ${BASE_API_URL}
       Services__GuildService: http://guild:8080
+      Services__UserService: http://user:8080
       Jwt__SecretKey: ${JWT_SECRET}
     depends_on:
       rabbitmq:

--- a/services/chat/src/Chat.Application/Abstractions/IUserClient.cs
+++ b/services/chat/src/Chat.Application/Abstractions/IUserClient.cs
@@ -5,4 +5,4 @@ public interface IUserClient
 	Task<UsersRelationship?> GetUsersRelationship(long callerId, long recipientId, CancellationToken ct);
 }
 
-public sealed record UsersRelationship(string Status, DateTimeOffset Since);
+public sealed record UsersRelationship(string Status, DateTimeOffset? Since);

--- a/services/chat/src/Chat.Application/Abstractions/IUserClient.cs
+++ b/services/chat/src/Chat.Application/Abstractions/IUserClient.cs
@@ -1,0 +1,8 @@
+namespace Chat.Application.Abstractions;
+
+public interface IUserClient
+{
+	Task<UsersRelationship?> GetUsersRelationship(long callerId, long recipientId, CancellationToken ct);
+}
+
+public sealed record UsersRelationship(string Status, DateTimeOffset Since);

--- a/services/chat/src/Chat.Domain/Results/MessageFailures.cs
+++ b/services/chat/src/Chat.Domain/Results/MessageFailures.cs
@@ -51,8 +51,8 @@ public static class MessageFailures
 		new("Message.UserNotFound", "User not found.");
 
 	public static readonly Failure RecipientNotFriend =
-		new("Messages.RecipientNotFriend", "You must be friends to send direct message");
+		new("Message.RecipientNotFriend", "You must be friends to send direct message");
 
 	public static readonly Failure RecipientBlocked =
-		new("Messages.RecipientBlocked", "You can't send messages to blocked user");
+		new("Message.RecipientBlocked", "You can't send messages to blocked user");
 }

--- a/services/chat/src/Chat.Domain/Results/MessageFailures.cs
+++ b/services/chat/src/Chat.Domain/Results/MessageFailures.cs
@@ -51,8 +51,8 @@ public static class MessageFailures
 		new("Message.UserNotFound", "User not found.");
 
 	public static readonly Failure RecipientNotFriend =
-		new("Message.RecipientNotFriend", "You must be friends to send direct message");
+		new("Message.RecipientNotFriend", "You must be friends to send direct message.");
 
 	public static readonly Failure RecipientBlocked =
-		new("Message.RecipientBlocked", "You can't send messages to blocked user");
+		new("Message.RecipientBlocked", "You can't send messages to blocked user.");
 }

--- a/services/chat/src/Chat.Domain/Results/MessageFailures.cs
+++ b/services/chat/src/Chat.Domain/Results/MessageFailures.cs
@@ -46,4 +46,13 @@ public static class MessageFailures
 
 	public static readonly Failure MissingReadPermission =
 		new("Message.MissingReadPermission", "Caller lacks READ_MESSAGES permission on this channel.");
+
+	public static readonly Failure UserNotFound =
+		new("Message.UserNotFound", "User not found.");
+
+	public static readonly Failure RecipientNotFriend =
+		new("Messages.RecipientNotFriend", "You must be friends to send direct message");
+
+	public static readonly Failure RecipientBlocked =
+		new("Messages.RecipientBlocked", "You can't send messages to blocked user");
 }

--- a/services/chat/src/Chat.Infrastructure/DependencyInjection.cs
+++ b/services/chat/src/Chat.Infrastructure/DependencyInjection.cs
@@ -74,6 +74,7 @@ public static class DependencyInjection
 			});
 		});
 
+		services.AddMemoryCache();
 		services.AddHttpContextAccessor();
 
 		services.AddScoped<IEventBus, EventBus>();

--- a/services/chat/src/Chat.Infrastructure/DependencyInjection.cs
+++ b/services/chat/src/Chat.Infrastructure/DependencyInjection.cs
@@ -81,12 +81,19 @@ public static class DependencyInjection
 		services.AddSingleton<ISnowflakeIdGenerator, SnowflakeIdGenerator>();
 		services.AddScoped<ICurrentUser, CurrentUser>();
 
-		services.AddHttpClient<IGuildClient, GuildClient>((sp, c) =>
+		RegisterAndConfHttpClient<IGuildClient, GuildClient>(services);
+		RegisterAndConfHttpClient<IUserClient, UserClient>(services);
+		return services;
+	}
+
+	private static void RegisterAndConfHttpClient<TInterface, T>(IServiceCollection services)
+		where TInterface: class
+		where T: class, TInterface
+	{
+		services.AddHttpClient<TInterface, T>((sp, c) =>
 		{
 			var opts = sp.GetRequiredService<IOptions<ServicesOptions>>().Value;
 			c.BaseAddress = new Uri(opts.GuildService.TrimEnd('/') + "/internal/");
 		});
-
-		return services;
 	}
 }

--- a/services/chat/src/Chat.Infrastructure/DependencyInjection.cs
+++ b/services/chat/src/Chat.Infrastructure/DependencyInjection.cs
@@ -81,19 +81,21 @@ public static class DependencyInjection
 		services.AddSingleton<ISnowflakeIdGenerator, SnowflakeIdGenerator>();
 		services.AddScoped<ICurrentUser, CurrentUser>();
 
-		RegisterAndConfHttpClient<IGuildClient, GuildClient>(services);
-		RegisterAndConfHttpClient<IUserClient, UserClient>(services);
+		RegisterAndConfHttpClient<IGuildClient, GuildClient>(services, opts => opts.GuildService);
+		RegisterAndConfHttpClient<IUserClient, UserClient>(services, opts => opts.UserService);
 		return services;
 	}
 
-	private static void RegisterAndConfHttpClient<TInterface, T>(IServiceCollection services)
+	private static void RegisterAndConfHttpClient<TInterface, T>(
+		IServiceCollection services,
+		Func<ServicesOptions, string> selectBaseUrl)
 		where TInterface: class
 		where T: class, TInterface
 	{
 		services.AddHttpClient<TInterface, T>((sp, c) =>
 		{
 			var opts = sp.GetRequiredService<IOptions<ServicesOptions>>().Value;
-			c.BaseAddress = new Uri(opts.GuildService.TrimEnd('/') + "/internal/");
+			c.BaseAddress = new Uri(selectBaseUrl(opts).TrimEnd('/') + "/internal/");
 		});
 	}
 }

--- a/services/chat/src/Chat.Infrastructure/Http/UserClient.cs
+++ b/services/chat/src/Chat.Infrastructure/Http/UserClient.cs
@@ -1,0 +1,29 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Chat.Application.Abstractions;
+
+namespace Chat.Infrastructure.Http;
+
+internal sealed class UserClient(HttpClient http) : IUserClient
+{
+	private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web)
+	{
+		PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+	};
+
+	public async Task<UsersRelationship?> GetUsersRelationship(long callerId, long recipientId, CancellationToken ct)
+	{
+		try
+		{
+			return await http.GetFromJsonAsync<UsersRelationship>(
+				$"users/{callerId}/realtionship-with/{recipientId}", JsonOptions, ct);
+		}
+		// GetFromJsonAsync throws on non-2xx; map 404 to null so the handler's
+		// `relationship is null -> UserNotFound` branch fires as intended
+		catch (HttpRequestException e) when (e.StatusCode == HttpStatusCode.NotFound)
+		{
+			return null;
+		}
+	}
+}

--- a/services/chat/src/Chat.Infrastructure/Http/UserClient.cs
+++ b/services/chat/src/Chat.Infrastructure/Http/UserClient.cs
@@ -17,7 +17,7 @@ internal sealed class UserClient(HttpClient http) : IUserClient
 		try
 		{
 			return await http.GetFromJsonAsync<UsersRelationship>(
-				$"users/{callerId}/realtionship-with/{recipientId}", JsonOptions, ct);
+				$"users/{callerId}/relationship-with/{recipientId}", JsonOptions, ct);
 		}
 		// GetFromJsonAsync throws on non-2xx; map 404 to null so the handler's
 		// `relationship is null -> UserNotFound` branch fires as intended

--- a/services/chat/src/Chat.Infrastructure/Options/ServicesOptions.cs
+++ b/services/chat/src/Chat.Infrastructure/Options/ServicesOptions.cs
@@ -5,4 +5,5 @@ namespace Chat.Infrastructure.Options;
 public sealed class ServicesOptions
 {
 	[Required] public required string GuildService { get; init; }
+	[Required] public required string UserService { get; init; }
 }

--- a/services/chat/src/Chat.Presentation/Hubs/ChatHub.cs
+++ b/services/chat/src/Chat.Presentation/Hubs/ChatHub.cs
@@ -1,10 +1,10 @@
-using System.Collections.Concurrent;
 using Chat.Application.Abstractions;
 using Chat.Application.Abstractions.Authentication;
 using Chat.Application.Contracts;
 using Chat.Domain.Results;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Caching.Memory;
 
 namespace Chat.Presentation.Hubs;
 
@@ -15,7 +15,8 @@ public sealed class ChatHub(
 	ICurrentUser currentUser,
 	UserConnectionTracker connectionTracker,
 	IEventBus eventBus,
-	IClock clock) : Hub<IChatClient>
+	IClock clock,
+	IMemoryCache cache) : Hub<IChatClient>
 {
 	private const long SendMessages = 1L << 0;
 	private const long ReadMessages = 1L << 1;
@@ -38,8 +39,6 @@ public sealed class ChatHub(
 			await eventBus.PublishAsync(new UserOffline(currentUser.UserId), CancellationToken.None);
 		await base.OnDisconnectedAsync(exception);
 	}
-
-	private static readonly ConcurrentDictionary<(long, string, long), DateTimeOffset> _ratelimit = new();
 
 	public async Task JoinChannel(long channelId)
 	{
@@ -66,11 +65,10 @@ public sealed class ChatHub(
 	public async Task Typing(string scope, long id)
 	{
 		var now = clock.UtcNow;
-		var key = (currentUser.UserId, scope, id);
+		var cacheKey = $"typing:{currentUser.UserId}:{scope}:{id}";
 
-		if (_ratelimit.TryGetValue(key, out var until) && until > now)
+		if (cache.TryGetValue(cacheKey, out DateTimeOffset until) && until > now)
 			return;
-		_ratelimit[key] = now.AddSeconds(TypingRateLimitDuration);
 
 		var err = scope switch
 		{
@@ -84,6 +82,10 @@ public sealed class ChatHub(
 			await Clients.Caller.Error(err.Code, err.Message);
 			return;
 		}
+
+		// ? Expiry stored as value so the check above uses IClock (testable); the cache TTL only drives memory eviction
+		var expiry = now.AddSeconds(TypingRateLimitDuration);
+		cache.Set(cacheKey, expiry, TimeSpan.FromSeconds(TypingRateLimitDuration));
 
 		var recipient = (scope == "channel") ? Clients.OthersInGroup($"channel:{id}") : Clients.User(id.ToString());
 		await recipient.TypingStarted(currentUser.UserId.ToString(), scope, id.ToString(), now.AddSeconds(TypingExpirationDelay));
@@ -110,9 +112,9 @@ public sealed class ChatHub(
 
 		return relationship.Status switch
 		{
-			"accepted"                         => null,
+			"accepted"                           => null,
 			"blocked_by_me" or "blocked_by_them" => MessageFailures.RecipientBlocked,
-			_                                  => MessageFailures.RecipientNotFriend
+			_                            => MessageFailures.RecipientNotFriend
 		};
 	}
 }

--- a/services/chat/src/Chat.Presentation/Hubs/ChatHub.cs
+++ b/services/chat/src/Chat.Presentation/Hubs/ChatHub.cs
@@ -1,6 +1,8 @@
+using System.Collections.Concurrent;
 using Chat.Application.Abstractions;
 using Chat.Application.Abstractions.Authentication;
 using Chat.Application.Contracts;
+using Chat.Domain.Results;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.SignalR;
 
@@ -9,12 +11,19 @@ namespace Chat.Presentation.Hubs;
 [Authorize]
 public sealed class ChatHub(
 	IGuildClient guildClient,
+	IUserClient userClient,
 	ICurrentUser currentUser,
+	UserConnectionTracker connectionTracker,
 	IEventBus eventBus,
-	UserConnectionTracker connectionTracker) : Hub<IChatClient>
+	IClock clock) : Hub<IChatClient>
 {
+	private const long SendMessages = 1L << 0;
 	private const long ReadMessages = 1L << 1;
 	private const long Administrator = 1L << 8;
+
+	// ? In seconds
+	private const int TypingRateLimitDuration = 3;
+	private const int TypingExpirationDelay = 8;
 
 	public override async Task OnConnectedAsync()
 	{
@@ -29,6 +38,8 @@ public sealed class ChatHub(
 			await eventBus.PublishAsync(new UserOffline(currentUser.UserId), CancellationToken.None);
 		await base.OnDisconnectedAsync(exception);
 	}
+
+	private static readonly ConcurrentDictionary<(long, string, long), DateTimeOffset> _ratelimit = new();
 
 	public async Task JoinChannel(long channelId)
 	{
@@ -51,4 +62,57 @@ public sealed class ChatHub(
 
 	public Task LeaveChannel(long channelId) =>
 		Groups.RemoveFromGroupAsync(Context.ConnectionId, $"channel:{channelId}");
+
+	public async Task Typing(string scope, long id)
+	{
+		var now = clock.UtcNow;
+		var key = (currentUser.UserId, scope, id);
+
+		if (_ratelimit.TryGetValue(key, out var until) && until > now)
+			return;
+		_ratelimit[key] = now.AddSeconds(TypingRateLimitDuration);
+
+		var err = scope switch
+		{
+			"channel" => await ValidateChannelTypingAsync(id),
+			"dm"      => await ValidateDmTypingAsync(id),
+			_         => new Failure("Typing.InvalidScope", "Invalid scope provided")
+		};
+
+		if (err is not null)
+		{
+			await Clients.Caller.Error(err.Code, err.Message);
+			return;
+		}
+
+		var recipient = (scope == "channel") ? Clients.OthersInGroup($"channel:{id}") : Clients.User(id.ToString());
+		await recipient.TypingStarted(currentUser.UserId.ToString(), scope, id.ToString(), now.AddSeconds(TypingExpirationDelay));
+	}
+
+	private async Task<Failure?> ValidateChannelTypingAsync(long channelId)
+	{
+		var membership = await guildClient.GetMembershipAsync(channelId, currentUser.UserId, Context.ConnectionAborted);
+		if (membership is null)
+			return MessageFailures.ChannelNotFound;
+
+		if (!membership.IsMember)
+			return MessageFailures.NotAMember;
+		if ((membership.Permissions & (SendMessages | Administrator)) == 0)
+			return MessageFailures.MissingSendPermission;
+		return null;
+	}
+
+	private async Task<Failure?> ValidateDmTypingAsync(long partnerId)
+	{
+		var relationship = await userClient.GetUsersRelationship(currentUser.UserId, partnerId, Context.ConnectionAborted);
+		if (relationship is null)
+			return MessageFailures.UserNotFound;
+
+		return relationship.Status switch
+		{
+			"accepted"                         => null,
+			"blocked_by_me" or "blocked_by_them" => MessageFailures.RecipientBlocked,
+			_                                  => MessageFailures.RecipientNotFriend
+		};
+	}
 }

--- a/services/chat/src/Chat.Presentation/Hubs/ChatHub.cs
+++ b/services/chat/src/Chat.Presentation/Hubs/ChatHub.cs
@@ -22,7 +22,7 @@ public sealed class ChatHub(
 	private const long ReadMessages = 1L << 1;
 	private const long Administrator = 1L << 8;
 
-	// ? In seconds
+	// In seconds
 	private const int TypingRateLimitDuration = 3;
 	private const int TypingExpirationDelay = 8;
 
@@ -83,7 +83,7 @@ public sealed class ChatHub(
 			return;
 		}
 
-		// ? Expiry stored as value so the check above uses IClock (testable); the cache TTL only drives memory eviction
+ 		// Store expiry in the value so the check above uses IClock (testable); cache TTL is only for eviction.
 		var expiry = now.AddSeconds(TypingRateLimitDuration);
 		cache.Set(cacheKey, expiry, TimeSpan.FromSeconds(TypingRateLimitDuration));
 

--- a/services/chat/src/Chat.Presentation/Hubs/IChatClient.cs
+++ b/services/chat/src/Chat.Presentation/Hubs/IChatClient.cs
@@ -7,6 +7,9 @@ public interface IChatClient
 	Task ReceiveMessage(MessageResponse message);
 	Task MessageEdited(MessageEditedEvent evt);
 	Task MessageDeleted(MessageDeletedEvent evt);
+
+	Task TypingStarted(string userId, string scope, string id, DateTimeOffset expiresAt);
+
 	Task GuildJoined(string guildId, string guildName);
 	Task GuildLeft(string guildId);
 	Task Error(string code, string message);

--- a/services/chat/tests/Chat.FunctionalTests/Features/TypingTests.cs
+++ b/services/chat/tests/Chat.FunctionalTests/Features/TypingTests.cs
@@ -378,7 +378,7 @@ public sealed class DmTypingTests(ChatApiFactory factory)
 		Assert.Equal("Message.UserNotFound", code);
 	}
 
-	// T4.13 & T4.14 — blocked relationship → Error("Messages.RecipientBlocked", ...)
+	// T4.13 & T4.14 — blocked relationship → Error("Message.RecipientBlocked", ...)
 	[Theory]
 	[InlineData("blocked_by_me")]
 	[InlineData("blocked_by_them")]
@@ -400,10 +400,10 @@ public sealed class DmTypingTests(ChatApiFactory factory)
 		await conn.InvokeAsync("Typing", "dm", partnerId);
 
 		var code = await errTcs.Task.WaitAsync(TimeSpan.FromSeconds(3));
-		Assert.Equal("Messages.RecipientBlocked", code);
+		Assert.Equal("Message.RecipientBlocked", code);
 	}
 
-	// T4.15 — pending relationship → Error("Messages.RecipientNotFriend", ...)
+	// T4.15 — pending relationship → Error("Message.RecipientNotFriend", ...)
 	[Fact]
 	public async Task Typing_DmPending_SendsError()
 	{
@@ -420,7 +420,7 @@ public sealed class DmTypingTests(ChatApiFactory factory)
 		await conn.InvokeAsync("Typing", "dm", UserDmPartnerPend);
 
 		var code = await errTcs.Task.WaitAsync(TimeSpan.FromSeconds(3));
-		Assert.Equal("Messages.RecipientNotFriend", code);
+		Assert.Equal("Message.RecipientNotFriend", code);
 	}
 }
 

--- a/services/chat/tests/Chat.FunctionalTests/Features/TypingTests.cs
+++ b/services/chat/tests/Chat.FunctionalTests/Features/TypingTests.cs
@@ -8,9 +8,9 @@ namespace Chat.FunctionalTests.Features;
 // ─────────────────────────────────────────────────────────────────────────────
 // T4.01 – T4.10 · Typing — channel scope
 //
-// _ratelimit is a static ConcurrentDictionary inside ChatHub that persists for
-// the entire process lifetime. every test uses unique (userId, channelId) pairs
-// so no two tests can share a rate-limit entry.
+// Rate limiting is backed by an IMemoryCache singleton inside the Chat service that
+// persists for the entire process lifetime. Every test uses unique (userId, scope, id)
+// triples so no two tests can share a rate-limit entry.
 // ─────────────────────────────────────────────────────────────────────────────
 public sealed class ChannelTypingTests(ChatApiFactory factory)
 	: IClassFixture<ChatApiFactory>, IAsyncLifetime

--- a/services/chat/tests/Chat.FunctionalTests/Features/TypingTests.cs
+++ b/services/chat/tests/Chat.FunctionalTests/Features/TypingTests.cs
@@ -1,0 +1,465 @@
+using Chat.Application.Abstractions;
+using Chat.FunctionalTests.Infrastructure;
+using Microsoft.AspNetCore.SignalR.Client;
+using Xunit;
+
+namespace Chat.FunctionalTests.Features;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// T4.01 – T4.10 · Typing — channel scope
+//
+// _ratelimit is a static ConcurrentDictionary inside ChatHub that persists for
+// the entire process lifetime. every test uses unique (userId, channelId) pairs
+// so no two tests can share a rate-limit entry.
+// ─────────────────────────────────────────────────────────────────────────────
+public sealed class ChannelTypingTests(ChatApiFactory factory)
+	: IClassFixture<ChatApiFactory>, IAsyncLifetime
+{
+	private const long SendMessages  = 1L << 0;
+	private const long ReadMessages  = 1L << 1;
+	private const long Administrator = 1L << 8;
+
+	// unique (userId, channelId) per test — static rate-limit isolation
+	private const long UserHappyPath       = 7_001;
+	private const long SubHappyPath        = 7_002;
+	private const long ChHappyPath         = 101_001;
+
+	private const long UserAdminOnly       = 7_003;
+	private const long SubAdminOnly        = 7_004;
+	private const long ChAdminOnly         = 101_003;
+
+	private const long UserChNotFound      = 7_005;
+	private const long ChNotFound          = 101_005;
+
+	private const long UserNotAMember      = 7_006;
+	private const long ChNotAMember        = 101_006;
+
+	private const long UserNoSend          = 7_007;
+	private const long ChNoSend            = 101_007;
+
+	private const long UserRateLimit       = 7_008;
+	private const long SubRateLimit        = 7_009;
+	private const long ChRateLimit         = 101_008;
+
+	private const long UserRateLimitExpiry = 7_010;
+	private const long SubRateLimitExpiry  = 7_011;
+	private const long ChRateLimitExpiry   = 101_010;
+
+	private const long UserRateLimitPerCh  = 7_012;
+	private const long SubRateLimitPerChA  = 7_013;
+	private const long SubRateLimitPerChB  = 7_014;
+	private const long ChRateLimitA        = 101_012;
+	private const long ChRateLimitB        = 101_013;
+
+	private static readonly DateTimeOffset ClockAnchor =
+		new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+	public Task InitializeAsync()
+	{
+		factory.GuildClient.Result = null;
+		factory.UserClient.Reset();
+		factory.Clock.Set(ClockAnchor);
+		return Task.CompletedTask;
+	}
+
+	public Task DisposeAsync() => Task.CompletedTask;
+
+	// T4.01 & T4.03 & T4.04 — subscriber receives TypingStarted with correct
+	// payload; sender (also in group) does not receive
+	[Fact]
+	public async Task Typing_ValidChannel_SubscriberReceivesTypingStarted_SenderDoesNot()
+	{
+		factory.GuildClient.Result = new ChannelMembership(
+			IsMember: true, GuildId: 5, Permissions: SendMessages | ReadMessages);
+
+		var senderToken = TestTokens.Issue(ChatApiFactory.JwtSecret, UserHappyPath);
+		var subToken    = TestTokens.Issue(ChatApiFactory.JwtSecret, SubHappyPath);
+
+		await using var sender     = HubConnectionHelper.Build(factory, senderToken);
+		await using var subscriber = HubConnectionHelper.Build(factory, subToken);
+
+		var subReceived     = new TaskCompletionSource<(string u, string s, string i, DateTimeOffset e)>();
+		var senderReceived  = 0;
+
+		subscriber.On<string, string, string, DateTimeOffset>("TypingStarted",
+			(u, s, i, e) => subReceived.TrySetResult((u, s, i, e)));
+		sender.On<string, string, string, DateTimeOffset>("TypingStarted",
+			(_, _, _, _) => Interlocked.Increment(ref senderReceived));
+
+		await subscriber.StartAsync();
+		await subscriber.InvokeAsync("JoinChannel", ChHappyPath);
+
+		await sender.StartAsync();
+		await sender.InvokeAsync("JoinChannel", ChHappyPath);
+
+		await sender.InvokeAsync("Typing", "channel", ChHappyPath);
+
+		var (userId, scope, id, expiresAt) =
+			await subReceived.Task.WaitAsync(TimeSpan.FromSeconds(3));
+
+		Assert.Equal(UserHappyPath.ToString(), userId);
+		Assert.Equal("channel", scope);
+		Assert.Equal(ChHappyPath.ToString(), id);
+		Assert.Equal(ClockAnchor.AddSeconds(8), expiresAt);
+		Assert.Equal(0, senderReceived);
+	}
+
+	// T4.02 — ADMINISTRATOR bit alone grants send access
+	[Fact]
+	public async Task Typing_AdministratorPermission_SubscriberReceivesTypingStarted()
+	{
+		factory.GuildClient.Result = new ChannelMembership(
+			IsMember: true, GuildId: 5, Permissions: Administrator);
+
+		var senderToken = TestTokens.Issue(ChatApiFactory.JwtSecret, UserAdminOnly);
+		var subToken    = TestTokens.Issue(ChatApiFactory.JwtSecret, SubAdminOnly);
+
+		await using var sender     = HubConnectionHelper.Build(factory, senderToken);
+		await using var subscriber = HubConnectionHelper.Build(factory, subToken);
+
+		var tcs = new TaskCompletionSource<bool>();
+		subscriber.On<string, string, string, DateTimeOffset>("TypingStarted",
+			(_, _, _, _) => tcs.TrySetResult(true));
+
+		await subscriber.StartAsync();
+		await subscriber.InvokeAsync("JoinChannel", ChAdminOnly);
+
+		await sender.StartAsync();
+		await sender.InvokeAsync("Typing", "channel", ChAdminOnly);
+
+		await tcs.Task.WaitAsync(TimeSpan.FromSeconds(3));
+	}
+
+	// T4.05 — membership null → Error("Message.ChannelNotFound", ...)
+	[Fact]
+	public async Task Typing_ChannelNotFound_SendsError()
+	{
+		factory.GuildClient.Result = null;
+
+		var token = TestTokens.Issue(ChatApiFactory.JwtSecret, UserChNotFound);
+		await using var conn = HubConnectionHelper.Build(factory, token);
+
+		var errTcs = new TaskCompletionSource<string>();
+		conn.On<string, string>("Error", (code, _) => errTcs.TrySetResult(code));
+
+		await conn.StartAsync();
+		await conn.InvokeAsync("Typing", "channel", ChNotFound);
+
+		var code = await errTcs.Task.WaitAsync(TimeSpan.FromSeconds(3));
+		Assert.Equal("Message.ChannelNotFound", code);
+	}
+
+	// T4.06 — Not a member → Error("Message.NotAMember", ...)
+	[Fact]
+	public async Task Typing_NotAMember_SendsError()
+	{
+		factory.GuildClient.Result = new ChannelMembership(
+			IsMember: false, GuildId: 5, Permissions: SendMessages | ReadMessages);
+
+		var token = TestTokens.Issue(ChatApiFactory.JwtSecret, UserNotAMember);
+		await using var conn = HubConnectionHelper.Build(factory, token);
+
+		var errTcs = new TaskCompletionSource<string>();
+		conn.On<string, string>("Error", (code, _) => errTcs.TrySetResult(code));
+
+		await conn.StartAsync();
+		await conn.InvokeAsync("Typing", "channel", ChNotAMember);
+
+		var code = await errTcs.Task.WaitAsync(TimeSpan.FromSeconds(3));
+		Assert.Equal("Message.NotAMember", code);
+	}
+
+	// T4.07 — No permissions → Error("Message.MissingSendPermission", ...)
+	[Fact]
+	public async Task Typing_MissingSendPermission_SendsError()
+	{
+		factory.GuildClient.Result = new ChannelMembership(
+			IsMember: true, GuildId: 5, Permissions: ReadMessages);
+
+		var token = TestTokens.Issue(ChatApiFactory.JwtSecret, UserNoSend);
+		await using var conn = HubConnectionHelper.Build(factory, token);
+
+		var errTcs = new TaskCompletionSource<string>();
+		conn.On<string, string>("Error", (code, _) => errTcs.TrySetResult(code));
+
+		await conn.StartAsync();
+		await conn.InvokeAsync("Typing", "channel", ChNoSend);
+
+		var code = await errTcs.Task.WaitAsync(TimeSpan.FromSeconds(3));
+		Assert.Equal("Message.MissingSendPermission", code);
+	}
+
+	// T4.08 — second Typing within the 3-second window is silently ignored
+	[Fact]
+	public async Task Typing_SecondCallWithinRateLimitWindow_IsIgnored()
+	{
+		factory.GuildClient.Result = new ChannelMembership(
+			IsMember: true, GuildId: 5, Permissions: SendMessages | ReadMessages);
+
+		var senderToken = TestTokens.Issue(ChatApiFactory.JwtSecret, UserRateLimit);
+		var subToken    = TestTokens.Issue(ChatApiFactory.JwtSecret, SubRateLimit);
+
+		await using var sender     = HubConnectionHelper.Build(factory, senderToken);
+		await using var subscriber = HubConnectionHelper.Build(factory, subToken);
+
+		var count = 0;
+		subscriber.On<string, string, string, DateTimeOffset>("TypingStarted",
+			(_, _, _, _) => Interlocked.Increment(ref count));
+
+		await subscriber.StartAsync();
+		await subscriber.InvokeAsync("JoinChannel", ChRateLimit);
+
+		await sender.StartAsync();
+
+		await sender.InvokeAsync("Typing", "channel", ChRateLimit);
+		await Task.Delay(100);
+
+		await sender.InvokeAsync("Typing", "channel", ChRateLimit); // rate limited
+		await Task.Delay(200);
+
+		Assert.Equal(1, count);
+	}
+
+	// T4.09 — after the 3-second window elapses, Typing works again
+	[Fact]
+	public async Task Typing_AfterRateLimitWindowExpires_WorksAgain()
+	{
+		factory.GuildClient.Result = new ChannelMembership(
+			IsMember: true, GuildId: 5, Permissions: SendMessages | ReadMessages);
+
+		var senderToken = TestTokens.Issue(ChatApiFactory.JwtSecret, UserRateLimitExpiry);
+		var subToken    = TestTokens.Issue(ChatApiFactory.JwtSecret, SubRateLimitExpiry);
+
+		await using var sender     = HubConnectionHelper.Build(factory, senderToken);
+		await using var subscriber = HubConnectionHelper.Build(factory, subToken);
+
+		var count = 0;
+		var tcs1  = new TaskCompletionSource<bool>();
+		var tcs2  = new TaskCompletionSource<bool>();
+		subscriber.On<string, string, string, DateTimeOffset>("TypingStarted", (_, _, _, _) =>
+		{
+			var c = Interlocked.Increment(ref count);
+			if (c == 1) tcs1.TrySetResult(true);
+			if (c == 2) tcs2.TrySetResult(true);
+		});
+
+		await subscriber.StartAsync();
+		await subscriber.InvokeAsync("JoinChannel", ChRateLimitExpiry);
+		await sender.StartAsync();
+
+		await sender.InvokeAsync("Typing", "channel", ChRateLimitExpiry);
+		await tcs1.Task.WaitAsync(TimeSpan.FromSeconds(3));
+
+		factory.Clock.Advance(TimeSpan.FromSeconds(3)); // expire the rate limit window
+
+		await sender.InvokeAsync("Typing", "channel", ChRateLimitExpiry);
+		await tcs2.Task.WaitAsync(TimeSpan.FromSeconds(3));
+
+		Assert.Equal(2, count);
+	}
+
+	// T4.10 — rate limit key includes channelId; different channel is unaffected
+	[Fact]
+	public async Task Typing_RateLimitIsPerChannelId_OtherChannelNotAffected()
+	{
+		factory.GuildClient.Result = new ChannelMembership(
+			IsMember: true, GuildId: 5, Permissions: SendMessages | ReadMessages);
+
+		var senderToken = TestTokens.Issue(ChatApiFactory.JwtSecret, UserRateLimitPerCh);
+		var subAToken   = TestTokens.Issue(ChatApiFactory.JwtSecret, SubRateLimitPerChA);
+		var subBToken   = TestTokens.Issue(ChatApiFactory.JwtSecret, SubRateLimitPerChB);
+
+		await using var sender = HubConnectionHelper.Build(factory, senderToken);
+		await using var subA   = HubConnectionHelper.Build(factory, subAToken);
+		await using var subB   = HubConnectionHelper.Build(factory, subBToken);
+
+		var countA = 0;
+		var tcsB   = new TaskCompletionSource<bool>();
+		subA.On<string, string, string, DateTimeOffset>("TypingStarted",
+			(_, _, _, _) => Interlocked.Increment(ref countA));
+		subB.On<string, string, string, DateTimeOffset>("TypingStarted",
+			(_, _, _, _) => tcsB.TrySetResult(true));
+
+		await subA.StartAsync();
+		await subA.InvokeAsync("JoinChannel", ChRateLimitA);
+
+		await subB.StartAsync();
+		await subB.InvokeAsync("JoinChannel", ChRateLimitB);
+
+		await sender.StartAsync();
+
+		// first call on ChA → rate limit set for (UserRateLimitPerCh, "channel", ChA)
+		await sender.InvokeAsync("Typing", "channel", ChRateLimitA);
+		await Task.Delay(100);
+
+		// second call on ChA → silently ignored by rate limit
+		await sender.InvokeAsync("Typing", "channel", ChRateLimitA);
+		await Task.Delay(100);
+
+		// call on ChB → different key, not affected by ChA's rate limit
+		await sender.InvokeAsync("Typing", "channel", ChRateLimitB);
+		await tcsB.Task.WaitAsync(TimeSpan.FromSeconds(3));
+
+		Assert.Equal(1, countA); // only the first ChA call went through
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// T4.11 – T4.15 · Typing — DM scope
+// ─────────────────────────────────────────────────────────────────────────────
+public sealed class DmTypingTests(ChatApiFactory factory)
+	: IClassFixture<ChatApiFactory>, IAsyncLifetime
+{
+	private const long UserDmSender      = 7_101;
+	private const long UserDmPartner     = 7_102;
+	private const long UserDmSenderNF    = 7_103;
+	private const long UserDmPartnerNF   = 7_104;
+	private const long UserDmSenderBlock = 7_105;
+	private const long UserDmPartnerBlock = 7_106;
+	private const long UserDmSenderPend  = 7_107;
+	private const long UserDmPartnerPend = 7_108;
+
+	private static readonly DateTimeOffset ClockAnchor =
+		new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+	public Task InitializeAsync()
+	{
+		factory.GuildClient.Result = null;
+		factory.UserClient.Reset();
+		factory.Clock.Set(ClockAnchor);
+		return Task.CompletedTask;
+	}
+
+	public Task DisposeAsync() => Task.CompletedTask;
+
+	// T4.11 — accepted relationship → partner receives TypingStarted
+	[Fact]
+	public async Task Typing_DmAccepted_PartnerReceivesTypingStarted()
+	{
+		factory.UserClient.Setup(UserDmSender, UserDmPartner,
+			new UsersRelationship("accepted", ClockAnchor));
+
+		var senderToken  = TestTokens.Issue(ChatApiFactory.JwtSecret, UserDmSender);
+		var partnerToken = TestTokens.Issue(ChatApiFactory.JwtSecret, UserDmPartner);
+
+		await using var sender  = HubConnectionHelper.Build(factory, senderToken);
+		await using var partner = HubConnectionHelper.Build(factory, partnerToken);
+
+		var tcs = new TaskCompletionSource<(string userId, string scope, string id)>();
+		partner.On<string, string, string, DateTimeOffset>("TypingStarted",
+			(u, s, i, _) => tcs.TrySetResult((u, s, i)));
+
+		await partner.StartAsync();
+		await sender.StartAsync();
+
+		await sender.InvokeAsync("Typing", "dm", UserDmPartner);
+
+		var (userId, scope, id) = await tcs.Task.WaitAsync(TimeSpan.FromSeconds(3));
+		Assert.Equal(UserDmSender.ToString(), userId);
+		Assert.Equal("dm", scope);
+		Assert.Equal(UserDmPartner.ToString(), id);
+	}
+
+	// T4.12 — relationship not found → Error("Message.UserNotFound", ...)
+	[Fact]
+	public async Task Typing_DmRelationshipNotFound_SendsError()
+	{
+		// no Setup → FakeUserClient returns null
+		var token = TestTokens.Issue(ChatApiFactory.JwtSecret, UserDmSenderNF);
+		await using var conn = HubConnectionHelper.Build(factory, token);
+
+		var errTcs = new TaskCompletionSource<string>();
+		conn.On<string, string>("Error", (code, _) => errTcs.TrySetResult(code));
+
+		await conn.StartAsync();
+		await conn.InvokeAsync("Typing", "dm", UserDmPartnerNF);
+
+		var code = await errTcs.Task.WaitAsync(TimeSpan.FromSeconds(3));
+		Assert.Equal("Message.UserNotFound", code);
+	}
+
+	// T4.13 & T4.14 — blocked relationship → Error("Messages.RecipientBlocked", ...)
+	[Theory]
+	[InlineData("blocked_by_me")]
+	[InlineData("blocked_by_them")]
+	public async Task Typing_DmBlocked_SendsError(string status)
+	{
+		// blocked tests share the same sender ID — use different partner IDs per status
+		// to avoid rate-limit collision on the static dict key (userId, "dm", partnerId)
+		var partnerId = status == "blocked_by_me" ? UserDmPartnerBlock : UserDmPartnerBlock + 1;
+		factory.UserClient.Setup(UserDmSenderBlock, partnerId,
+			new UsersRelationship(status, ClockAnchor));
+
+		var token = TestTokens.Issue(ChatApiFactory.JwtSecret, UserDmSenderBlock);
+		await using var conn = HubConnectionHelper.Build(factory, token);
+
+		var errTcs = new TaskCompletionSource<string>();
+		conn.On<string, string>("Error", (code, _) => errTcs.TrySetResult(code));
+
+		await conn.StartAsync();
+		await conn.InvokeAsync("Typing", "dm", partnerId);
+
+		var code = await errTcs.Task.WaitAsync(TimeSpan.FromSeconds(3));
+		Assert.Equal("Messages.RecipientBlocked", code);
+	}
+
+	// T4.15 — pending relationship → Error("Messages.RecipientNotFriend", ...)
+	[Fact]
+	public async Task Typing_DmPending_SendsError()
+	{
+		factory.UserClient.Setup(UserDmSenderPend, UserDmPartnerPend,
+			new UsersRelationship("pending", ClockAnchor));
+
+		var token = TestTokens.Issue(ChatApiFactory.JwtSecret, UserDmSenderPend);
+		await using var conn = HubConnectionHelper.Build(factory, token);
+
+		var errTcs = new TaskCompletionSource<string>();
+		conn.On<string, string>("Error", (code, _) => errTcs.TrySetResult(code));
+
+		await conn.StartAsync();
+		await conn.InvokeAsync("Typing", "dm", UserDmPartnerPend);
+
+		var code = await errTcs.Task.WaitAsync(TimeSpan.FromSeconds(3));
+		Assert.Equal("Messages.RecipientNotFriend", code);
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// T4.16 – T4.17 · Typing — invalid scope
+// ─────────────────────────────────────────────────────────────────────────────
+public sealed class TypingScopeTests(ChatApiFactory factory)
+	: IClassFixture<ChatApiFactory>, IAsyncLifetime
+{
+	private const long UserInvalidScope = 7_201;
+
+	public Task InitializeAsync()
+	{
+		factory.GuildClient.Result = null;
+		factory.UserClient.Reset();
+		return Task.CompletedTask;
+	}
+
+	public Task DisposeAsync() => Task.CompletedTask;
+
+	// T4.16 & T4.17 — any scope other than "channel" or "dm" → Error("Typing.InvalidScope", ...)
+	[Theory]
+	[InlineData("guild")]
+	[InlineData("")]
+	public async Task Typing_InvalidScope_SendsError(string scope)
+	{
+		// use different target IDs per scope string to isolate rate-limit keys
+		var targetId = scope == "guild" ? 201_001L : 201_002L;
+
+		var token = TestTokens.Issue(ChatApiFactory.JwtSecret, UserInvalidScope);
+		await using var conn = HubConnectionHelper.Build(factory, token);
+
+		var errTcs = new TaskCompletionSource<string>();
+		conn.On<string, string>("Error", (code, _) => errTcs.TrySetResult(code));
+
+		await conn.StartAsync();
+		await conn.InvokeAsync("Typing", scope, targetId);
+
+		var code = await errTcs.Task.WaitAsync(TimeSpan.FromSeconds(3));
+		Assert.Equal("Typing.InvalidScope", code);
+	}
+}

--- a/services/chat/tests/Chat.FunctionalTests/Infrastructure/ChatApiFactory.cs
+++ b/services/chat/tests/Chat.FunctionalTests/Infrastructure/ChatApiFactory.cs
@@ -133,6 +133,7 @@ public sealed class ChatApiFactory : WebApplicationFactory<Program>
 				["BackendConfiguration:BaseApiUrl"] = "http://localhost/api",
 
 				["Services:GuildService"] = "http://localhost:5101",
+				["Services:UserService"] = "http://localhost:5101",
 			});
 		});
 

--- a/services/chat/tests/Chat.FunctionalTests/Infrastructure/ChatApiFactory.cs
+++ b/services/chat/tests/Chat.FunctionalTests/Infrastructure/ChatApiFactory.cs
@@ -3,6 +3,7 @@ using Chat.Application.Abstractions;
 using Chat.Application.Abstractions.Persistence;
 using Chat.Application.Features.Messages.Common;
 using Chat.Presentation.Hubs;
+using Chat.Domain.Messages;
 using Chat.UnitTests.Fakes;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
@@ -35,13 +36,14 @@ public sealed class ChatApiFactory : WebApplicationFactory<Program>
 	// fakes are shared across the factory instance so tests can both inject
 	// canned membership/permission rows and assert on what the handler did
 	public FakeGuildClient GuildClient { get; } = new();
+	public FakeUserClient UserClient { get; } = new();
 	public FakeMessageRepository MessageRepository { get; } = new();
 	public FakeEventBus EventBus { get; } = new();
 	public FakeChannelBroadcaster Broadcaster { get; } = new();
 	public FakeClock Clock { get; } = new();
 	public FakeIdGenerator IdGenerator { get; } = new();
 
-	public IReadOnlyList<Chat.Domain.Messages.Message> SavedMessages => MessageRepository.Saved;
+	public IReadOnlyList<Message> SavedMessages => MessageRepository.Saved;
 
 	public void WithMembership(long channelId, long userId, long guildId, long permissions)
 	{
@@ -147,6 +149,9 @@ public sealed class ChatApiFactory : WebApplicationFactory<Program>
 
 			services.RemoveAll<IGuildClient>();
 			services.AddSingleton<IGuildClient>(GuildClient);
+
+			services.RemoveAll<IUserClient>();
+			services.AddSingleton<IUserClient>(UserClient);
 
 			services.RemoveAll<IMessageRepository>();
 			services.AddSingleton<IMessageRepository>(MessageRepository);

--- a/services/chat/tests/Chat.UnitTests/Fakes/FakeUserClient.cs
+++ b/services/chat/tests/Chat.UnitTests/Fakes/FakeUserClient.cs
@@ -1,0 +1,16 @@
+using Chat.Application.Abstractions;
+
+namespace Chat.UnitTests.Fakes;
+
+public sealed class FakeUserClient : IUserClient
+{
+	private readonly Dictionary<(long, long), UsersRelationship?> _map = new();
+
+	public void Setup(long callerId, long recipientId, UsersRelationship? relationship)
+		=> _map[(callerId, recipientId)] = relationship;
+
+	public void Reset() => _map.Clear();
+
+	public Task<UsersRelationship?> GetUsersRelationship(long callerId, long recipientId, CancellationToken ct)
+		=> Task.FromResult(_map.TryGetValue((callerId, recipientId), out var rel) ? rel : null);
+}

--- a/services/chat/tools/HubTester/Program.cs
+++ b/services/chat/tools/HubTester/Program.cs
@@ -25,9 +25,14 @@ app.AddCommand("listen", async (string url = DefaultChatHub, string? token = nul
 	conn.On<object>("MessageEdited",        m => Console.WriteLine($"<- MessageEdited: {m}"));
 	conn.On<object>("MessageDeleted",       m => Console.WriteLine($"<- MessageDeleted: {m}"));
 	conn.On<object>("UserPresence",         m => Console.WriteLine($"<- UserPresence: {m}"));
-	conn.On<object, object>("GuildJoined",  (id, name) => Console.WriteLine($"<- GuildJoined: {id} ({name})"));
 	conn.On<object>("GuildLeft",            id => Console.WriteLine($"<- GuildLeft: {id}"));
-	conn.On<string, string>("Error",        (code, msg) => Console.WriteLine($"<- Error: {code} — {msg}"));
+	conn.On<object,
+			object>("GuildJoined",   (id, name) => Console.WriteLine($"<- GuildJoined: {id} ({name})"));
+	conn.On<string,
+			string,
+			string,
+			object>("TypingStarted", (userId, scope, id, until) => Console.WriteLine($"<- TypingStarted: user={userId} scope={scope} id={id} until={until}"));
+	conn.On<string, string>("Error", (code, msg) => Console.WriteLine($"<- Error: {code} — {msg}"));
 
 	await conn.StartAsync();
 	Console.WriteLine($"connected to {url}");
@@ -41,6 +46,32 @@ app.AddCommand("listen", async (string url = DefaultChatHub, string? token = nul
 	Console.WriteLine($"listening {seconds}s...");
 	await Task.Delay(TimeSpan.FromSeconds(seconds));
 }).WithDescription("hold a connection open and print every server-pushed event");
+
+app.AddCommand("send-typing", async ([Argument] string scope, [Argument] long id, string url = DefaultChatHub, string? token = null) =>
+{
+	await using var conn = Build(url, token);
+	conn.On<string, string>("Error", (code, msg) => Console.WriteLine($"<- Error: {code} — {msg}"));
+
+	await conn.StartAsync();
+	Console.WriteLine($"connected to {url}");
+
+	if (scope == "channel")
+	{
+		await conn.InvokeAsync("JoinChannel", id);
+		Console.WriteLine($"-> JoinChannel({id})");
+	}
+
+	Console.WriteLine("press Enter to send Typing, Esc to quit");
+	while (true)
+	{
+		var key = Console.ReadKey(intercept: true);
+		if (key.Key == ConsoleKey.Escape) break;
+		if (key.Key != ConsoleKey.Enter) continue;
+
+		await conn.InvokeAsync("Typing", scope, id);
+		Console.WriteLine($"-> Typing({scope}, {id})");
+	}
+}).WithDescription("join a channel (if scope=channel) and invoke Typing interactively — Enter sends, Esc quits");
 
 app.AddCommand("signal-listen", async (string url = DefaultSignalingHub, string? token = null, int seconds = 60) =>
 {


### PR DESCRIPTION
Implement **Typing hub invocation**

## This PR contains:

- `Typing(scope, id)` hub method supporting `"channel"` and `"dm"` scopes
- per-(userId, scope, id) rate limiting (3-second window, silently ignored on repeat)
- `IUserClient` interface and HTTP implementation to retrieve user relationship status from the user service
- `TypingStarted` broadcast to `Clients.OthersInGroup` for channels, `Clients.User` for DMs
- error mapping: `ChannelNotFound`, `NotAMember`, `MissingSendPermission`, `UserNotFound`, `RecipientBlocked`, `RecipientNotFriend`, `InvalidScope`
- functional tests covering channel happy path, payload shape, `OthersInGroup` exclusion, rate limit window and per-channel isolation, all DM error cases, invalid scopes

Close #186