### PR TITLE
Feat(infra): setup coturn

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,3 +37,12 @@ MINIO_SECRET_KEY=
 MINIO_BUCKET=chat-attachments
 MINIO_USER_BUCKET=user-avatars
 MINIO_GUILD_BUCKET=guild-icons
+
+#    ╭─────────────────────────────────────────────────────────────────────╮
+#    │            coturn (STUN/TURN) long-term credentials.                │
+#    │   ───── Example: localhost / ft_turn / a-long-random-secret ─────   │
+#    ╰─────────────────────────────────────────────────────────────────────╯
+
+TURN_REALM=
+TURN_USERNAME=
+TURN_PASSWORD=

--- a/.env.example
+++ b/.env.example
@@ -46,3 +46,7 @@ MINIO_GUILD_BUCKET=guild-icons
 TURN_REALM=
 TURN_USERNAME=
 TURN_PASSWORD=
+# optional: force the IPv4 the TURN relay advertises (must be reachable by the
+# other device, e.g. your LAN IP like 192.168.1.52). leave blank to auto-detect
+# the host's primary LAN address from its default route
+TURN_RELAY_IP=

--- a/Tiltfile
+++ b/Tiltfile
@@ -68,12 +68,17 @@ local_resource(
         '--network host ' +
         # run as root so coturn can read the 0600 TLS key in ./certs (see compose.yaml)
         '--user 0:0 ' +
+        # entrypoint pins the relay/external IP to one reachable IPv4 (see
+        # infra/coturn/entrypoint.sh); realm + user come from the environment.
+        '-e TURN_REALM=' + TURN_REALM + ' ' +
+        '-e TURN_USERNAME=' + TURN_USERNAME + ' ' +
+        '-e TURN_PASSWORD=' + TURN_PASSWORD + ' ' +
+        '-e TURN_RELAY_IP=' + root_env.get('TURN_RELAY_IP', '') + ' ' +
+        '--entrypoint /usr/local/bin/coturn-entrypoint.sh ' +
         '-v $(pwd)/infra/coturn/turnserver.conf:/etc/coturn/turnserver.conf:ro ' +
+        '-v $(pwd)/infra/coturn/entrypoint.sh:/usr/local/bin/coturn-entrypoint.sh:ro ' +
         '-v $(pwd)/certs:/etc/coturn/certs:ro ' +
-        'docker.io/coturn/coturn:alpine ' +
-        '-c /etc/coturn/turnserver.conf ' +
-        '--realm=' + TURN_REALM + ' ' +
-        '--user=' + TURN_USERNAME + ':' + TURN_PASSWORD
+        'docker.io/coturn/coturn:alpine'
     ),
     resource_deps=['cert-gen', 'dev-network'],
     labels=['infra'],

--- a/Tiltfile
+++ b/Tiltfile
@@ -10,6 +10,9 @@ MINIO_SECRET = root_env.get('MINIO_SECRET_KEY', 'minioadmin')
 MINIO_BUCKET = root_env.get('MINIO_BUCKET',       'chat-attachments')
 MINIO_USER_BUCKET  = root_env.get('MINIO_USER_BUCKET',  'user-avatars')
 MINIO_GUILD_BUCKET = root_env.get('MINIO_GUILD_BUCKET', 'guild-icons')
+TURN_REALM    = root_env.get('TURN_REALM',    'localhost')
+TURN_USERNAME = root_env.get('TURN_USERNAME', 'ft_turn')
+TURN_PASSWORD = root_env.get('TURN_PASSWORD', 'ft_turn')
 DOCKER       = detect_engine()
 FLAGS        = run_flags(DOCKER)
 
