### PR TITLE
Feat(chat): attachments upload and downloads

### DIFF
--- a/infra/nginx/nginx.conf
+++ b/infra/nginx/nginx.conf
@@ -32,6 +32,9 @@ http {
         }
 
         location /api/ {
+            # attachment / avatar uploads cap at 25 MB per file in the services;
+            # allow a little multipart overhead on top so nginx doesn't 413 first
+            client_max_body_size 26m;
             proxy_pass http://127.0.0.1:8080;
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;

--- a/services/chat/src/Chat.Application/Abstractions/IAttachmentUrlFactory.cs
+++ b/services/chat/src/Chat.Application/Abstractions/IAttachmentUrlFactory.cs
@@ -1,0 +1,11 @@
+namespace Chat.Application.Abstractions;
+
+/// <summary>
+/// builds the public download URL clients render for an attachment. the URL routes
+/// back through <c>GET /attachments/{id}/{filename}</c> (auth-checked on every hit),
+/// so it is derived from the gateway base URL, not the storage endpoint
+/// </summary>
+public interface IAttachmentUrlFactory
+{
+	string BuildUrl(long attachmentId, string filename);
+}

--- a/services/chat/src/Chat.Application/Abstractions/IObjectStore.cs
+++ b/services/chat/src/Chat.Application/Abstractions/IObjectStore.cs
@@ -11,4 +11,13 @@ public interface IObjectStore
 
 	/// <summary>opens a read stream for the blob, or <c>null</c> if the key is absent</summary>
 	Task<Stream?> GetAsync(string key, CancellationToken ct);
+
+	/// <summary>deletes the blob; a no-op if the key is already absent</summary>
+	Task DeleteAsync(string key, CancellationToken ct);
+
+	/// <summary>streams every stored blob's key and last-modified time, for the reaper</summary>
+	IAsyncEnumerable<ObjectInfo> ListAsync(CancellationToken ct);
 }
+
+/// <summary>minimal listing entry: the object key and when it was last written</summary>
+public sealed record ObjectInfo(string Key, DateTimeOffset LastModified);

--- a/services/chat/src/Chat.Application/Abstractions/IObjectStore.cs
+++ b/services/chat/src/Chat.Application/Abstractions/IObjectStore.cs
@@ -1,0 +1,14 @@
+namespace Chat.Application.Abstractions;
+
+/// <summary>
+/// blob storage for attachment payloads (backed by S3-compatible object storage)
+/// the Chat Service is the only reader/writer; clients never touch it directly so
+/// authorization stays in the REST layer
+/// </summary>
+public interface IObjectStore
+{
+	Task PutAsync(string key, Stream content, string contentType, long length, CancellationToken ct);
+
+	/// <summary>opens a read stream for the blob, or <c>null</c> if the key is absent</summary>
+	Task<Stream?> GetAsync(string key, CancellationToken ct);
+}

--- a/services/chat/src/Chat.Application/Abstractions/Persistence/IAttachmentRepository.cs
+++ b/services/chat/src/Chat.Application/Abstractions/Persistence/IAttachmentRepository.cs
@@ -1,0 +1,27 @@
+using Chat.Domain.Attachments;
+
+namespace Chat.Application.Abstractions.Persistence;
+
+public interface IAttachmentRepository
+{
+	Task AddDraftAsync(DraftAttachment draft, CancellationToken ct);
+
+	Task<DraftAttachment?> GetDraftAsync(long id, CancellationToken ct);
+
+	/// <summary>true if the attachment is already bound to a sent message</summary>
+	Task<bool> IsAttachedAsync(long id, CancellationToken ct);
+
+	/// <summary>resolves an attachment id to its owning message for the download path</summary>
+	Task<AttachmentLocation?> GetLocationAsync(long id, CancellationToken ct);
+
+	Task<AttachmentMetadata?> GetChannelAttachmentAsync(long channelId, long messageId, long id, CancellationToken ct);
+
+	Task<IReadOnlyList<AttachmentMetadata>> GetChannelMessageAttachmentsAsync(long channelId, long messageId, CancellationToken ct);
+}
+
+/// <summary>
+/// where an attached attachment lives, per <c>attachment_lookup</c>. channel
+/// attachments carry <see cref="ChannelId"/>; DM attachments carry
+/// <see cref="ConversationId"/>
+/// </summary>
+public sealed record AttachmentLocation(bool IsDm, long? ChannelId, long? ConversationId, long MessageId);

--- a/services/chat/src/Chat.Application/Abstractions/Persistence/IAttachmentRepository.cs
+++ b/services/chat/src/Chat.Application/Abstractions/Persistence/IAttachmentRepository.cs
@@ -17,6 +17,13 @@ public interface IAttachmentRepository
 	Task<AttachmentMetadata?> GetChannelAttachmentAsync(long channelId, long messageId, long id, CancellationToken ct);
 
 	Task<IReadOnlyList<AttachmentMetadata>> GetChannelMessageAttachmentsAsync(long channelId, long messageId, CancellationToken ct);
+
+	/// <summary>
+	/// hydrates attachments for a whole page of messages in one query, keyed by
+	/// message id (messages with no attachments are simply absent from the lookup)
+	/// </summary>
+	Task<ILookup<long, AttachmentMetadata>> GetChannelMessagesAttachmentsAsync(
+		long channelId, IReadOnlyList<long> messageIds, CancellationToken ct);
 }
 
 /// <summary>

