### PR TITLE
Feat(chat): channel eviction

### DIFF
--- a/services/chat/src/Chat.Application/Abstractions/IUserBroadcaster.cs
+++ b/services/chat/src/Chat.Application/Abstractions/IUserBroadcaster.cs
@@ -9,4 +9,20 @@ public interface IUserBroadcaster
 {
 	Task BroadcastGuildJoinedAsync(long userId, long guildId, string guildName, CancellationToken ct);
 	Task BroadcastGuildLeftAsync(long userId, long guildId, CancellationToken ct);
+
+	/// <summary>
+	/// purges every connection of <paramref name="userId"/> from the SignalR
+	/// groups of all channels they had joined under <paramref name="guildId"/>.
+	/// used when a member is kicked/banned or leaves a guild so they stop
+	/// receiving channel broadcasts even if their client never unsubscribes.
+	/// returns the number of channel subscriptions purged.
+	/// </summary>
+	Task<int> EvictFromGuildChannelsAsync(long userId, long guildId, CancellationToken ct);
+
+	/// <summary>
+	/// purges every connection of <paramref name="userId"/> from the SignalR
+	/// group of a single channel. used when read access to one channel is
+	/// revoked without leaving the guild. returns the number of connections purged.
+	/// </summary>
+	Task<int> EvictFromChannelAsync(long userId, long channelId, CancellationToken ct);
 }

--- a/services/chat/src/Chat.Infrastructure/Messaging/Consumers/MembershipConsumers.cs
+++ b/services/chat/src/Chat.Infrastructure/Messaging/Consumers/MembershipConsumers.cs
@@ -35,14 +35,22 @@ public sealed class GuildMemberLeftConsumer(
 	{
 		var msg = context.Message;
 
+		// pull the user's connections out of the guild's channel groups *before*
+		// notifying the client, so a kicked/banned member stops receiving channel
+		// broadcasts server-side even if their client never calls LeaveChannel.
+		var evicted = await broadcaster.EvictFromGuildChannelsAsync(
+			userId: msg.UserId,
+			guildId: msg.GuildId,
+			ct: context.CancellationToken);
+
 		await broadcaster.BroadcastGuildLeftAsync(
 			userId: msg.UserId,
 			guildId: msg.GuildId,
 			ct: context.CancellationToken);
 
 		logger.LogDebug(
-			"guild.member_left consumed: guild_id={GuildId} user_id={UserId}",
-			msg.GuildId, msg.UserId);
+			"guild.member_left consumed: guild_id={GuildId} user_id={UserId} evicted_subscriptions={Evicted}",
+			msg.GuildId, msg.UserId, evicted);
 	}
 }
 

--- a/services/chat/src/Chat.Presentation/Chat.Presentation.csproj
+++ b/services/chat/src/Chat.Presentation/Chat.Presentation.csproj
@@ -9,6 +9,10 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <InternalsVisibleTo Include="Chat.UnitTests"/>
+    </ItemGroup>
+
+    <ItemGroup>
         <ProjectReference Include="..\Chat.Application\Chat.Application.csproj"/>
         <ProjectReference Include="..\Chat.Infrastructure\Chat.Infrastructure.csproj"/>
         <ProjectReference Include="..\Chat.Persistence\Chat.Persistence.csproj"/>

--- a/services/chat/src/Chat.Presentation/Hubs/ChatHub.cs
+++ b/services/chat/src/Chat.Presentation/Hubs/ChatHub.cs
@@ -28,14 +28,14 @@ public sealed class ChatHub(
 
 	public override async Task OnConnectedAsync()
 	{
-		if (connectionTracker.TrackConnected(currentUser.UserId))
+		if (connectionTracker.TrackConnected(currentUser.UserId, Context.ConnectionId))
 			await eventBus.PublishAsync(new UserOnline(currentUser.UserId), CancellationToken.None);
 		await base.OnConnectedAsync();
 	}
 
 	public override async Task OnDisconnectedAsync(Exception? exception)
 	{
-		if (connectionTracker.TrackDisconnected(currentUser.UserId))
+		if (connectionTracker.TrackDisconnected(currentUser.UserId, Context.ConnectionId))
 			await eventBus.PublishAsync(new UserOffline(currentUser.UserId), CancellationToken.None);
 		await base.OnDisconnectedAsync(exception);
 	}
@@ -57,10 +57,14 @@ public sealed class ChatHub(
 		}
 
 		await Groups.AddToGroupAsync(Context.ConnectionId, $"channel:{channelId}", Context.ConnectionAborted);
+		connectionTracker.TrackChannelJoined(currentUser.UserId, Context.ConnectionId, channelId, membership.GuildId);
 	}
 
