### PR TITLE
Fix(infra): reliable single-command startup on podman and docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,20 @@
 NAME         := ft_transcendence
 ANNOUNCER    := Announcer
 
-COMPOSE      ?= podman-compose
-DOCKER       ?= podman
+# engine autodetect (podman preferred, docker fallback), override with
+# `make ENGINE=docker` to force docker, or set DOCKER / COMPOSE directly
+ENGINE       ?= $(shell if command -v podman >/dev/null 2>&1; then echo podman; elif command -v docker >/dev/null 2>&1; then echo docker; fi)
+ifeq ($(ENGINE),docker)
+    DOCKER   := docker
+    COMPOSE  := docker compose
+else
+    DOCKER   := podman
+    COMPOSE  := podman-compose
+endif
+
+MIGRATE_SERVICES = $(filter-out $(shell $(COMPOSE) config --services 2>/dev/null),$(shell $(COMPOSE) --profile migrate config --services 2>/dev/null))
+DB_SERVICES      = $(filter %-db,$(shell $(COMPOSE) config --services 2>/dev/null))
+BUILT_IMAGES     = $(shell $(COMPOSE) --profile migrate config 2>/dev/null | awk '/^  [a-z].*:$$/{if(b&&i)print i;b=0;i=""} /^    build:/{b=1} /^    image:/{i=$$2} END{if(b&&i)print i}')
 
 ENV_FILES := .env \
              frontend/.env \
@@ -18,62 +30,77 @@ SECRETMANAGER_DIR := tools/secretman
 get_color = $(if $(filter Purple,$(1)),$(shell tput setaf 5),$(if $(filter Red,$(1)),$(shell tput setaf 1),$(if $(filter Cyan,$(1)),$(shell tput setaf 6),$(if $(filter Blue,$(1)),$(shell tput setaf 4),$(if $(filter Yellow,$(1)),$(shell tput setaf 3),$(if $(filter Green,$(1)),$(shell tput setaf 2),$(shell tput sgr0)))))))
 ann = $(call get_color,$(1))[$(call get_color,Off)$(ANNOUNCER)$(call get_color,$(1))]$(call get_color,Off)
 
-.PHONY: all build up down re clean fclean logs ps login dev check-env _build _up secrets-setup secrets-decrypt secrets-encrypt secrets-refresh
+.PHONY: all help build up down re clean fclean logs ps login dev check-env _build _up _certs _migrate secrets-setup secrets-decrypt secrets-encrypt secrets-refresh
 
-all: check-env _build _up
+all: check-env _build _up ## Build all images and start the full stack (default)
 
-build: check-env _build
-	@echo "$(call ann,Green) It works on my machine™"
+help: ## Show this help
+	@echo "$(call ann,Cyan) $(call get_color,Purple)$(NAME)$(call get_color,Off) - available targets:"
+	@grep -hE '^[a-zA-Z][a-zA-Z_-]*:.*## ' $(MAKEFILE_LIST) | sort | \
+		awk 'BEGIN{FS=":.*## "}{printf "  $(call get_color,Green)%-16s$(call get_color,Off) %s\n", $$1, $$2}'
 
-up: check-env _up
-	@echo "$(call ann,Green) $(call get_color,Purple)$(NAME)$(call get_color,Off): All systems go (famous last words)"
+build: check-env _build ## Build all service images
+	@echo "$(call ann,Green) All service images built. It works on my machine™"
 
-down:
-	@echo "$(call ann,Yellow) Going dark. At least you won't need to download more RAM today :)"
+up: check-env _up ## Start the stack (assumes images are already built)
+	@echo "$(call ann,Green) $(call get_color,Purple)$(NAME)$(call get_color,Off) is up at https://localhost:1443. All systems go (famous last words)"
+
+down: ## Stop and remove all containers
+	@echo "$(call ann,Yellow) Stopping and removing all containers. Going dark, at least you won't need to download more RAM today :)"
 	@$(COMPOSE) down
 
-re:
-	@echo "$(call ann,Yellow) Scorched earth and rebuild. Classic."
+re: ## Full clean, then rebuild and start from scratch
+	@echo "$(call ann,Yellow) Full clean, then rebuild and start from scratch. Scorched earth. Classic."
 	@$(MAKE) fclean all
 
-clean: down
-	@echo "$(call ann,Yellow) Those images knew too much anyway"
+clean: down ## Stop the stack and prune dangling images
+	@echo "$(call ann,Yellow) Pruning dangling images. They knew too much anyway"
 	@$(DOCKER) image prune -f
 	@echo "$(call ann,Green) Poof. Like it never happened :O"
 