--- a/services/chat/src/Chat.Application/Abstractions/Persistence/IMessageRepository.cs
+++ b/services/chat/src/Chat.Application/Abstractions/Persistence/IMessageRepository.cs
@@ -1,10 +1,11 @@
+using Chat.Domain.Attachments;
 using Chat.Domain.Messages;
 
 namespace Chat.Application.Abstractions.Persistence;
 
 public interface IMessageRepository
 {
-	Task AddAsync(Message message, string? nonce, CancellationToken ct);
+	Task AddAsync(Message message, string? nonce, IReadOnlyList<AttachmentMetadata> attachments, CancellationToken ct);
 	Task<long?> FindNonceAsync(long authorId, long channelId, string nonce, CancellationToken ct);
 	Task<Message?> GetByIdAsync(long messageId, CancellationToken ct);
 	Task UpdateContentAsync(Message message, CancellationToken ct);

--- a/services/chat/src/Chat.Application/Features/Attachments/Common/AttachmentDownload.cs
+++ b/services/chat/src/Chat.Application/Features/Attachments/Common/AttachmentDownload.cs
@@ -1,0 +1,8 @@
+namespace Chat.Application.Features.Attachments.Common;
+
+/// <summary>
+/// the payload of a successful <c>GET /attachments/{id}/{filename}</c>: an open
+/// read stream plus the headers the endpoint streams it back with. Caller owns
+/// disposing <see cref="Content"/>
+/// </summary>
+public sealed record AttachmentDownload(Stream Content, string MimeType, string Filename);

--- a/services/chat/src/Chat.Application/Features/Attachments/Common/AttachmentResponse.cs
+++ b/services/chat/src/Chat.Application/Features/Attachments/Common/AttachmentResponse.cs
@@ -1,0 +1,23 @@
+using Chat.Domain.Attachments;
+
+namespace Chat.Application.Features.Attachments.Common;
+
+/// <summary>
+/// wire shape for an attachment, mirroring the <c>attachments[]</c> entries in the
+/// contract. <c>id</c> is a quoted snowflake; <c>url</c> routes through the
+/// auth-checked download endpoint
+/// </summary>
+public sealed record AttachmentResponse(
+	string Id,
+	string Url,
+	string Filename,
+	long SizeBytes,
+	string MimeType)
+{
+	public static AttachmentResponse From(AttachmentMetadata m) => new(
+		Id: m.Id.ToString(),
+		Url: m.Url,
+		Filename: m.Filename,
+		SizeBytes: m.SizeBytes,
+		MimeType: m.MimeType);
+}

--- a/services/chat/src/Chat.Application/Features/Attachments/DownloadAttachment/DownloadAttachmentHandler.cs
+++ b/services/chat/src/Chat.Application/Features/Attachments/DownloadAttachment/DownloadAttachmentHandler.cs
@@ -1,0 +1,92 @@
+using Chat.Application.Abstractions;
+using Chat.Application.Abstractions.Authentication;
+using Chat.Application.Abstractions.Messaging;
+using Chat.Application.Abstractions.Persistence;
+using Chat.Application.Features.Attachments.Common;
+using Chat.Application.Features.Attachments.UploadAttachment;
+using Chat.Domain.Attachments;
+using Chat.Domain.Results;
+
+namespace Chat.Application.Features.Attachments.DownloadAttachment;
+
+internal sealed class DownloadAttachmentHandler(
+	ICurrentUser currentUser,
+	IAttachmentRepository repository,
+	IGuildClient guildClient,
+	IObjectStore objectStore)
+	: IQueryHandler<DownloadAttachmentQuery, Result<AttachmentDownload>>
+{
+	// mirrors the Guild Service permission bitmask; see SendMessageHandler
+	private const long ReadMessages = 1L << 1;
+	private const long Administrator = 1L << 8;
+
+	public async Task<Result<AttachmentDownload>> HandleAsync(
+		DownloadAttachmentQuery query,
+		CancellationToken cancellationToken = default)
+	{
+		var location = await repository.GetLocationAsync(query.Id, cancellationToken);
+
+		// no lookup row -> still a draft (or never existed): only the uploader may fetch
+		if (location is null)
+			return await DownloadDraftAsync(query, cancellationToken);
+
+		if (location.IsDm)
+			// DM attachments arrive with the DM feature; nothing on the channel path
+			// can produce one, so deny rather than leak an unauthorized stream
+			return AttachmentFailures.NotAuthorized;
+
+		return await DownloadChannelAttachmentAsync(query, location, cancellationToken);
+	}
+
+	private async Task<Result<AttachmentDownload>> DownloadChannelAttachmentAsync(
+		DownloadAttachmentQuery query,
+		AttachmentLocation location,
+		CancellationToken ct)
+	{
+		var channelId = location.ChannelId!.Value;
+
+		var membership = await guildClient.GetMembershipAsync(channelId, currentUser.UserId, ct);
+		if (membership is null || !membership.IsMember)
+			return AttachmentFailures.NotAuthorized;
+
+		if ((membership.Permissions & (ReadMessages | Administrator)) == 0)
+			return AttachmentFailures.NotAuthorized;
+
+		var metadata = await repository.GetChannelAttachmentAsync(
+			channelId, location.MessageId, query.Id, ct);
+		if (metadata is null)
+			return AttachmentFailures.NotFound;
+
+		return await OpenAsync(metadata, query.Filename, ct);
+	}
+
+	private async Task<Result<AttachmentDownload>> DownloadDraftAsync(
+		DownloadAttachmentQuery query,
+		CancellationToken ct)
+	{
+		var draft = await repository.GetDraftAsync(query.Id, ct);
+		if (draft is null)
+			return AttachmentFailures.NotFound;
+
+		if (draft.UploaderId != currentUser.UserId)
+			return AttachmentFailures.NotAuthorized;
+
+		return await OpenAsync(draft.ToMetadata(), query.Filename, ct);
+	}
+
+	private async Task<Result<AttachmentDownload>> OpenAsync(
+		AttachmentMetadata metadata,
+		string requestedFilename,
+		CancellationToken ct)
+	{
+		// the filename is part of the canonical URL; a mismatch is treated as a miss
+		if (!string.Equals(metadata.Filename, requestedFilename, StringComparison.Ordinal))
+			return AttachmentFailures.NotFound;
+
+		var stream = await objectStore.GetAsync(UploadAttachmentHandler.ObjectKey(metadata.Id), ct);
+		if (stream is null)
+			return AttachmentFailures.NotFound;
+
+		return new AttachmentDownload(stream, metadata.MimeType, metadata.Filename);
+	}
+}

--- a/services/chat/src/Chat.Application/Features/Attachments/DownloadAttachment/DownloadAttachmentQuery.cs
+++ b/services/chat/src/Chat.Application/Features/Attachments/DownloadAttachment/DownloadAttachmentQuery.cs
@@ -1,0 +1,8 @@
+using Chat.Application.Abstractions.Messaging;
+using Chat.Application.Features.Attachments.Common;
+using Chat.Domain.Results;
+
+namespace Chat.Application.Features.Attachments.DownloadAttachment;
+
+public sealed record DownloadAttachmentQuery(long Id, string Filename)
+	: IQuery<Result<AttachmentDownload>>;

--- a/services/chat/src/Chat.Application/Features/Attachments/UploadAttachment/UploadAttachmentCommand.cs
+++ b/services/chat/src/Chat.Application/Features/Attachments/UploadAttachment/UploadAttachmentCommand.cs
@@ -1,0 +1,16 @@
+using Chat.Application.Abstractions.Messaging;
+using Chat.Application.Features.Attachments.Common;
+using Chat.Domain.Results;
+
+namespace Chat.Application.Features.Attachments.UploadAttachment;
+
+/// <summary>
+/// upload a draft attachment. <see cref="Content"/> is the open request stream; the
+/// handler reads it straight into object storage without buffering the whole file
+/// </summary>
+public sealed record UploadAttachmentCommand(
+	Stream Content,
+	string FileName,
+	string? ContentType,
+	long Length)
+	: ICommand<Result<AttachmentResponse>>;

--- a/services/chat/src/Chat.Application/Features/Attachments/UploadAttachment/UploadAttachmentHandler.cs
+++ b/services/chat/src/Chat.Application/Features/Attachments/UploadAttachment/UploadAttachmentHandler.cs
@@ -1,0 +1,52 @@
+using Chat.Application.Abstractions;
+using Chat.Application.Abstractions.Authentication;
+using Chat.Application.Abstractions.Messaging;
+using Chat.Application.Abstractions.Persistence;
+using Chat.Application.Features.Attachments.Common;
+using Chat.Domain.Attachments;
+using Chat.Domain.Results;
+
+namespace Chat.Application.Features.Attachments.UploadAttachment;
+
+internal sealed class UploadAttachmentHandler(
+	ICurrentUser currentUser,
+	ISnowflakeIdGenerator ids,
+	IClock clock,
+	IObjectStore objectStore,
+	IAttachmentUrlFactory urlFactory,
+	IAttachmentRepository repository)
+	: ICommandHandler<UploadAttachmentCommand, Result<AttachmentResponse>>
+{
+	public async Task<Result<AttachmentResponse>> HandleAsync(
+		UploadAttachmentCommand command,
+		CancellationToken cancellationToken = default)
+	{
+		var id = ids.NextId();
+		var url = urlFactory.BuildUrl(id, command.FileName);
+
+		// validate size / MIME before touching object storage so a rejected upload
+		// never leaves an orphaned blob behind
+		var draftResult = DraftAttachment.Create(
+			id: id,
+			uploaderId: currentUser.UserId,
+			url: url,
+			filename: command.FileName,
+			sizeBytes: command.Length,
+			mimeType: command.ContentType ?? string.Empty,
+			now: clock.UtcNow);
+		if (draftResult.IsFailure)
+			return draftResult.Error;
+
+		var draft = draftResult.Value;
+
+		await objectStore.PutAsync(
+			ObjectKey(draft.Id), command.Content, draft.MimeType, draft.SizeBytes, cancellationToken);
+		await repository.AddDraftAsync(draft, cancellationToken);
+
+		return AttachmentResponse.From(draft.ToMetadata());
+	}
+
+	// object storage is keyed by the attachment snowflake; the filename only lives
+	// in metadata and the public URL
+	internal static string ObjectKey(long attachmentId) => attachmentId.ToString();
+}

--- a/services/chat/src/Chat.Application/Features/Messages/Common/MessageResponse.cs
+++ b/services/chat/src/Chat.Application/Features/Messages/Common/MessageResponse.cs
@@ -1,11 +1,13 @@
+using Chat.Domain.Attachments;
 using Chat.Domain.Messages;
+using Chat.Application.Features.Attachments.Common;
 
 namespace Chat.Application.Features.Messages.Common;
 
 /// <summary>
 /// wire shape that mirrors the contract's <c>ReceiveMessage</c> event. snowflake
 /// IDs are quoted strings so JS clients can hold them without precision loss.
-/// attachments and reactions are empty arrays on freshly-created messages
+/// reactions are an empty array on freshly-created messages
 /// </summary>
 public sealed record MessageResponse(
 	string Id,
@@ -15,11 +17,14 @@ public sealed record MessageResponse(
 	string? ReplyToId,
 	DateTimeOffset? EditedAt,
 	DateTimeOffset CreatedAt,
-	object[] Attachments,
+	IReadOnlyList<AttachmentResponse> Attachments,
 	object[] Reactions,
 	string? Nonce)
 {
-	public static MessageResponse From(Message m, string? nonce) => new(
+	public static MessageResponse From(
+		Message m,
+		string? nonce,
+		IReadOnlyList<AttachmentMetadata>? attachments = null) => new(
 		Id: m.Id.ToString(),
 		ChannelId: m.ChannelId.ToString(),
 		AuthorId: m.AuthorId.ToString(),
@@ -27,7 +32,9 @@ public sealed record MessageResponse(
 		ReplyToId: m.ReplyToId?.ToString(),
 		EditedAt: m.EditedAt,
 		CreatedAt: m.CreatedAt,
-		Attachments: [],
+		Attachments: attachments is null or { Count: 0 }
+			? []
+			: attachments.Select(AttachmentResponse.From).ToArray(),
 		Reactions: [],
 		Nonce: nonce);
 }

--- a/services/chat/src/Chat.Application/Features/Messages/GetChannelMessages/GetChannelMessagesHandler.cs
+++ b/services/chat/src/Chat.Application/Features/Messages/GetChannelMessages/GetChannelMessagesHandler.cs
@@ -11,6 +11,7 @@ internal sealed class GetChannelMessagesHandler(
 	ICurrentUser currentUser,
 	IGuildClient guildClient,
 	IMessageRepository repository,
+	IAttachmentRepository attachmentRepository,
 	IClock clock)
 	: IQueryHandler<GetChannelMessagesQuery, Result<IReadOnlyList<MessageResponse>>>
 {
@@ -36,7 +37,15 @@ internal sealed class GetChannelMessagesHandler(
 		var beforeTime = query.BeforeTime ?? clock.UtcNow;
 		var messages = await repository.GetChannelMessagesAsync(query.ChannelId, beforeTime, query.Limit, cancellationToken);
 
-		return Result.Ok<IReadOnlyList<MessageResponse>>(
-			messages.Select(m => MessageResponse.From(m, null)).ToList());
+		// hydrate each message's attachments; message_attachments is partitioned by
+		// (channel_id, message_id) so this is one point read per message in the page
+		var hydrated = await Task.WhenAll(messages.Select(async m =>
+		{
+			var attachments = await attachmentRepository
+				.GetChannelMessageAttachmentsAsync(m.ChannelId, m.Id, cancellationToken);
+			return MessageResponse.From(m, null, attachments);
+		}));
+
+		return Result.Ok<IReadOnlyList<MessageResponse>>(hydrated);
 	}
 }

--- a/services/chat/src/Chat.Application/Features/Messages/GetChannelMessages/GetChannelMessagesHandler.cs
+++ b/services/chat/src/Chat.Application/Features/Messages/GetChannelMessages/GetChannelMessagesHandler.cs
@@ -37,14 +37,16 @@ internal sealed class GetChannelMessagesHandler(
 		var beforeTime = query.BeforeTime ?? clock.UtcNow;
 		var messages = await repository.GetChannelMessagesAsync(query.ChannelId, beforeTime, query.Limit, cancellationToken);
 
-		// hydrate each message's attachments; message_attachments is partitioned by
-		// (channel_id, message_id) so this is one point read per message in the page
-		var hydrated = await Task.WhenAll(messages.Select(async m =>
-		{
-			var attachments = await attachmentRepository
-				.GetChannelMessageAttachmentsAsync(m.ChannelId, m.Id, cancellationToken);
-			return MessageResponse.From(m, null, attachments);
-		}));
+		// hydrate the whole page's attachments in a single multi-message read rather
+		// than one point read per message; the lookup yields an empty sequence for
+		// any message that has none
+		var messageIds = messages.Select(m => m.Id).ToList();
+		var attachmentsByMessage = await attachmentRepository
+			.GetChannelMessagesAttachmentsAsync(query.ChannelId, messageIds, cancellationToken);
+
+		var hydrated = messages
+			.Select(m => MessageResponse.From(m, null, [.. attachmentsByMessage[m.Id]]))
+			.ToList();
 
 		return Result.Ok<IReadOnlyList<MessageResponse>>(hydrated);
 	}

--- a/services/chat/src/Chat.Application/Features/Messages/SendMessage/SendMessageCommand.cs
+++ b/services/chat/src/Chat.Application/Features/Messages/SendMessage/SendMessageCommand.cs
@@ -4,5 +4,10 @@ using Chat.Domain.Results;
 
 namespace Chat.Application.Features.Messages.SendMessage;
 
-public sealed record SendMessageCommand(long ChannelId, string? Content, long? ReplyToId, string? Nonce)
+public sealed record SendMessageCommand(
+	long ChannelId,
+	string? Content,
+	long? ReplyToId,
+	IReadOnlyList<long> AttachmentIds,
+	string? Nonce)
 	: ICommand<Result<MessageResponse>>;

--- a/services/chat/src/Chat.Application/Features/Messages/SendMessage/SendMessageHandler.cs
+++ b/services/chat/src/Chat.Application/Features/Messages/SendMessage/SendMessageHandler.cs
@@ -4,6 +4,7 @@ using Chat.Application.Abstractions.Messaging;
 using Chat.Application.Abstractions.Persistence;
 using Chat.Application.Contracts;
 using Chat.Application.Features.Messages.Common;
+using Chat.Domain.Attachments;
 using Chat.Domain.Messages;
 using Chat.Domain.Results;
 
@@ -13,6 +14,7 @@ internal sealed class SendMessageHandler(
 	ICurrentUser currentUser,
 	IGuildClient guildClient,
 	IMessageRepository repository,
+	IAttachmentRepository attachmentRepository,
 	ISnowflakeIdGenerator ids,
 	IClock clock,
 	IEventBus eventBus,
@@ -25,6 +27,7 @@ internal sealed class SendMessageHandler(
 	private const long SendMessages = 1L << 0;
 	private const long Administrator = 1L << 8;
 	private const int MaxNonceLen = 64;
+	private const int MaxAttachments = 10;
 
 	public async Task<Result<MessageResponse>> HandleAsync(
 		SendMessageCommand command,
@@ -45,6 +48,8 @@ internal sealed class SendMessageHandler(
 		if ((membership.Permissions & (SendMessages | Administrator)) == 0)
 			return MessageFailures.MissingSendPermission;
 
+		// nonce dedup runs before draft validation: a retried send re-references
+		// drafts that the first call already consumed, so it must short-circuit here
 		if (command.Nonce is not null)
 		{
 			var existingId = await repository.FindNonceAsync(userId, command.ChannelId, command.Nonce, cancellationToken);
@@ -52,9 +57,18 @@ internal sealed class SendMessageHandler(
 			{
 				var existing = await repository.GetByIdAsync(existingId.Value, cancellationToken);
 				if (existing is not null)
-					return MessageResponse.From(existing, command.Nonce);
+				{
+					var existingAttachments = await attachmentRepository
+						.GetChannelMessageAttachmentsAsync(existing.ChannelId, existing.Id, cancellationToken);
+					return MessageResponse.From(existing, command.Nonce, existingAttachments);
+				}
 			}
 		}
+
+		var attachmentsResult = await ResolveAttachmentsAsync(command.AttachmentIds, userId, cancellationToken);
+		if (attachmentsResult.IsFailure)
+			return attachmentsResult.Error;
+		var attachments = attachmentsResult.Value;
 
 		var messageId = ids.NextId();
 
@@ -64,14 +78,15 @@ internal sealed class SendMessageHandler(
 			authorId: userId,
 			content: command.Content,
 			replyToId: command.ReplyToId,
-			now: clock.UtcNow);
+			now: clock.UtcNow,
+			hasAttachments: attachments.Count > 0);
 		if (messageResult.IsFailure)
 			return messageResult.Error;
 
 		var message = messageResult.Value;
-		await repository.AddAsync(message, command.Nonce, cancellationToken);
+		await repository.AddAsync(message, command.Nonce, attachments, cancellationToken);
 
-		var response = MessageResponse.From(message, command.Nonce);
+		var response = MessageResponse.From(message, command.Nonce, attachments);
 
 		await eventBus.PublishAsync(
 			new ChatMessageSent(
@@ -79,12 +94,41 @@ internal sealed class SendMessageHandler(
 				GuildId: membership.GuildId,
 				AuthorId: userId,
 				MessageId: messageId,
-				Content: message.Content!,
+				Content: message.Content ?? string.Empty,
 				Mentions: []),
 			cancellationToken);
 
 		await broadcaster.BroadcastMessageAsync(command.ChannelId, response, cancellationToken);
 
 		return response;
+	}
+
+	private async Task<Result<IReadOnlyList<AttachmentMetadata>>> ResolveAttachmentsAsync(
+		IReadOnlyList<long> attachmentIds,
+		long userId,
+		CancellationToken ct)
+	{
+		if (attachmentIds.Count == 0)
+			return Array.Empty<AttachmentMetadata>();
+
+		if (attachmentIds.Count > MaxAttachments)
+			return AttachmentFailures.TooMany;
+
+		var resolved = new List<AttachmentMetadata>(attachmentIds.Count);
+		foreach (var attachmentId in attachmentIds.Distinct())
+		{
+			// each referenced draft must exist, be owned by the caller, and not yet
+			// belong to another message; an expired draft is simply gone (table TTL)
+			var draft = await attachmentRepository.GetDraftAsync(attachmentId, ct);
+			if (draft is null || draft.UploaderId != userId)
+				return AttachmentFailures.InvalidReference;
+
+			if (await attachmentRepository.IsAttachedAsync(attachmentId, ct))
+				return AttachmentFailures.InvalidReference;
+
+			resolved.Add(draft.ToMetadata());
+		}
+
+		return resolved;
 	}
 }

--- a/services/chat/src/Chat.Domain/Attachments/AttachmentMetadata.cs
+++ b/services/chat/src/Chat.Domain/Attachments/AttachmentMetadata.cs
@@ -1,0 +1,13 @@
+namespace Chat.Domain.Attachments;
+
+/// <summary>
+/// wire-and-storage shape of a persisted attachment: the metadata a client needs
+/// to render and download it. shared by draft uploads, message attachments and
+/// the REST response mapping
+/// </summary>
+public sealed record AttachmentMetadata(
+	long Id,
+	string Url,
+	string Filename,
+	long SizeBytes,
+	string MimeType);

--- a/services/chat/src/Chat.Domain/Attachments/DraftAttachment.cs
+++ b/services/chat/src/Chat.Domain/Attachments/DraftAttachment.cs
@@ -1,0 +1,89 @@
+using Chat.Domain.Results;
+
+namespace Chat.Domain.Attachments;
+
+/// <summary>
+/// a file uploaded via <c>POST /attachments</c> but not yet attached to a message.
+/// owned by the uploader, lives for 1 hour (enforced by the table TTL), and becomes
+/// permanent once referenced by a sent message
+/// </summary>
+public sealed class DraftAttachment
+{
+	public const long MaxSizeBytes = 25L * 1024 * 1024;
+
+	// executables / scripts per docs/contracts/chat.md
+	private static readonly HashSet<string> BlockedMimeTypes = new(StringComparer.OrdinalIgnoreCase)
+	{
+		"application/x-msdownload",
+		"application/x-executable",
+		"application/x-mach-binary",
+		"application/vnd.android.package-archive",
+		"application/x-sh",
+	};
+
+	private DraftAttachment(
+		long id,
+		long uploaderId,
+		string url,
+		string filename,
+		long sizeBytes,
+		string mimeType,
+		DateTimeOffset createdAt)
+	{
+		Id = id;
+		UploaderId = uploaderId;
+		Url = url;
+		Filename = filename;
+		SizeBytes = sizeBytes;
+		MimeType = mimeType;
+		CreatedAt = createdAt;
+	}
+
+	public long Id { get; }
+	public long UploaderId { get; }
+	public string Url { get; }
+	public string Filename { get; }
+	public long SizeBytes { get; }
+	public string MimeType { get; }
+	public DateTimeOffset CreatedAt { get; }
+
+	public static Result<DraftAttachment> Create(
+		long id,
+		long uploaderId,
+		string url,
+		string filename,
+		long sizeBytes,
+		string mimeType,
+		DateTimeOffset now)
+	{
+		if (string.IsNullOrWhiteSpace(filename))
+			return AttachmentFailures.FileRequired;
+
+		if (sizeBytes <= 0)
+			return AttachmentFailures.FileEmpty;
+
+		if (sizeBytes > MaxSizeBytes)
+			return AttachmentFailures.FileTooLarge;
+
+		var normalizedMime = string.IsNullOrWhiteSpace(mimeType)
+			? "application/octet-stream"
+			: mimeType;
+
+		if (BlockedMimeTypes.Contains(normalizedMime))
+			return AttachmentFailures.BlockedMimeType;
+
+		return new DraftAttachment(id, uploaderId, url, filename, sizeBytes, normalizedMime, now);
+	}
+
+	public static DraftAttachment Reconstitute(
+		long id,
+		long uploaderId,
+		string url,
+		string filename,
+		long sizeBytes,
+		string mimeType,
+		DateTimeOffset createdAt)
+		=> new(id, uploaderId, url, filename, sizeBytes, mimeType, createdAt);
+
+	public AttachmentMetadata ToMetadata() => new(Id, Url, Filename, SizeBytes, MimeType);
+}

--- a/services/chat/src/Chat.Domain/Messages/Message.cs
+++ b/services/chat/src/Chat.Domain/Messages/Message.cs
@@ -80,7 +80,8 @@ public sealed class Message
 		long authorId,
 		string? content,
 		long? replyToId,
-		DateTimeOffset now)
+		DateTimeOffset now,
+		bool hasAttachments = false)
 	{
 		if (id <= 0)
 			return MessageFailures.InvalidId;
@@ -91,17 +92,22 @@ public sealed class Message
 		if (authorId <= 0)
 			return MessageFailures.InvalidAuthorId;
 
+		// content is optional only when the message carries at least one attachment
 		if (string.IsNullOrWhiteSpace(content))
-			return MessageFailures.ContentRequired;
-
-		if (content.Length > MaxContentLen)
+		{
+			if (!hasAttachments)
+				return MessageFailures.ContentRequired;
+		}
+		else if (content.Length > MaxContentLen)
+		{
 			return MessageFailures.ContentTooLong;
+		}
 
 		return new Message(
 			id: id,
 			channelId: channelId,
 			authorId: authorId,
-			content: content,
+			content: string.IsNullOrWhiteSpace(content) ? null : content,
 			replyToId: replyToId,
 			editedAt: null,
 			isDeleted: false,

--- a/services/chat/src/Chat.Domain/Results/AttachmentFailures.cs
+++ b/services/chat/src/Chat.Domain/Results/AttachmentFailures.cs
@@ -1,0 +1,34 @@
+using Chat.Domain.Attachments;
+
+namespace Chat.Domain.Results;
+
+public static class AttachmentFailures
+{
+	public static readonly Failure FileRequired =
+		new("Attachment.FileRequired", "A file is required.");
+
+	public static readonly Failure FileEmpty =
+		new("Attachment.FileEmpty", "Uploaded file is empty.");
+
+	public static readonly Failure FileTooLarge =
+		new("Attachment.FileTooLarge",
+			$"File exceeds the {DraftAttachment.MaxSizeBytes / (1024 * 1024)} MB limit.");
+
+	public static readonly Failure BlockedMimeType =
+		new("Attachment.BlockedMimeType", "This file type is not allowed.");
+
+	public static readonly Failure NotFound =
+		new("Attachment.NotFound", "Attachment not found.");
+
+	public static readonly Failure NotAuthorized =
+		new("Attachment.NotAuthorized", "Not authorized to view this attachment.");
+
+	public static readonly Failure TooMany =
+		new("Attachment.TooMany", "A message can carry at most 10 attachments.");
+
+	// covers every "you can't reference this draft" case the send path rejects:
+	// missing, owned by someone else, already attached, or TTL-expired
+	public static readonly Failure InvalidReference =
+		new("Attachment.InvalidReference",
+			"Referenced attachment not found, not owned by caller, already attached, or expired.");
+}

--- a/services/chat/src/Chat.Infrastructure/Chat.Infrastructure.csproj
+++ b/services/chat/src/Chat.Infrastructure/Chat.Infrastructure.csproj
@@ -16,6 +16,7 @@
     </ItemGroup>
 
     <ItemGroup>
+        <PackageReference Include="AWSSDK.S3" Version="3.7.416.4"/>
         <PackageReference Include="MassTransit.RabbitMQ" Version="8.4.1"/>
     </ItemGroup>
 

--- a/services/chat/src/Chat.Infrastructure/DependencyInjection.cs
+++ b/services/chat/src/Chat.Infrastructure/DependencyInjection.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using Amazon.S3;
 using Chat.Application.Abstractions;
 using Chat.Application.Abstractions.Authentication;
 using Chat.Application.Contracts;
@@ -8,6 +9,7 @@ using Chat.Infrastructure.Messaging;
 using Chat.Infrastructure.Messaging.Consumers;
 using Chat.Infrastructure.Messaging.Contracts;
 using Chat.Infrastructure.Options;
+using Chat.Infrastructure.Storage;
 using MassTransit;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
@@ -35,6 +37,11 @@ public static class DependencyInjection
 
 		services.AddOptions<SnowflakeOptions>()
 			.BindConfiguration("Snowflake")
+			.ValidateDataAnnotations()
+			.ValidateOnStart();
+
+		services.AddOptions<MinioOptions>()
+			.BindConfiguration("Minio")
 			.ValidateDataAnnotations()
 			.ValidateOnStart();
 
@@ -81,6 +88,20 @@ public static class DependencyInjection
 		services.AddSingleton<IClock, SystemClock>();
 		services.AddSingleton<ISnowflakeIdGenerator, SnowflakeIdGenerator>();
 		services.AddScoped<ICurrentUser, CurrentUser>();
+
+		services.AddSingleton<IAmazonS3>(sp =>
+		{
+			var opts = sp.GetRequiredService<IOptions<MinioOptions>>().Value;
+			var config = new AmazonS3Config
+			{
+				ServiceURL = opts.Endpoint,
+				// MinIO only speaks path-style addressing (no virtual-host buckets)
+				ForcePathStyle = true,
+			};
+			return new AmazonS3Client(opts.AccessKey, opts.SecretKey, config);
+		});
+		services.AddSingleton<IObjectStore, MinioObjectStore>();
+		services.AddSingleton<IAttachmentUrlFactory, AttachmentUrlFactory>();
 
 		RegisterAndConfHttpClient<IGuildClient, GuildClient>(services, opts => opts.GuildService);
 		RegisterAndConfHttpClient<IUserClient, UserClient>(services, opts => opts.UserService);

--- a/services/chat/src/Chat.Infrastructure/DependencyInjection.cs
+++ b/services/chat/src/Chat.Infrastructure/DependencyInjection.cs
@@ -45,6 +45,11 @@ public static class DependencyInjection
 			.ValidateDataAnnotations()
 			.ValidateOnStart();
 
+		services.AddOptions<AttachmentReaperOptions>()
+			.BindConfiguration("AttachmentReaper")
+			.ValidateDataAnnotations()
+			.ValidateOnStart();
+
 		services.AddMassTransit(x =>
 		{
 			x.AddConsumer<GuildMemberJoinedConsumer>();
@@ -102,6 +107,7 @@ public static class DependencyInjection
 		});
 		services.AddSingleton<IObjectStore, MinioObjectStore>();
 		services.AddSingleton<IAttachmentUrlFactory, AttachmentUrlFactory>();
+		services.AddHostedService<AttachmentReaper>();
 
 		RegisterAndConfHttpClient<IGuildClient, GuildClient>(services, opts => opts.GuildService);
 		RegisterAndConfHttpClient<IUserClient, UserClient>(services, opts => opts.UserService);

--- a/services/chat/src/Chat.Infrastructure/Options/AttachmentReaperOptions.cs
+++ b/services/chat/src/Chat.Infrastructure/Options/AttachmentReaperOptions.cs
@@ -1,0 +1,21 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Chat.Infrastructure.Options;
+
+public sealed class AttachmentReaperOptions
+{
+	/// <summary>master switch; turned off in tests so it never reaps seeded blobs</summary>
+	public bool Enabled { get; init; } = true;
+
+	/// <summary>how often the orphan sweep runs</summary>
+	[Range(60, int.MaxValue)]
+	public int IntervalSeconds { get; init; } = 900; // 15 minutes
+
+	/// <summary>
+	/// only blobs older than this are eligible for reaping. it MUST exceed the
+	/// draft_attachments TTL (3600s) so a still-sendable draft is never deleted:
+	/// past the TTL the draft row is gone and the blob can no longer be attached
+	/// </summary>
+	[Range(3601, int.MaxValue)]
+	public int MinAgeSeconds { get; init; } = 7200; // 2 hours
+}

--- a/services/chat/src/Chat.Infrastructure/Options/MinioOptions.cs
+++ b/services/chat/src/Chat.Infrastructure/Options/MinioOptions.cs
@@ -1,0 +1,11 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Chat.Infrastructure.Options;
+
+public sealed class MinioOptions
+{
+	[Required] public required string Endpoint { get; init; }
+	[Required] public required string AccessKey { get; init; }
+	[Required] public required string SecretKey { get; init; }
+	[Required] public required string Bucket { get; init; }
+}

--- a/services/chat/src/Chat.Infrastructure/Storage/AttachmentReaper.cs
+++ b/services/chat/src/Chat.Infrastructure/Storage/AttachmentReaper.cs
@@ -1,0 +1,89 @@
+using Chat.Application.Abstractions;
+using Chat.Application.Abstractions.Persistence;
+using Chat.Infrastructure.Options;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Chat.Infrastructure.Storage;
+
+/// <summary>
+/// periodically deletes orphaned attachment blobs from object storage. an orphan is
+/// any blob that is (a) older than a draft's whole sendable lifetime yet (b) not
+/// bound to a message. this covers both a never-sent draft (its row TTL'd out) and a
+/// blob whose draft-row write failed after the upload. the message table is the sole
+/// source of truth via <see cref="IAttachmentRepository.IsAttachedAsync"/>, so the
+/// sweep can never delete a legitimately attached blob. deletes are idempotent, so
+/// running this on several replicas at once is harmless
+/// </summary>
+public sealed class AttachmentReaper(
+	IServiceScopeFactory scopeFactory,
+	IObjectStore objectStore,
+	IOptions<AttachmentReaperOptions> options,
+	ILogger<AttachmentReaper> logger)
+	: BackgroundService
+{
+	private readonly AttachmentReaperOptions _options = options.Value;
+
+	protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+	{
+		if (!_options.Enabled)
+			return;
+
+		using var timer = new PeriodicTimer(TimeSpan.FromSeconds(_options.IntervalSeconds));
+		do
+		{
+			try
+			{
+				await ReapOnceAsync(stoppingToken);
+			}
+			catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+			{
+				break;
+			}
+			catch (Exception ex)
+			{
+				// a transient storage / db hiccup must not kill the loop; the next
+				// tick retries the sweep
+				logger.LogError(ex, "attachment reaper sweep failed");
+			}
+		}
+		while (await timer.WaitForNextTickAsync(stoppingToken));
+	}
+
+	/// <summary>runs a single sweep; exposed so it can be exercised deterministically</summary>
+	public async Task<int> ReapOnceAsync(CancellationToken ct)
+	{
+		var cutoff = DateTimeOffset.UtcNow - TimeSpan.FromSeconds(_options.MinAgeSeconds);
+
+		// IAttachmentRepository is scoped (it shares the request-scoped Scylla usage),
+		// so resolve it inside a fresh scope rather than capturing it in this singleton
+		using var scope = scopeFactory.CreateScope();
+		var attachments = scope.ServiceProvider.GetRequiredService<IAttachmentRepository>();
+
+		var reaped = 0;
+		await foreach (var obj in objectStore.ListAsync(ct))
+		{
+			// younger than the cutoff: a draft could still be live and sendable
+			if (obj.LastModified > cutoff)
+				continue;
+
+			// keys are attachment snowflakes; anything else isn't ours to touch
+			if (!long.TryParse(obj.Key, out var id))
+				continue;
+
+			// bound to a message -> permanent, keep it
+			if (await attachments.IsAttachedAsync(id, ct))
+				continue;
+
+			await objectStore.DeleteAsync(obj.Key, ct);
+			reaped++;
+		}
+
+		if (reaped > 0)
+			logger.LogInformation("attachment reaper deleted {Count} orphaned blob(s)", reaped);
+
+		return reaped;
+	}
+}

--- a/services/chat/src/Chat.Infrastructure/Storage/AttachmentUrlFactory.cs
+++ b/services/chat/src/Chat.Infrastructure/Storage/AttachmentUrlFactory.cs
@@ -1,0 +1,19 @@
+using Chat.Application.Abstractions;
+using Chat.Infrastructure.Options;
+using Microsoft.Extensions.Options;
+
+namespace Chat.Infrastructure.Storage;
+
+/// <summary>
+/// builds the public, auth-checked download URL for an attachment off the gateway
+/// base API URL, e.g. <c>https://host/api/chat/attachments/{id}/{filename}</c>
+/// </summary>
+internal sealed class AttachmentUrlFactory(IOptions<BackendConfigurationOptions> options) : IAttachmentUrlFactory
+{
+	private readonly string _baseApiUrl = options.Value.BaseApiUrl.TrimEnd('/');
+
+	// the /v1 segment is required: the gateway routes on /api/{service}/v{N}/...,
+	// so a versionless URL (as drawn in the contract) is not reachable
+	public string BuildUrl(long attachmentId, string filename) =>
+		$"{_baseApiUrl}/chat/v1/attachments/{attachmentId}/{Uri.EscapeDataString(filename)}";
+}

--- a/services/chat/src/Chat.Infrastructure/Storage/MinioObjectStore.cs
+++ b/services/chat/src/Chat.Infrastructure/Storage/MinioObjectStore.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using Amazon.S3;
 using Amazon.S3.Model;
 using Chat.Application.Abstractions;
@@ -40,6 +41,31 @@ internal sealed class MinioObjectStore(IAmazonS3 client, IOptions<MinioOptions> 
 		catch (AmazonS3Exception e) when (e.StatusCode == System.Net.HttpStatusCode.NotFound)
 		{
 			return null;
+		}
+	}
+
+	public async Task DeleteAsync(string key, CancellationToken ct)
+		=> await client.DeleteObjectAsync(_bucket, key, ct);
+
+	public async IAsyncEnumerable<ObjectInfo> ListAsync([EnumeratorCancellation] CancellationToken ct)
+	{
+		var request = new ListObjectsV2Request { BucketName = _bucket };
+
+		// page through the bucket; S3 caps each response at 1000 keys and hands back
+		// a continuation token until the listing is exhausted
+		while (true)
+		{
+			var response = await client.ListObjectsV2Async(request, ct);
+
+			foreach (var obj in response.S3Objects ?? [])
+				yield return new ObjectInfo(
+					obj.Key,
+					new DateTimeOffset(DateTime.SpecifyKind(obj.LastModified, DateTimeKind.Utc)));
+
+			if (response.IsTruncated != true)
+				yield break;
+
+			request.ContinuationToken = response.NextContinuationToken;
 		}
 	}
 }

--- a/services/chat/src/Chat.Infrastructure/Storage/MinioObjectStore.cs
+++ b/services/chat/src/Chat.Infrastructure/Storage/MinioObjectStore.cs
@@ -1,0 +1,45 @@
+using Amazon.S3;
+using Amazon.S3.Model;
+using Chat.Application.Abstractions;
+using Chat.Infrastructure.Options;
+using Microsoft.Extensions.Options;
+
+namespace Chat.Infrastructure.Storage;
+
+/// <summary>
+/// <see cref="IObjectStore"/> backed by MinIO over the S3 API. The bucket is created
+/// out-of-band by the infra layer, so this only reads and writes objects.
+/// </summary>
+internal sealed class MinioObjectStore(IAmazonS3 client, IOptions<MinioOptions> options) : IObjectStore
+{
+	private readonly string _bucket = options.Value.Bucket;
+
+	public async Task PutAsync(string key, Stream content, string contentType, long length, CancellationToken ct)
+	{
+		var request = new PutObjectRequest
+		{
+			BucketName = _bucket,
+			Key = key,
+			InputStream = content,
+			ContentType = contentType,
+			// hand S3 the known length up front so it doesn't probe the stream for it
+			Headers = { ContentLength = length },
+			AutoCloseStream = false,
+		};
+
+		await client.PutObjectAsync(request, ct);
+	}
+
+	public async Task<Stream?> GetAsync(string key, CancellationToken ct)
+	{
+		try
+		{
+			var response = await client.GetObjectAsync(_bucket, key, ct);
+			return response.ResponseStream;
+		}
+		catch (AmazonS3Exception e) when (e.StatusCode == System.Net.HttpStatusCode.NotFound)
+		{
+			return null;
+		}
+	}
+}

--- a/services/chat/src/Chat.Persistence/DependencyInjection.cs
+++ b/services/chat/src/Chat.Persistence/DependencyInjection.cs
@@ -32,6 +32,8 @@ public static class DependencyInjection
 
 		services.AddSingleton<MessageStatements>();
 		services.AddScoped<IMessageRepository, MessageRepository>();
+		services.AddSingleton<AttachmentStatements>();
+		services.AddScoped<IAttachmentRepository, AttachmentRepository>();
 		return services;
 	}
 

--- a/services/chat/src/Chat.Persistence/Repositories/AttachmentRepository.cs
+++ b/services/chat/src/Chat.Persistence/Repositories/AttachmentRepository.cs
@@ -71,6 +71,18 @@ internal sealed class AttachmentRepository(ISession session, AttachmentStatement
 		return rows.Select(MapMetadata).ToList();
 	}
 
+	public async Task<ILookup<long, AttachmentMetadata>> GetChannelMessagesAttachmentsAsync(
+		long channelId, IReadOnlyList<long> messageIds, CancellationToken ct)
+	{
+		if (messageIds.Count == 0)
+			return Enumerable.Empty<AttachmentMetadata>().ToLookup(_ => 0L);
+
+		var stmt = await statements.SelectChannelMessagesAttachments.Value;
+		var rows = await session.ExecuteAsync(stmt.Bind(channelId, messageIds.ToArray()));
+
+		return rows.ToLookup(row => row.GetValue<long>("message_id"), MapMetadata);
+	}
+
 	private static AttachmentMetadata MapMetadata(Row row) => new(
 		Id: row.GetValue<long>("id"),
 		Url: row.GetValue<string>("url"),

--- a/services/chat/src/Chat.Persistence/Repositories/AttachmentRepository.cs
+++ b/services/chat/src/Chat.Persistence/Repositories/AttachmentRepository.cs
@@ -1,0 +1,80 @@
+using Cassandra;
+using Chat.Application.Abstractions.Persistence;
+using Chat.Domain.Attachments;
+
+namespace Chat.Persistence.Repositories;
+
+internal sealed class AttachmentRepository(ISession session, AttachmentStatements statements) : IAttachmentRepository
+{
+	public async Task AddDraftAsync(DraftAttachment draft, CancellationToken ct)
+	{
+		var stmt = await statements.InsertDraft.Value;
+		await session.ExecuteAsync(stmt.Bind(
+			draft.Id,
+			draft.UploaderId,
+			draft.Url,
+			draft.Filename,
+			draft.SizeBytes,
+			draft.MimeType,
+			draft.CreatedAt.UtcDateTime));
+	}
+
+	public async Task<DraftAttachment?> GetDraftAsync(long id, CancellationToken ct)
+	{
+		var stmt = await statements.SelectDraft.Value;
+		var row = (await session.ExecuteAsync(stmt.Bind(id))).FirstOrDefault();
+		if (row is null)
+			return null;
+
+		return DraftAttachment.Reconstitute(
+			id: row.GetValue<long>("id"),
+			uploaderId: row.GetValue<long>("uploader_id"),
+			url: row.GetValue<string>("url"),
+			filename: row.GetValue<string>("filename"),
+			sizeBytes: row.GetValue<long>("size_bytes"),
+			mimeType: row.GetValue<string>("mime_type"),
+			createdAt: new DateTimeOffset(row.GetValue<DateTime>("created_at"), TimeSpan.Zero));
+	}
+
+	public async Task<bool> IsAttachedAsync(long id, CancellationToken ct)
+	{
+		var stmt = await statements.SelectLookup.Value;
+		var row = (await session.ExecuteAsync(stmt.Bind(id))).FirstOrDefault();
+		return row is not null;
+	}
+
+	public async Task<AttachmentLocation?> GetLocationAsync(long id, CancellationToken ct)
+	{
+		var stmt = await statements.SelectLookup.Value;
+		var row = (await session.ExecuteAsync(stmt.Bind(id))).FirstOrDefault();
+		if (row is null)
+			return null;
+
+		return new AttachmentLocation(
+			IsDm: row.GetValue<bool>("is_dm"),
+			ChannelId: row.GetValue<long?>("channel_id"),
+			ConversationId: row.GetValue<long?>("conversation_id"),
+			MessageId: row.GetValue<long>("message_id"));
+	}
+
+	public async Task<AttachmentMetadata?> GetChannelAttachmentAsync(long channelId, long messageId, long id, CancellationToken ct)
+	{
+		var stmt = await statements.SelectChannelAttachment.Value;
+		var row = (await session.ExecuteAsync(stmt.Bind(channelId, messageId, id))).FirstOrDefault();
+		return row is null ? null : MapMetadata(row);
+	}
+
+	public async Task<IReadOnlyList<AttachmentMetadata>> GetChannelMessageAttachmentsAsync(long channelId, long messageId, CancellationToken ct)
+	{
+		var stmt = await statements.SelectChannelMessageAttachments.Value;
+		var rows = await session.ExecuteAsync(stmt.Bind(channelId, messageId));
+		return rows.Select(MapMetadata).ToList();
+	}
+
+	private static AttachmentMetadata MapMetadata(Row row) => new(
+		Id: row.GetValue<long>("id"),
+		Url: row.GetValue<string>("url"),
+		Filename: row.GetValue<string>("filename"),
+		SizeBytes: row.GetValue<long>("size_bytes"),
+		MimeType: row.GetValue<string>("mime_type"));
+}

--- a/services/chat/src/Chat.Persistence/Repositories/AttachmentStatements.cs
+++ b/services/chat/src/Chat.Persistence/Repositories/AttachmentStatements.cs
@@ -1,0 +1,29 @@
+using Cassandra;
+
+namespace Chat.Persistence.Repositories;
+
+internal sealed class AttachmentStatements(ISession session)
+{
+	// draft_attachments carries default_time_to_live = 3600, so the row auto-expires
+	// an hour after this insert unless it gets attached to a message first
+	public Lazy<Task<PreparedStatement>> InsertDraft { get; } = new(() => session.PrepareAsync(
+		"INSERT INTO draft_attachments " +
+		"(id, uploader_id, url, filename, size_bytes, mime_type, created_at) " +
+		"VALUES (?, ?, ?, ?, ?, ?, ?)"));
+
+	public Lazy<Task<PreparedStatement>> SelectDraft { get; } = new(() => session.PrepareAsync(
+		"SELECT id, uploader_id, url, filename, size_bytes, mime_type, created_at " +
+		"FROM draft_attachments WHERE id = ?"));
+
+	public Lazy<Task<PreparedStatement>> SelectLookup { get; } = new(() => session.PrepareAsync(
+		"SELECT is_dm, channel_id, conversation_id, message_id " +
+		"FROM attachment_lookup WHERE attachment_id = ?"));
+
+	public Lazy<Task<PreparedStatement>> SelectChannelAttachment { get; } = new(() => session.PrepareAsync(
+		"SELECT id, url, filename, size_bytes, mime_type " +
+		"FROM message_attachments WHERE channel_id = ? AND message_id = ? AND id = ?"));
+
+	public Lazy<Task<PreparedStatement>> SelectChannelMessageAttachments { get; } = new(() => session.PrepareAsync(
+		"SELECT id, url, filename, size_bytes, mime_type " +
+		"FROM message_attachments WHERE channel_id = ? AND message_id = ?"));
+}

--- a/services/chat/src/Chat.Persistence/Repositories/AttachmentStatements.cs
+++ b/services/chat/src/Chat.Persistence/Repositories/AttachmentStatements.cs
@@ -26,4 +26,11 @@ internal sealed class AttachmentStatements(ISession session)
 	public Lazy<Task<PreparedStatement>> SelectChannelMessageAttachments { get; } = new(() => session.PrepareAsync(
 		"SELECT id, url, filename, size_bytes, mime_type " +
 		"FROM message_attachments WHERE channel_id = ? AND message_id = ?"));
+
+	// IN on message_id (the trailing partition-key column) collapses a page's worth
+	// of per-message reads into one query; channel_id pins the leading component.
+	// the page limit bounds the IN list, so coordinator fan-out stays small
+	public Lazy<Task<PreparedStatement>> SelectChannelMessagesAttachments { get; } = new(() => session.PrepareAsync(
+		"SELECT message_id, id, url, filename, size_bytes, mime_type " +
+		"FROM message_attachments WHERE channel_id = ? AND message_id IN ?"));
 }

--- a/services/chat/src/Chat.Persistence/Repositories/MessageRepository.cs
+++ b/services/chat/src/Chat.Persistence/Repositories/MessageRepository.cs
@@ -1,12 +1,13 @@
 using Cassandra;
 using Chat.Application.Abstractions.Persistence;
+using Chat.Domain.Attachments;
 using Chat.Domain.Messages;
 
 namespace Chat.Persistence.Repositories;
 
 internal sealed class MessageRepository(ISession session, MessageStatements statements) : IMessageRepository
 {
-	public async Task AddAsync(Message message, string? nonce, CancellationToken ct)
+	public async Task AddAsync(Message message, string? nonce, IReadOnlyList<AttachmentMetadata> attachments, CancellationToken ct)
 	{
 		var insertMessage = await statements.InsertMessage.Value;
 		var insertLookup = await statements.InsertLookup.Value;
@@ -36,6 +37,33 @@ internal sealed class MessageRepository(ISession session, MessageStatements stat
 		{
 			var insertNonce = await statements.InsertNonce.Value;
 			batch.Add(insertNonce.Bind(message.AuthorId, message.ChannelId, nonce, message.Id));
+		}
+
+		// binding drafts to the message: write the permanent metadata + download
+		// lookup row and tombstone the draft, all atomic with the message itself
+		if (attachments.Count > 0)
+		{
+			var insertAttachment = await statements.InsertMessageAttachment.Value;
+			var insertAttachmentLookup = await statements.InsertAttachmentLookup.Value;
+			var deleteDraft = await statements.DeleteDraftAttachment.Value;
+
+			foreach (var attachment in attachments)
+			{
+				batch.Add(insertAttachment.Bind(
+					message.ChannelId,
+					message.Id,
+					attachment.Id,
+					attachment.Url,
+					attachment.Filename,
+					attachment.SizeBytes,
+					attachment.MimeType));
+				batch.Add(insertAttachmentLookup.Bind(
+					attachment.Id,
+					message.ChannelId,
+					(long?)null,
+					message.Id));
+				batch.Add(deleteDraft.Bind(attachment.Id));
+			}
 		}
 
 		await session.ExecuteAsync(batch);

--- a/services/chat/src/Chat.Persistence/Repositories/MessageStatements.cs
+++ b/services/chat/src/Chat.Persistence/Repositories/MessageStatements.cs
@@ -38,4 +38,17 @@ internal sealed class MessageStatements(ISession session)
 	public Lazy<Task<PreparedStatement>> SelectChannelMessages { get; } = new(() => session.PrepareAsync(
 		"SELECT channel_id, created_at, id, author_id, content, edited_at, is_deleted, reply_to_id " +
 		"FROM messages WHERE channel_id = ? AND created_at < ? LIMIT ?"));
+
+	public Lazy<Task<PreparedStatement>> InsertMessageAttachment { get; } = new(() => session.PrepareAsync(
+		"INSERT INTO message_attachments " +
+		"(channel_id, message_id, id, url, filename, size_bytes, mime_type) " +
+		"VALUES (?, ?, ?, ?, ?, ?, ?)"));
+
+	public Lazy<Task<PreparedStatement>> InsertAttachmentLookup { get; } = new(() => session.PrepareAsync(
+		"INSERT INTO attachment_lookup " +
+		"(attachment_id, is_dm, channel_id, conversation_id, message_id) " +
+		"VALUES (?, false, ?, ?, ?)"));
+
+	public Lazy<Task<PreparedStatement>> DeleteDraftAttachment { get; } = new(() => session.PrepareAsync(
+		"DELETE FROM draft_attachments WHERE id = ?"));
 }

--- a/services/chat/src/Chat.Presentation/Endpoints/AttachmentsEndpoint.cs
+++ b/services/chat/src/Chat.Presentation/Endpoints/AttachmentsEndpoint.cs
@@ -1,0 +1,81 @@
+using Carter;
+using Chat.Application.Abstractions.Messaging;
+using Chat.Application.Features.Attachments.Common;
+using Chat.Application.Features.Attachments.DownloadAttachment;
+using Chat.Application.Features.Attachments.UploadAttachment;
+using Chat.Domain.Results;
+using Microsoft.AspNetCore.Http.HttpResults;
+
+namespace Chat.Presentation.Endpoints;
+
+public sealed class AttachmentsEndpoint : ICarterModule
+{
+	public void AddRoutes(IEndpointRouteBuilder endpoints)
+	{
+		var group = endpoints.MapGroup("/attachments");
+		// form binding requires antiforgery validation by default; this API is
+		// Bearer-authenticated and not browser-form driven, so opt out
+		group.MapPost("/", UploadAsync).DisableAntiforgery();
+		group.MapGet("/{id:long}/{filename}", DownloadAsync);
+	}
+
+	private static async Task<Results<
+		Created<AttachmentResponse>,
+		BadRequest<ErrorBody>,
+		JsonHttpResult<ErrorBody>>>
+	UploadAsync(
+		IFormFile? file,
+		ICommandHandler<UploadAttachmentCommand, Result<AttachmentResponse>> handler,
+		CancellationToken cancellationToken)
+	{
+		if (file is null || file.Length == 0)
+			return TypedResults.BadRequest(new ErrorBody("A non-empty 'file' field is required."));
+
+		await using var stream = file.OpenReadStream();
+		var result = await handler.HandleAsync(
+			new UploadAttachmentCommand(stream, file.FileName, file.ContentType, file.Length),
+			cancellationToken);
+
+		return result.Succeeded
+			? TypedResults.Created(result.Value.Url, result.Value)
+			: MapUploadError(result.Error);
+	}
+
+	private static async Task<Results<
+		FileStreamHttpResult,
+		JsonHttpResult<ErrorBody>,
+		NotFound<ErrorBody>>>
+	DownloadAsync(
+		long id,
+		string filename,
+		IQueryHandler<DownloadAttachmentQuery, Result<AttachmentDownload>> handler,
+		HttpContext http,
+		CancellationToken cancellationToken)
+	{
+		var result = await handler.HandleAsync(new DownloadAttachmentQuery(id, filename), cancellationToken);
+		if (result.IsFailure)
+			return MapDownloadError(result.Error);
+
+		var download = result.Value;
+		// stream inline (contract); TypedResults.Stream would force "attachment" if
+		// we passed a download name, so set the disposition explicitly
+		http.Response.Headers.ContentDisposition = $"inline; filename=\"{download.Filename}\"";
+		return TypedResults.Stream(download.Content, download.MimeType);
+	}
+
+	private static Results<Created<AttachmentResponse>, BadRequest<ErrorBody>, JsonHttpResult<ErrorBody>>
+		MapUploadError(Failure failure) => failure.Code switch
+		{
+			"Attachment.BlockedMimeType" => TypedResults.Json(
+				new ErrorBody(failure.Message), statusCode: StatusCodes.Status415UnsupportedMediaType),
+			_ => TypedResults.BadRequest(new ErrorBody(failure.Message)),
+		};
+
+	private static Results<FileStreamHttpResult, JsonHttpResult<ErrorBody>, NotFound<ErrorBody>>
+		MapDownloadError(Failure failure) => failure.Code switch
+		{
+			"Attachment.NotAuthorized" => TypedResults.Json(
+				new ErrorBody(failure.Message), statusCode: StatusCodes.Status403Forbidden),
+			_ => TypedResults.NotFound(new ErrorBody(failure.Message)),
+		};
+}

--- a/services/chat/src/Chat.Presentation/Endpoints/AttachmentsEndpoint.cs
+++ b/services/chat/src/Chat.Presentation/Endpoints/AttachmentsEndpoint.cs
@@ -5,11 +5,23 @@ using Chat.Application.Features.Attachments.DownloadAttachment;
 using Chat.Application.Features.Attachments.UploadAttachment;
 using Chat.Domain.Results;
 using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.Net.Http.Headers;
 
 namespace Chat.Presentation.Endpoints;
 
 public sealed class AttachmentsEndpoint : ICarterModule
 {
+	// browsers render these natively; everything else is forced to download so a
+	// spoofed/active MIME (text/html, image/svg+xml, ...) can't execute on our
+	// origin. the stored MIME is client-supplied at upload time, so it's untrusted
+	private static readonly HashSet<string> InlineRenderableTypes = new(StringComparer.OrdinalIgnoreCase)
+	{
+		"image/png", "image/jpeg", "image/gif", "image/webp", "image/bmp",
+		"audio/mpeg", "audio/ogg", "audio/wav",
+		"video/mp4", "video/webm",
+		"application/pdf",
+	};
+
 	public void AddRoutes(IEndpointRouteBuilder endpoints)
 	{
 		var group = endpoints.MapGroup("/attachments");
@@ -57,9 +69,22 @@ public sealed class AttachmentsEndpoint : ICarterModule
 			return MapDownloadError(result.Error);
 
 		var download = result.Value;
-		// stream inline (contract); TypedResults.Stream would force "attachment" if
-		// we passed a download name, so set the disposition explicitly
-		http.Response.Headers.ContentDisposition = $"inline; filename=\"{download.Filename}\"";
+
+		// never let the browser sniff a different (executable) type out of the bytes:
+		// the stored MIME is attacker-controllable, so disable content sniffing
+		http.Response.Headers[HeaderNames.XContentTypeOptions] = "nosniff";
+
+		// render known-safe media inline (the contract intent for images); force a
+		// download for anything else so an HTML/SVG payload can't run on our origin
+		var disposition = InlineRenderableTypes.Contains(download.MimeType) ? "inline" : "attachment";
+
+		// SetHttpFileName safely encodes the user-supplied filename into both the
+		// ascii `filename` fallback and the RFC 5987 `filename*` form, so a quote or
+		// non-ascii char in the name can't break out of the header
+		var contentDisposition = new ContentDispositionHeaderValue(disposition);
+		contentDisposition.SetHttpFileName(download.Filename);
+		http.Response.Headers.ContentDisposition = contentDisposition.ToString();
+
 		return TypedResults.Stream(download.Content, download.MimeType);
 	}
 

--- a/services/chat/src/Chat.Presentation/Endpoints/MessagesEndpoint.cs
+++ b/services/chat/src/Chat.Presentation/Endpoints/MessagesEndpoint.cs
@@ -56,7 +56,12 @@ public sealed class MessagesEndpoint : ICarterModule
 		CancellationToken cancellationToken)
 	{
 		var result = await handler.HandleAsync(
-			new SendMessageCommand(channelId, request.Content, request.ReplyToId, request.Nonce),
+			new SendMessageCommand(
+				channelId,
+				request.Content,
+				request.ReplyToId,
+				request.AttachmentIds ?? [],
+				request.Nonce),
 			cancellationToken);
 
 		return result.Succeeded
@@ -134,6 +139,10 @@ public sealed class MessagesEndpoint : ICarterModule
 			_ => TypedResults.NotFound(new ErrorBody(failure.Message)),
 		};
 
-	private sealed record SendMessageRequest(string? Content, long? ReplyToId, string? Nonce);
+	private sealed record SendMessageRequest(
+		string? Content,
+		long? ReplyToId,
+		IReadOnlyList<long>? AttachmentIds,
+		string? Nonce);
 	private sealed record EditMessageRequest(string? Content);
 }

--- a/services/chat/src/Chat.Presentation/appsettings.json
+++ b/services/chat/src/Chat.Presentation/appsettings.json
@@ -9,5 +9,10 @@
   "RabbitMQ": {
     "Host": "localhost",
     "VirtualHost": "/"
+  },
+  "AttachmentReaper": {
+    "Enabled": true,
+    "IntervalSeconds": 900,
+    "MinAgeSeconds": 7200
   }
 }

--- a/services/chat/tests/Chat.FunctionalTests/Endpoints/AttachmentsEndpointTests.cs
+++ b/services/chat/tests/Chat.FunctionalTests/Endpoints/AttachmentsEndpointTests.cs
@@ -1,0 +1,208 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+using Chat.Domain.Attachments;
+using Chat.FunctionalTests.Infrastructure;
+using Xunit;
+
+namespace Chat.FunctionalTests.Endpoints;
+
+public sealed class AttachmentsEndpointTests(ChatApiFactory factory)
+	: IClassFixture<ChatApiFactory>, IAsyncLifetime
+{
+	private const long ReadMessagesPermission = 1L << 1;
+
+	// a 1x1 PNG; the exact bytes don't matter, only that the round trip is identical
+	private static readonly byte[] PngBytes = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x01];
+
+	private static readonly JsonSerializerOptions JsonOptions = new()
+	{
+		PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+		PropertyNameCaseInsensitive = true,
+	};
+
+	public Task InitializeAsync()
+	{
+		factory.GuildClient.Result = null;
+		factory.AttachmentRepository.Reset();
+		factory.ObjectStore.Reset();
+		return Task.CompletedTask;
+	}
+
+	public Task DisposeAsync() => Task.CompletedTask;
+
+	private HttpClient BuildClient(long userId)
+	{
+		var client = factory.CreateClient();
+		var token = TestTokens.Issue(ChatApiFactory.JwtSecret, userId: userId);
+		client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+		return client;
+	}
+
+	private static MultipartFormDataContent FilePart(byte[] bytes, string filename, string contentType)
+	{
+		var fileContent = new ByteArrayContent(bytes);
+		fileContent.Headers.ContentType = new MediaTypeHeaderValue(contentType);
+		return new MultipartFormDataContent { { fileContent, "file", filename } };
+	}
+
+	// ---- upload ----
+
+	[Fact]
+	public async Task Post_WithoutToken_Returns401()
+	{
+		var client = factory.CreateClient();
+
+		var response = await client.PostAsync("/v1/attachments", FilePart(PngBytes, "pic.png", "image/png"));
+
+		Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+	}
+
+	[Fact]
+	public async Task Post_HappyPath_Returns201_StoresBlobAndDraft()
+	{
+		var client = BuildClient(userId: 42);
+
+		var response = await client.PostAsync("/v1/attachments", FilePart(PngBytes, "pic.png", "image/png"));
+
+		Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+		var body = await response.Content.ReadFromJsonAsync<AttachmentBody>(JsonOptions);
+		Assert.NotNull(body);
+		Assert.Equal("pic.png", body.Filename);
+		Assert.Equal("image/png", body.MimeType);
+		Assert.Equal(PngBytes.Length, body.SizeBytes);
+		Assert.True(long.TryParse(body.Id, out var id));
+
+		// the blob landed in object storage under the snowflake key, and the draft
+		// is owned by the uploader
+		Assert.True(factory.ObjectStore.Objects.ContainsKey(id.ToString()));
+		var draft = await factory.AttachmentRepository.GetDraftAsync(id, CancellationToken.None);
+		Assert.NotNull(draft);
+		Assert.Equal(42L, draft.UploaderId);
+	}
+
+	[Fact]
+	public async Task Post_NoFile_Returns400()
+	{
+		var client = BuildClient(userId: 42);
+
+		var response = await client.PostAsync("/v1/attachments", new MultipartFormDataContent());
+
+		Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+	}
+
+	[Fact]
+	public async Task Post_BlockedMimeType_Returns415_StoresNothing()
+	{
+		var client = BuildClient(userId: 42);
+
+		var response = await client.PostAsync("/v1/attachments",
+			FilePart(Encoding.UTF8.GetBytes("#!/bin/sh\necho hi"), "run.sh", "application/x-sh"));
+
+		Assert.Equal(HttpStatusCode.UnsupportedMediaType, response.StatusCode);
+		Assert.Empty(factory.ObjectStore.Objects);
+	}
+
+	// ---- download: draft path (uploader-only) ----
+
+	[Fact]
+	public async Task Get_DraftByUploader_Returns200_InlineNosniff_ByteIdentical()
+	{
+		var client = BuildClient(userId: 42);
+		var id = await UploadAsync(client, "pic.png", "image/png");
+
+		var response = await client.GetAsync($"/v1/attachments/{id}/pic.png");
+
+		Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+		Assert.Equal("nosniff", response.Headers.GetValues("X-Content-Type-Options").Single());
+		Assert.Equal("inline", response.Content.Headers.ContentDisposition!.DispositionType);
+		Assert.Equal(PngBytes, await response.Content.ReadAsByteArrayAsync());
+	}
+
+	[Fact]
+	public async Task Get_DraftByAnotherUser_Returns403()
+	{
+		var owner = BuildClient(userId: 42);
+		var id = await UploadAsync(owner, "pic.png", "image/png");
+
+		var stranger = BuildClient(userId: 99);
+		var response = await stranger.GetAsync($"/v1/attachments/{id}/pic.png");
+
+		Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+	}
+
+	[Fact]
+	public async Task Get_WrongFilename_Returns404()
+	{
+		var client = BuildClient(userId: 42);
+		var id = await UploadAsync(client, "pic.png", "image/png");
+
+		var response = await client.GetAsync($"/v1/attachments/{id}/other.png");
+
+		Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+	}
+
+	[Fact]
+	public async Task Get_UnknownId_Returns404()
+	{
+		var client = BuildClient(userId: 42);
+
+		var response = await client.GetAsync("/v1/attachments/123456/pic.png");
+
+		Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+	}
+
+	// ---- download: channel path (membership-gated) ----
+
+	[Fact]
+	public async Task Get_ChannelAttachmentAsMember_Returns200()
+	{
+		const long attachmentId = 7001, channelId = 100, messageId = 5001;
+		SeedChannelAttachment(attachmentId, channelId, messageId, "pic.png", "image/png");
+		factory.WithMembership(channelId, userId: 42, guildId: 9, permissions: ReadMessagesPermission);
+
+		var client = BuildClient(userId: 42);
+		var response = await client.GetAsync($"/v1/attachments/{attachmentId}/pic.png");
+
+		Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+		Assert.Equal(PngBytes, await response.Content.ReadAsByteArrayAsync());
+	}
+
+	[Fact]
+	public async Task Get_ChannelAttachmentAsNonMember_Returns403()
+	{
+		const long attachmentId = 7002, channelId = 100, messageId = 5002;
+		SeedChannelAttachment(attachmentId, channelId, messageId, "pic.png", "image/png");
+		factory.WithoutMembership();
+
+		var client = BuildClient(userId: 99);
+		var response = await client.GetAsync($"/v1/attachments/{attachmentId}/pic.png");
+
+		Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+	}
+
+	private async Task<long> UploadAsync(HttpClient client, string filename, string contentType)
+	{
+		var response = await client.PostAsync("/v1/attachments", FilePart(PngBytes, filename, contentType));
+		response.EnsureSuccessStatusCode();
+		var body = await response.Content.ReadFromJsonAsync<AttachmentBody>(JsonOptions);
+		return long.Parse(body!.Id);
+	}
+
+	private void SeedChannelAttachment(long attachmentId, long channelId, long messageId, string filename, string mimeType)
+	{
+		var url = $"http://localhost/api/chat/v1/attachments/{attachmentId}/{filename}";
+		factory.AttachmentRepository.SeedChannelAttachment(channelId, messageId,
+			new AttachmentMetadata(attachmentId, url, filename, PngBytes.Length, mimeType));
+		factory.ObjectStore.Seed(attachmentId.ToString(), PngBytes);
+	}
+
+	private sealed record AttachmentBody(
+		string Id,
+		string Url,
+		string Filename,
+		long SizeBytes,
+		string MimeType);
+}

--- a/services/chat/tests/Chat.FunctionalTests/Infrastructure/ChatApiFactory.cs
+++ b/services/chat/tests/Chat.FunctionalTests/Infrastructure/ChatApiFactory.cs
@@ -38,6 +38,7 @@ public sealed class ChatApiFactory : WebApplicationFactory<Program>
 	public FakeGuildClient GuildClient { get; } = new();
 	public FakeUserClient UserClient { get; } = new();
 	public FakeMessageRepository MessageRepository { get; } = new();
+	public FakeAttachmentRepository AttachmentRepository { get; } = new();
 	public FakeEventBus EventBus { get; } = new();
 	public FakeChannelBroadcaster Broadcaster { get; } = new();
 	public FakeClock Clock { get; } = new();
@@ -150,6 +151,13 @@ public sealed class ChatApiFactory : WebApplicationFactory<Program>
 				["BackendConfiguration:BaseUrl"] = "http://localhost",
 				["BackendConfiguration:BaseApiUrl"] = "http://localhost/api",
 
+				// MinioOptions validates on start even though IObjectStore is never
+				// exercised in these tests; supply dummy values to keep the bind happy
+				["Minio:Endpoint"] = "http://localhost:9000",
+				["Minio:AccessKey"] = "test",
+				["Minio:SecretKey"] = "test",
+				["Minio:Bucket"] = "chat-attachments",
+
 				["Services:GuildService"] = "http://localhost:5101",
 				["Services:UserService"] = "http://localhost:5101",
 			});
@@ -174,6 +182,11 @@ public sealed class ChatApiFactory : WebApplicationFactory<Program>
 
 			services.RemoveAll<IMessageRepository>();
 			services.AddSingleton<IMessageRepository>(MessageRepository);
+
+			// the real AttachmentRepository needs ISession (stripped above), so
+			// swap in the in-memory fake for the message handlers that depend on it
+			services.RemoveAll<IAttachmentRepository>();
+			services.AddSingleton<IAttachmentRepository>(AttachmentRepository);
 
 			services.RemoveAll<IChannelBroadcaster>();
 			services.AddSingleton<IChannelBroadcaster>(Broadcaster);

--- a/services/chat/tests/Chat.FunctionalTests/Infrastructure/ChatApiFactory.cs
+++ b/services/chat/tests/Chat.FunctionalTests/Infrastructure/ChatApiFactory.cs
@@ -39,6 +39,7 @@ public sealed class ChatApiFactory : WebApplicationFactory<Program>
 	public FakeUserClient UserClient { get; } = new();
 	public FakeMessageRepository MessageRepository { get; } = new();
 	public FakeAttachmentRepository AttachmentRepository { get; } = new();
+	public FakeObjectStore ObjectStore { get; } = new();
 	public FakeEventBus EventBus { get; } = new();
 	public FakeChannelBroadcaster Broadcaster { get; } = new();
 	public FakeClock Clock { get; } = new();
@@ -187,6 +188,11 @@ public sealed class ChatApiFactory : WebApplicationFactory<Program>
 			// swap in the in-memory fake for the message handlers that depend on it
 			services.RemoveAll<IAttachmentRepository>();
 			services.AddSingleton<IAttachmentRepository>(AttachmentRepository);
+
+			// the real MinioObjectStore would dial MinIO; serve attachment blobs
+			// from memory instead so the upload/download endpoints stay hermetic
+			services.RemoveAll<IObjectStore>();
+			services.AddSingleton<IObjectStore>(ObjectStore);
 
 			services.RemoveAll<IChannelBroadcaster>();
 			services.AddSingleton<IChannelBroadcaster>(Broadcaster);

--- a/services/chat/tests/Chat.FunctionalTests/Infrastructure/ChatApiFactory.cs
+++ b/services/chat/tests/Chat.FunctionalTests/Infrastructure/ChatApiFactory.cs
@@ -159,6 +159,10 @@ public sealed class ChatApiFactory : WebApplicationFactory<Program>
 				["Minio:SecretKey"] = "test",
 				["Minio:Bucket"] = "chat-attachments",
 
+				// the background reaper would otherwise wake up and sweep the fake
+				// object store mid-test; keep it dormant for deterministic runs
+				["AttachmentReaper:Enabled"] = "false",
+
 				["Services:GuildService"] = "http://localhost:5101",
 				["Services:UserService"] = "http://localhost:5101",
 			});