-	public Task LeaveChannel(long channelId) =>
-		Groups.RemoveFromGroupAsync(Context.ConnectionId, $"channel:{channelId}");
+	public async Task LeaveChannel(long channelId)
+	{
+		await Groups.RemoveFromGroupAsync(Context.ConnectionId, $"channel:{channelId}");
+		connectionTracker.TrackChannelLeft(currentUser.UserId, Context.ConnectionId, channelId);
+	}
 
 	public async Task Typing(string scope, long id)
 	{

--- a/services/chat/src/Chat.Presentation/Hubs/SignalRUserBroadcaster.cs
+++ b/services/chat/src/Chat.Presentation/Hubs/SignalRUserBroadcaster.cs
@@ -10,7 +10,9 @@ namespace Chat.Presentation.Hubs;
 /// off the JWT-authenticated identity (the user's snowflake string, since the
 /// JwtBearer middleware auto-maps the <c>sub</c> claim to it)
 /// </summary>
-internal sealed class SignalRUserBroadcaster(IHubContext<ChatHub, IChatClient> hub)
+internal sealed class SignalRUserBroadcaster(
+	IHubContext<ChatHub, IChatClient> hub,
+	UserConnectionTracker tracker)
 	: IUserBroadcaster
 {
 	public Task BroadcastGuildJoinedAsync(long userId, long guildId, string guildName, CancellationToken ct) =>
@@ -18,4 +20,26 @@ internal sealed class SignalRUserBroadcaster(IHubContext<ChatHub, IChatClient> h
 
 	public Task BroadcastGuildLeftAsync(long userId, long guildId, CancellationToken ct) =>
 		hub.Clients.User(userId.ToString()).GuildLeft(guildId.ToString());
+
+	public async Task<int> EvictFromGuildChannelsAsync(long userId, long guildId, CancellationToken ct)
+	{
+		var subscriptions = tracker.ConnectionsInGuild(userId, guildId);
+		foreach (var (connectionId, channelId) in subscriptions)
+		{
+			await hub.Groups.RemoveFromGroupAsync(connectionId, $"channel:{channelId}", ct);
+			tracker.TrackChannelLeft(userId, connectionId, channelId);
+		}
+		return subscriptions.Count;
+	}
+
+	public async Task<int> EvictFromChannelAsync(long userId, long channelId, CancellationToken ct)
+	{
+		var connections = tracker.ConnectionsInChannel(userId, channelId);
+		foreach (var connectionId in connections)
+		{
+			await hub.Groups.RemoveFromGroupAsync(connectionId, $"channel:{channelId}", ct);
+			tracker.TrackChannelLeft(userId, connectionId, channelId);
+		}
+		return connections.Count;
+	}
 }

--- a/services/chat/src/Chat.Presentation/Hubs/UserConnectionTracker.cs
+++ b/services/chat/src/Chat.Presentation/Hubs/UserConnectionTracker.cs
@@ -2,31 +2,120 @@ using System.Collections.Concurrent;
 
 namespace Chat.Presentation.Hubs;
 
+/// <summary>
+/// tracks, per user, which connections are open and which <c>channel:{id}</c>
+/// groups each connection has joined (along with the channel's guild). presence
+/// (first/last connection) is derived from the per-user connection set, and the
+/// channel bookkeeping powers server-side eviction: events only carry a userId,
+/// but SignalR group removal needs a connectionId + group name, so we keep the
+/// connectionId -> joined-channels mapping ourselves.
+/// </summary>
 public sealed class UserConnectionTracker
 {
-	private readonly ConcurrentDictionary<long, int> _counts = new();
+	// per-user state. Each connection maps to the set of channels it has joined
+	// (channelId -> guildId). all reads/writes are guarded by locking the
+	// instance, and the instance is removed from _users only while holding its
+	// lock, so the connect/disconnect race is closed (see TrackConnected).
+	private sealed class UserState
+	{
+		public readonly Dictionary<string, Dictionary<long, long>> Connections = [];
+	}
 
-	// Returns true if this is the user's first connection.
-	public bool TrackConnected(long userId)
-		=> _counts.AddOrUpdate(userId, 1, (_, c) => c + 1) == 1;
+	private readonly ConcurrentDictionary<long, UserState> _users = new();
 
-	// Returns true if this was the user's last connection.
-	public bool TrackDisconnected(long userId)
+	// returns true if this is the user's first connection.
+	public bool TrackConnected(long userId, string connectionId)
 	{
 		while (true)
 		{
-			if (!_counts.TryGetValue(userId, out var count))
-				return true;
-			if (count <= 1)
+			var state = _users.GetOrAdd(userId, _ => new UserState());
+			lock (state)
 			{
-				if (_counts.TryRemove(new KeyValuePair<long, int>(userId, count)))
-					return true;
-			}
-			else
-			{
-				if (_counts.TryUpdate(userId, count - 1, count))
-					return false;
+				// a concurrent last-disconnect may have removed this instance
+				// between GetOrAdd and the lock; retry with a fresh one.
+				if (!_users.TryGetValue(userId, out var current) || !ReferenceEquals(current, state))
+					continue;
+
+				var wasEmpty = state.Connections.Count == 0;
+				state.Connections[connectionId] = [];
+				return wasEmpty;
 			}
 		}
+	}
+
+	// returns true if this was the user's last connection.
+	public bool TrackDisconnected(long userId, string connectionId)
+	{
+		if (!_users.TryGetValue(userId, out var state))
+			return true;
+
+		lock (state)
+		{
+			state.Connections.Remove(connectionId);
+			if (state.Connections.Count == 0)
+			{
+				_users.TryRemove(userId, out _);
+				return true;
+			}
+			return false;
+		}
+	}
+
+	public void TrackChannelJoined(long userId, string connectionId, long channelId, long guildId)
+	{
+		if (!_users.TryGetValue(userId, out var state))
+			return;
+
+		lock (state)
+		{
+			if (state.Connections.TryGetValue(connectionId, out var channels))
+				channels[channelId] = guildId;
+		}
+	}
+
+	public void TrackChannelLeft(long userId, string connectionId, long channelId)
+	{
+		if (!_users.TryGetValue(userId, out var state))
+			return;
+
+		lock (state)
+		{
+			if (state.Connections.TryGetValue(connectionId, out var channels))
+				channels.Remove(channelId);
+		}
+	}
+
+	// snapshot of every (connection, channel) the user has joined under the given
+	// guild. pure read: the caller removes these from their SignalR groups and
+	// then calls TrackChannelLeft, so a mid-way failure can be safely retried.
+	public IReadOnlyList<(string ConnectionId, long ChannelId)> ConnectionsInGuild(long userId, long guildId)
+	{
+		if (!_users.TryGetValue(userId, out var state))
+			return [];
+
+		var matches = new List<(string, long)>();
+		lock (state)
+		{
+			foreach (var (connectionId, channels) in state.Connections)
+				foreach (var (channelId, joinedGuildId) in channels)
+					if (joinedGuildId == guildId)
+						matches.Add((connectionId, channelId));
+		}
+		return matches;
+	}
+
+	public IReadOnlyList<string> ConnectionsInChannel(long userId, long channelId)
+	{
+		if (!_users.TryGetValue(userId, out var state))
+			return [];
+
+		var matches = new List<string>();
+		lock (state)
+		{
+			foreach (var (connectionId, channels) in state.Connections)
+				if (channels.ContainsKey(channelId))
+					matches.Add(connectionId);
+		}
+		return matches;
 	}
 }

--- a/services/chat/tests/Chat.FunctionalTests/Features/ChannelLazySubscriptionTests.cs
+++ b/services/chat/tests/Chat.FunctionalTests/Features/ChannelLazySubscriptionTests.cs
@@ -490,3 +490,139 @@ public sealed class GuildEventTests(ChatApiFactory factory)
 		Assert.False(bReceived);
 	}
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// T1.25 – T1.28 · Server-side eviction (guild.member_left / kick / ban)
+// ─────────────────────────────────────────────────────────────────────────────
+
+public sealed class ChannelEvictionTests(ChatApiFactory factory)
+	: IClassFixture<ChatApiFactory>, IAsyncLifetime
+{
+	private const long ReadMessages = 1L << 1;
+	private const long GuildId      = 777;
+	private const long OtherGuildId = 778;
+	private const long ChannelId    = 400;
+	private const long OtherChannel = 401;
+
+	private const long UserEvicted       = 5_001;
+	private const long UserOtherGuild    = 5_002;
+	private const long UserRejoinAfter   = 5_003;
+	private const long UserChannelEvict  = 5_004;
+
+	public Task InitializeAsync() { factory.EventBus.Reset(); return Task.CompletedTask; }
+	public Task DisposeAsync() => Task.CompletedTask;
+
+	// T1.25 - after guild eviction, a joined member stops receiving channel messages
+	[Fact]
+	public async Task GuildEviction_AfterJoin_StopsReceivingMessages()
+	{
+		factory.WithMembershipFor(ChannelId, UserEvicted, GuildId, ReadMessages);
+		var token = TestTokens.Issue(ChatApiFactory.JwtSecret, UserEvicted);
+		await using var conn = HubConnectionHelper.Build(factory, token);
+
+		var received = false;
+		conn.On<MessageResponse>("ReceiveMessage", _ => received = true);
+
+		await conn.StartAsync();
+		await conn.InvokeAsync("JoinChannel", ChannelId);
+
+		await factory.SimulateGuildEvictionAsync(UserEvicted, GuildId);
+
+		await factory.SimulateChannelMessageAsync(ChannelId, Message(ChannelId, "after eviction"));
+		await Task.Delay(300);
+
+		Assert.False(received);
+	}
+
+	// T1.26 - eviction only targets channels of the named guild
+	[Fact]
+	public async Task GuildEviction_LeavesOtherGuildChannelsSubscribed()
+	{
+		factory.GuildClient.Setup(ChannelId, UserOtherGuild,
+			new ChannelMembership(IsMember: true, GuildId: GuildId, Permissions: ReadMessages));
+		factory.GuildClient.Setup(OtherChannel, UserOtherGuild,
+			new ChannelMembership(IsMember: true, GuildId: OtherGuildId, Permissions: ReadMessages));
+		var token = TestTokens.Issue(ChatApiFactory.JwtSecret, UserOtherGuild);
+		await using var conn = HubConnectionHelper.Build(factory, token);
+
+		var otherReceived = new TaskCompletionSource<MessageResponse>();
+		conn.On<MessageResponse>("ReceiveMessage", msg =>
+		{
+			if (msg.ChannelId == OtherChannel.ToString())
+				otherReceived.TrySetResult(msg);
+		});
+
+		await conn.StartAsync();
+		await conn.InvokeAsync("JoinChannel", ChannelId);
+		await conn.InvokeAsync("JoinChannel", OtherChannel);
+
+		await factory.SimulateGuildEvictionAsync(UserOtherGuild, GuildId);
+
+		await factory.SimulateChannelMessageAsync(OtherChannel, Message(OtherChannel, "still here"));
+
+		var received = await otherReceived.Task.WaitAsync(TimeSpan.FromSeconds(3));
+		Assert.Equal("still here", received.Content);
+	}
+
+	// T1.27 - an evicted user can re-join (e.g. re-invited) and receive again
+	[Fact]
+	public async Task GuildEviction_ThenRejoin_ReceivesMessagesAgain()
+	{
+		factory.WithMembershipFor(ChannelId, UserRejoinAfter, GuildId, ReadMessages);
+		var token = TestTokens.Issue(ChatApiFactory.JwtSecret, UserRejoinAfter);
+		await using var conn = HubConnectionHelper.Build(factory, token);
+
+		var messageTcs = new TaskCompletionSource<MessageResponse>();
+		conn.On<MessageResponse>("ReceiveMessage", msg => messageTcs.TrySetResult(msg));
+
+		await conn.StartAsync();
+		await conn.InvokeAsync("JoinChannel", ChannelId);
+		await factory.SimulateGuildEvictionAsync(UserRejoinAfter, GuildId);
+
+		await conn.InvokeAsync("JoinChannel", ChannelId);
+		await factory.SimulateChannelMessageAsync(ChannelId, Message(ChannelId, "welcome back"));
+
+		var received = await messageTcs.Task.WaitAsync(TimeSpan.FromSeconds(3));
+		Assert.Equal("welcome back", received.Content);
+	}
+
+	// T1.28 - channel-scoped eviction drops one channel but leaves the rest
+	[Fact]
+	public async Task ChannelEviction_DropsTargetChannelOnly()
+	{
+		factory.GuildClient.Setup(ChannelId, UserChannelEvict,
+			new ChannelMembership(IsMember: true, GuildId: GuildId, Permissions: ReadMessages));
+		factory.GuildClient.Setup(OtherChannel, UserChannelEvict,
+			new ChannelMembership(IsMember: true, GuildId: GuildId, Permissions: ReadMessages));
+		var token = TestTokens.Issue(ChatApiFactory.JwtSecret, UserChannelEvict);
+		await using var conn = HubConnectionHelper.Build(factory, token);
+
+		var evictedReceived = false;
+		var survivorReceived = new TaskCompletionSource<MessageResponse>();
+		conn.On<MessageResponse>("ReceiveMessage", msg =>
+		{
+			if (msg.ChannelId == ChannelId.ToString())
+				evictedReceived = true;
+			else if (msg.ChannelId == OtherChannel.ToString())
+				survivorReceived.TrySetResult(msg);
+		});
+
+		await conn.StartAsync();
+		await conn.InvokeAsync("JoinChannel", ChannelId);
+		await conn.InvokeAsync("JoinChannel", OtherChannel);
+
+		await factory.SimulateChannelEvictionAsync(UserChannelEvict, ChannelId);
+
+		await factory.SimulateChannelMessageAsync(ChannelId, Message(ChannelId, "gone"));
+		await factory.SimulateChannelMessageAsync(OtherChannel, Message(OtherChannel, "kept"));
+
+		var received = await survivorReceived.Task.WaitAsync(TimeSpan.FromSeconds(3));
+		Assert.Equal("kept", received.Content);
+		Assert.False(evictedReceived);
+	}
+
+	private static MessageResponse Message(long channelId, string content) =>
+		new(Id: "1", ChannelId: channelId.ToString(), AuthorId: "1",
+			Content: content, ReplyToId: null, EditedAt: null,
+			CreatedAt: DateTimeOffset.UtcNow, Attachments: [], Reactions: [], Nonce: null);
+}

--- a/services/chat/tests/Chat.FunctionalTests/Infrastructure/ChatApiFactory.cs
+++ b/services/chat/tests/Chat.FunctionalTests/Infrastructure/ChatApiFactory.cs
@@ -97,6 +97,24 @@ public sealed class ChatApiFactory : WebApplicationFactory<Program>
 		await broadcaster.BroadcastGuildLeftAsync(userId, guildId, CancellationToken.None);
 	}
 