-fclean: down
-	@echo "$(call ann,Red) docker system prune but make it personal"
-	@$(DOCKER) container rm -af 2>/dev/null || true
-	@$(DOCKER) image rm -f $$($(DOCKER) image ls -q) 2>/dev/null || true
-	@$(DOCKER) system prune -a --volumes -f
-	@echo "$(call ann,Red) It's all gone. You won't have to download extra storage (no need to thank me) :)"
+fclean: ## Remove containers + our built images (prompts before deleting DB volumes)
+	@echo "$(call ann,Red) Tearing down $(NAME): containers + our built images (base images and cache kept)"
+	@printf "$(call ann,Yellow) Also delete database volumes? This permanently destroys all data [y/N] "; \
+	read ans; \
+	case "$$ans" in \
+		[yY]|[yY][eE][sS]) vols="--volumes"; echo "$(call ann,Red) Nuking volumes too, hope you meant it";; \
+		*) vols=""; echo "$(call ann,Green) Keeping volumes (your data lives another day)";; \
+	esac; \
+	$(COMPOSE) --profile migrate down $$vols --remove-orphans
+	@$(DOCKER) image rm -f $(BUILT_IMAGES) 2>/dev/null || true
+	@echo "$(call ann,Red) Done. Base images and build cache untouched :)"
 
-logs:
-	@echo "$(call ann,Cyan) Looking at the containers' yapping... (Ctrl+C to look away)"
-	@$(COMPOSE) logs -f
+ifeq (logs,$(firstword $(MAKECMDGOALS)))
+  LOG_ARGS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
+  $(eval $(LOG_ARGS):;@:)
+endif
 
-ps:
+logs: ## Tail logs of all containers, or specific ones: make logs auth chat
+	@echo "$(call ann,Cyan) Tuning into the logs ($(if $(LOG_ARGS),$(LOG_ARGS),everything)). Ctrl+C to look away"
+	@$(COMPOSE) logs -f $(LOG_ARGS)
+
+ps: ## List the stack's containers
 	@$(COMPOSE) ps
 
-login:
+login: ## Log in to docker.io (raise pull rate limits)
 	@echo "$(call ann,Cyan) Exchanging dignity for pull access"
 	@$(DOCKER) login docker.io
 	@echo "$(call ann,Green) You're in. The rate limiter is watching"
 
-secrets-setup:
+secrets-setup: ## Set up SOPS secret management
 	@$(MAKE) --no-print-directory -C $(SECRETMANAGER_DIR) setup
 
-secrets-decrypt:
+secrets-decrypt: ## Decrypt the encrypted .env files
 	@$(MAKE) --no-print-directory -C $(SECRETMANAGER_DIR) decrypt
 
-secrets-encrypt:
+secrets-encrypt: ## Encrypt the .env files
 	@$(MAKE) --no-print-directory -C $(SECRETMANAGER_DIR) encrypt
 
-secrets-refresh:
+secrets-refresh: ## Re-encrypt secrets with the current recipients
 	@$(MAKE) --no-print-directory -C $(SECRETMANAGER_DIR) refresh
 
-dev: check-env
-	@echo "$(call ann,Cyan) Go do wonders. We believe in you (we don't have a choice)"
+dev: check-env ## Start the Tilt hot-reload dev environment
+	@echo "$(call ann,Cyan) Starting the Tilt dev environment (hot-reload). Go do wonders, we believe in you (we don't have a choice)"
 	@tilt up
 
 check-env:
@@ -89,9 +116,32 @@ check-env:
 	done
 
 _build:
-	@echo "$(call ann,Cyan) Turning caffeine and regret into Docker layers."
-	@$(COMPOSE) build
+	@echo "$(call ann,Cyan) Building all service images. Turning caffeine and regret into Docker layers."
+	@$(COMPOSE) --profile migrate build
 