--- a/services/chat/tests/Chat.UnitTests/Application/GetChannelMessagesHandlerTests.cs
+++ b/services/chat/tests/Chat.UnitTests/Application/GetChannelMessagesHandlerTests.cs
@@ -2,6 +2,7 @@ using Chat.Application.Abstractions;
 using Chat.Application.Abstractions.Messaging;
 using Chat.Application.Features.Messages.Common;
 using Chat.Application.Features.Messages.GetChannelMessages;
+using Chat.Domain.Attachments;
 using Chat.Domain.Messages;
 using Chat.Domain.Results;
 using Chat.UnitTests.Fakes;
@@ -114,6 +115,33 @@ public sealed class GetChannelMessagesHandlerTests
 
 		Assert.True(result.Succeeded);
 		Assert.Single(result.Value);
+	}
+
+	[Fact]
+	public async Task HydratesAttachments_PerMessage_InOneBatch()
+	{
+		var (h, handler) = BuildHandler();
+		h.GuildClient.Result = new ChannelMembership(IsMember: true, GuildId: 5, Permissions: ReadMessagesPermission);
+
+		var anchor = new DateTimeOffset(2026, 1, 1, 12, 0, 0, TimeSpan.Zero);
+		SeedMessage(h.Repository, id: 1, channelId: 100, createdAt: anchor.AddMinutes(-10));
+		SeedMessage(h.Repository, id: 2, channelId: 100, createdAt: anchor.AddMinutes(-5));
+
+		// only message 2 carries an attachment
+		h.AttachmentRepository.SeedChannelAttachment(channelId: 100, messageId: 2,
+			new AttachmentMetadata(555, "http://localhost/api/chat/v1/attachments/555/pic.png", "pic.png", 1024, "image/png"));
+
+		var result = await handler.HandleAsync(new GetChannelMessagesQuery(ChannelId: 100, BeforeTime: anchor, Limit: 50));
+
+		Assert.True(result.Succeeded);
+		var withAttachment = Assert.Single(result.Value, m => m.Id == "2");
+		var attachment = Assert.Single(withAttachment.Attachments);
+		Assert.Equal("555", attachment.Id);
+		Assert.Equal("pic.png", attachment.Filename);
+
+		// the other message hydrates to an empty list, not null
+		var withoutAttachment = Assert.Single(result.Value, m => m.Id == "1");
+		Assert.Empty(withoutAttachment.Attachments);
 	}
 
 	[Fact]