+	// server-side eviction primitive (the guild.member_left side effect): purges
+	// the user's connections from every channel group they joined under the guild.
+	public async Task SimulateGuildEvictionAsync(long userId, long guildId)
+	{
+		using var scope = Server.Services.CreateScope();
+		var broadcaster = scope.ServiceProvider.GetRequiredService<IUserBroadcaster>();
+		await broadcaster.EvictFromGuildChannelsAsync(userId, guildId, CancellationToken.None);
+	}
+
+	// server-side eviction primitive scoped to a single channel (the future
+	// channel.access_revoked side effect): purges the user from one channel group.
+	public async Task SimulateChannelEvictionAsync(long userId, long channelId)
+	{
+		using var scope = Server.Services.CreateScope();
+		var broadcaster = scope.ServiceProvider.GetRequiredService<IUserBroadcaster>();
+		await broadcaster.EvictFromChannelAsync(userId, channelId, CancellationToken.None);
+	}
+
 	// Bypasses IChannelBroadcaster (replaced by a fake) and pushes a message
 	// directly into the SignalR channel group. Use to verify that a connected
 	// client receives ReceiveMessage after JoinChannel.

--- a/services/chat/tests/Chat.UnitTests/Fakes/FakeUserBroadcaster.cs
+++ b/services/chat/tests/Chat.UnitTests/Fakes/FakeUserBroadcaster.cs
@@ -6,9 +6,13 @@ public sealed class FakeUserBroadcaster : IUserBroadcaster
 {
 	private readonly List<(long UserId, long GuildId, string GuildName)> _joinCalls = [];
 	private readonly List<(long UserId, long GuildId)> _leftCalls = [];
+	private readonly List<(long UserId, long GuildId)> _evictGuildCalls = [];
+	private readonly List<(long UserId, long ChannelId)> _evictChannelCalls = [];
 
 	public IReadOnlyList<(long UserId, long GuildId, string GuildName)> JoinCalls => _joinCalls;
 	public IReadOnlyList<(long UserId, long GuildId)> LeftCalls => _leftCalls;
+	public IReadOnlyList<(long UserId, long GuildId)> EvictGuildCalls => _evictGuildCalls;
+	public IReadOnlyList<(long UserId, long ChannelId)> EvictChannelCalls => _evictChannelCalls;
 
 	public Task BroadcastGuildJoinedAsync(long userId, long guildId, string guildName, CancellationToken ct)
 	{
@@ -20,5 +24,21 @@ public sealed class FakeUserBroadcaster : IUserBroadcaster
 	{
 		_leftCalls.Add((userId, guildId));
 		return Task.CompletedTask;
+	}
+
+	// EvictedCount is returned from both evict methods so consumer tests can
+	// exercise whatever the caller does with the purged-subscription count.
+	public int EvictedCount { get; set; }
+
+	public Task<int> EvictFromGuildChannelsAsync(long userId, long guildId, CancellationToken ct)
+	{
+		_evictGuildCalls.Add((userId, guildId));
+		return Task.FromResult(EvictedCount);
+	}
+
+	public Task<int> EvictFromChannelAsync(long userId, long channelId, CancellationToken ct)
+	{
+		_evictChannelCalls.Add((userId, channelId));
+		return Task.FromResult(EvictedCount);
 	}
 }

--- a/services/chat/tests/Chat.UnitTests/Infrastructure/GuildMemberJoinedConsumerTests.cs
+++ b/services/chat/tests/Chat.UnitTests/Infrastructure/GuildMemberJoinedConsumerTests.cs
@@ -34,3 +34,31 @@ public sealed class GuildMemberJoinedConsumerTests
 		Assert.Equal("skafenings", call.GuildName);
 	}
 }
