### PR TITLE
Feat(infra): health endpoints

### DIFF
--- a/services/auth/compose.yaml
+++ b/services/auth/compose.yaml
@@ -40,7 +40,7 @@ services:
       RabbitMQ__Password: ${RABBITMQ_PASS}
       Jwt__SecretKey: ${JWT_SECRET}
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080/v1/hello-world"]
+      test: ["CMD", "curl", "-f", "http://localhost:8080/healthz"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/services/auth/src/Auth.Persistence/Auth.Persistence.csproj
+++ b/services/auth/src/Auth.Persistence/Auth.Persistence.csproj
@@ -12,6 +12,7 @@
         </PackageReference>
         <!-- pin transitive to a non-vulnerable version (ef design 10.0.1 pulls 9.0.0, that's a shame) -->
         <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.7" />
+        <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.0" />
         <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.0"/>
         <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.0"/>
     </ItemGroup>

--- a/services/auth/src/Auth.Persistence/DependencyInjection.cs
+++ b/services/auth/src/Auth.Persistence/DependencyInjection.cs
@@ -1,8 +1,10 @@
 using Auth.Application.Abstractions.Persistence;
 using Auth.Persistence.Db;
+using Auth.Persistence.Health;
 using Auth.Persistence.Repositories;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Options;
 
 namespace Auth.Persistence;
@@ -25,4 +27,7 @@ public static class DependencyInjection
 
         return services;
     }
+
+    public static IHealthChecksBuilder AddPersistenceHealthChecks(this IHealthChecksBuilder builder)
+        => builder.AddCheck<EfCoreHealthCheck>("postgres");
 }

--- a/services/auth/src/Auth.Persistence/Health/EfCoreHealthCheck.cs
+++ b/services/auth/src/Auth.Persistence/Health/EfCoreHealthCheck.cs
@@ -1,0 +1,25 @@
+using Auth.Persistence.Db;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace Auth.Persistence.Health;
+
+internal sealed class EfCoreHealthCheck(AuthDbContext db) : IHealthCheck
+{
+    public async Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var canConnect = await db.Database.CanConnectAsync(cancellationToken);
+            return canConnect
+                ? HealthCheckResult.Healthy()
+                : HealthCheckResult.Unhealthy("postgres unreachable");
+        }
+        catch (Exception ex)
+        {
+            return HealthCheckResult.Unhealthy("postgres unreachable", ex);
+        }
+    }
+}

--- a/services/auth/src/Auth.Presentation/Program.cs
+++ b/services/auth/src/Auth.Presentation/Program.cs
@@ -4,6 +4,7 @@ using Auth.Infrastructure;
 using Auth.Persistence;
 using Auth.Presentation.Middleware;
 using Auth.Presentation;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Scalar.AspNetCore;
 using System.Text.Json;
 
@@ -14,8 +15,9 @@ builder.Services.ConfigureHttpJsonOptions(o =>
                     o.SerializerOptions.PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower
                 );
 
-builder.Services.AddOpenApi()
-                .AddHealthChecks();
+builder.Services.AddOpenApi();
+builder.Services.AddHealthChecks()
+                .AddPersistenceHealthChecks();
 
 builder.Services.AddApplication()
                 .AddInfrastructure()
@@ -40,7 +42,23 @@ app.UseMiddleware<ExceptionHandlingMiddleware>();
 app.UseAuthentication();
 app.UseAuthorization();
 
-app.MapHealthChecks("/healthz");
+app.MapHealthChecks("/healthz", new HealthCheckOptions
+{
+    ResponseWriter = static async (ctx, report) =>
+    {
+        ctx.Response.ContentType = "application/json";
+        await ctx.Response.WriteAsync(JsonSerializer.Serialize(new
+        {
+            status = report.Status.ToString(),
+            checks = report.Entries.Select(e => new
+            {
+                name = e.Key,
+                status = e.Value.Status.ToString(),
+                description = e.Value.Description,
+            }),
+        }));
+    },
+});
 var v1 = app.MapGroup("/v1");
 v1.MapCarter();
 