--- a/services/chat/tests/Chat.UnitTests/Application/GetChannelMessagesHandlerTests.cs
+++ b/services/chat/tests/Chat.UnitTests/Application/GetChannelMessagesHandlerTests.cs
@@ -18,6 +18,7 @@ public sealed class GetChannelMessagesHandlerTests
 		FakeCurrentUser CurrentUser,
 		FakeGuildClient GuildClient,
 		FakeMessageRepository Repository,
+		FakeAttachmentRepository AttachmentRepository,
 		FakeClock Clock);
 
 	private static (Harness Harness, IQueryHandler<GetChannelMessagesQuery, Result<IReadOnlyList<MessageResponse>>> Handler)
@@ -26,12 +27,13 @@ public sealed class GetChannelMessagesHandlerTests
 		var currentUser = new FakeCurrentUser { UserId = userId };
 		var guildClient = new FakeGuildClient();
 		var repository = new FakeMessageRepository();
+		var attachmentRepository = new FakeAttachmentRepository();
 		var clock = new FakeClock();
 
 		var handler = HandlerFactory.CreateQuery<GetChannelMessagesQuery, Result<IReadOnlyList<MessageResponse>>>(
-			currentUser, guildClient, repository, clock);
+			currentUser, guildClient, repository, attachmentRepository, clock);
 