+
+public sealed class GuildMemberLeftConsumerTests
+{
+	[Fact]
+	public async Task Consume_EvictsFromGuildChannels_AndNotifiesClient()
+	{
+		var broadcaster = new FakeUserBroadcaster();
+		await using var provider = new ServiceCollection()
+			.AddSingleton<IUserBroadcaster>(broadcaster)
+			.AddMassTransitTestHarness(x => x.AddConsumer<GuildMemberLeftConsumer>())
+			.BuildServiceProvider(true);
+
+		var harness = provider.GetRequiredService<ITestHarness>();
+		await harness.Start();
+
+		await harness.Bus.Publish(new GuildMemberLeft(GuildId: 100, UserId: 42));
+
+		Assert.True(await harness.Consumed.Any<GuildMemberLeft>());
+
+		var (UserId, GuildId) = Assert.Single(broadcaster.EvictGuildCalls);
+		Assert.Equal(42L, UserId);
+		Assert.Equal(100L, GuildId);
+
+		var left = Assert.Single(broadcaster.LeftCalls);
+		Assert.Equal(42L, left.UserId);
+		Assert.Equal(100L, left.GuildId);
+	}
+}

--- a/services/chat/tests/Chat.UnitTests/Presentation/SignalRUserBroadcasterTests.cs
+++ b/services/chat/tests/Chat.UnitTests/Presentation/SignalRUserBroadcasterTests.cs
@@ -1,0 +1,84 @@
+using Chat.Presentation.Hubs;
+using Microsoft.AspNetCore.SignalR;
+using Xunit;
+
+namespace Chat.UnitTests.Presentation;
+
+public sealed class SignalRUserBroadcasterTests
+{
+	private const long User = 42;
+	private const long Guild = 7;
+	private const long ChannelA = 100;
+	private const long ChannelB = 200;
+
+	[Fact]
+	public async Task EvictFromGuildChannels_RemovesEveryConnectionAndForgetsThem()
+	{
+		var tracker = new UserConnectionTracker();
+		tracker.TrackConnected(User, "c1");
+		tracker.TrackChannelJoined(User, "c1", ChannelA, Guild);
+		tracker.TrackChannelJoined(User, "c1", ChannelB, Guild);
+
+		var groups = new RecordingGroupManager();
+		var broadcaster = new SignalRUserBroadcaster(new FakeHubContext(groups), tracker);
+
+		var evicted = await broadcaster.EvictFromGuildChannelsAsync(User, Guild, CancellationToken.None);
+
+		Assert.Equal(2, evicted);
+		Assert.Contains(("c1", $"channel:{ChannelA}"), groups.Removed);
+		Assert.Contains(("c1", $"channel:{ChannelB}"), groups.Removed);
+		Assert.Empty(tracker.ConnectionsInGuild(User, Guild));
+	}
+
+	// guards the retry-safety contract: GuildMemberLeftConsumer is a MassTransit
+	// consumer, so a throw mid-eviction redelivers the message. a connection whose
+	// group removal failed must NOT be forgotten, or the retry can never evict it.
+	[Fact]
+	public async Task EvictFromGuildChannels_WhenAGroupRemovalFails_LeavesItRetryable()
+	{
+		var tracker = new UserConnectionTracker();
+		tracker.TrackConnected(User, "c1");
+		tracker.TrackChannelJoined(User, "c1", ChannelA, Guild);
+		tracker.TrackChannelJoined(User, "c1", ChannelB, Guild);
+
+		var groups = new RecordingGroupManager { FailOnGroup = $"channel:{ChannelB}" };
+		var broadcaster = new SignalRUserBroadcaster(new FakeHubContext(groups), tracker);
+
+		await Assert.ThrowsAsync<InvalidOperationException>(
+			() => broadcaster.EvictFromGuildChannelsAsync(User, Guild, CancellationToken.None));
+
+		// the connection that failed to leave is still tracked, so a retry can find it
+		Assert.Equal("c1", Assert.Single(tracker.ConnectionsInChannel(User, ChannelB)));
+
+		groups.FailOnGroup = null;
+		await broadcaster.EvictFromGuildChannelsAsync(User, Guild, CancellationToken.None);
+
+		Assert.Empty(tracker.ConnectionsInGuild(User, Guild));
+		Assert.Contains(("c1", $"channel:{ChannelB}"), groups.Removed);
+	}
+
+	private sealed class RecordingGroupManager : IGroupManager
+	{
+		public List<(string ConnectionId, string Group)> Removed { get; } = [];
+		public string? FailOnGroup { get; set; }
+
+		public Task RemoveFromGroupAsync(string connectionId, string groupName, CancellationToken cancellationToken = default)
+		{
+			if (groupName == FailOnGroup)
+				throw new InvalidOperationException($"group removal failed for {groupName}");
+			Removed.Add((connectionId, groupName));
+			return Task.CompletedTask;
+		}
+
+		public Task AddToGroupAsync(string connectionId, string groupName, CancellationToken cancellationToken = default)
+			=> Task.CompletedTask;
+	}
+
+	private sealed class FakeHubContext(IGroupManager groups) : IHubContext<ChatHub, IChatClient>
+	{
+		public IGroupManager Groups => groups;
+
+		// eviction only touches Groups; Clients is never reached.
+		public IHubClients<IChatClient> Clients => throw new NotSupportedException();
+	}
+}