--- a/services/gateway/cmd/gateway/main.go
+++ b/services/gateway/cmd/gateway/main.go
@@ -30,7 +30,7 @@ func main() {
 	if cfg.Dev {
 		mux.HandleFunc("/api/openapi.json", handler.AggregateOpenAPI(cfg))
 	}
-	mux.HandleFunc("/api/gateway/health", handler.Healthcheck())
+	mux.HandleFunc("/healthz", handler.Healthcheck())
 	mux.HandleFunc("/api/{rest...}", handler.Redirect(proxies))
 
 	//  ─────────────────────────────────────────────

--- a/services/gateway/compose.yaml
+++ b/services/gateway/compose.yaml
@@ -13,7 +13,7 @@ services:
       JWT_SECRET: ${JWT_SECRET}
     restart: unless-stopped
     healthcheck:
-      test: ["CMD-SHELL", "curl -f http://localhost:$$GATEWAY_PORT/api/gateway/health"]
+      test: ["CMD-SHELL", "curl -f http://localhost:$$GATEWAY_PORT/healthz"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/services/gateway/handler/healthcheck.go
+++ b/services/gateway/handler/healthcheck.go
@@ -1,18 +1,35 @@
 package handler
 
 import (
-	"fmt"
+	"encoding/json"
 	"net/http"
-
-	"github.com/vantavoids/ft_transcendence/services/gateway/healthcheck"
 )
 
-type StatusCode = healthcheck.StatusCode
+type healthCheck struct {
+	Name        string  `json:"name"`
+	Status      string  `json:"status"`
+	Description *string `json:"description"`
+}
 
+type healthReport struct {
+	Status string        `json:"status"`
+	Checks []healthCheck `json:"checks"`
+}
+
+// healthcheck reports the gateway's liveness. the gateway holds no backing
+// store of its own, so the only registered check is its own liveness;
+// downstream service health is surfaced by each service's own /healthz.
 func Healthcheck() http.HandlerFunc {
 
 	return func(w http.ResponseWriter, r *http.Request) {
 
-		fmt.Fprintf(w, "status: OK")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		json.NewEncoder(w).Encode(healthReport{
+			Status: "Healthy",
+			Checks: []healthCheck{
+				{Name: "self", Status: "Healthy"},
+			},
+		})
 	}
 }

--- a/services/gateway/middleware/dispatch.go
+++ b/services/gateway/middleware/dispatch.go
@@ -24,7 +24,7 @@ func Dispatch(bypassHandler http.Handler, fullpathHandler http.Handler) http.Han
 
 		bypass := func(path string) bool {
 			return path == "/api/openapi.json" ||
-				strings.HasPrefix(path, "/api/gateway/")
+				path == "/healthz"
 		}
 
 		if bypass(r.URL.Path) {

--- a/services/guild/src/Guild.Presentation/Program.cs
+++ b/services/guild/src/Guild.Presentation/Program.cs
@@ -6,6 +6,7 @@ using Guild.Infrastructure;
 using Guild.Persistence;
 using Guild.Presentation.Endpoints;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.IdentityModel.Tokens;
 using Scalar.AspNetCore;
 
@@ -81,7 +82,23 @@ app.UseExceptionHandler(exApp => exApp.Run(async ctx =>
 app.UseAuthentication();
 app.UseAuthorization();
 
-app.MapHealthChecks("/healthz");
+app.MapHealthChecks("/healthz", new HealthCheckOptions
+{
+	ResponseWriter = static async (ctx, report) =>
+	{
+		ctx.Response.ContentType = "application/json";
+		await ctx.Response.WriteAsync(JsonSerializer.Serialize(new
+		{
+			status = report.Status.ToString(),
+			checks = report.Entries.Select(e => new
+			{
+				name = e.Key,
+				status = e.Value.Status.ToString(),
+				description = e.Value.Description,
+			}),
+		}));
+	},
+});
 
 var v1 = app.MapGroup("/v1").RequireAuthorization();
 v1.MapCarter();

--- a/services/notification/compose.yaml
+++ b/services/notification/compose.yaml
@@ -34,7 +34,7 @@ services:
     env_file: ${PWD}/services/notification/.env
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080/v1/hello-world"]
+      test: ["CMD", "curl", "-f", "http://localhost:8080/healthz"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/services/notification/main.go
+++ b/services/notification/main.go
@@ -22,6 +22,31 @@ func helloWorld(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+type healthCheck struct {
+	Name        string  `json:"name"`
+	Status      string  `json:"status"`
+	Description *string `json:"description"`
+}
+
+type healthReport struct {
+	Status string        `json:"status"`
+	Checks []healthCheck `json:"checks"`
+}
+
+// healthz reports the service's liveness. notification has no
+// app-layer DB client wired yet, so the only registered check is its own
+// liveness; the backing DB is gated separately by the compose healthcheck.
+func healthz(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(healthReport{
+		Status: "Healthy",
+		Checks: []healthCheck{
+			{Name: "self", Status: "Healthy"},
+		},
+	})
+}
+
 func main() {
 	// I dont have a config loader like Cartoone for the moment
 	port := os.Getenv("APP_PORT")
@@ -34,6 +59,7 @@ func main() {
 	// For the moment, the endpoint hello world is in the main,
 	// this will be fixed after the pull request
 	mux.HandleFunc("GET /v1/hello-world", helloWorld)
+	mux.HandleFunc("GET /healthz", healthz)
 
 	srv := &http.Server{
 		Addr:              ":" + port,

--- a/services/user/compose.yaml
+++ b/services/user/compose.yaml
@@ -21,7 +21,7 @@ services:
     env_file: ${PWD}/services/user/.env
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080/v1/hello-world"]
+      test: ["CMD", "curl", "-f", "http://localhost:8080/healthz"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/services/user/src/main.rs
+++ b/services/user/src/main.rs
@@ -2,7 +2,7 @@ use aide::{
     axum::{routing::get_with, ApiRouter},
     openapi::{Info, OpenApi},
 };
-use axum::{routing::get, Extension, Json};
+use axum::{http::StatusCode, routing::get, Extension, Json};
 use chrono::NaiveDateTime;
 use schemars::JsonSchema;
 use sqlx::{postgres::PgPoolOptions, FromRow, PgPool};
@@ -34,6 +34,39 @@ async fn serve_openapi(Extension(api): Extension<Arc<OpenApi>>) -> Json<OpenApi>
     Json((*api).clone())
 }
 
+#[derive(serde::Serialize)]
+struct HealthCheckEntry {
+    name: &'static str,
+    status: &'static str,
+    description: Option<String>,
+}
+
+#[derive(serde::Serialize)]
+struct HealthReport {
+    status: &'static str,
+    checks: Vec<HealthCheckEntry>,
+}
+
+async fn healthz(Extension(db): Extension<PgPool>) -> (StatusCode, Json<HealthReport>) {
+    let (code, check) = match sqlx::query("SELECT 1").execute(&db).await {
+        Ok(_) => (
+            StatusCode::OK,
+            HealthCheckEntry { name: "postgres", status: "Healthy", description: None },
+        ),
+        Err(e) => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            HealthCheckEntry {
+                name: "postgres",
+                status: "Unhealthy",
+                description: Some(format!("postgres unreachable: {e}")),
+            },
+        ),
+    };
+
+    let status = if code == StatusCode::OK { "Healthy" } else { "Unhealthy" };
+    (code, Json(HealthReport { status, checks: vec![check] }))
+}
+
 #[tokio::main]
 async fn main() {
     let database_url = std::env::var("DATABASE_URL").expect("DATABASE_URL missing");
@@ -43,7 +76,7 @@ async fn main() {
         .await
         .expect("db connect failed");
 
-    let _state = AppState { db };
+    let _state = AppState { db: db.clone() };
 
     let is_dev = std::env::var("APP_ENV").as_deref() == Ok("development");
 
@@ -57,13 +90,14 @@ async fn main() {
     };
 
     let mut router = ApiRouter::new()
-        .api_route("/v1/hello-world", get_with(hello, |t| t));
+        .api_route("/v1/hello-world", get_with(hello, |t| t))
+        .route("/healthz", get(healthz));
 
     if is_dev {
         router = router.route("/openapi/v1.json", get(serve_openapi));
     }
 
-    let app = router.finish_api(&mut api);
+    let app = router.finish_api(&mut api).layer(Extension(db));
 
     let app = if is_dev {
         app.layer(Extension(Arc::new(api)))


### PR DESCRIPTION
Resolves #93 

Every service now exposes `GET /healthz` returning a JSON document of its registered checks (`{ status, checks: [{ name, status, description }] }`), and each app container's compose healthcheck hits `/healthz` instead of a feature endpoint.

| Service | Checks |
|---|---|
| auth, guild | postgres + masstransit-bus |
| chat | scylla + masstransit-bus |
| user | postgres (`SELECT 1`) |
| notification, gateway | liveness |

Verified live: all six return `200` + `{"status":"Healthy",...}` and every container reports `(healthy)`.