-		return (new Harness(currentUser, guildClient, repository, clock), handler);
+		return (new Harness(currentUser, guildClient, repository, attachmentRepository, clock), handler);
 	}
 
 	private static Message SeedMessage(FakeMessageRepository repo, long id, long channelId, DateTimeOffset createdAt, bool isDeleted = false)

--- a/services/chat/tests/Chat.UnitTests/Application/SendMessageHandlerTests.cs
+++ b/services/chat/tests/Chat.UnitTests/Application/SendMessageHandlerTests.cs
@@ -2,6 +2,7 @@ using Chat.Application.Abstractions;
 using Chat.Application.Contracts;
 using Chat.Application.Features.Messages.Common;
 using Chat.Application.Features.Messages.SendMessage;
+using Chat.Domain.Attachments;
 using Chat.Domain.Results;
 using Chat.UnitTests.Fakes;
 using Xunit;
@@ -18,6 +19,7 @@ public sealed class SendMessageHandlerTests
 		FakeCurrentUser CurrentUser,
 		FakeGuildClient GuildClient,
 		FakeMessageRepository Repository,
+		FakeAttachmentRepository AttachmentRepository,
 		FakeIdGenerator IdGenerator,
 		FakeClock Clock,
 		FakeEventBus EventBus,
@@ -30,15 +32,16 @@ public sealed class SendMessageHandlerTests
 		var currentUser = new FakeCurrentUser { UserId = userId };
 		var guildClient = new FakeGuildClient();
 		var repository = new FakeMessageRepository();