--- a/services/chat/tests/Chat.UnitTests/Presentation/UserConnectionTrackerTests.cs
+++ b/services/chat/tests/Chat.UnitTests/Presentation/UserConnectionTrackerTests.cs
@@ -1,0 +1,140 @@
+using Chat.Presentation.Hubs;
+using Xunit;
+
+namespace Chat.UnitTests.Presentation;
+
+public sealed class UserConnectionTrackerTests
+{
+	private const long User = 42;
+	private const long Guild = 7;
+	private const long OtherGuild = 8;
+	private const long Channel = 100;
+	private const long OtherChannel = 200;
+
+	[Fact]
+	public void TrackConnected_FirstConnection_ReturnsTrue()
+	{
+		var tracker = new UserConnectionTracker();
+
+		Assert.True(tracker.TrackConnected(User, "c1"));
+	}
+
+	[Fact]
+	public void TrackConnected_SecondConnection_ReturnsFalse()
+	{
+		var tracker = new UserConnectionTracker();
+		tracker.TrackConnected(User, "c1");
+
+		Assert.False(tracker.TrackConnected(User, "c2"));
+	}
+
+	[Fact]
+	public void TrackDisconnected_LastConnection_ReturnsTrue()
+	{
+		var tracker = new UserConnectionTracker();
+		tracker.TrackConnected(User, "c1");
+		tracker.TrackConnected(User, "c2");
+
+		Assert.False(tracker.TrackDisconnected(User, "c1"));
+		Assert.True(tracker.TrackDisconnected(User, "c2"));
+	}
+
+	[Fact]
+	public void TrackDisconnected_UnknownUser_ReturnsTrue()
+	{
+		var tracker = new UserConnectionTracker();
+
+		Assert.True(tracker.TrackDisconnected(User, "c1"));
+	}
+
+	[Fact]
+	public void ConnectionsInGuild_ReturnsOnlyChannelsJoinedUnderThatGuild()
+	{
+		var tracker = new UserConnectionTracker();
+		tracker.TrackConnected(User, "c1");
+		tracker.TrackConnected(User, "c2");
+		tracker.TrackChannelJoined(User, "c1", Channel, Guild);
+		tracker.TrackChannelJoined(User, "c2", OtherChannel, OtherGuild);
+
+		Assert.Equal(("c1", Channel), Assert.Single(tracker.ConnectionsInGuild(User, Guild)));
+		Assert.Equal(("c2", OtherChannel), Assert.Single(tracker.ConnectionsInGuild(User, OtherGuild)));
+	}
+
+	[Fact]
+	public void ConnectionsInGuild_IsNonDestructive()
+	{
+		var tracker = new UserConnectionTracker();
+		tracker.TrackConnected(User, "c1");
+		tracker.TrackChannelJoined(User, "c1", Channel, Guild);
+
+		tracker.ConnectionsInGuild(User, Guild);
+
+		Assert.Equal(("c1", Channel), Assert.Single(tracker.ConnectionsInGuild(User, Guild)));
+	}
+
+	[Fact]
+	public void ConnectionsInGuild_CoversMultipleChannelsAcrossConnections()
+	{
+		var tracker = new UserConnectionTracker();
+		tracker.TrackConnected(User, "c1");
+		tracker.TrackChannelJoined(User, "c1", Channel, Guild);
+		tracker.TrackChannelJoined(User, "c1", OtherChannel, Guild);
+
+		var inGuild = tracker.ConnectionsInGuild(User, Guild);
+
+		Assert.Equal(2, inGuild.Count);
+		Assert.Contains(("c1", Channel), inGuild);
+		Assert.Contains(("c1", OtherChannel), inGuild);
+	}
+
+	[Fact]
+	public void ConnectionsInChannel_ReturnsEveryConnectionJoinedToThatChannel()
+	{
+		var tracker = new UserConnectionTracker();
+		tracker.TrackConnected(User, "c1");
+		tracker.TrackConnected(User, "c2");
+		tracker.TrackChannelJoined(User, "c1", Channel, Guild);
+		tracker.TrackChannelJoined(User, "c2", Channel, Guild);
+		tracker.TrackChannelJoined(User, "c2", OtherChannel, Guild);
+
+		var inChannel = tracker.ConnectionsInChannel(User, Channel);
+
+		Assert.Equal(2, inChannel.Count);
+		Assert.Contains("c1", inChannel);
+		Assert.Contains("c2", inChannel);
+		Assert.Equal("c2", Assert.Single(tracker.ConnectionsInChannel(User, OtherChannel)));
+	}
+
+	[Fact]
+	public void TrackChannelLeft_RemovesEntry_SoQueriesFindNothing()
+	{
+		var tracker = new UserConnectionTracker();
+		tracker.TrackConnected(User, "c1");
+		tracker.TrackChannelJoined(User, "c1", Channel, Guild);
+
+		tracker.TrackChannelLeft(User, "c1", Channel);
+
+		Assert.Empty(tracker.ConnectionsInGuild(User, Guild));
+		Assert.Empty(tracker.ConnectionsInChannel(User, Channel));
+	}
+
+	[Fact]
+	public void TrackDisconnected_DropsJoinedChannels()
+	{
+		var tracker = new UserConnectionTracker();
+		tracker.TrackConnected(User, "c1");
+		tracker.TrackChannelJoined(User, "c1", Channel, Guild);
+
+		tracker.TrackDisconnected(User, "c1");
+
+		Assert.Empty(tracker.ConnectionsInGuild(User, Guild));
+	}
+
+	[Fact]
+	public void ConnectionsInGuild_UnknownUser_ReturnsEmpty()
+	{
+		var tracker = new UserConnectionTracker();
+
+		Assert.Empty(tracker.ConnectionsInGuild(User, Guild));
+	}
+}