@@ -54,6 +57,26 @@ local_resource(
     resource_deps=['dev-network'],
     labels=['infra'],
     links=['http://localhost:9001'],
+)
+
+local_resource(
+    'coturn',
+    # STUN/TURN for WebRTC. Host networking (like nginx) so the relay UDP range
+    # and 3478/5349 bind directly. Realm + long-term user come from the root .env;
+    # the rest of the config is in infra/coturn/turnserver.conf.
+    serve_cmd=container_serve(DOCKER, FLAGS, 'coturn',
+        '--network host ' +
+        # run as root so coturn can read the 0600 TLS key in ./certs (see compose.yaml)
+        '--user 0:0 ' +
+        '-v $(pwd)/infra/coturn/turnserver.conf:/etc/coturn/turnserver.conf:ro ' +
+        '-v $(pwd)/certs:/etc/coturn/certs:ro ' +
+        'docker.io/coturn/coturn:alpine ' +
+        '-c /etc/coturn/turnserver.conf ' +
+        '--realm=' + TURN_REALM + ' ' +
+        '--user=' + TURN_USERNAME + ':' + TURN_PASSWORD
+    ),
+    resource_deps=['cert-gen', 'dev-network'],
+    labels=['infra'],
 )
 
 local_resource(

--- a/compose.yaml
+++ b/compose.yaml
@@ -40,6 +40,25 @@ services:
       timeout: 5s
       retries: 5
 
+  coturn:
+    container_name: coturn
+    image: docker.io/coturn/coturn:alpine
+    # the image runs as 'nobody', which cannot read the 0600 TLS private key in
+    # ./certs; run as root to read it (same effective access as nginx's root
+    # master process). without this the 5349 TLS/DTLS listener fails to start.
+    user: "0:0"
+    # host networking so the UDP relay port range and 3478/5349 are reachable
+    # without publishing a large port span (same approach as nginx)
+    network_mode: host
+    command: >
+      -c /etc/coturn/turnserver.conf
+      --realm=${TURN_REALM}
+      --user=${TURN_USERNAME}:${TURN_PASSWORD}
+    volumes:
+      - ./infra/coturn/turnserver.conf:/etc/coturn/turnserver.conf:ro,z
+      - ./certs:/etc/coturn/certs:ro,z
+    restart: unless-stopped
+
   minio:
     container_name: minio
     image: docker.io/minio/minio

--- a/compose.yaml
+++ b/compose.yaml
@@ -50,12 +50,18 @@ services:
     # host networking so the UDP relay port range and 3478/5349 are reachable
     # without publishing a large port span (same approach as nginx)
     network_mode: host
-    command: >
-      -c /etc/coturn/turnserver.conf
-      --realm=${TURN_REALM}
-      --user=${TURN_USERNAME}:${TURN_PASSWORD}
+    # entrypoint pins the relay/external IP to one reachable IPv4 (see
+    # infra/coturn/entrypoint.sh); realm + user come from the environment.
+    entrypoint: ["/usr/local/bin/coturn-entrypoint.sh"]
+    environment:
+      TURN_REALM: ${TURN_REALM}
+      TURN_USERNAME: ${TURN_USERNAME}
+      TURN_PASSWORD: ${TURN_PASSWORD}
+      # optional: force the advertised relay IP; empty => auto-detect the LAN IP
+      TURN_RELAY_IP: ${TURN_RELAY_IP:-}
     volumes:
       - ./infra/coturn/turnserver.conf:/etc/coturn/turnserver.conf:ro,z
+      - ./infra/coturn/entrypoint.sh:/usr/local/bin/coturn-entrypoint.sh:ro,z
       - ./certs:/etc/coturn/certs:ro,z
     restart: unless-stopped
 

--- a/infra/coturn/entrypoint.sh
+++ b/infra/coturn/entrypoint.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+# coturn entrypoint: pin the relay / advertised address to a single IPv4.
+#
+# why: with host networking and no explicit address, coturn auto-discovers
+# every interface and round-robins relay allocations across all of them -
+# including the docker bridge (172.17.0.1) and a public IPv6. A peer device on
+# the LAN cannot reach those, so any call that lands on the wrong candidate
+# fails with rb=0 / allocation timeout. Pinning relay-ip + external-ip to one
+# reachable IPv4 removes that footgun
+#
+# address resolution order:
+#   1. TURN_RELAY_IP from the environment (explicit override), else
+#   2. the source IP of the host's default route (its primary LAN address)
+#
+# the image's own `detect-external-ip` is deliberately NOT used: it returns the
+# public WAN IP via DNS, which is wrong for a LAN-only 1-on-1 relay (the peer is
+# on the private subnet, not the internet)
+set -eu
+
+RELAY_IP="${TURN_RELAY_IP:-}"
+if [ -z "$RELAY_IP" ]; then
+  RELAY_IP="$(ip route get 1.1.1.1 2>/dev/null | sed -n 's/.* src \([0-9.]*\).*/\1/p' | head -n1)"
+fi
+
+set -- turnserver -c /etc/coturn/turnserver.conf \
+  --realm="${TURN_REALM}" \
+  --user="${TURN_USERNAME}:${TURN_PASSWORD}"
+
+if [ -n "$RELAY_IP" ]; then
+  echo "coturn: pinning relay/external IP to $RELAY_IP"
+  set -- "$@" --relay-ip="$RELAY_IP" --external-ip="$RELAY_IP"
+else
+  echo "coturn: WARNING could not determine a LAN IP; falling back to coturn auto-discovery (relay may pick an unreachable interface, and that'd be unfortunate)" >&2
+fi
+
+exec "$@"

--- a/infra/coturn/turnserver.conf
+++ b/infra/coturn/turnserver.conf
@@ -1,0 +1,37 @@
+# coturn (STUN/TURN) static configuration for the dev / eval stack.
+#
+# Credentials are intentionally NOT here: the long-term user and the realm are
+# passed on the command line from the root .env (--user / --realm) so this file
+# stays credential-free and safe to commit. See compose.yaml / Tiltfile.
+
+# --- listeners ---------------------------------------------------------------
+# Plain STUN/TURN over UDP and TCP.
+listening-port=3478
+# TLS / DTLS (turns://). Reuses the stack's self-signed certs (same ones nginx
+# serves), bind-mounted read-only at /etc/coturn/certs.
+tls-listening-port=5349
+cert=/etc/coturn/certs/cert.pem
+pkey=/etc/coturn/certs/key.pem
+
+# --- relay -------------------------------------------------------------------
+# UDP port range coturn hands out for relayed (TURN) media. Kept small for the
+# eval environment; with host networking these are reachable directly.
+min-port=49152
+max-port=49251
+
+# --- auth --------------------------------------------------------------------
+# Long-term credential mechanism (username/password). The actual --user is
+# supplied at startup from the root .env.
+lt-cred-mech
+
+# --- hardening ---------------------------------------------------------------
+# Append a FINGERPRINT to messages so peers can tell coturn traffic apart.
+fingerprint
+# Refuse to relay to multicast addresses. (The telnet admin CLI is off by
+# default in current coturn, so no flag is needed to keep that port closed.)
+no-multicast-peers
+
+# --- logging -----------------------------------------------------------------
+# Log to stdout so `docker logs coturn` / Tilt show it inline.
+log-file=stdout
+simple-log

--- a/infra/coturn/turnserver.conf
+++ b/infra/coturn/turnserver.conf
@@ -34,4 +34,9 @@ no-multicast-peers
 # --- logging -----------------------------------------------------------------
 # Log to stdout so `docker logs coturn` / Tilt show it inline.
 log-file=stdout
-simple-log
+# `verbose` logs every packet, including the per-Allocate 401 challenge that is
+# a NORMAL part of the long-term-credential handshake (client sends one
+# anonymous request, gets 401 + nonce/realm, retries authenticated). That reads
+# as a flood of "error 401: Unauthorized" even when auth is fine. Leave it off
+# for normal runs; uncomment to debug a specific relay problem (good luck).
+#verbose

--- a/infra/secretman/secrets/root.env.crypt
+++ b/infra/secretman/secrets/root.env.crypt
@@ -1,9 +1,17 @@
 {
-	"RABBITMQ_USER": "ENC[AES256_GCM,data:swzWSk4=,iv:rk3H5gx+OKultP/zoO4xo10QqlYi0JyvPlGWHw8MrXs=,tag:TUjjnLv/QlvhssKB1f+LMQ==,type:str]",
-	"RABBITMQ_PASS": "ENC[AES256_GCM,data:JZv0UJQ=,iv:cr+48ehHDV4VYNSxYQM9jCQMDaLcN7QENL8rC3B8CrA=,tag:Hv961wbFaR/JUVb6x/ymQA==,type:str]",
-	"BASE_URL": "ENC[AES256_GCM,data:ACq9j+eRj6IZiidgQ9oCKJFE6kEopw==,iv:Xo8jNQ3jpnCQNewVv2b5HUxjDbhc+HVln1BEGctOASI=,tag:URg9pY2bZK83l/pmeiIYTw==,type:str]",
+	"RABBITMQ_USER": "ENC[AES256_GCM,data:f267xsaU,iv:o6h8zBeQlkC6yxydMj9M8ED0VNxA0e/OkwrMWfBKO/A=,tag:eDo5Qk+oukDHm7/zOegQDA==,type:str]",
+	"RABBITMQ_PASS": "ENC[AES256_GCM,data:SyqCYg==,iv:DKJw1mF/xZaNtTig58uou7apcgKEnriSSa66Sd1nPvw=,tag:k0LMj/q+YyEc8SfYKgUktQ==,type:str]",
+	"BASE_URL": "ENC[AES256_GCM,data:t/f9t44xA4/zu5AJEbfXlevm7ZarKN4=,iv:fBfVsnKnF/7o5UGsTRu7QG+8uh72PtymVgJ+9tfE0sg=,tag:LMvdW70VKNmq8gK2i+sH7Q==,type:str]",
 	"BASE_API_URL": "ENC[AES256_GCM,data:ZSuaC7MCP3jWa8q97ty4hFUS009tnE5cfL8=,iv:6NTqo84CUgiqHzzjwPMGk/bar/JhAnDZUtLoTyVTUIk=,tag:LsA07WQTiDvVhRP3NJS8sQ==,type:str]",
-	"JWT_SECRET": "ENC[AES256_GCM,data:afwv/OpeSSws6VitB4Cojvo7qzVEwvPvTPusYemzbWElp+5LDFAbpA==,iv:RFiQrfxDp9gWav867TdKg72ZWeMDxJpM4p5R+Xp2U7Q=,tag:LW4sLRb4GKUUnJHkv6c54Q==,type:str]",
+	"JWT_SECRET": "ENC[AES256_GCM,data:ozleNm7S6K2PmlEwQ74iZKAWSLKQr0ZuW1q+lJGfLd8uyI94wQ4IaXQ=,iv:CxWtt3wgiSM4LyVoH1hugBMbGx05vx7wFkQMVSv/SgM=,tag:lB5+8m9IyAfNvz9cgMV25A==,type:str]",
+	"MINIO_SECRET_KEY": "ENC[AES256_GCM,data:0JUsAQIe6hwbUg==,iv:Wasl7ieQ6SWtQaAFnxRK4XCUWW9ynWCP2ZA9KzQ98lE=,tag:Vj4nNiLSOpilcBIQPicULA==,type:str]",
+	"MINIO_USER_BUCKET": "ENC[AES256_GCM,data:5skXH03RpKj4PkKo,iv:6ignOuhKPBQ49PGtN77RDRC5F9um8Ye5WGv7EwZOiks=,tag:obFU9AoB/BJS5jnTAinLgg==,type:str]",
+	"MINIO_GUILD_BUCKET": "ENC[AES256_GCM,data:vnLcu8YNWNpSm/o=,iv:lfC7lYvm5UQ7pYZeitXA/GPDU7E2aW8aJTo/8A0AKdQ=,tag:4N5OycuMMj/k4znyjJJ5cw==,type:str]",
+	"TURN_USERNAME": "ENC[AES256_GCM,data:PCRypoHCSg==,iv:G6HHjDE1ZZqMONsQ9vQYePWgmg+p8t/c5PESwZLsxgU=,tag:IyghSgwGUCE5aa6qgrhm2g==,type:str]",
+	"MINIO_ACCESS_KEY": "ENC[AES256_GCM,data:JVUtJaaHK0ZbFQ==,iv:EYWdmmpYLdwLsZ3CBfYlPgdGFJNoZWtPJI3FWmjluKY=,tag:TMHob1WH24xMh44QoMzeQQ==,type:str]",
+	"MINIO_BUCKET": "ENC[AES256_GCM,data:1R5eKY3wJ9RRgkfZs8cIQg==,iv:qRxEt6jE0cHgE9tAbrGprjwHyhGNIhDD3iah6vMQwkI=,tag:dignm1CgPf9jicHtJPrFeQ==,type:str]",
+	"TURN_REALM": "ENC[AES256_GCM,data:5/+PQWZENe9p,iv:ZlYvOSfyOBKmHbm9KsqFE1L8kvzs1Omg+zPvpJLIhrk=,tag:gTRKm9lTl/7Is2Hj1M9SfA==,type:str]",
+	"TURN_PASSWORD": "ENC[AES256_GCM,data:P0iA4tCbQM4oj60TVmjwKUX5WtDA2Ku3323iTTO9XCF30l/apDranGEPIZWUJNQW,iv:28EzbdA41Rd07Uvxwyr33rPV3cDEOlGXqKXH5/bscz0=,tag:3Nz9nlEeshyGGXnZnwQ3pg==,type:str]",
 	"sops": {
 		"age": [
 			{
@@ -27,8 +35,8 @@
 				"recipient": "age1h94z5det0mgtg4j62m6wndj8cl222avxxrjq90hzmzhwsglxc57qsspl8p"
 			}
 		],
-		"lastmodified": "2026-06-06T12:01:10Z",
-		"mac": "ENC[AES256_GCM,data:TjfYZSn3v1uTLKJMFAzpUhGJi7CKxQqgn0tGihy+oeBXHOpD73slZTk2O4B5hBTVvpgQm6KSHpQrpkctlE0FNjwJrkfmesjOXmjNDItcjUYWd+yXRsnx82gCFyqa+4fivvTy3xLR8V2YMXdSgZGhqGGZmuNCYjRPd6YN9SC9p6M=,iv:6koXt6QGiOgxfVTQ2Ts7BtFinAyNHktsZ4zh9l3wIQs=,tag:gafm3oss1rKwQ1yZsadfHA==,type:str]",
+		"lastmodified": "2026-06-27T12:27:58Z",
+		"mac": "ENC[AES256_GCM,data:glumeYEhkvoobwdM64BUdA39F5KdEkYSPVlUM6J+sVfq8idwFtyI5Mv37gUmE5bB1v1MEtfSBCALmlLBfANwMM8gR6IAl+yh38M76e9GkkpC61hXr8xxaW65HcPMNW+x+Dhp/KoV3+p/CcuEhveA3VOyC+w5TOtREuaOayxqoQ4=,iv:LBAmL1j4Qhea1mmMVz2YqgdkN1rH+gm48vluCs7NM8o=,tag:S/qmfHiRN2uZNUDgHjCr2Q==,type:str]",
 		"unencrypted_suffix": "_unencrypted",
 		"version": "3.13.1"
 	}


### PR DESCRIPTION
Resolves #210 

<img width="480" height="480" alt="image" src="https://github.com/user-attachments/assets/27971f94-4eed-477e-9337-2e3137a55ed6" />

Gives our 1-on-1 voice/video module (IV.10) an actual relay to phone home to.

### "what even is STUN/TURN/ICE" (60-second primer)
When two browsers want to send each other video, they first have to *find* a way to reach each other. That whole negotiation is **ICE**.

- **ICE candidates** are just "ways you might be reachable": your LAN IP (`host`), your public IP as seen from outside (`srflx`), or a relayed address (`relay`). Each side gathers a bunch and they try pairs until one sticks.
- **STUN** is the "yo, what's my public IP?" service. It lets a peer discover how it looks from the outside world so the two can try to talk *directly*. Cheap, but it gives up the moment a firewall/NAT is feeling unfriendly.
- **TURN** is the bouncer you hire when direct fails: both peers connect *out* to the TURN server and it relays all the media through itself. Slower, but it works basically everywhere. coturn is one server that does both STUN and TURN.

Our test page forces `iceTransportPolicy: 'relay'`, i.e. "TURN or bust", so if coturn is broken the call just... doesn't. Which is exactly what was happening.

### What's in here
- **coturn service** (`compose.yaml`, `Tiltfile`): `coturn/coturn:alpine` on host networking (same trick as nginx) so 3478/5349 and the UDP relay range bind directly. Runs as root purely to read the 0600 TLS key, and reuses the stack's
self-signed certs for `turns://`.
- **`infra/coturn/turnserver.conf`**: STUN/TURN on 3478, TLS/DTLS on 5349, a tiny relay port range (49152-49251), long-term credential auth, plus the usual hardening (fingerprint, no-multicast-peers). No secrets live in the file.
- **Credentials via secretman** (`infra/secretman/secrets/root.env.crypt`, `.env.example`): `TURN_REALM` / `TURN_USERNAME` / `TURN_PASSWORD` as encrypted secrets, documented in `.env.example`.
- **`infra/coturn/entrypoint.sh`** (the actual bug-squashing): pins coturn's relay/external address to one reachable IPv4 (`TURN_RELAY_IP`, else auto-detected from the default-route source IP). With host networking and no
pin, coturn happily hands out relay candidates on the docker bridge and a public IPv6 that the other device cannot reach, so calls died with rb=0 / allocation timeout. Now it picks the one address that actually works.
- **Quieter logs**: `verbose` is commented out. The per-Allocate `401` everyone panics about is just the normal long-term-credential handshake (probe anonymously, get a nonce/realm, retry authenticated). Under `verbose` it
cosplays as a flood of "Unauthorized" even when auth is perfectly fine.

### Validation
- `turnutils` relay self-tests through coturn: external-peer and relay-to-relay (the real two-peers-one-server topology) both at 0% packet loss.
- Confirmed a genuine cross-device LAN call relaying media through coturn (yes, it works, I saw myself twice and it was deeply unsettling).

### Notes
- `TURN_RELAY_IP` is optional; blank = auto-detect the LAN IP. Set it if auto-detection grabs the wrong interface.
- Single-machine (loopback) calls need zero firewall fiddling and are our safe eval fallback. Cross-device over a LAN leans on the host firewall and the network not isolating clients, neither of which we can fix without root on 42 boxes, so we don't bet the eval on it (and I'm not messaging staff-it either)