+		var attachmentRepository = new FakeAttachmentRepository();
 		var ids = new FakeIdGenerator();
 		var clock = new FakeClock();
 		var eventBus = new FakeEventBus();
 		var broadcaster = new FakeChannelBroadcaster();
 
 		var handler = HandlerFactory.CreateCommand<SendMessageCommand, Result<MessageResponse>>(
-			currentUser, guildClient, repository, ids, clock, eventBus, broadcaster);
+			currentUser, guildClient, repository, attachmentRepository, ids, clock, eventBus, broadcaster);
 
-		return (new Harness(currentUser, guildClient, repository, ids, clock, eventBus, broadcaster), handler);
+		return (new Harness(currentUser, guildClient, repository, attachmentRepository, ids, clock, eventBus, broadcaster), handler);
 	}
 
 	[Fact]
@@ -47,7 +50,7 @@ public sealed class SendMessageHandlerTests
 		var (h, handler) = BuildHandler();
 		h.GuildClient.Result = null;
 
-		var result = await handler.HandleAsync(new SendMessageCommand(ChannelId: 100, Content: "hi", ReplyToId: null, Nonce: null));
+		var result = await handler.HandleAsync(new SendMessageCommand(ChannelId: 100, Content: "hi", ReplyToId: null, AttachmentIds: [], Nonce: null));
 
 		Assert.True(result.IsFailure);
 		Assert.Equal(MessageFailures.ChannelNotFound, result.Error);
@@ -62,7 +65,7 @@ public sealed class SendMessageHandlerTests
 		var (h, handler) = BuildHandler();
 		h.GuildClient.Result = new ChannelMembership(IsMember: false, GuildId: 5, Permissions: 0);
 
-		var result = await handler.HandleAsync(new SendMessageCommand(ChannelId: 100, Content: "hi", ReplyToId: null, Nonce: null));
+		var result = await handler.HandleAsync(new SendMessageCommand(ChannelId: 100, Content: "hi", ReplyToId: null, AttachmentIds: [], Nonce: null));
 
 		Assert.True(result.IsFailure);
 		Assert.Equal(MessageFailures.NotAMember, result.Error);
@@ -75,7 +78,7 @@ public sealed class SendMessageHandlerTests
 		var (h, handler) = BuildHandler();
 		h.GuildClient.Result = new ChannelMembership(IsMember: true, GuildId: 5, Permissions: 0);
 
-		var result = await handler.HandleAsync(new SendMessageCommand(ChannelId: 100, Content: "hi", ReplyToId: null, Nonce: null));
+		var result = await handler.HandleAsync(new SendMessageCommand(ChannelId: 100, Content: "hi", ReplyToId: null, AttachmentIds: [], Nonce: null));
 
 		Assert.True(result.IsFailure);
 		Assert.Equal(MessageFailures.MissingSendPermission, result.Error);
@@ -91,7 +94,7 @@ public sealed class SendMessageHandlerTests
 		// admin bit set, SEND_MESSAGES clear: should still go through
 		h.GuildClient.Result = new ChannelMembership(IsMember: true, GuildId: 5, Permissions: AdministratorPermission);
 
-		var result = await handler.HandleAsync(new SendMessageCommand(ChannelId: 100, Content: "hi", ReplyToId: null, Nonce: null));
+		var result = await handler.HandleAsync(new SendMessageCommand(ChannelId: 100, Content: "hi", ReplyToId: null, AttachmentIds: [], Nonce: null));
 
 		Assert.True(result.Succeeded);
 		Assert.Single(h.Repository.Saved);
@@ -105,7 +108,7 @@ public sealed class SendMessageHandlerTests
 		var (h, handler) = BuildHandler(userId: 42);
 		h.GuildClient.Result = new ChannelMembership(IsMember: true, GuildId: 9, Permissions: SendMessagesPermission);
 
-		var result = await handler.HandleAsync(new SendMessageCommand(ChannelId: 100, Content: "hello", ReplyToId: 7, Nonce: null));
+		var result = await handler.HandleAsync(new SendMessageCommand(ChannelId: 100, Content: "hello", ReplyToId: 7, AttachmentIds: [], Nonce: null));
 
 		Assert.True(result.Succeeded);
 		var response = result.Value;
@@ -147,7 +150,7 @@ public sealed class SendMessageHandlerTests
 		h.GuildClient.Result = new ChannelMembership(IsMember: true, GuildId: 5, Permissions: SendMessagesPermission);
 		var nonce = new string('x', 64);
 
-		var result = await handler.HandleAsync(new SendMessageCommand(ChannelId: 100, Content: "hi", ReplyToId: null, Nonce: nonce));
+		var result = await handler.HandleAsync(new SendMessageCommand(ChannelId: 100, Content: "hi", ReplyToId: null, AttachmentIds: [], Nonce: nonce));
 
 		Assert.True(result.Succeeded);
 		Assert.Equal(nonce, result.Value.Nonce);
@@ -159,7 +162,7 @@ public sealed class SendMessageHandlerTests
 		var (h, handler) = BuildHandler();
 		h.GuildClient.Result = new ChannelMembership(IsMember: true, GuildId: 5, Permissions: SendMessagesPermission);
 
-		var result = await handler.HandleAsync(new SendMessageCommand(ChannelId: 100, Content: "hi", ReplyToId: null, Nonce: new string('x', 65)));
+		var result = await handler.HandleAsync(new SendMessageCommand(ChannelId: 100, Content: "hi", ReplyToId: null, AttachmentIds: [], Nonce: new string('x', 65)));
 
 		Assert.True(result.IsFailure);
 		Assert.Equal(MessageFailures.NonceTooLong, result.Error);
@@ -175,14 +178,14 @@ public sealed class SendMessageHandlerTests
 		h.GuildClient.Result = new ChannelMembership(IsMember: true, GuildId: 9, Permissions: SendMessagesPermission);
 
 		// first call — persists the message
-		var first = await handler.HandleAsync(new SendMessageCommand(ChannelId: 100, Content: "hello", ReplyToId: null, Nonce: "my-nonce"));
+		var first = await handler.HandleAsync(new SendMessageCommand(ChannelId: 100, Content: "hello", ReplyToId: null, AttachmentIds: [], Nonce: "my-nonce"));
 		Assert.True(first.Succeeded);
 
 		h.EventBus.Reset();
 		h.Broadcaster.Reset();
 
 		// second call with the same nonce — must return the original message
-		var second = await handler.HandleAsync(new SendMessageCommand(ChannelId: 100, Content: "hello", ReplyToId: null, Nonce: "my-nonce"));
+		var second = await handler.HandleAsync(new SendMessageCommand(ChannelId: 100, Content: "hello", ReplyToId: null, AttachmentIds: [], Nonce: "my-nonce"));
 
 		Assert.True(second.Succeeded);
 		Assert.Equal(first.Value.Id, second.Value.Id);
@@ -201,8 +204,8 @@ public sealed class SendMessageHandlerTests
 		var (h, handler) = BuildHandler(userId: 42);
 		h.GuildClient.Result = new ChannelMembership(IsMember: true, GuildId: 9, Permissions: SendMessagesPermission);
 
-		var first = await handler.HandleAsync(new SendMessageCommand(ChannelId: 100, Content: "hello", ReplyToId: null, Nonce: "nonce-a"));
-		var second = await handler.HandleAsync(new SendMessageCommand(ChannelId: 100, Content: "hello", ReplyToId: null, Nonce: "nonce-b"));
+		var first = await handler.HandleAsync(new SendMessageCommand(ChannelId: 100, Content: "hello", ReplyToId: null, AttachmentIds: [], Nonce: "nonce-a"));
+		var second = await handler.HandleAsync(new SendMessageCommand(ChannelId: 100, Content: "hello", ReplyToId: null, AttachmentIds: [], Nonce: "nonce-b"));
 
 		Assert.True(first.Succeeded);
 		Assert.True(second.Succeeded);
@@ -218,12 +221,120 @@ public sealed class SendMessageHandlerTests
 		var (h, handler) = BuildHandler();
 		h.GuildClient.Result = new ChannelMembership(IsMember: true, GuildId: 5, Permissions: SendMessagesPermission);
 
-		var result = await handler.HandleAsync(new SendMessageCommand(ChannelId: 100, Content: "   ", ReplyToId: null, Nonce: null));
+		var result = await handler.HandleAsync(new SendMessageCommand(ChannelId: 100, Content: "   ", ReplyToId: null, AttachmentIds: [], Nonce: null));
 
 		Assert.True(result.IsFailure);
 		Assert.Equal(MessageFailures.ContentRequired, result.Error);
 		Assert.Empty(h.Repository.Saved);
 		Assert.Empty(h.EventBus.Published);
 		Assert.Empty(h.Broadcaster.Broadcasts);