### PR DESCRIPTION
Resolves #223. Follows #198.

## Problem

Since #198, Chat uses client-driven lazy subscription (`JoinChannel`/`LeaveChannel`), with membership and `READ_MESSAGES` checked only at `JoinChannel` time. Once a connection is in a `channel:{id}` SignalR group, nothing removes it server-side: `guild.member_left` only sent the client a `GuildLeft` notification and trusted the client to call `LeaveChannel` itself.

So a kicked or banned member (or a stale / hand-crafted client that never unsubscribes) kept receiving `ReceiveMessage` broadcasts indefinitely.

## Approach

A reusable server-side eviction primitive that purges a user's connections from `channel:{id}` groups. SignalR group removal needs a `connectionId` + group name, but events only carry a `userId`, so this requires connection bookkeeping.

- **`UserConnectionTracker`** is extended from a per-user connection *count* to a `userId -> connectionId -> {channelId -> guildId}` map. Presence (first/last connection) is still derived from the per-user connection set; the channel mapping powers eviction. `membership.GuildId` is already known at `JoinChannel` time.
- **`IUserBroadcaster`** gains two methods:
  - `EvictFromGuildChannelsAsync(userId, guildId)` purges every connection of the user from all channel groups joined under that guild.
  - `EvictFromChannelAsync(userId, channelId)` purges one channel (primitive for a future `channel.access_revoked` event; not yet wired to a live trigger).