-_up:
-	@echo "$(call ann,Cyan) Rise and shine, you beautiful disasters!"
+_certs:
+	@echo "$(call ann,Cyan) Minting TLS certs host-side, before the containers wake up. Self-signed and proud (your browser won't be)"
+	@sh infra/cert-gen/cert-gen.sh
+
+_migrate:
+	@echo "$(call ann,Cyan) Waking the databases and waiting for them to be healthy (no operating on a patient without a pulse)"
+	@$(COMPOSE) up -d $(DB_SERVICES)
+	@for db in $(DB_SERVICES); do \
+		echo "$(call ann,Blue) checking $$db for a pulse ..."; \
+		ok=; \
+		for i in $$(seq 1 120); do \
+			hs=$$($(DOCKER) inspect -f '{{.State.Health.Status}}' "$$db" 2>/dev/null || echo missing); \
+			[ "$$hs" = "healthy" ] && { ok=1; break; }; \
+			sleep 2; \
+		done; \
+		[ -n "$$ok" ] || { echo "$(call ann,Red) $$db flatlined (never became healthy). Calling it, aborting"; exit 1; }; \
+	done
+	@echo "$(call ann,Cyan) Applying database migrations one-shot, before the apps wake up asking for tables that don't exist"
+	@for m in $(MIGRATE_SERVICES); do \
+		echo "$(call ann,Blue) running migration: $$m (hold still)"; \
+		$(COMPOSE) --profile migrate run --rm $$m || { echo "$(call ann,Red) migration $$m belly-flopped. Aborting"; exit 1; }; \
+	done
+
+_up: _certs _migrate
+	@echo "$(call ann,Cyan) Starting the application containers. Rise and shine, you beautiful disasters!"
 	@$(COMPOSE) up -d