+	}
+
+	private static DraftAttachment SeedDraft(FakeAttachmentRepository repo, long id, long uploaderId)
+	{
+		var draft = DraftAttachment.Create(
+			id: id, uploaderId: uploaderId,
+			url: $"http://localhost/api/chat/v1/attachments/{id}/pic.png",
+			filename: "pic.png", sizeBytes: 1024, mimeType: "image/png",
+			now: new DateTimeOffset(2026, 1, 1, 12, 0, 0, TimeSpan.Zero)).Value;
+		repo.SeedDraft(draft);
+		return draft;
+	}
+
+	[Fact]
+	public async Task ValidDraft_AttachesToMessage_HydratesResponse_AndPersists()
+	{
+		var (h, handler) = BuildHandler(userId: 42);
+		h.GuildClient.Result = new ChannelMembership(IsMember: true, GuildId: 9, Permissions: SendMessagesPermission);
+		var draft = SeedDraft(h.AttachmentRepository, id: 555, uploaderId: 42);
+
+		var result = await handler.HandleAsync(new SendMessageCommand(
+			ChannelId: 100, Content: "look", ReplyToId: null, AttachmentIds: [draft.Id], Nonce: null));
+
+		Assert.True(result.Succeeded);
+		var attachment = Assert.Single(result.Value.Attachments);
+		Assert.Equal("555", attachment.Id);
+		Assert.Equal("pic.png", attachment.Filename);
+
+		// the message persisted with its attachment metadata attached
+		var saved = Assert.Single(h.Repository.Saved);
+		var persisted = Assert.Single(h.Repository.SavedAttachments[saved.Id]);
+		Assert.Equal(555L, persisted.Id);
+	}
+
+	[Fact]
+	public async Task AttachmentWithoutContent_Succeeds()
+	{
+		var (h, handler) = BuildHandler(userId: 42);
+		h.GuildClient.Result = new ChannelMembership(IsMember: true, GuildId: 9, Permissions: SendMessagesPermission);
+		var draft = SeedDraft(h.AttachmentRepository, id: 777, uploaderId: 42);
+
+		var result = await handler.HandleAsync(new SendMessageCommand(
+			ChannelId: 100, Content: null, ReplyToId: null, AttachmentIds: [draft.Id], Nonce: null));
+
+		Assert.True(result.Succeeded);
+		Assert.Single(result.Value.Attachments);
+	}
+
+	[Fact]
+	public async Task TooManyAttachments_ReturnsTooMany_NoSideEffects()
+	{
+		var (h, handler) = BuildHandler(userId: 42);
+		h.GuildClient.Result = new ChannelMembership(IsMember: true, GuildId: 9, Permissions: SendMessagesPermission);
+		long[] ids = [.. Enumerable.Range(1, 11).Select(i => (long)i)];
+
+		var result = await handler.HandleAsync(new SendMessageCommand(
+			ChannelId: 100, Content: "hi", ReplyToId: null, AttachmentIds: ids, Nonce: null));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal(AttachmentFailures.TooMany, result.Error);
+		Assert.Empty(h.Repository.Saved);
+		Assert.Empty(h.EventBus.Published);
+		Assert.Empty(h.Broadcaster.Broadcasts);
+	}
+
+	[Fact]
+	public async Task UnknownDraft_ReturnsInvalidReference_NoSideEffects()
+	{
+		var (h, handler) = BuildHandler(userId: 42);
+		h.GuildClient.Result = new ChannelMembership(IsMember: true, GuildId: 9, Permissions: SendMessagesPermission);
+
+		var result = await handler.HandleAsync(new SendMessageCommand(
+			ChannelId: 100, Content: "hi", ReplyToId: null, AttachmentIds: [999], Nonce: null));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal(AttachmentFailures.InvalidReference, result.Error);
+		Assert.Empty(h.Repository.Saved);
+	}
+
+	[Fact]
+	public async Task DraftOwnedByAnotherUser_ReturnsInvalidReference()
+	{
+		var (h, handler) = BuildHandler(userId: 42);
+		h.GuildClient.Result = new ChannelMembership(IsMember: true, GuildId: 9, Permissions: SendMessagesPermission);
+		var draft = SeedDraft(h.AttachmentRepository, id: 555, uploaderId: 7); // not 42
+
+		var result = await handler.HandleAsync(new SendMessageCommand(
+			ChannelId: 100, Content: "hi", ReplyToId: null, AttachmentIds: [draft.Id], Nonce: null));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal(AttachmentFailures.InvalidReference, result.Error);
+		Assert.Empty(h.Repository.Saved);
+	}
+
+	[Fact]
+	public async Task AlreadyAttachedDraft_ReturnsInvalidReference()
+	{
+		var (h, handler) = BuildHandler(userId: 42);
+		h.GuildClient.Result = new ChannelMembership(IsMember: true, GuildId: 9, Permissions: SendMessagesPermission);
+		var draft = SeedDraft(h.AttachmentRepository, id: 555, uploaderId: 42);
+		h.AttachmentRepository.MarkAttached(draft.Id);
+
+		var result = await handler.HandleAsync(new SendMessageCommand(
+			ChannelId: 100, Content: "hi", ReplyToId: null, AttachmentIds: [draft.Id], Nonce: null));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal(AttachmentFailures.InvalidReference, result.Error);
+		Assert.Empty(h.Repository.Saved);
 	}
 }

--- a/services/chat/tests/Chat.UnitTests/Fakes/FakeAttachmentRepository.cs
+++ b/services/chat/tests/Chat.UnitTests/Fakes/FakeAttachmentRepository.cs
@@ -30,6 +30,22 @@ public sealed class FakeAttachmentRepository : IAttachmentRepository
 	/// <summary>mark an attachment as already bound to a message</summary>
 	public void MarkAttached(long id) => _attached.Add(id);
 
+	/// <summary>
+	/// seed an attachment already bound to a channel message, so the download path's
+	/// lookup + per-message read both resolve (mirrors the real attachment_lookup +
+	/// message_attachments rows written when a draft is sent)
+	/// </summary>
+	public void SeedChannelAttachment(long channelId, long messageId, AttachmentMetadata metadata)
+	{
+		_attached.Add(metadata.Id);
+		_locations[metadata.Id] = new AttachmentLocation(
+			IsDm: false, ChannelId: channelId, ConversationId: null, MessageId: messageId);
+
+		if (!_byMessage.TryGetValue((channelId, messageId), out var list))
+			_byMessage[(channelId, messageId)] = list = [];
+		list.Add(metadata);
+	}
+
 	public Task AddDraftAsync(DraftAttachment draft, CancellationToken ct)
 	{
 		_drafts[draft.Id] = draft;

--- a/services/chat/tests/Chat.UnitTests/Fakes/FakeAttachmentRepository.cs
+++ b/services/chat/tests/Chat.UnitTests/Fakes/FakeAttachmentRepository.cs
@@ -74,4 +74,15 @@ public sealed class FakeAttachmentRepository : IAttachmentRepository
 			_byMessage.GetValueOrDefault((channelId, messageId)) ?? [];
 		return Task.FromResult(result);
 	}
+
+	public Task<ILookup<long, AttachmentMetadata>> GetChannelMessagesAttachmentsAsync(
+		long channelId, IReadOnlyList<long> messageIds, CancellationToken ct)
+	{
+		var wanted = messageIds.ToHashSet();
+		var lookup = _byMessage
+			.Where(e => e.Key.ChannelId == channelId && wanted.Contains(e.Key.MessageId))
+			.SelectMany(e => e.Value.Select(m => (e.Key.MessageId, Metadata: m)))
+			.ToLookup(x => x.MessageId, x => x.Metadata);
+		return Task.FromResult(lookup);
+	}
 }

--- a/services/chat/tests/Chat.UnitTests/Fakes/FakeAttachmentRepository.cs
+++ b/services/chat/tests/Chat.UnitTests/Fakes/FakeAttachmentRepository.cs
@@ -1,0 +1,61 @@
+using Chat.Application.Abstractions.Persistence;
+using Chat.Domain.Attachments;
+
+namespace Chat.UnitTests.Fakes;
+
+/// <summary>
+/// in-memory <see cref="IAttachmentRepository"/>. drafts are seeded directly;
+/// "attaching" a draft (sending it with a message) moves it from the drafts map
+/// into the attached set so <see cref="IsAttachedAsync"/> flips to true, mirroring
+/// the real repo's batched draft delete + lookup insert
+/// </summary>
+public sealed class FakeAttachmentRepository : IAttachmentRepository
+{
+	private readonly Dictionary<long, DraftAttachment> _drafts = [];
+	private readonly HashSet<long> _attached = [];
+	private readonly Dictionary<long, AttachmentLocation> _locations = [];
+	private readonly Dictionary<(long ChannelId, long MessageId), List<AttachmentMetadata>> _byMessage = [];
+
+	public void Reset()
+	{
+		_drafts.Clear();
+		_attached.Clear();
+		_locations.Clear();
+		_byMessage.Clear();
+	}
+
+	/// <summary>seed an uploaded-but-unattached draft for the resolve path</summary>
+	public void SeedDraft(DraftAttachment draft) => _drafts[draft.Id] = draft;
+
+	/// <summary>mark an attachment as already bound to a message</summary>
+	public void MarkAttached(long id) => _attached.Add(id);
+
+	public Task AddDraftAsync(DraftAttachment draft, CancellationToken ct)
+	{
+		_drafts[draft.Id] = draft;
+		return Task.CompletedTask;
+	}
+
+	public Task<DraftAttachment?> GetDraftAsync(long id, CancellationToken ct)
+		=> Task.FromResult(_drafts.GetValueOrDefault(id));
+
+	public Task<bool> IsAttachedAsync(long id, CancellationToken ct)
+		=> Task.FromResult(_attached.Contains(id));
+
+	public Task<AttachmentLocation?> GetLocationAsync(long id, CancellationToken ct)
+		=> Task.FromResult(_locations.GetValueOrDefault(id));
+
+	public Task<AttachmentMetadata?> GetChannelAttachmentAsync(long channelId, long messageId, long id, CancellationToken ct)
+	{
+		var match = _byMessage.GetValueOrDefault((channelId, messageId))?
+			.FirstOrDefault(a => a.Id == id);
+		return Task.FromResult(match);
+	}
+
+	public Task<IReadOnlyList<AttachmentMetadata>> GetChannelMessageAttachmentsAsync(long channelId, long messageId, CancellationToken ct)
+	{
+		IReadOnlyList<AttachmentMetadata> result =
+			_byMessage.GetValueOrDefault((channelId, messageId)) ?? [];
+		return Task.FromResult(result);
+	}
+}

--- a/services/chat/tests/Chat.UnitTests/Fakes/FakeMessageRepository.cs
+++ b/services/chat/tests/Chat.UnitTests/Fakes/FakeMessageRepository.cs
@@ -1,4 +1,5 @@
 using Chat.Application.Abstractions.Persistence;
+using Chat.Domain.Attachments;
 using Chat.Domain.Messages;
 
 namespace Chat.UnitTests.Fakes;