- **`GuildMemberLeftConsumer`** now evicts *before* notifying the client, and logs the purged-subscription count.
- The hub feeds the tracker on connect / disconnect / `JoinChannel` / `LeaveChannel`.

## Concurrency and retry-safety

- `UserConnectionTracker` mutations are guarded by a per-user lock; the user entry is removed from the map only while holding that lock. `TrackConnected` revalidates after locking and retries with a fresh instance, closing the connect/disconnect race.
- Eviction takes a snapshot, removes from the SignalR group, then forgets the entry. If a group removal throws mid-loop, the failed connection stays tracked so the redelivered MassTransit message can re-evict it. Evicting before `BroadcastGuildLeftAsync` keeps the whole consumer idempotent on redelivery.

## Tests

- `UserConnectionTrackerTests`: presence counting, per-guild / per-channel queries, non-destructive reads, cleanup on leave/disconnect.
- `SignalRUserBroadcasterTests`: full eviction removes every connection and forgets them; a failed group removal leaves the connection retryable.
- `GuildMemberLeftConsumerTests`: consumer evicts then notifies.
- `ChannelEvictionTests` (functional): evicted member stops receiving; other-guild channels stay subscribed; rejoin works; channel-scoped eviction drops one channel only.

## Notes / out of scope

- `channel.access_revoked` (READ_MESSAGES revoked via role or permission-overwrite change) is not published by Guild yet, so `EvictFromChannelAsync` has no live trigger and is wired only in tests. Tracked as a follow-up.
- Eviction is best-effort defense; the authoritative access gate remains the membership check in `JoinChannel`.