--- a/Tiltfile
+++ b/Tiltfile
@@ -32,16 +32,9 @@ local_resource(
 
 local_resource(
     'cert-gen',
-    cmd=(
-        DOCKER + ' run ' + FLAGS + '--rm ' +
-        '-v certs:/certs ' +
-        '--entrypoint sh docker.io/alpine/openssl ' +
-        '-c "rm -f /certs/key.pem /certs/cert.pem && ' +
-        'openssl req -x509 -newkey rsa:4096 -nodes ' +
-        '-keyout /certs/key.pem -out /certs/cert.pem ' +
-        '-days 365 -subj \'/CN=localhost\' ' +
-        '-addext \'subjectAltName=DNS:localhost\'"'
-    ),
+    # host-side generation (openssl on the host) to mirror `make` and keep the
+    # certs owned by the current user; nginx bind-mounts them below.
+    cmd='sh infra/cert-gen/cert-gen.sh',
     labels=['infra'],
 )
 
@@ -51,7 +44,7 @@ local_resource(
         '--network host ' +
         '-v $(pwd)/infra/nginx/nginx.conf:/etc/nginx/nginx.conf:ro ' +
         '-v $(pwd)/infra/nginx/docs.html:/etc/nginx/docs.html:ro ' +
-        '-v certs:/etc/nginx/certs:ro ' +
+        '-v $(pwd)/certs:/etc/nginx/certs:ro ' +
         'docker.io/nginx:alpine'
     ),
     resource_deps=['cert-gen', 'dev-network', 'gateway', 'frontend'],

--- a/compose.yaml
+++ b/compose.yaml
@@ -8,28 +8,14 @@ include:
   - services/user/compose.yaml
 
 services:
-  cert-gen:
-    container_name: cert-gen
-    image: docker.io/alpine/openssl
-    entrypoint: ["sh", "-c"]
-    command:
-      - "rm -f /certs/key.pem /certs/cert.pem && openssl req -x509 -newkey rsa:4096 -nodes -keyout /certs/key.pem -out /certs/cert.pem -days 365 -subj '/CN=localhost' -addext 'subjectAltName=DNS:localhost'"
-    volumes:
-      - certs:/certs
-
   nginx:
     container_name: nginx
     image: docker.io/nginx:alpine
-    entrypoint: ["sh", "-c"]
-    command:
-      - "until [ -f /etc/nginx/certs/cert.pem ]; do echo 'waiting for certs...'; sleep 1; done; exec /docker-entrypoint.sh nginx -g 'daemon off;'"
     network_mode: host
     volumes:
       - ./infra/nginx/nginx.conf:/etc/nginx/nginx.conf:ro,z
-      - certs:/etc/nginx/certs:ro
+      - ./certs:/etc/nginx/certs:ro
     depends_on:
-      cert-gen:
-        condition: service_completed_successfully
       gateway:
         condition: service_healthy
       frontend:
@@ -55,5 +41,4 @@ services:
       retries: 5
 
 volumes:
-  certs:
   rabbitmq_data:

--- a/infra/cert-gen/cert-gen.sh
+++ b/infra/cert-gen/cert-gen.sh
@@ -1,0 +1,34 @@
+#!/bin/env sh
+# generate the self-signed TLS cert used by nginx, host-side
+#
+# why host-side: it avoids a one-shot cert-gen container (podman dislikes
+# `service_completed_successfully` dependencies) and the files end up owned by
+# the current user, so the nginx bind mount reads them without permission games
+#
+# AND once a certificate has been trusted, we don't need to trust it again upon
+# a stack restart :D
+set -e
+
+BLUE="\033[36m"
+RESET="\033[0m"
+
+CERT_DIR="certs"
+
+if [ -f "$CERT_DIR/cert.pem" ] && [ -f "$CERT_DIR/key.pem" ]; then
+	printf "Certs already exist, nothing to do\n"
+	exit 0
+fi
+
+if ! command -v openssl >/dev/null 2>&1; then
+	printf "Error: openssl is not installed or not on PATH\n" >&2
+	printf "Install it and re-run" >&2
+	exit 1
+fi
+
+mkdir -p "$CERT_DIR"
+openssl req -x509 -newkey rsa:4096 -nodes \
+	-keyout "$CERT_DIR/key.pem" -out "$CERT_DIR/cert.pem" \
+	-days 365 -subj '/CN=localhost' \
+	-addext 'subjectAltName=DNS:localhost,IP:127.0.0.1'
+
+printf "TLS certs generated in ${BLUE}%s/${RESET}\n" "$CERT_DIR"

--- a/services/auth/Dockerfile.migrate
+++ b/services/auth/Dockerfile.migrate
@@ -1,7 +1,7 @@
 FROM mcr.microsoft.com/dotnet/sdk:10.0
 WORKDIR /app
 
-RUN dotnet tool install --global dotnet-ef --version 10.0.1
+RUN dotnet tool install --global dotnet-ef --version 10.0.4
 ENV PATH="${PATH}:/root/.dotnet/tools"
 
 COPY Auth.slnx ./

--- a/services/auth/compose.yaml
+++ b/services/auth/compose.yaml
@@ -13,6 +13,7 @@ services:
 
   auth-migrate:
     container_name: auth-migrate
+    profiles: ["migrate"]
     image: auth-migrate-service
     pull_policy: never
     build:
@@ -49,8 +50,6 @@ services:
         condition: service_healthy
       auth-db:
         condition: service_healthy
-      auth-migrate:
-        condition: service_completed_successfully
 
 volumes:
   auth_db_data:

--- a/services/chat/compose.yaml
+++ b/services/chat/compose.yaml
@@ -13,6 +13,7 @@ services:
 
   chat-migrate:
     container_name: chat-migrate
+    profiles: ["migrate"]
     image: docker.io/scylladb/scylla:6.2
     entrypoint: ["sh", "/schema/apply.sh"]
     volumes:
@@ -50,8 +51,6 @@ services:
         condition: service_healthy
       chat-db:
         condition: service_healthy
-      chat-migrate:
-        condition: service_completed_successfully
 
 volumes:
   chat_db_data:

--- a/services/guild/.env.example
+++ b/services/guild/.env.example
@@ -1,15 +1,20 @@
 #    ╭─────────────────────────────────────────────────────────────────────╮
 #    │                     PostgreSQL credentials.                         │
-#    │   Used both by the postgres container (POSTGRES_*) and forwarded    │
-#    │   into the service via Database__User / Database__Password by       │
-#    │   compose.yaml. The connection itself is bound through the Options  │
-#    │   pattern (Database section) — no connection string lives in env.   │
-#    │         ───── Example: guild / guild / guild ─────                  │
+#    │   POSTGRES_* configure the postgres container. The app binds the    │
+#    │   Database section via the Options pattern, so the same values are  │
+#    │   repeated as Database__* below: Compose ${...} interpolation       │
+#    │   cannot read a service env_file, so they must be literal here      │
+#    │   (compose.yaml supplies only the Host/Port topology).              │
+#    │         ----- Example: guild / guild / guild -----                  │
 #    ╰─────────────────────────────────────────────────────────────────────╯
 
 POSTGRES_USER=
 POSTGRES_PASSWORD=
 POSTGRES_DB=
+
+Database__Name=
+Database__User=
+Database__Password=
 
 #    ╭─────────────────────────────────────────────────────────────────────╮
 #    │                        JWT validation.                              │

--- a/services/guild/Dockerfile.migrate
+++ b/services/guild/Dockerfile.migrate
@@ -1,7 +1,7 @@
 FROM mcr.microsoft.com/dotnet/sdk:10.0
 WORKDIR /app
 
-RUN dotnet tool install --global dotnet-ef --version 10.0.1
+RUN dotnet tool install --global dotnet-ef --version 10.0.4
 ENV PATH="${PATH}:/root/.dotnet/tools"
 
 COPY Guild.slnx ./

--- a/services/guild/compose.yaml
+++ b/services/guild/compose.yaml
@@ -25,9 +25,6 @@ services:
       POSTGRES_PORT: 5432
       Database__Host: guild-db
       Database__Port: 5432
-      Database__Name: ${POSTGRES_DB:-guild}
-      Database__User: ${POSTGRES_USER}
-      Database__Password: ${POSTGRES_PASSWORD}
     depends_on:
       guild-db:
         condition: service_healthy
@@ -54,9 +51,6 @@ services:
       RabbitMQ__Password: ${RABBITMQ_PASS}
       Database__Host: guild-db
       Database__Port: 5432
-      Database__Name: ${POSTGRES_DB:-guild}
-      Database__User: ${POSTGRES_USER}
-      Database__Password: ${POSTGRES_PASSWORD}
       Services__UserService: http://user:8080
       BackendConfiguration__BaseUrl: ${BASE_URL}
       BackendConfiguration__BaseApiUrl: ${BASE_API_URL}

--- a/services/guild/compose.yaml
+++ b/services/guild/compose.yaml
@@ -13,6 +13,7 @@ services:
 
   guild-migrate:
     container_name: guild-migrate
+    profiles: ["migrate"]
     image: guild-migrate-service
     pull_policy: never
     build:
@@ -66,8 +67,6 @@ services:
         condition: service_healthy
       guild-db:
         condition: service_healthy
-      guild-migrate:
-        condition: service_completed_successfully
 
 volumes:
   guild_db_data:

--- a/services/notification/compose.yaml
+++ b/services/notification/compose.yaml
@@ -13,6 +13,7 @@ services:
 
   notification-migrate:
     container_name: notification-migrate
+    profiles: ["migrate"]
     image: notification-migrate-service
     pull_policy: never
     build:
@@ -43,8 +44,6 @@ services:
         condition: service_healthy
       notification-db:
         condition: service_healthy
-      notification-migrate:
-        condition: service_completed_successfully
 
 volumes:
   notification_db_data:


### PR DESCRIPTION
## What

Reworks how the stack starts so `make` brings everything up cleanly on both podman-compose and docker compose, and fixes the cert + guild-startup issues along the way.

## Why

~~YAPM (yet another podman moment)~~ 🤡

`make` was deadlocking on podman: podman-compose translates every `depends_on` into a podman `--requires`, which does in fact demand the dependency to be *running*. A completed one-shot migration container is *stopped*, so podman refused to start the app ("container state improper").

Why does the issue arise only now? It turns out we were somehow lucky (or i guess, unlucky) enough for podman to race condition with the just the perfect timing for the app container to start *right* while its migration dependency was still up (merci philoman).

Obviously, docker compose doesn't suffer from this, but we need something that works on both and ESPECIALLY podman

## What changes?

**Migrations as a deploy step (not a runtime `depends_on`)**
- `*-migrate` services moved behind a `migrate` compose profile, excluded from the default `up`.
- Apps no longer `depends_on` their migrate one-shot, so no `--requires` on a stopped container.
- `make` now: build -> certs -> bring up DBs and wait for healthy -> run each migration to completion (`compose run --rm`) -> `up -d` the apps. This is the standard production pattern (migrations are a deploy step, not container ordering).

**Host-side TLS certs**
- `infra/cert-gen/cert-gen.sh` generates the self-signed cert on the host with `openssl` (idempotent, fails clearly if openssl is missing).
- Removes the one-shot `cert-gen` container; nginx bind-mounts `./certs`. Certs are owned by the current user and survive restarts (meaning we don't need to retrust a certificate if it's already been trusted before)

**Makefile quality-of-life**
- Engine autodetect (`podman` preferred, `docker` fallback; `make ENGINE=docker` to force).
- Service/image lists derived from `compose config` instead of hardcoded.
- `fclean` scoped to this project only (no more global `system prune`); prompts before deleting DB volumes. It also preserves build cache so later fresh builds are FAST
- `make help`, `make logs <svc...>` to follow specific services.

**Other**
- `fix(guild)`: DB credentials kept in `.env` (compose `${...}` interpolation can't read a service `env_file`).
- Bumps `dotnet-ef` to 10.0.4 in the auth and guild migrate images (matches the SDK runtime, silences the version warning).

## Testing

Full `make` (build -> migrate -> up) verified end to end on **both** podman-compose 1.6.0 and docker compose v2.40: all migrations apply (EF, cqlsh, goose), all 14 containers reach healthy, gateway and nginx come up.

## What's next?

- No changes to the dev workflow: `make dev` (Tilt) is unaffected since it doesn't rely on podman-compose (or any compose actually, yw)
- Make sure we run `make` regularly. Even if it *shouldn't* happen again, we can catch similar or other bugs as early as possible
- Wish Vanta a good night of sleep, they probably need it (it's like 6 in the morning help)

<img width="498" height="498" alt="IMG_7106" src="https://github.com/user-attachments/assets/5b54422f-90b9-43de-b0b5-a3c71d81a45d" />