@@ -7,18 +8,24 @@ public sealed class FakeMessageRepository : IMessageRepository
 {
 	private readonly List<Message> _saved = [];
 	private readonly Dictionary<(long AuthorId, long ChannelId, string Nonce), long> _nonces = [];
+	private readonly Dictionary<long, IReadOnlyList<AttachmentMetadata>> _attachments = [];
 
 	public IReadOnlyList<Message> Saved => _saved;
+
+	/// <summary>attachments persisted alongside each message, keyed by message id</summary>
+	public IReadOnlyDictionary<long, IReadOnlyList<AttachmentMetadata>> SavedAttachments => _attachments;
 
 	public void Reset()
 	{
 		_saved.Clear();
 		_nonces.Clear();
+		_attachments.Clear();
 	}
 
-	public Task AddAsync(Message message, string? nonce, CancellationToken ct)
+	public Task AddAsync(Message message, string? nonce, IReadOnlyList<AttachmentMetadata> attachments, CancellationToken ct)
 	{
 		_saved.Add(message);
+		_attachments[message.Id] = attachments;
 		if (nonce is not null)
 			_nonces[(message.AuthorId, message.ChannelId, nonce)] = message.Id;
 		return Task.CompletedTask;

--- a/services/chat/tests/Chat.UnitTests/Fakes/FakeObjectStore.cs
+++ b/services/chat/tests/Chat.UnitTests/Fakes/FakeObjectStore.cs
@@ -1,0 +1,31 @@
+using Chat.Application.Abstractions;
+
+namespace Chat.UnitTests.Fakes;
+
+/// <summary>
+/// in-memory <see cref="IObjectStore"/> standing in for MinIO. blobs are buffered
+/// into byte arrays on put and replayed as fresh streams on get
+/// </summary>
+public sealed class FakeObjectStore : IObjectStore
+{
+	private readonly Dictionary<string, byte[]> _objects = [];
+
+	public IReadOnlyDictionary<string, byte[]> Objects => _objects;
+
+	public void Reset() => _objects.Clear();
+
+	/// <summary>seed a stored blob directly (e.g. for the download path)</summary>
+	public void Seed(string key, byte[] content) => _objects[key] = content;
+
+	public async Task PutAsync(string key, Stream content, string contentType, long length, CancellationToken ct)
+	{
+		using var buffer = new MemoryStream();
+		await content.CopyToAsync(buffer, ct);
+		_objects[key] = buffer.ToArray();
+	}
+
+	public Task<Stream?> GetAsync(string key, CancellationToken ct)
+		=> Task.FromResult(_objects.TryGetValue(key, out var bytes)
+			? new MemoryStream(bytes)
+			: (Stream?)null);
+}

--- a/services/chat/tests/Chat.UnitTests/Fakes/FakeObjectStore.cs
+++ b/services/chat/tests/Chat.UnitTests/Fakes/FakeObjectStore.cs
@@ -1,31 +1,52 @@
+using System.Runtime.CompilerServices;
 using Chat.Application.Abstractions;
 
 namespace Chat.UnitTests.Fakes;
 
 /// <summary>
 /// in-memory <see cref="IObjectStore"/> standing in for MinIO. blobs are buffered
-/// into byte arrays on put and replayed as fresh streams on get
+/// into byte arrays on put and replayed as fresh streams on get; each carries a
+/// last-modified timestamp so the reaper's age filter can be exercised
 /// </summary>
 public sealed class FakeObjectStore : IObjectStore
 {
-	private readonly Dictionary<string, byte[]> _objects = [];
+	private sealed record Entry(byte[] Content, DateTimeOffset LastModified);
 
-	public IReadOnlyDictionary<string, byte[]> Objects => _objects;
+	private readonly Dictionary<string, Entry> _objects = [];
+
+	public IReadOnlyDictionary<string, byte[]> Objects =>
+		_objects.ToDictionary(e => e.Key, e => e.Value.Content);
 
 	public void Reset() => _objects.Clear();
 
-	/// <summary>seed a stored blob directly (e.g. for the download path)</summary>
-	public void Seed(string key, byte[] content) => _objects[key] = content;
+	/// <summary>seed a stored blob, last-modified now (or at an explicit time)</summary>
+	public void Seed(string key, byte[] content, DateTimeOffset? lastModified = null)
+		=> _objects[key] = new Entry(content, lastModified ?? DateTimeOffset.UtcNow);
 
 	public async Task PutAsync(string key, Stream content, string contentType, long length, CancellationToken ct)
 	{
 		using var buffer = new MemoryStream();
 		await content.CopyToAsync(buffer, ct);
-		_objects[key] = buffer.ToArray();
+		_objects[key] = new Entry(buffer.ToArray(), DateTimeOffset.UtcNow);
 	}
 
 	public Task<Stream?> GetAsync(string key, CancellationToken ct)
-		=> Task.FromResult(_objects.TryGetValue(key, out var bytes)
-			? new MemoryStream(bytes)
+		=> Task.FromResult(_objects.TryGetValue(key, out var entry)
+			? new MemoryStream(entry.Content)
 			: (Stream?)null);
+
+	public Task DeleteAsync(string key, CancellationToken ct)
+	{
+		_objects.Remove(key);
+		return Task.CompletedTask;
+	}
+
+	public async IAsyncEnumerable<ObjectInfo> ListAsync([EnumeratorCancellation] CancellationToken ct)
+	{
+		// snapshot so a caller may delete blobs while enumerating (the reaper does)
+		foreach (var entry in _objects.Select(e => new ObjectInfo(e.Key, e.Value.LastModified)).ToList())
+			yield return entry;
+
+		await Task.CompletedTask;
+	}
 }

--- a/services/chat/tests/Chat.UnitTests/Infrastructure/AttachmentReaperTests.cs
+++ b/services/chat/tests/Chat.UnitTests/Infrastructure/AttachmentReaperTests.cs
@@ -1,0 +1,106 @@
+using Chat.Application.Abstractions.Persistence;
+using Chat.Infrastructure.Options;
+using Chat.Infrastructure.Storage;
+using Chat.UnitTests.Fakes;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Chat.UnitTests.Infrastructure;
+
+public sealed class AttachmentReaperTests
+{
+	private const int MinAgeSeconds = 7200; // 2h, matches the default
+
+	private static (AttachmentReaper Reaper, FakeObjectStore Store, FakeAttachmentRepository Attachments) Build()
+	{
+		var store = new FakeObjectStore();
+		var attachments = new FakeAttachmentRepository();
+
+		// IAttachmentRepository is resolved per-sweep through a scope, so back the
+		// scope factory with a real container holding the fake
+		var services = new ServiceCollection();
+		services.AddSingleton<IAttachmentRepository>(attachments);
+		var scopeFactory = services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>();
+
+		var options = Options.Create(new AttachmentReaperOptions
+		{
+			Enabled = true,
+			IntervalSeconds = 900,
+			MinAgeSeconds = MinAgeSeconds,
+		});
+
+		var reaper = new AttachmentReaper(scopeFactory, store, options, NullLogger<AttachmentReaper>.Instance);
+		return (reaper, store, attachments);
+	}
+
+	private static DateTimeOffset Old => DateTimeOffset.UtcNow.AddSeconds(-(MinAgeSeconds + 600));
+	private static DateTimeOffset Fresh => DateTimeOffset.UtcNow;
+
+	[Fact]
+	public async Task DeletesOldUnattachedBlob()
+	{
+		var (reaper, store, _) = Build();
+		store.Seed("100", [1, 2, 3], Old);
+
+		var reaped = await reaper.ReapOnceAsync(CancellationToken.None);
+
+		Assert.Equal(1, reaped);
+		Assert.False(store.Objects.ContainsKey("100"));
+	}
+
+	[Fact]
+	public async Task KeepsOldAttachedBlob()
+	{
+		var (reaper, store, attachments) = Build();
+		store.Seed("200", [1, 2, 3], Old);
+		attachments.MarkAttached(200);
+
+		var reaped = await reaper.ReapOnceAsync(CancellationToken.None);
+
+		Assert.Equal(0, reaped);
+		Assert.True(store.Objects.ContainsKey("200"));
+	}
+
+	[Fact]
+	public async Task KeepsFreshUnattachedBlob_StillWithinDraftLifetime()
+	{
+		var (reaper, store, _) = Build();
+		store.Seed("300", [1, 2, 3], Fresh);
+
+		var reaped = await reaper.ReapOnceAsync(CancellationToken.None);
+
+		Assert.Equal(0, reaped);
+		Assert.True(store.Objects.ContainsKey("300"));
+	}
+
+	[Fact]
+	public async Task IgnoresBlobsWhoseKeyIsNotAnAttachmentId()
+	{
+		var (reaper, store, _) = Build();
+		store.Seed("not-a-snowflake", [1, 2, 3], Old);
+
+		var reaped = await reaper.ReapOnceAsync(CancellationToken.None);
+
+		Assert.Equal(0, reaped);
+		Assert.True(store.Objects.ContainsKey("not-a-snowflake"));
+	}
+
+	[Fact]
+	public async Task SweepsMixedBucket_DeletingOnlyOrphans()
+	{
+		var (reaper, store, attachments) = Build();
+		store.Seed("100", [1], Old);    // orphan -> deleted
+		store.Seed("200", [1], Old);    // attached -> kept
+		store.Seed("300", [1], Fresh);  // too fresh -> kept
+		attachments.MarkAttached(200);
+
+		var reaped = await reaper.ReapOnceAsync(CancellationToken.None);
+
+		Assert.Equal(1, reaped);
+		Assert.False(store.Objects.ContainsKey("100"));
+		Assert.True(store.Objects.ContainsKey("200"));
+		Assert.True(store.Objects.ContainsKey("300"));
+	}
+}

--- a/services/gateway/middleware/routecheck.go
+++ b/services/gateway/middleware/routecheck.go
@@ -14,10 +14,9 @@ type timeoutCatKey struct{}
 type TimeoutCategory uint8
 
 const (
-	CatJSON       TimeoutCategory = 1
-	CatUpload     TimeoutCategory = 2
-	CatWebSocket  TimeoutCategory = 3
-	CatAttachment TimeoutCategory = 4
+	CatJSON      TimeoutCategory = 1
+	CatUpload    TimeoutCategory = 2
+	CatWebSocket TimeoutCategory = 3
 )
 
 var validServices = map[string]bool{
@@ -106,29 +105,10 @@ func pickTimeoutCat(r *http.Request, service string) TimeoutCategory {
 	if isWebSocketUpgrade(r) && wsCapable[service] {
 		return CatWebSocket // 3
 	}
-	if isAttachmentUpload(r) {
-		return CatAttachment // 4
-	}
 	if isAvatarUpload(r) {
 		return CatUpload // 2
 	}
 	return CatJSON // 1
-}
-
-// chat file attachments: POST /api/chat/v1/attachments. Capped at 25 MB per file
-// by the Chat Service, so this only needs a larger body budget than plain JSON.
-func isAttachmentUpload(r *http.Request) bool {
-
-	if r.Method != http.MethodPost {
-		return false
-	}
-
-	parts := strings.Split(strings.TrimSuffix(r.URL.Path, "/"), "/")
-	if len(parts) != 5 {
-		return false
-	}
-
-	return parts[2] == "chat" && parts[4] == "attachments"
 }
 
 func isWebSocketUpgrade(r *http.Request) bool {

--- a/services/gateway/middleware/routecheck.go
+++ b/services/gateway/middleware/routecheck.go
@@ -14,9 +14,10 @@ type timeoutCatKey struct{}
 type TimeoutCategory uint8
 
 const (
-	CatJSON      TimeoutCategory = 1
-	CatUpload    TimeoutCategory = 2
-	CatWebSocket TimeoutCategory = 3
+	CatJSON       TimeoutCategory = 1
+	CatUpload     TimeoutCategory = 2
+	CatWebSocket  TimeoutCategory = 3
+	CatAttachment TimeoutCategory = 4
 )
 
 var validServices = map[string]bool{
@@ -105,10 +106,29 @@ func pickTimeoutCat(r *http.Request, service string) TimeoutCategory {
 	if isWebSocketUpgrade(r) && wsCapable[service] {
 		return CatWebSocket // 3
 	}
+	if isAttachmentUpload(r) {
+		return CatAttachment // 4
+	}
 	if isAvatarUpload(r) {
 		return CatUpload // 2
 	}
 	return CatJSON // 1
+}
+
+// chat file attachments: POST /api/chat/v1/attachments. Capped at 25 MB per file
+// by the Chat Service, so this only needs a larger body budget than plain JSON.
+func isAttachmentUpload(r *http.Request) bool {
+
+	if r.Method != http.MethodPost {
+		return false
+	}
+
+	parts := strings.Split(strings.TrimSuffix(r.URL.Path, "/"), "/")
+	if len(parts) != 5 {
+		return false
+	}
+
+	return parts[2] == "chat" && parts[4] == "attachments"
 }
 
 func isWebSocketUpgrade(r *http.Request) bool {

--- a/services/gateway/middleware/routecheck.go
+++ b/services/gateway/middleware/routecheck.go
@@ -105,7 +105,7 @@ func pickTimeoutCat(r *http.Request, service string) TimeoutCategory {
 	if isWebSocketUpgrade(r) && wsCapable[service] {
 		return CatWebSocket // 3
 	}
-	if isAvatarUpload(r) {
+	if isUpload(r) {
 		return CatUpload // 2
 	}
 	return CatJSON // 1
@@ -118,19 +118,28 @@ func isWebSocketUpgrade(r *http.Request) bool {
 		strings.Contains(strings.ToLower(r.Header.Get("Connection")), "upgrade")
 }
 
-func isAvatarUpload(r *http.Request) bool {
+func isUpload(r *http.Request) bool {
 
 	if r.Method != http.MethodPost && r.Method != http.MethodPut {
 		return false
 	}
 
 	parts := strings.Split(strings.TrimSuffix(r.URL.Path, "/"), "/")
-	if len(parts) < 6 {
+	partsLen := len(parts)
+	if partsLen < 5 {
 		return false
 	}
 
 	service := parts[2]
+	if service == "chat" && parts[4] == "attachments" {
+		return true
+	}
+
 	if service != "user" && service != "guild" {
+		return false
+	}
+
+	if partsLen < 6 {
 		return false
 	}
 

--- a/services/gateway/middleware/timeoutcat.go
+++ b/services/gateway/middleware/timeoutcat.go
@@ -34,7 +34,7 @@ func TimeoutCat(next http.Handler) http.Handler {
 
 		case CatUpload:
 			logs.Info(host, "Attributed timeout category Upload...")
-			r.Body = http.MaxBytesReader(w, r.Body, 5<<20) // 5 MB
+			r.Body = http.MaxBytesReader(w, r.Body, 26<<20) // 26 MB
 			_ = rc.SetReadDeadline(time.Now().Add(60 * time.Second))
 			_ = rc.SetWriteDeadline(time.Now().Add(30 * time.Second))
 

--- a/services/gateway/middleware/timeoutcat.go
+++ b/services/gateway/middleware/timeoutcat.go
@@ -38,12 +38,6 @@ func TimeoutCat(next http.Handler) http.Handler {
 			_ = rc.SetReadDeadline(time.Now().Add(60 * time.Second))
 			_ = rc.SetWriteDeadline(time.Now().Add(30 * time.Second))
 
-		case CatAttachment:
-			logs.Info(host, "Attributed timeout category Attachment...")
-			r.Body = http.MaxBytesReader(w, r.Body, 26<<20) // 26 MB (25 MB file + multipart overhead)
-			_ = rc.SetReadDeadline(time.Now().Add(60 * time.Second))
-			_ = rc.SetWriteDeadline(time.Now().Add(30 * time.Second))
-
 		default:
 			logs.Info(host, "Attributed timeout category JSON...")
 			r.Body = http.MaxBytesReader(w, r.Body, 1<<20) // 1 MB

--- a/services/gateway/middleware/timeoutcat.go
+++ b/services/gateway/middleware/timeoutcat.go
@@ -38,6 +38,12 @@ func TimeoutCat(next http.Handler) http.Handler {
 			_ = rc.SetReadDeadline(time.Now().Add(60 * time.Second))
 			_ = rc.SetWriteDeadline(time.Now().Add(30 * time.Second))
 
+		case CatAttachment:
+			logs.Info(host, "Attributed timeout category Attachment...")
+			r.Body = http.MaxBytesReader(w, r.Body, 26<<20) // 26 MB (25 MB file + multipart overhead)
+			_ = rc.SetReadDeadline(time.Now().Add(60 * time.Second))
+			_ = rc.SetWriteDeadline(time.Now().Add(30 * time.Second))
+
 		default:
 			logs.Info(host, "Attributed timeout category JSON...")
 			r.Body = http.MaxBytesReader(w, r.Body, 1<<20) // 1 MB


### PR DESCRIPTION
Resolves #151 

## Summary

Implements file attachments for chat: upload, download, and sending messages with attachments. This covers the full lifecycle from a multipart upload, through binding a draft to a sent message, to an auth-checked download, plus the gateway and nginx changes needed to move files end to end, security hardening on the download path, a background cleanup job for orphaned blobs, and a query optimization for message history (and some bits of my sanity here and there)

## Storage model

Three ScyllaDB tables back the feature:
- `draft_attachments`: uploaded but not yet sent. Carries a 3600s TTL so an abandoned draft expires on its own.
- `message_attachments`: permanent attachment metadata, partitioned by  `(channel_id, message_id)`.
- `attachment_lookup`: resolves an attachment id to its owning message for the download auth check.

Blob payloads live in object storage (MinIO over the S3 API), keyed by the attachment snowflake id. Chat is the only reader and writer, so all authorization stays in the REST layer and clients never touch storage directly.

## Endpoints

**`POST /attachments`** (multipart, Bearer auth)
- Returns draft attachment metadata (201 Created).
- 25 MB per-file cap.
- Rejects executable and script MIME types (415 Unsupported Media Type).
- Rejects an empty or missing file field (400 Bad Request).
- Validation runs before the blob is written to storage, so a rejected upload never leaves an orphaned object behind.

**`GET /attachments/{id}/{filename}`** (Bearer auth)
- Streams the blob from object storage (200 OK), or 403 / 404 on a failed check.
- Auth: for a draft, only the uploader may fetch it; for a sent attachment, the caller must be a member of the channel with read permission. DM attachments are denied defensively until the DM feature lands.
- The requested filename must match the stored one, otherwise it is treated as a miss (404).

**Sending** (`attachment_ids` on send message)
- Each referenced draft must be owned by the caller, still exist (not TTL expired), and not already be attached to another message. Max 10 per message.
- Content becomes optional when a message carries at least one attachment.
- The message row, attachment metadata, lookup rows, and draft cleanup are all written in one logged batch, so attaching is atomic with the message itself.
- Nonce dedup runs before draft validation so a retried send returns the original message instead of failing on already-consumed drafts.

## Security hardening on download

The stored MIME type is client supplied at upload time, so it is untrusted on the
way back out. The download path now:
- Sets `X-Content-Type-Options: nosniff` so the browser cannot sniff a different, executable type out of the bytes.
- Serves only a small allow-list of known-safe media types (images, audio, video, pdf) inline, and forces everything else to download. An HTML or SVG payload can therefore never render and execute on our origin.
- Encodes the user-supplied filename into the Content-Disposition header (ascii fallback plus RFC 5987 form) instead of interpolating it raw, so a quote or non-ascii character cannot break out of the header.

## Background cleanup

A hosted `AttachmentReaper` periodically sweeps object storage and deletes orphaned blobs. This closes two leaks in one mechanism: drafts that are uploaded but never sent (the row TTLs out but the blob would otherwise linger forever), and the rare case where the blob is written but the draft row write fails.

It deletes a blob only when it is older than the full draft lifetime AND not bound to any message, checked against `attachment_lookup`. Because the message table is the sole source of truth, it can never delete a live attachment. Deletes are idempotent, so running it on several replicas at once is safe. Default interval is 15 minutes with a 2 hour minimum age, both configurable.

## Performance

Channel message history previously did one attachment read per message in the page. It now hydrates a whole page in a single query using `message_id IN ?` (valid because `message_id` is the trailing partition-key column with `channel_id` pinned), collapsing N reads into one. The page limit bounds the IN list so coordinator fan-out stays small.

## Infrastructure

- Gateway: a dedicated body-size category for attachment uploads (26 MB), separate from the 1 MB JSON default.
- nginx: raised `client_max_body_size` to 26 MB on the API location.
- The 26 MB ceiling is the 25 MB file cap plus a little multipart overhead.

## Testing

188 tests passing (17 architecture, 71 unit, 100 functional):
- Unit: send wiring with attachments (happy path, too many, unknown / unowned / already-attached draft), batched history hydration, and the reaper sweep across a mixed bucket.
- Functional: upload (201, 400, 415), download draft and channel paths (200, 403, 404), plus assertions on the nosniff header, inline disposition, and a byte-identical round trip.

## Notes

- DM attachment wiring lands with the DM feature branch.
- The reaper lists the whole bucket each interval. If attachment volume ever grows large, a `drafts/` key prefix would narrow the scan, but we're not there yet :)
