### PR TITLE
Refactor(guild): Big cleanup

### DIFF
--- a/services/guild/src/Guild.Application/Abstractions/Persistence/IChannelCategoryRepository.cs
+++ b/services/guild/src/Guild.Application/Abstractions/Persistence/IChannelCategoryRepository.cs
@@ -19,6 +19,4 @@ public interface IChannelCategoryRepository
 	Task AddAsync(ChannelCategory category, CancellationToken cancellationToken = default);
 	void Update(ChannelCategory category);
 	void Remove(ChannelCategory category);
-
-	Task SaveChangesAsync(CancellationToken cancellationToken = default);
 }

--- a/services/guild/src/Guild.Application/Abstractions/Persistence/IChannelCategoryRepository.cs
+++ b/services/guild/src/Guild.Application/Abstractions/Persistence/IChannelCategoryRepository.cs
@@ -16,7 +16,7 @@ public interface IChannelCategoryRepository
 	/// </summary>
 	Task<int?> GetMaxPositionAsync(long guildId, CancellationToken cancellationToken = default);
 
-	Task AddAsync(ChannelCategory category, CancellationToken cancellationToken = default);
+	void Add(ChannelCategory category);
 	void Update(ChannelCategory category);
 	void Remove(ChannelCategory category);
 }

--- a/services/guild/src/Guild.Application/Abstractions/Persistence/IChannelPermissionOverwriteRepository.cs
+++ b/services/guild/src/Guild.Application/Abstractions/Persistence/IChannelPermissionOverwriteRepository.cs
@@ -25,7 +25,7 @@ public interface IChannelPermissionOverwriteRepository
 		long targetId,
 		CancellationToken cancellationToken = default);
 
-	Task AddAsync(ChannelPermissionOverwrite overwrite, CancellationToken cancellationToken = default);
+	void Add(ChannelPermissionOverwrite overwrite);
 	void Update(ChannelPermissionOverwrite overwrite);
 	void Remove(ChannelPermissionOverwrite overwrite);
 }

--- a/services/guild/src/Guild.Application/Abstractions/Persistence/IChannelPermissionOverwriteRepository.cs
+++ b/services/guild/src/Guild.Application/Abstractions/Persistence/IChannelPermissionOverwriteRepository.cs
@@ -28,6 +28,4 @@ public interface IChannelPermissionOverwriteRepository
 	Task AddAsync(ChannelPermissionOverwrite overwrite, CancellationToken cancellationToken = default);
 	void Update(ChannelPermissionOverwrite overwrite);
 	void Remove(ChannelPermissionOverwrite overwrite);
-
-	Task SaveChangesAsync(CancellationToken cancellationToken = default);
 }

--- a/services/guild/src/Guild.Application/Abstractions/Persistence/IChannelRepository.cs
+++ b/services/guild/src/Guild.Application/Abstractions/Persistence/IChannelRepository.cs
@@ -22,6 +22,4 @@ public interface IChannelRepository
 	Task AddAsync(Channel channel, CancellationToken cancellationToken = default);
 	void Update(Channel channel);
 	void Remove(Channel channel);
-
-	Task SaveChangesAsync(CancellationToken cancellationToken = default);
 }

--- a/services/guild/src/Guild.Application/Abstractions/Persistence/IChannelRepository.cs
+++ b/services/guild/src/Guild.Application/Abstractions/Persistence/IChannelRepository.cs
@@ -19,7 +19,7 @@ public interface IChannelRepository
 		long? categoryId,
 		CancellationToken cancellationToken = default);
 
-	Task AddAsync(Channel channel, CancellationToken cancellationToken = default);
+	void Add(Channel channel);
 	void Update(Channel channel);
 	void Remove(Channel channel);
 }

--- a/services/guild/src/Guild.Application/Abstractions/Persistence/IGuildBanRepository.cs
+++ b/services/guild/src/Guild.Application/Abstractions/Persistence/IGuildBanRepository.cs
@@ -18,7 +18,7 @@ public interface IGuildBanRepository
 
 	Task<GuildBan?> FindAsync(long guildId, long userId, CancellationToken cancellationToken = default);
 
-	Task AddAsync(GuildBan ban, CancellationToken cancellationToken = default);
+	void Add(GuildBan ban);
 
 	void Remove(GuildBan ban);
 

--- a/services/guild/src/Guild.Application/Abstractions/Persistence/IGuildInviteRepository.cs
+++ b/services/guild/src/Guild.Application/Abstractions/Persistence/IGuildInviteRepository.cs
@@ -16,6 +16,6 @@ public interface IGuildInviteRepository
 	/// </summary>
 	Task<int> DeleteRevokedAndExpiredAsync(DateTimeOffset expiredBefore, CancellationToken cancellationToken = default);
 
-	Task AddAsync(GuildInvite invite, CancellationToken cancellationToken = default);
+	void Add(GuildInvite invite);
 	void Update(GuildInvite invite);
 }

--- a/services/guild/src/Guild.Application/Abstractions/Persistence/IGuildInviteRepository.cs
+++ b/services/guild/src/Guild.Application/Abstractions/Persistence/IGuildInviteRepository.cs
@@ -18,6 +18,4 @@ public interface IGuildInviteRepository
 
 	Task AddAsync(GuildInvite invite, CancellationToken cancellationToken = default);
 	void Update(GuildInvite invite);
-
-	Task SaveChangesAsync(CancellationToken cancellationToken = default);
 }

--- a/services/guild/src/Guild.Application/Abstractions/Persistence/IGuildRepository.cs
+++ b/services/guild/src/Guild.Application/Abstractions/Persistence/IGuildRepository.cs
@@ -10,9 +10,24 @@ public interface IGuildRepository
 	/// <summary>loads the Guild plus Members, Roles and MemberRoles so PermissionResolver can run</summary>
 	Task<GuildEntity?> GetByIdWithMembershipAsync(long id, CancellationToken cancellationToken = default);
 
+	/// <summary>
+	/// same shape as <see cref="GetByIdWithMembershipAsync"/> but read-only: no
+	/// change tracking and a split query. for handlers that only read the
+	/// aggregate to resolve permissions and never mutate it.
+	/// </summary>
+	Task<GuildEntity?> GetByIdWithMembershipAsNoTrackingAsync(long id, CancellationToken cancellationToken = default);
+
 	Task<int> CountMembersAsync(long guildId, CancellationToken cancellationToken = default);
 	Task<int> CountOwnedByAsync(long userId, CancellationToken cancellationToken = default);
 	Task<bool> IsMemberAsync(long guildId, long userId, CancellationToken cancellationToken = default);
+
+	/// <summary>
+	/// keyset page of members (ordered by user id, cursor = <paramref name="afterUserId"/>)
+	/// projected straight to <see cref="MemberPage"/> in the database, so listing
+	/// members never hydrates the whole guild aggregate into memory.
+	/// </summary>
+	Task<IReadOnlyList<MemberPage>> PageMembersAsync(
+		long guildId, long? afterUserId, int limit, CancellationToken cancellationToken = default);
 
 	Task AddAsync(GuildEntity guild, CancellationToken cancellationToken = default);
 	void Update(GuildEntity guild);
@@ -20,3 +35,14 @@ public interface IGuildRepository
 
 	Task SaveChangesAsync(CancellationToken cancellationToken = default);
 }
+
+/// <summary>
+/// flat projection of one guild member for list endpoints: the member's own
+/// columns plus the ids of their explicitly assigned roles (the implicit
+/// @everyone is not included, matching the wire contract).
+/// </summary>
+public sealed record MemberPage(
+	long UserId,
+	string? Nickname,
+	DateTimeOffset JoinedAt,
+	IReadOnlyList<long> RoleIds);

--- a/services/guild/src/Guild.Application/Abstractions/Persistence/IGuildRepository.cs
+++ b/services/guild/src/Guild.Application/Abstractions/Persistence/IGuildRepository.cs
@@ -29,7 +29,7 @@ public interface IGuildRepository
 	Task<IReadOnlyList<MemberPage>> PageMembersAsync(
 		long guildId, long? afterUserId, int limit, CancellationToken cancellationToken = default);
 
-	Task AddAsync(GuildEntity guild, CancellationToken cancellationToken = default);
+	void Add(GuildEntity guild);
 	void Update(GuildEntity guild);
 	void Remove(GuildEntity guild);
 }

--- a/services/guild/src/Guild.Application/Abstractions/Persistence/IGuildRepository.cs
+++ b/services/guild/src/Guild.Application/Abstractions/Persistence/IGuildRepository.cs
@@ -32,8 +32,6 @@ public interface IGuildRepository
 	Task AddAsync(GuildEntity guild, CancellationToken cancellationToken = default);
 	void Update(GuildEntity guild);
 	void Remove(GuildEntity guild);
-
-	Task SaveChangesAsync(CancellationToken cancellationToken = default);
 }
 
 /// <summary>

--- a/services/guild/src/Guild.Application/Abstractions/Persistence/IUnitOfWork.cs
+++ b/services/guild/src/Guild.Application/Abstractions/Persistence/IUnitOfWork.cs
@@ -1,0 +1,13 @@
+namespace Guild.Application.Abstractions.Persistence;
+
+/// <summary>
+/// the transaction boundary. all repositories share one scoped DbContext, so
+/// committing is a cross-aggregate concern that does not belong on any single
+/// repository (a ban handler used to call <c>guilds.SaveChangesAsync()</c> just
+/// to commit). handlers stage changes through their repositories, then call
+/// <see cref="SaveChangesAsync"/> once to persist them all atomically.
+/// </summary>
+public interface IUnitOfWork
+{
+	Task SaveChangesAsync(CancellationToken cancellationToken = default);
+}

--- a/services/guild/src/Guild.Application/Authorization/AuthorizationContext.cs
+++ b/services/guild/src/Guild.Application/Authorization/AuthorizationContext.cs
@@ -39,9 +39,12 @@ internal sealed class AuthorizationContext
 		ICurrentUser currentUser,
 		long guildId,
 		Permission required,
-		CancellationToken cancellationToken = default)
+		CancellationToken cancellationToken = default,
+		bool asNoTracking = false)
 	{
-		var guild = await guilds.GetByIdWithMembershipAsync(guildId, cancellationToken);
+		var guild = asNoTracking
+			? await guilds.GetByIdWithMembershipAsNoTrackingAsync(guildId, cancellationToken)
+			: await guilds.GetByIdWithMembershipAsync(guildId, cancellationToken);
 		if (guild is null)
 			return GuildFailures.GuildNotFound;
 

--- a/services/guild/src/Guild.Application/Authorization/AuthorizationContext.cs
+++ b/services/guild/src/Guild.Application/Authorization/AuthorizationContext.cs
@@ -1,0 +1,57 @@
+using Guild.Application.Abstractions.Persistence;
+using Guild.Application.Abstractions.Security;
+using Guild.Domain.Guild;
+using Guild.Domain.Results;
+using GuildEntity = Guild.Domain.Guild.Guild;
+
+namespace Guild.Application.Authorization;
+
+/// <summary>
+/// the result of the authorization preamble that almost every guild-scoped
+/// handler runs: load the guild with its membership graph, confirm the caller
+/// is a member, and (optionally) confirm the caller holds a required
+/// permission. carries the loaded <see cref="Guild"/> and the caller's
+/// <see cref="EffectiveMask"/> so the handler can do any further checks
+/// (hierarchy, grant, self-vs-other) without re-loading or re-resolving.
+/// </summary>
+internal sealed class AuthorizationContext
+{
+	private AuthorizationContext(GuildEntity guild, long effectiveMask)
+	{
+		Guild = guild;
+		EffectiveMask = effectiveMask;
+	}
+
+	public GuildEntity Guild { get; }
+	public long EffectiveMask { get; }
+
+	/// <summary>
+	/// loads the guild and runs the standard preamble. returns
+	/// <see cref="GuildFailures.GuildNotFound"/> when the guild does not exist,
+	/// <see cref="GuildFailures.NotAMember"/> when the caller is not a member,
+	/// and <see cref="GuildFailures.MissingPermission"/> when
+	/// <paramref name="required"/> is set and the caller lacks it. pass
+	/// <see cref="Permission.None"/> for a membership-only gate (reads, or
+	/// handlers whose permission requirement is conditional).
+	/// </summary>
+	public static async Task<Result<AuthorizationContext>> LoadAsync(
+		IGuildRepository guilds,
+		ICurrentUser currentUser,
+		long guildId,
+		Permission required,
+		CancellationToken cancellationToken = default)
+	{
+		var guild = await guilds.GetByIdWithMembershipAsync(guildId, cancellationToken);
+		if (guild is null)
+			return GuildFailures.GuildNotFound;
+
+		if (guild.Members.All(m => m.UserId != currentUser.Id))
+			return GuildFailures.NotAMember;
+
+		var mask = PermissionResolver.Resolve(guild, currentUser.Id);
+		if (required != Permission.None && !PermissionResolver.HasPermission(mask, required))
+			return GuildFailures.MissingPermission;
+
+		return new AuthorizationContext(guild, mask);
+	}
+}

--- a/services/guild/src/Guild.Application/Features/Bans/BanMember/BanMemberHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Bans/BanMember/BanMemberHandler.cs
@@ -60,7 +60,6 @@ internal sealed class BanMemberHandler(
 			var removeResult = guild.RemoveMember(command.TargetUserId, now);
 			if (removeResult.IsFailure)
 				return removeResult.Error;
-			guilds.Update(guild);
 
 			// publish BEFORE SaveChanges so the bus outbox binds the event to the
 			// same transaction as the ban insert + member removal. only a member

--- a/services/guild/src/Guild.Application/Features/Bans/BanMember/BanMemberHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Bans/BanMember/BanMemberHandler.cs
@@ -66,16 +66,17 @@ internal sealed class BanMemberHandler(
 			if (removeResult.IsFailure)
 				return removeResult.Error;
 			guilds.Update(guild);
-		}
 
-		await guilds.SaveChangesAsync(cancellationToken);
-
-		if (wasMember)
-		{
+			// publish BEFORE SaveChanges so the bus outbox binds the event to the
+			// same transaction as the ban insert + member removal. only a member
+			// who was actually in the guild produces a GuildMemberLeft (a
+			// pre-emptive ban against a non-member has nothing to announce)
 			await eventBus.PublishAsync(
 				new GuildMemberLeft(guild.Id, command.TargetUserId),
 				cancellationToken);
 		}
+
+		await guilds.SaveChangesAsync(cancellationToken);
 
 		return Result.Ok();
 	}

--- a/services/guild/src/Guild.Application/Features/Bans/BanMember/BanMemberHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Bans/BanMember/BanMemberHandler.cs
@@ -58,7 +58,7 @@ internal sealed class BanMemberHandler(
 		if (banResult.IsFailure)
 			return banResult.Error;
 
-		await bans.AddAsync(banResult.Value, cancellationToken);
+		bans.Add(banResult.Value);
 
 		if (wasMember)
 		{

--- a/services/guild/src/Guild.Application/Features/Bans/BanMember/BanMemberHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Bans/BanMember/BanMemberHandler.cs
@@ -2,6 +2,7 @@ using Guild.Application.Abstractions;
 using Guild.Application.Abstractions.Messaging;
 using Guild.Application.Abstractions.Persistence;
 using Guild.Application.Abstractions.Security;
+using Guild.Application.Authorization;
 using Guild.Application.Contracts;
 using Guild.Domain.Guild;
 using Guild.Domain.Results;
@@ -20,17 +21,11 @@ internal sealed class BanMemberHandler(
 		BanMemberCommand command,
 		CancellationToken cancellationToken = default)
 	{
-		var guild = await guilds.GetByIdWithMembershipAsync(command.GuildId, cancellationToken);
-		if (guild is null)
-			return GuildFailures.GuildNotFound;
-
-		if (guild.Members.All(m => m.UserId != currentUser.Id))
-			return GuildFailures.NotAMember;
-
-		var mask = PermissionResolver.Resolve(
-			currentUser.Id, guild.OwnerId, guild.Roles, guild.MemberRoles);
-		if (!PermissionResolver.HasPermission(mask, Permission.BanMembers))
-			return GuildFailures.MissingPermission;
+		var auth = await AuthorizationContext.LoadAsync(
+			guilds, currentUser, command.GuildId, Permission.BanMembers, cancellationToken);
+		if (auth.IsFailure)
+			return auth.Error;
+		var guild = auth.Value.Guild;
 
 		if (command.TargetUserId == currentUser.Id)
 			return GuildFailures.CannotBanSelf;

--- a/services/guild/src/Guild.Application/Features/Bans/BanMember/BanMemberHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Bans/BanMember/BanMemberHandler.cs
@@ -14,7 +14,8 @@ internal sealed class BanMemberHandler(
 	IGuildBanRepository bans,
 	IEventBus eventBus,
 	IClock clock,
-	ICurrentUser currentUser)
+	ICurrentUser currentUser,
+	IUnitOfWork unitOfWork)
 	: ICommandHandler<BanMemberCommand, Result>
 {
 	public async Task<Result> HandleAsync(
@@ -27,6 +28,10 @@ internal sealed class BanMemberHandler(
 			return auth.Error;
 		var guild = auth.Value.Guild;
 
+		// NOTE: unlike KickMember, there is intentionally no TargetNotAMember guard
+		// here - banning a user who has never joined is a legal pre-emptive ban.
+		// the `wasMember` branch below only removes membership / emits the left
+		// event when the target actually was in the guild.
 		if (command.TargetUserId == currentUser.Id)
 			return GuildFailures.CannotBanSelf;
 
@@ -70,7 +75,7 @@ internal sealed class BanMemberHandler(
 				cancellationToken);
 		}
 
-		await guilds.SaveChangesAsync(cancellationToken);
+		await unitOfWork.SaveChangesAsync(cancellationToken);
 
 		return Result.Ok();
 	}

--- a/services/guild/src/Guild.Application/Features/Bans/ListBans/ListBansHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Bans/ListBans/ListBansHandler.cs
@@ -19,7 +19,7 @@ internal sealed class ListBansHandler(
 		CancellationToken cancellationToken = default)
 	{
 		var auth = await AuthorizationContext.LoadAsync(
-			guilds, currentUser, query.GuildId, Permission.BanMembers, cancellationToken);
+			guilds, currentUser, query.GuildId, Permission.BanMembers, cancellationToken, asNoTracking: true);
 		if (auth.IsFailure)
 			return auth.Error;
 		var guild = auth.Value.Guild;

--- a/services/guild/src/Guild.Application/Features/Bans/ListBans/ListBansHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Bans/ListBans/ListBansHandler.cs
@@ -12,9 +12,9 @@ internal sealed class ListBansHandler(
 	IGuildRepository guilds,
 	IGuildBanRepository bans,
 	ICurrentUser currentUser)
-	: IQueryHandler<ListBansQuery, Result<BanListResponse>>
+	: IQueryHandler<ListBansQuery, Result<IReadOnlyList<BanResponse>>>
 {
-	public async Task<Result<BanListResponse>> HandleAsync(
+	public async Task<Result<IReadOnlyList<BanResponse>>> HandleAsync(
 		ListBansQuery query,
 		CancellationToken cancellationToken = default)
 	{
@@ -25,6 +25,7 @@ internal sealed class ListBansHandler(
 		var guild = auth.Value.Guild;
 
 		var page = await bans.ListByGuildAsync(guild.Id, query.After, query.Limit, cancellationToken);
-		return new BanListResponse(page.Select(BanResponse.From).ToList());
+		IReadOnlyList<BanResponse> items = page.Select(BanResponse.From).ToList();
+		return Result.Ok(items);
 	}
 }

--- a/services/guild/src/Guild.Application/Features/Bans/ListBans/ListBansHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Bans/ListBans/ListBansHandler.cs
@@ -1,6 +1,7 @@
 using Guild.Application.Abstractions.Messaging;
 using Guild.Application.Abstractions.Persistence;
 using Guild.Application.Abstractions.Security;
+using Guild.Application.Authorization;
 using Guild.Application.Features.Bans.Common;
 using Guild.Domain.Guild;
 using Guild.Domain.Results;
@@ -17,17 +18,11 @@ internal sealed class ListBansHandler(
 		ListBansQuery query,
 		CancellationToken cancellationToken = default)
 	{
-		var guild = await guilds.GetByIdWithMembershipAsync(query.GuildId, cancellationToken);
-		if (guild is null)
-			return GuildFailures.GuildNotFound;
-
-		if (guild.Members.All(m => m.UserId != currentUser.Id))
-			return GuildFailures.NotAMember;
-
-		var mask = PermissionResolver.Resolve(
-			currentUser.Id, guild.OwnerId, guild.Roles, guild.MemberRoles);
-		if (!PermissionResolver.HasPermission(mask, Permission.BanMembers))
-			return GuildFailures.MissingPermission;
+		var auth = await AuthorizationContext.LoadAsync(
+			guilds, currentUser, query.GuildId, Permission.BanMembers, cancellationToken);
+		if (auth.IsFailure)
+			return auth.Error;
+		var guild = auth.Value.Guild;
 
 		var page = await bans.ListByGuildAsync(guild.Id, query.After, query.Limit, cancellationToken);
 		return new BanListResponse(page.Select(BanResponse.From).ToList());

--- a/services/guild/src/Guild.Application/Features/Bans/ListBans/ListBansQuery.cs
+++ b/services/guild/src/Guild.Application/Features/Bans/ListBans/ListBansQuery.cs
@@ -4,11 +4,5 @@ using Guild.Domain.Results;
 
 namespace Guild.Application.Features.Bans.ListBans;
 
-public sealed record ListBansQuery(long GuildId, long? After, int Limit) : IQuery<Result<BanListResponse>>;
+public sealed record ListBansQuery(long GuildId, long? After, int Limit) : IQuery<Result<IReadOnlyList<BanResponse>>>;
 
-/// <summary>
-/// wrapped in a record so the generic <c>IQueryHandler&lt;,&gt;</c> constraint
-/// (<c>TResponse : class</c>) is satisfied; the endpoint unwraps to return
-/// <see cref="Items"/> as a flat JSON array per the contract
-/// </summary>
-public sealed record BanListResponse(IReadOnlyList<BanResponse> Items);

--- a/services/guild/src/Guild.Application/Features/Bans/UnbanMember/UnbanMemberHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Bans/UnbanMember/UnbanMemberHandler.cs
@@ -10,7 +10,8 @@ namespace Guild.Application.Features.Bans.UnbanMember;
 internal sealed class UnbanMemberHandler(
 	IGuildRepository guilds,
 	IGuildBanRepository bans,
-	ICurrentUser currentUser)
+	ICurrentUser currentUser,
+	IUnitOfWork unitOfWork)
 	: ICommandHandler<UnbanMemberCommand, Result>
 {
 	public async Task<Result> HandleAsync(
@@ -28,7 +29,7 @@ internal sealed class UnbanMemberHandler(
 			return GuildFailures.BanNotFound;
 
 		bans.Remove(ban);
-		await guilds.SaveChangesAsync(cancellationToken);
+		await unitOfWork.SaveChangesAsync(cancellationToken);
 
 		return Result.Ok();
 	}

--- a/services/guild/src/Guild.Application/Features/Bans/UnbanMember/UnbanMemberHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Bans/UnbanMember/UnbanMemberHandler.cs
@@ -1,6 +1,7 @@
 using Guild.Application.Abstractions.Messaging;
 using Guild.Application.Abstractions.Persistence;
 using Guild.Application.Abstractions.Security;
+using Guild.Application.Authorization;
 using Guild.Domain.Guild;
 using Guild.Domain.Results;
 
@@ -16,17 +17,11 @@ internal sealed class UnbanMemberHandler(
 		UnbanMemberCommand command,
 		CancellationToken cancellationToken = default)
 	{
-		var guild = await guilds.GetByIdWithMembershipAsync(command.GuildId, cancellationToken);
-		if (guild is null)
-			return GuildFailures.GuildNotFound;
-
-		if (guild.Members.All(m => m.UserId != currentUser.Id))
-			return GuildFailures.NotAMember;
-
-		var mask = PermissionResolver.Resolve(
-			currentUser.Id, guild.OwnerId, guild.Roles, guild.MemberRoles);
-		if (!PermissionResolver.HasPermission(mask, Permission.BanMembers))
-			return GuildFailures.MissingPermission;
+		var auth = await AuthorizationContext.LoadAsync(
+			guilds, currentUser, command.GuildId, Permission.BanMembers, cancellationToken);
+		if (auth.IsFailure)
+			return auth.Error;
+		var guild = auth.Value.Guild;
 
 		var ban = await bans.FindAsync(guild.Id, command.TargetUserId, cancellationToken);
 		if (ban is null)

--- a/services/guild/src/Guild.Application/Features/Categories/CreateCategory/CreateCategoryHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Categories/CreateCategory/CreateCategoryHandler.cs
@@ -49,7 +49,7 @@ internal sealed class CreateCategoryHandler(
 		if (categoryResult.IsFailure)
 			return categoryResult.Error;
 
-		await categories.AddAsync(categoryResult.Value, cancellationToken);
+		categories.Add(categoryResult.Value);
 		await unitOfWork.SaveChangesAsync(cancellationToken);
 
 		return CategoryResponse.From(categoryResult.Value);

--- a/services/guild/src/Guild.Application/Features/Categories/CreateCategory/CreateCategoryHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Categories/CreateCategory/CreateCategoryHandler.cs
@@ -2,6 +2,7 @@ using Guild.Application.Abstractions;
 using Guild.Application.Abstractions.Messaging;
 using Guild.Application.Abstractions.Persistence;
 using Guild.Application.Abstractions.Security;
+using Guild.Application.Authorization;
 using Guild.Application.Features.Categories.Common;
 using Guild.Domain.Guild;
 using Guild.Domain.Results;
@@ -20,22 +21,11 @@ internal sealed class CreateCategoryHandler(
 		CreateCategoryCommand command,
 		CancellationToken cancellationToken = default)
 	{
-		var guild = await guilds.GetByIdWithMembershipAsync(command.GuildId, cancellationToken);
-		if (guild is null)
-			return GuildFailures.GuildNotFound;
-
-		var isMember = guild.Members.Any(m => m.UserId == currentUser.Id);
-		if (!isMember)
-			return GuildFailures.NotAMember;
-
-		var effectiveMask = PermissionResolver.Resolve(
-			currentUser.Id,
-			guild.OwnerId,
-			guild.Roles,
-			guild.MemberRoles);
-
-		if (!PermissionResolver.HasPermission(effectiveMask, Permission.ManageChannels))
-			return GuildFailures.MissingPermission;
+		var auth = await AuthorizationContext.LoadAsync(
+			guilds, currentUser, command.GuildId, Permission.ManageChannels, cancellationToken);
+		if (auth.IsFailure)
+			return auth.Error;
+		var guild = auth.Value.Guild;
 
 		int position;
 		if (command.Position is int requested)

--- a/services/guild/src/Guild.Application/Features/Categories/CreateCategory/CreateCategoryHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Categories/CreateCategory/CreateCategoryHandler.cs
@@ -14,7 +14,8 @@ internal sealed class CreateCategoryHandler(
 	IChannelCategoryRepository categories,
 	IIdGenerator ids,
 	IClock clock,
-	ICurrentUser currentUser)
+	ICurrentUser currentUser,
+	IUnitOfWork unitOfWork)
 	: ICommandHandler<CreateCategoryCommand, Result<CategoryResponse>>
 {
 	public async Task<Result<CategoryResponse>> HandleAsync(
@@ -49,7 +50,7 @@ internal sealed class CreateCategoryHandler(
 			return categoryResult.Error;
 
 		await categories.AddAsync(categoryResult.Value, cancellationToken);
-		await categories.SaveChangesAsync(cancellationToken);
+		await unitOfWork.SaveChangesAsync(cancellationToken);
 
 		return CategoryResponse.From(categoryResult.Value);
 	}

--- a/services/guild/src/Guild.Application/Features/Categories/DeleteCategory/DeleteCategoryHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Categories/DeleteCategory/DeleteCategoryHandler.cs
@@ -1,6 +1,7 @@
 using Guild.Application.Abstractions.Messaging;
 using Guild.Application.Abstractions.Persistence;
 using Guild.Application.Abstractions.Security;
+using Guild.Application.Authorization;
 using Guild.Domain.Guild;
 using Guild.Domain.Results;
 
@@ -16,22 +17,11 @@ internal sealed class DeleteCategoryHandler(
 		DeleteCategoryCommand command,
 		CancellationToken cancellationToken = default)
 	{
-		var guild = await guilds.GetByIdWithMembershipAsync(command.GuildId, cancellationToken);
-		if (guild is null)
-			return GuildFailures.GuildNotFound;
-
-		var isMember = guild.Members.Any(m => m.UserId == currentUser.Id);
-		if (!isMember)
-			return GuildFailures.NotAMember;
-
-		var effectiveMask = PermissionResolver.Resolve(
-			currentUser.Id,
-			guild.OwnerId,
-			guild.Roles,
-			guild.MemberRoles);
-
-		if (!PermissionResolver.HasPermission(effectiveMask, Permission.ManageChannels))
-			return GuildFailures.MissingPermission;
+		var auth = await AuthorizationContext.LoadAsync(
+			guilds, currentUser, command.GuildId, Permission.ManageChannels, cancellationToken);
+		if (auth.IsFailure)
+			return auth.Error;
+		var guild = auth.Value.Guild;
 
 		var category = await categories.GetByIdAsync(command.GuildId, command.CategoryId, cancellationToken);
 		if (category is null)

--- a/services/guild/src/Guild.Application/Features/Categories/DeleteCategory/DeleteCategoryHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Categories/DeleteCategory/DeleteCategoryHandler.cs
@@ -10,7 +10,8 @@ namespace Guild.Application.Features.Categories.DeleteCategory;
 internal sealed class DeleteCategoryHandler(
 	IGuildRepository guilds,
 	IChannelCategoryRepository categories,
-	ICurrentUser currentUser)
+	ICurrentUser currentUser,
+	IUnitOfWork unitOfWork)
 	: ICommandHandler<DeleteCategoryCommand, Result>
 {
 	public async Task<Result> HandleAsync(
@@ -28,7 +29,7 @@ internal sealed class DeleteCategoryHandler(
 			return GuildFailures.CategoryNotFound;
 
 		categories.Remove(category);
-		await categories.SaveChangesAsync(cancellationToken);
+		await unitOfWork.SaveChangesAsync(cancellationToken);
 
 		return Result.Ok();
 	}

--- a/services/guild/src/Guild.Application/Features/Categories/UpdateCategory/UpdateCategoryHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Categories/UpdateCategory/UpdateCategoryHandler.cs
@@ -13,7 +13,8 @@ internal sealed class UpdateCategoryHandler(
 	IGuildRepository guilds,
 	IChannelCategoryRepository categories,
 	IClock clock,
-	ICurrentUser currentUser)
+	ICurrentUser currentUser,
+	IUnitOfWork unitOfWork)
 	: ICommandHandler<UpdateCategoryCommand, Result<CategoryResponse>>
 {
 	public async Task<Result<CategoryResponse>> HandleAsync(
@@ -47,7 +48,7 @@ internal sealed class UpdateCategoryHandler(
 		}
 
 		categories.Update(category);
-		await categories.SaveChangesAsync(cancellationToken);
+		await unitOfWork.SaveChangesAsync(cancellationToken);
 
 		return CategoryResponse.From(category);
 	}

--- a/services/guild/src/Guild.Application/Features/Categories/UpdateCategory/UpdateCategoryHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Categories/UpdateCategory/UpdateCategoryHandler.cs
@@ -2,6 +2,7 @@ using Guild.Application.Abstractions;
 using Guild.Application.Abstractions.Messaging;
 using Guild.Application.Abstractions.Persistence;
 using Guild.Application.Abstractions.Security;
+using Guild.Application.Authorization;
 using Guild.Application.Features.Categories.Common;
 using Guild.Domain.Guild;
 using Guild.Domain.Results;
@@ -19,22 +20,11 @@ internal sealed class UpdateCategoryHandler(
 		UpdateCategoryCommand command,
 		CancellationToken cancellationToken = default)
 	{
-		var guild = await guilds.GetByIdWithMembershipAsync(command.GuildId, cancellationToken);
-		if (guild is null)
-			return GuildFailures.GuildNotFound;
-
-		var isMember = guild.Members.Any(m => m.UserId == currentUser.Id);
-		if (!isMember)
-			return GuildFailures.NotAMember;
-
-		var effectiveMask = PermissionResolver.Resolve(
-			currentUser.Id,
-			guild.OwnerId,
-			guild.Roles,
-			guild.MemberRoles);
-
-		if (!PermissionResolver.HasPermission(effectiveMask, Permission.ManageChannels))
-			return GuildFailures.MissingPermission;
+		var auth = await AuthorizationContext.LoadAsync(
+			guilds, currentUser, command.GuildId, Permission.ManageChannels, cancellationToken);
+		if (auth.IsFailure)
+			return auth.Error;
+		var guild = auth.Value.Guild;
 
 		var category = await categories.GetByIdAsync(command.GuildId, command.CategoryId, cancellationToken);
 		if (category is null)

--- a/services/guild/src/Guild.Application/Features/Channels/CreateChannel/CreateChannelHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Channels/CreateChannel/CreateChannelHandler.cs
@@ -2,6 +2,7 @@ using Guild.Application.Abstractions;
 using Guild.Application.Abstractions.Messaging;
 using Guild.Application.Abstractions.Persistence;
 using Guild.Application.Abstractions.Security;
+using Guild.Application.Authorization;
 using Guild.Application.Features.Channels.Common;
 using Guild.Domain.Guild;
 using Guild.Domain.Results;
@@ -21,17 +22,11 @@ internal sealed class CreateChannelHandler(
 		CreateChannelCommand command,
 		CancellationToken cancellationToken = default)
 	{
-		var guild = await guilds.GetByIdWithMembershipAsync(command.GuildId, cancellationToken);
-		if (guild is null)
-			return GuildFailures.GuildNotFound;
-
-		if (guild.Members.All(m => m.UserId != currentUser.Id))
-			return GuildFailures.NotAMember;
-
-		var mask = PermissionResolver.Resolve(
-			currentUser.Id, guild.OwnerId, guild.Roles, guild.MemberRoles);
-		if (!PermissionResolver.HasPermission(mask, Permission.ManageChannels))
-			return GuildFailures.MissingPermission;
+		var auth = await AuthorizationContext.LoadAsync(
+			guilds, currentUser, command.GuildId, Permission.ManageChannels, cancellationToken);
+		if (auth.IsFailure)
+			return auth.Error;
+		var guild = auth.Value.Guild;
 
 		// optional category must belong to this guild if supplied
 		if (command.CategoryId is { } categoryId)

--- a/services/guild/src/Guild.Application/Features/Channels/CreateChannel/CreateChannelHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Channels/CreateChannel/CreateChannelHandler.cs
@@ -66,7 +66,7 @@ internal sealed class CreateChannelHandler(
 		if (channelResult.IsFailure)
 			return channelResult.Error;
 
-		await channels.AddAsync(channelResult.Value, cancellationToken);
+		channels.Add(channelResult.Value);
 		await unitOfWork.SaveChangesAsync(cancellationToken);
 
 		return ChannelResponse.From(channelResult.Value);

--- a/services/guild/src/Guild.Application/Features/Channels/CreateChannel/CreateChannelHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Channels/CreateChannel/CreateChannelHandler.cs
@@ -15,7 +15,8 @@ internal sealed class CreateChannelHandler(
 	IChannelCategoryRepository categories,
 	IIdGenerator ids,
 	IClock clock,
-	ICurrentUser currentUser)
+	ICurrentUser currentUser,
+	IUnitOfWork unitOfWork)
 	: ICommandHandler<CreateChannelCommand, Result<ChannelResponse>>
 {
 	public async Task<Result<ChannelResponse>> HandleAsync(
@@ -66,7 +67,7 @@ internal sealed class CreateChannelHandler(
 			return channelResult.Error;
 
 		await channels.AddAsync(channelResult.Value, cancellationToken);
-		await channels.SaveChangesAsync(cancellationToken);
+		await unitOfWork.SaveChangesAsync(cancellationToken);
 
 		return ChannelResponse.From(channelResult.Value);
 	}

--- a/services/guild/src/Guild.Application/Features/Channels/DeleteChannel/DeleteChannelHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Channels/DeleteChannel/DeleteChannelHandler.cs
@@ -1,6 +1,7 @@
 using Guild.Application.Abstractions.Messaging;
 using Guild.Application.Abstractions.Persistence;
 using Guild.Application.Abstractions.Security;
+using Guild.Application.Authorization;
 using Guild.Domain.Guild;
 using Guild.Domain.Results;
 
@@ -16,17 +17,11 @@ internal sealed class DeleteChannelHandler(
 		DeleteChannelCommand command,
 		CancellationToken cancellationToken = default)
 	{
-		var guild = await guilds.GetByIdWithMembershipAsync(command.GuildId, cancellationToken);
-		if (guild is null)
-			return GuildFailures.GuildNotFound;
-
-		if (guild.Members.All(m => m.UserId != currentUser.Id))
-			return GuildFailures.NotAMember;
-
-		var mask = PermissionResolver.Resolve(
-			currentUser.Id, guild.OwnerId, guild.Roles, guild.MemberRoles);
-		if (!PermissionResolver.HasPermission(mask, Permission.ManageChannels))
-			return GuildFailures.MissingPermission;
+		var auth = await AuthorizationContext.LoadAsync(
+			guilds, currentUser, command.GuildId, Permission.ManageChannels, cancellationToken);
+		if (auth.IsFailure)
+			return auth.Error;
+		var guild = auth.Value.Guild;
 
 		var channel = await channels.GetByIdAsync(command.ChannelId, cancellationToken);
 		if (channel is null || channel.GuildId != command.GuildId)

--- a/services/guild/src/Guild.Application/Features/Channels/DeleteChannel/DeleteChannelHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Channels/DeleteChannel/DeleteChannelHandler.cs
@@ -10,7 +10,8 @@ namespace Guild.Application.Features.Channels.DeleteChannel;
 internal sealed class DeleteChannelHandler(
 	IGuildRepository guilds,
 	IChannelRepository channels,
-	ICurrentUser currentUser)
+	ICurrentUser currentUser,
+	IUnitOfWork unitOfWork)
 	: ICommandHandler<DeleteChannelCommand, Result>
 {
 	public async Task<Result> HandleAsync(
@@ -28,7 +29,7 @@ internal sealed class DeleteChannelHandler(
 			return GuildFailures.ChannelNotFound;
 
 		channels.Remove(channel);
-		await channels.SaveChangesAsync(cancellationToken);
+		await unitOfWork.SaveChangesAsync(cancellationToken);
 
 		return Result.Ok();
 	}

--- a/services/guild/src/Guild.Application/Features/Channels/ListChannels/ListChannelsQuery.cs
+++ b/services/guild/src/Guild.Application/Features/Channels/ListChannels/ListChannelsQuery.cs
@@ -9,6 +9,6 @@ public sealed record ListChannelsQuery(long GuildId) : IQuery<Result<ChannelList
 /// <summary>
 /// wrapped in a record so the generic <c>IQueryHandler&lt;,&gt;</c> constraint
 /// (<c>TResponse : class</c>) is satisfied; deserialised by Carter as a JSON
-/// array via <see cref="ChannelListResponse.Items"/>
+/// array via <see cref="Items"/>
 /// </summary>
 public sealed record ChannelListResponse(IReadOnlyList<ChannelResponse> Items);

--- a/services/guild/src/Guild.Application/Features/Channels/Permissions/DeleteOverwrite/DeleteOverwriteHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Channels/Permissions/DeleteOverwrite/DeleteOverwriteHandler.cs
@@ -1,6 +1,7 @@
 using Guild.Application.Abstractions.Messaging;
 using Guild.Application.Abstractions.Persistence;
 using Guild.Application.Abstractions.Security;
+using Guild.Application.Authorization;
 using Guild.Domain.Guild;
 using Guild.Domain.Results;
 
@@ -21,17 +22,11 @@ internal sealed class DeleteOverwriteHandler(
 		if (channel is null)
 			return GuildFailures.ChannelNotFound;
 
-		var guild = await guilds.GetByIdWithMembershipAsync(channel.GuildId, cancellationToken);
-		if (guild is null)
-			return GuildFailures.GuildNotFound;
-
-		if (guild.Members.All(m => m.UserId != currentUser.Id))
-			return GuildFailures.NotAMember;
-
-		var mask = PermissionResolver.Resolve(
-			currentUser.Id, guild.OwnerId, guild.Roles, guild.MemberRoles);
-		if (!PermissionResolver.HasPermission(mask, Permission.ManageChannels))
-			return GuildFailures.MissingPermission;
+		var auth = await AuthorizationContext.LoadAsync(
+			guilds, currentUser, channel.GuildId, Permission.ManageChannels, cancellationToken);
+		if (auth.IsFailure)
+			return auth.Error;
+		var guild = auth.Value.Guild;
 
 		// the URL carries only (channel_id, target_id); since snowflake ids are
 		// unique across roles and members, a single server-side probe by

--- a/services/guild/src/Guild.Application/Features/Channels/Permissions/DeleteOverwrite/DeleteOverwriteHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Channels/Permissions/DeleteOverwrite/DeleteOverwriteHandler.cs
@@ -11,7 +11,8 @@ internal sealed class DeleteOverwriteHandler(
 	IGuildRepository guilds,
 	IChannelRepository channels,
 	IChannelPermissionOverwriteRepository overwrites,
-	ICurrentUser currentUser)
+	ICurrentUser currentUser,
+	IUnitOfWork unitOfWork)
 	: ICommandHandler<DeleteOverwriteCommand, Result>
 {
 	public async Task<Result> HandleAsync(
@@ -37,7 +38,7 @@ internal sealed class DeleteOverwriteHandler(
 			return GuildFailures.OverwriteNotFound;
 
 		overwrites.Remove(match);
-		await overwrites.SaveChangesAsync(cancellationToken);
+		await unitOfWork.SaveChangesAsync(cancellationToken);
 
 		return Result.Ok();
 	}

--- a/services/guild/src/Guild.Application/Features/Channels/Permissions/GetOverwrites/GetOverwritesQueryHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Channels/Permissions/GetOverwrites/GetOverwritesQueryHandler.cs
@@ -1,6 +1,7 @@
 using Guild.Application.Abstractions.Messaging;
 using Guild.Application.Abstractions.Persistence;
 using Guild.Application.Abstractions.Security;
+using Guild.Application.Authorization;
 using Guild.Domain.Guild;
 using Guild.Domain.Results;
 
@@ -21,17 +22,11 @@ internal sealed class GetOverwritesQueryHandler(
 		if (channel is null)
 			return GuildFailures.ChannelNotFound;
 
-		var guild = await guilds.GetByIdWithMembershipAsync(channel.GuildId, cancellationToken);
-		if (guild is null)
-			return GuildFailures.GuildNotFound;
-
-		if (guild.Members.All(m => m.UserId != currentUser.Id))
-			return GuildFailures.NotAMember;
-
-		var mask = PermissionResolver.Resolve(
-			currentUser.Id, guild.OwnerId, guild.Roles, guild.MemberRoles);
-		if (!PermissionResolver.HasPermission(mask, Permission.ManageChannels))
-			return GuildFailures.MissingPermission;
+		var auth = await AuthorizationContext.LoadAsync(
+			guilds, currentUser, channel.GuildId, Permission.ManageChannels, cancellationToken);
+		if (auth.IsFailure)
+			return auth.Error;
+		var guild = auth.Value.Guild;
 
 		var rows = await overwrites.GetForChannelAsync(channel.Id, cancellationToken);
 		return new OverwritesResponse([.. rows.Select(OverwriteItem.From)]);

--- a/services/guild/src/Guild.Application/Features/Channels/Permissions/PutOverwrite/PutOverwriteHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Channels/Permissions/PutOverwrite/PutOverwriteHandler.cs
@@ -2,6 +2,7 @@ using Guild.Application.Abstractions;
 using Guild.Application.Abstractions.Messaging;
 using Guild.Application.Abstractions.Persistence;
 using Guild.Application.Abstractions.Security;
+using Guild.Application.Authorization;
 using Guild.Domain.Guild;
 using Guild.Domain.Results;
 
@@ -24,17 +25,11 @@ internal sealed class PutOverwriteHandler(
 		if (channel is null)
 			return GuildFailures.ChannelNotFound;
 
-		var guild = await guilds.GetByIdWithMembershipAsync(channel.GuildId, cancellationToken);
-		if (guild is null)
-			return GuildFailures.GuildNotFound;
-
-		if (guild.Members.All(m => m.UserId != currentUser.Id))
-			return GuildFailures.NotAMember;
-
-		var mask = PermissionResolver.Resolve(
-			currentUser.Id, guild.OwnerId, guild.Roles, guild.MemberRoles);
-		if (!PermissionResolver.HasPermission(mask, Permission.ManageChannels))
-			return GuildFailures.MissingPermission;
+		var auth = await AuthorizationContext.LoadAsync(
+			guilds, currentUser, channel.GuildId, Permission.ManageChannels, cancellationToken);
+		if (auth.IsFailure)
+			return auth.Error;
+		var guild = auth.Value.Guild;
 
 		if (!TryParseTargetType(command.TargetType, out var targetType))
 			return GuildFailures.OverwriteInvalidTarget;

--- a/services/guild/src/Guild.Application/Features/Channels/Permissions/PutOverwrite/PutOverwriteHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Channels/Permissions/PutOverwrite/PutOverwriteHandler.cs
@@ -14,7 +14,8 @@ internal sealed class PutOverwriteHandler(
 	IChannelPermissionOverwriteRepository overwrites,
 	IIdGenerator ids,
 	IClock clock,
-	ICurrentUser currentUser)
+	ICurrentUser currentUser,
+	IUnitOfWork unitOfWork)
 	: ICommandHandler<PutOverwriteCommand, Result>
 {
 	public async Task<Result> HandleAsync(
@@ -58,7 +59,7 @@ internal sealed class PutOverwriteHandler(
 				return updateResult.Error;
 
 			overwrites.Update(existing);
-			await overwrites.SaveChangesAsync(cancellationToken);
+			await unitOfWork.SaveChangesAsync(cancellationToken);
 			return Result.Ok();
 		}
 
@@ -76,7 +77,7 @@ internal sealed class PutOverwriteHandler(
 			return createResult.Error;
 
 		await overwrites.AddAsync(createResult.Value, cancellationToken);
-		await overwrites.SaveChangesAsync(cancellationToken);
+		await unitOfWork.SaveChangesAsync(cancellationToken);
 
 		return Result.Ok();
 	}

--- a/services/guild/src/Guild.Application/Features/Channels/Permissions/PutOverwrite/PutOverwriteHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Channels/Permissions/PutOverwrite/PutOverwriteHandler.cs
@@ -76,7 +76,7 @@ internal sealed class PutOverwriteHandler(
 		if (createResult.IsFailure)
 			return createResult.Error;
 
-		await overwrites.AddAsync(createResult.Value, cancellationToken);
+		overwrites.Add(createResult.Value);
 		await unitOfWork.SaveChangesAsync(cancellationToken);
 
 		return Result.Ok();

--- a/services/guild/src/Guild.Application/Features/Channels/UpdateChannel/UpdateChannelHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Channels/UpdateChannel/UpdateChannelHandler.cs
@@ -2,6 +2,7 @@ using Guild.Application.Abstractions;
 using Guild.Application.Abstractions.Messaging;
 using Guild.Application.Abstractions.Persistence;
 using Guild.Application.Abstractions.Security;
+using Guild.Application.Authorization;
 using Guild.Application.Features.Channels.Common;
 using Guild.Domain.Guild;
 using Guild.Domain.Results;
@@ -20,17 +21,11 @@ internal sealed class UpdateChannelHandler(
 		UpdateChannelCommand command,
 		CancellationToken cancellationToken = default)
 	{
-		var guild = await guilds.GetByIdWithMembershipAsync(command.GuildId, cancellationToken);
-		if (guild is null)
-			return GuildFailures.GuildNotFound;
-
-		if (guild.Members.All(m => m.UserId != currentUser.Id))
-			return GuildFailures.NotAMember;
-
-		var mask = PermissionResolver.Resolve(
-			currentUser.Id, guild.OwnerId, guild.Roles, guild.MemberRoles);
-		if (!PermissionResolver.HasPermission(mask, Permission.ManageChannels))
-			return GuildFailures.MissingPermission;
+		var auth = await AuthorizationContext.LoadAsync(
+			guilds, currentUser, command.GuildId, Permission.ManageChannels, cancellationToken);
+		if (auth.IsFailure)
+			return auth.Error;
+		var guild = auth.Value.Guild;
 
 		var channel = await channels.GetByIdAsync(command.ChannelId, cancellationToken);
 		if (channel is null || channel.GuildId != command.GuildId)

--- a/services/guild/src/Guild.Application/Features/Channels/UpdateChannel/UpdateChannelHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Channels/UpdateChannel/UpdateChannelHandler.cs
@@ -14,7 +14,8 @@ internal sealed class UpdateChannelHandler(
 	IChannelRepository channels,
 	IChannelCategoryRepository categories,
 	IClock clock,
-	ICurrentUser currentUser)
+	ICurrentUser currentUser,
+	IUnitOfWork unitOfWork)
 	: ICommandHandler<UpdateChannelCommand, Result<ChannelResponse>>
 {
 	public async Task<Result<ChannelResponse>> HandleAsync(
@@ -69,7 +70,7 @@ internal sealed class UpdateChannelHandler(
 		}
 
 		channels.Update(channel);
-		await channels.SaveChangesAsync(cancellationToken);
+		await unitOfWork.SaveChangesAsync(cancellationToken);
 
 		return ChannelResponse.From(channel);
 	}

--- a/services/guild/src/Guild.Application/Features/Guilds/CreateGuild/CreateGuildHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Guilds/CreateGuild/CreateGuildHandler.cs
@@ -39,7 +39,7 @@ internal sealed class CreateGuildHandler(
 		if (guildResult.IsFailure)
 			return guildResult.Error;
 
-		await repository.AddAsync(guildResult.Value, cancellationToken);
+		repository.Add(guildResult.Value);
 		await unitOfWork.SaveChangesAsync(cancellationToken);
 
 		return GuildDto.FromEntity(guildResult.Value);

--- a/services/guild/src/Guild.Application/Features/Guilds/CreateGuild/CreateGuildHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Guilds/CreateGuild/CreateGuildHandler.cs
@@ -12,7 +12,8 @@ internal sealed class CreateGuildHandler(
 	IGuildRepository repository,
 	IIdGenerator ids,
 	IClock clock,
-	ICurrentUser currentUser)
+	ICurrentUser currentUser,
+	IUnitOfWork unitOfWork)
 	: ICommandHandler<CreateGuildCommand, Result<GuildDto>>
 {
 	public async Task<Result<GuildDto>> HandleAsync(
@@ -39,7 +40,7 @@ internal sealed class CreateGuildHandler(
 			return guildResult.Error;
 
 		await repository.AddAsync(guildResult.Value, cancellationToken);
-		await repository.SaveChangesAsync(cancellationToken);
+		await unitOfWork.SaveChangesAsync(cancellationToken);
 
 		return GuildDto.FromEntity(guildResult.Value);
 	}

--- a/services/guild/src/Guild.Application/Features/Guilds/DeleteGuild/DeleteGuildHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Guilds/DeleteGuild/DeleteGuildHandler.cs
@@ -7,7 +7,8 @@ namespace Guild.Application.Features.Guilds.DeleteGuild;
 
 internal sealed class DeleteGuildHandler(
 	IGuildRepository repository,
-	ICurrentUser currentUser)
+	ICurrentUser currentUser,
+	IUnitOfWork unitOfWork)
 	: ICommandHandler<DeleteGuildCommand, Result>
 {
 	public async Task<Result> HandleAsync(
@@ -22,7 +23,7 @@ internal sealed class DeleteGuildHandler(
 			return GuildFailures.NotTheOwner;
 
 		repository.Remove(guild);
-		await repository.SaveChangesAsync(cancellationToken);
+		await unitOfWork.SaveChangesAsync(cancellationToken);
 
 		return Result.Ok();
 	}

--- a/services/guild/src/Guild.Application/Features/Guilds/TransferOwnership/TransferOwnershipHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Guilds/TransferOwnership/TransferOwnershipHandler.cs
@@ -10,7 +10,8 @@ namespace Guild.Application.Features.Guilds.TransferOwnership;
 internal sealed class TransferOwnershipHandler(
 	IGuildRepository repository,
 	IClock clock,
-	ICurrentUser currentUser)
+	ICurrentUser currentUser,
+	IUnitOfWork unitOfWork)
 	: ICommandHandler<TransferOwnershipCommand, Result<GuildDto>>
 {
 	public async Task<Result<GuildDto>> HandleAsync(
@@ -35,7 +36,7 @@ internal sealed class TransferOwnershipHandler(
 		if (transferResult.IsFailure)
 			return transferResult.Error;
 
-		await repository.SaveChangesAsync(cancellationToken);
+		await unitOfWork.SaveChangesAsync(cancellationToken);
 
 		return GuildDto.FromEntity(guild);
 	}

--- a/services/guild/src/Guild.Application/Features/Guilds/TransferOwnership/TransferOwnershipHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Guilds/TransferOwnership/TransferOwnershipHandler.cs
@@ -35,7 +35,6 @@ internal sealed class TransferOwnershipHandler(
 		if (transferResult.IsFailure)
 			return transferResult.Error;
 
-		repository.Update(guild);
 		await repository.SaveChangesAsync(cancellationToken);
 
 		return GuildDto.FromEntity(guild);

--- a/services/guild/src/Guild.Application/Features/Guilds/UpdateGuild/UpdateGuildHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Guilds/UpdateGuild/UpdateGuildHandler.cs
@@ -12,7 +12,8 @@ namespace Guild.Application.Features.Guilds.UpdateGuild;
 internal sealed class UpdateGuildHandler(
 	IGuildRepository repository,
 	IClock clock,
-	ICurrentUser currentUser)
+	ICurrentUser currentUser,
+	IUnitOfWork unitOfWork)
 	: ICommandHandler<UpdateGuildCommand, Result<GuildDto>>
 {
 	public async Task<Result<GuildDto>> HandleAsync(
@@ -35,7 +36,7 @@ internal sealed class UpdateGuildHandler(
 		if (updateResult.IsFailure)
 			return updateResult.Error;
 
-		await repository.SaveChangesAsync(cancellationToken);
+		await unitOfWork.SaveChangesAsync(cancellationToken);
 
 		return GuildDto.FromEntity(guild);
 	}

--- a/services/guild/src/Guild.Application/Features/Guilds/UpdateGuild/UpdateGuildHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Guilds/UpdateGuild/UpdateGuildHandler.cs
@@ -35,7 +35,6 @@ internal sealed class UpdateGuildHandler(
 		if (updateResult.IsFailure)
 			return updateResult.Error;
 
-		repository.Update(guild);
 		await repository.SaveChangesAsync(cancellationToken);
 
 		return GuildDto.FromEntity(guild);

--- a/services/guild/src/Guild.Application/Features/Guilds/UpdateGuild/UpdateGuildHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Guilds/UpdateGuild/UpdateGuildHandler.cs
@@ -2,6 +2,7 @@ using Guild.Application.Abstractions;
 using Guild.Application.Abstractions.Messaging;
 using Guild.Application.Abstractions.Persistence;
 using Guild.Application.Abstractions.Security;
+using Guild.Application.Authorization;
 using Guild.Application.Features.Guilds.Common;
 using Guild.Domain.Guild;
 using Guild.Domain.Results;
@@ -18,25 +19,11 @@ internal sealed class UpdateGuildHandler(
 		UpdateGuildCommand command,
 		CancellationToken cancellationToken = default)
 	{
-		var guild = await repository.GetByIdWithMembershipAsync(command.GuildId, cancellationToken);
-		if (guild is null)
-			return GuildFailures.GuildNotFound;
-
-		var effectiveMask = PermissionResolver.Resolve(
-			currentUser.Id,
-			guild.OwnerId,
-			guild.Roles,
-			guild.MemberRoles);
-
-		// MANAGE_GUILD also requires the caller to actually be a member; the
-		// resolver gives @everyone perms unconditionally, but a non-member can
-		// never legitimately reach this branch with MANAGE_GUILD.
-		var isMember = guild.Members.Any(m => m.UserId == currentUser.Id);
-		if (!isMember)
-			return GuildFailures.NotAMember;
-
-		if (!PermissionResolver.HasPermission(effectiveMask, Permission.ManageGuild))
-			return GuildFailures.MissingPermission;
+		var auth = await AuthorizationContext.LoadAsync(
+			repository, currentUser, command.GuildId, Permission.ManageGuild, cancellationToken);
+		if (auth.IsFailure)
+			return auth.Error;
+		var guild = auth.Value.Guild;
 
 		var updateResult = guild.UpdateSettings(
 			name: command.Name,

--- a/services/guild/src/Guild.Application/Features/Invites/CreateInvite/CreateInviteHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Invites/CreateInvite/CreateInviteHandler.cs
@@ -45,7 +45,7 @@ internal sealed class CreateInviteHandler(
 		if (inviteResult.IsFailure)
 			return inviteResult.Error;
 
-		await invites.AddAsync(inviteResult.Value, cancellationToken);
+		invites.Add(inviteResult.Value);
 
 		// publish BEFORE SaveChanges so the bus outbox binds the GuildInviteCreated
 		// event to the same transaction as the invite insert

--- a/services/guild/src/Guild.Application/Features/Invites/CreateInvite/CreateInviteHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Invites/CreateInvite/CreateInviteHandler.cs
@@ -16,7 +16,8 @@ internal sealed class CreateInviteHandler(
 	IInviteCodeGenerator codes,
 	IEventBus eventBus,
 	IClock clock,
-	ICurrentUser currentUser)
+	ICurrentUser currentUser,
+	IUnitOfWork unitOfWork)
 	: ICommandHandler<CreateInviteCommand, Result<InviteDto>>
 {
 	public async Task<Result<InviteDto>> HandleAsync(
@@ -52,7 +53,7 @@ internal sealed class CreateInviteHandler(
 			new GuildInviteCreated(guild.Id, guild.Name, currentUser.Id, InvitedUserId: null),
 			cancellationToken);
 
-		await invites.SaveChangesAsync(cancellationToken);
+		await unitOfWork.SaveChangesAsync(cancellationToken);
 
 		return InviteDto.FromEntity(inviteResult.Value);
 	}

--- a/services/guild/src/Guild.Application/Features/Invites/CreateInvite/CreateInviteHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Invites/CreateInvite/CreateInviteHandler.cs
@@ -50,11 +50,14 @@ internal sealed class CreateInviteHandler(
 			return inviteResult.Error;
 
 		await invites.AddAsync(inviteResult.Value, cancellationToken);
-		await invites.SaveChangesAsync(cancellationToken);
 
+		// publish BEFORE SaveChanges so the bus outbox binds the GuildInviteCreated
+		// event to the same transaction as the invite insert
 		await eventBus.PublishAsync(
 			new GuildInviteCreated(guild.Id, guild.Name, currentUser.Id, InvitedUserId: null),
 			cancellationToken);
+
+		await invites.SaveChangesAsync(cancellationToken);
 
 		return InviteDto.FromEntity(inviteResult.Value);
 	}

--- a/services/guild/src/Guild.Application/Features/Invites/CreateInvite/CreateInviteHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Invites/CreateInvite/CreateInviteHandler.cs
@@ -2,6 +2,7 @@ using Guild.Application.Abstractions;
 using Guild.Application.Abstractions.Messaging;
 using Guild.Application.Abstractions.Persistence;
 using Guild.Application.Abstractions.Security;
+using Guild.Application.Authorization;
 using Guild.Application.Contracts;
 using Guild.Application.Features.Invites.Common;
 using Guild.Domain.Guild;
@@ -22,17 +23,11 @@ internal sealed class CreateInviteHandler(
 		CreateInviteCommand command,
 		CancellationToken cancellationToken = default)
 	{
-		var guild = await guilds.GetByIdWithMembershipAsync(command.GuildId, cancellationToken);
-		if (guild is null)
-			return GuildFailures.GuildNotFound;
-
-		if (guild.Members.All(m => m.UserId != currentUser.Id))
-			return GuildFailures.NotAMember;
-
-		var mask = PermissionResolver.Resolve(
-			currentUser.Id, guild.OwnerId, guild.Roles, guild.MemberRoles);
-		if (!PermissionResolver.HasPermission(mask, Permission.CreateInvite))
-			return GuildFailures.MissingPermission;
+		var auth = await AuthorizationContext.LoadAsync(
+			guilds, currentUser, command.GuildId, Permission.CreateInvite, cancellationToken);
+		if (auth.IsFailure)
+			return auth.Error;
+		var guild = auth.Value.Guild;
 
 		var now = clock.UtcNow;
 		var expiresAt = command.ExpiresInHours is { } hours

--- a/services/guild/src/Guild.Application/Features/Invites/DeleteInvite/DeleteInviteCommand.cs
+++ b/services/guild/src/Guild.Application/Features/Invites/DeleteInvite/DeleteInviteCommand.cs
@@ -1,6 +1,0 @@
-using Guild.Application.Abstractions.Messaging;
-using Guild.Domain.Results;
-
-namespace Guild.Application.Features.Invites.DeleteInvite;
-
-public sealed record DeleteInviteCommand(long GuildId, string Code) : ICommand<Result>;

--- a/services/guild/src/Guild.Application/Features/Invites/DeleteInvite/DeleteInviteHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Invites/DeleteInvite/DeleteInviteHandler.cs
@@ -10,7 +10,8 @@ namespace Guild.Application.Features.Invites.DeleteInvite;
 internal sealed class DeleteInviteHandler(
 	IGuildRepository guilds,
 	IGuildInviteRepository invites,
-	ICurrentUser currentUser)
+	ICurrentUser currentUser,
+	IUnitOfWork unitOfWork)
 	: ICommandHandler<DeleteInviteCommand, Result>
 {
 	public async Task<Result> HandleAsync(
@@ -40,7 +41,7 @@ internal sealed class DeleteInviteHandler(
 			return revokeResult.Error;
 
 		invites.Update(invite);
-		await invites.SaveChangesAsync(cancellationToken);
+		await unitOfWork.SaveChangesAsync(cancellationToken);
 
 		return Result.Ok();
 	}

--- a/services/guild/src/Guild.Application/Features/Invites/DeleteInvite/DeleteInviteHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Invites/DeleteInvite/DeleteInviteHandler.cs
@@ -1,6 +1,7 @@
 using Guild.Application.Abstractions.Messaging;
 using Guild.Application.Abstractions.Persistence;
 using Guild.Application.Abstractions.Security;
+using Guild.Application.Authorization;
 using Guild.Domain.Guild;
 using Guild.Domain.Results;
 
@@ -23,21 +24,16 @@ internal sealed class DeleteInviteHandler(
 		if (invite.GuildId != command.GuildId)
 			return GuildFailures.InviteGuildMismatch;
 
-		var guild = await guilds.GetByIdWithMembershipAsync(command.GuildId, cancellationToken);
-		if (guild is null)
-			return GuildFailures.GuildNotFound;
+		var auth = await AuthorizationContext.LoadAsync(
+			guilds, currentUser, command.GuildId, Permission.None, cancellationToken);
+		if (auth.IsFailure)
+			return auth.Error;
 
-		if (guild.Members.All(m => m.UserId != currentUser.Id))
-			return GuildFailures.NotAMember;
-
+		// the invite creator may revoke their own invite without MANAGE_GUILD;
+		// anyone else needs it
 		var isCreator = invite.CreatedBy == currentUser.Id;
-		if (!isCreator)
-		{
-			var mask = PermissionResolver.Resolve(
-				currentUser.Id, guild.OwnerId, guild.Roles, guild.MemberRoles);
-			if (!PermissionResolver.HasPermission(mask, Permission.ManageGuild))
-				return GuildFailures.MissingPermission;
-		}
+		if (!isCreator && !PermissionResolver.HasPermission(auth.Value.EffectiveMask, Permission.ManageGuild))
+			return GuildFailures.MissingPermission;
 
 		var revokeResult = invite.Revoke();
 		if (revokeResult.IsFailure)

--- a/services/guild/src/Guild.Application/Features/Invites/ListInvites/ListInvitesHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Invites/ListInvites/ListInvitesHandler.cs
@@ -1,6 +1,7 @@
 using Guild.Application.Abstractions.Messaging;
 using Guild.Application.Abstractions.Persistence;
 using Guild.Application.Abstractions.Security;
+using Guild.Application.Authorization;
 using Guild.Application.Features.Invites.Common;
 using Guild.Domain.Guild;
 using Guild.Domain.Results;
@@ -17,17 +18,11 @@ internal sealed class ListInvitesHandler(
 		ListInvitesQuery query,
 		CancellationToken cancellationToken = default)
 	{
-		var guild = await guilds.GetByIdWithMembershipAsync(query.GuildId, cancellationToken);
-		if (guild is null)
-			return GuildFailures.GuildNotFound;
-
-		if (guild.Members.All(m => m.UserId != currentUser.Id))
-			return GuildFailures.NotAMember;
-
-		var mask = PermissionResolver.Resolve(
-			currentUser.Id, guild.OwnerId, guild.Roles, guild.MemberRoles);
-		if (!PermissionResolver.HasPermission(mask, Permission.ManageGuild))
-			return GuildFailures.MissingPermission;
+		var auth = await AuthorizationContext.LoadAsync(
+			guilds, currentUser, query.GuildId, Permission.ManageGuild, cancellationToken);
+		if (auth.IsFailure)
+			return auth.Error;
+		var guild = auth.Value.Guild;
 
 		var rows = await invites.ListByGuildAsync(query.GuildId, cancellationToken);
 		IReadOnlyList<InviteDto> dtos = rows.Select(InviteDto.FromEntity).ToList();

--- a/services/guild/src/Guild.Application/Features/Invites/RevokeInvite/RevokeInviteCommand.cs
+++ b/services/guild/src/Guild.Application/Features/Invites/RevokeInvite/RevokeInviteCommand.cs
@@ -1,0 +1,6 @@
+using Guild.Application.Abstractions.Messaging;
+using Guild.Domain.Results;
+
+namespace Guild.Application.Features.Invites.RevokeInvite;
+
+public sealed record RevokeInviteCommand(long GuildId, string Code) : ICommand<Result>;

--- a/services/guild/src/Guild.Application/Features/Invites/RevokeInvite/RevokeInviteHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Invites/RevokeInvite/RevokeInviteHandler.cs
@@ -5,17 +5,17 @@ using Guild.Application.Authorization;
 using Guild.Domain.Guild;
 using Guild.Domain.Results;
 
-namespace Guild.Application.Features.Invites.DeleteInvite;
+namespace Guild.Application.Features.Invites.RevokeInvite;
 
-internal sealed class DeleteInviteHandler(
+internal sealed class RevokeInviteHandler(
 	IGuildRepository guilds,
 	IGuildInviteRepository invites,
 	ICurrentUser currentUser,
 	IUnitOfWork unitOfWork)
-	: ICommandHandler<DeleteInviteCommand, Result>
+	: ICommandHandler<RevokeInviteCommand, Result>
 {
 	public async Task<Result> HandleAsync(
-		DeleteInviteCommand command,
+		RevokeInviteCommand command,
 		CancellationToken cancellationToken = default)
 	{
 		var invite = await invites.GetByCodeAsync(command.Code, cancellationToken);

--- a/services/guild/src/Guild.Application/Features/Membership/AssignRole/AssignRoleHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Membership/AssignRole/AssignRoleHandler.cs
@@ -2,6 +2,7 @@ using Guild.Application.Abstractions;
 using Guild.Application.Abstractions.Messaging;
 using Guild.Application.Abstractions.Persistence;
 using Guild.Application.Abstractions.Security;
+using Guild.Application.Authorization;
 using Guild.Domain.Guild;
 using Guild.Domain.Results;
 
@@ -17,17 +18,12 @@ internal sealed class AssignRoleHandler(
 		AssignRoleCommand command,
 		CancellationToken cancellationToken = default)
 	{
-		var guild = await guilds.GetByIdWithMembershipAsync(command.GuildId, cancellationToken);
-		if (guild is null)
-			return GuildFailures.GuildNotFound;
-
-		if (guild.Members.All(m => m.UserId != currentUser.Id))
-			return GuildFailures.NotAMember;
-
-		var mask = PermissionResolver.Resolve(
-			currentUser.Id, guild.OwnerId, guild.Roles, guild.MemberRoles);
-		if (!PermissionResolver.HasPermission(mask, Permission.ManageRoles))
-			return GuildFailures.MissingPermission;
+		var auth = await AuthorizationContext.LoadAsync(
+			guilds, currentUser, command.GuildId, Permission.ManageRoles, cancellationToken);
+		if (auth.IsFailure)
+			return auth.Error;
+		var guild = auth.Value.Guild;
+		var mask = auth.Value.EffectiveMask;
 
 		var role = guild.Roles.FirstOrDefault(r => r.Id == command.RoleId);
 		if (role is null)

--- a/services/guild/src/Guild.Application/Features/Membership/AssignRole/AssignRoleHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Membership/AssignRole/AssignRoleHandler.cs
@@ -11,7 +11,8 @@ namespace Guild.Application.Features.Membership.AssignRole;
 internal sealed class AssignRoleHandler(
 	IGuildRepository guilds,
 	IClock clock,
-	ICurrentUser currentUser)
+	ICurrentUser currentUser,
+	IUnitOfWork unitOfWork)
 	: ICommandHandler<AssignRoleCommand, Result>
 {
 	public async Task<Result> HandleAsync(
@@ -39,7 +40,7 @@ internal sealed class AssignRoleHandler(
 		if (assignResult.IsFailure)
 			return assignResult.Error;
 
-		await guilds.SaveChangesAsync(cancellationToken);
+		await unitOfWork.SaveChangesAsync(cancellationToken);
 
 		return Result.Ok();
 	}

--- a/services/guild/src/Guild.Application/Features/Membership/AssignRole/AssignRoleHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Membership/AssignRole/AssignRoleHandler.cs
@@ -39,7 +39,6 @@ internal sealed class AssignRoleHandler(
 		if (assignResult.IsFailure)
 			return assignResult.Error;
 
-		guilds.Update(guild);
 		await guilds.SaveChangesAsync(cancellationToken);
 
 		return Result.Ok();

--- a/services/guild/src/Guild.Application/Features/Membership/GetMemberPermissions/GetMemberPermissionsHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Membership/GetMemberPermissions/GetMemberPermissionsHandler.cs
@@ -17,7 +17,7 @@ internal sealed class GetMemberPermissionsHandler(
 		CancellationToken cancellationToken = default)
 	{
 		var auth = await AuthorizationContext.LoadAsync(
-			guilds, currentUser, query.GuildId, Permission.None, cancellationToken);
+			guilds, currentUser, query.GuildId, Permission.None, cancellationToken, asNoTracking: true);
 		if (auth.IsFailure)
 			return auth.Error;
 		var guild = auth.Value.Guild;

--- a/services/guild/src/Guild.Application/Features/Membership/GetMemberPermissions/GetMemberPermissionsHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Membership/GetMemberPermissions/GetMemberPermissionsHandler.cs
@@ -1,6 +1,7 @@
 using Guild.Application.Abstractions.Messaging;
 using Guild.Application.Abstractions.Persistence;
 using Guild.Application.Abstractions.Security;
+using Guild.Application.Authorization;
 using Guild.Domain.Guild;
 using Guild.Domain.Results;
 
@@ -15,19 +16,17 @@ internal sealed class GetMemberPermissionsHandler(
 		GetMemberPermissionsQuery query,
 		CancellationToken cancellationToken = default)
 	{
-		var guild = await guilds.GetByIdWithMembershipAsync(query.GuildId, cancellationToken);
-		if (guild is null)
-			return GuildFailures.GuildNotFound;
-
-		if (guild.Members.All(m => m.UserId != currentUser.Id))
-			return GuildFailures.NotAMember;
+		var auth = await AuthorizationContext.LoadAsync(
+			guilds, currentUser, query.GuildId, Permission.None, cancellationToken);
+		if (auth.IsFailure)
+			return auth.Error;
+		var guild = auth.Value.Guild;
 
 		if (guild.Members.All(m => m.UserId != query.TargetUserId))
 			return GuildFailures.TargetNotAMember;
 
 		var isOwner = query.TargetUserId == guild.OwnerId;
-		var effective = PermissionResolver.Resolve(
-			query.TargetUserId, guild.OwnerId, guild.Roles, guild.MemberRoles);
+		var effective = PermissionResolver.Resolve(guild, query.TargetUserId);
 
 		// @everyone is implicit for every member; explicit assignments add to that.
 		// the owner additionally sees the seeded Administrator role.

--- a/services/guild/src/Guild.Application/Features/Membership/GetMemberPermissions/MemberPermissionsResponse.cs
+++ b/services/guild/src/Guild.Application/Features/Membership/GetMemberPermissions/MemberPermissionsResponse.cs
@@ -4,7 +4,7 @@ namespace Guild.Application.Features.Membership.GetMemberPermissions;
 /// guild-scoped effective permissions for a member. channel overwrites are NOT
 /// folded in here (use the internal channel-membership endpoint for that).
 /// for the owner, <c>EffectivePermissions</c> is the Administrator bit only,
-/// matching <see cref="Guild.Domain.Guild.PermissionResolver.Resolve(long, long, System.Collections.Generic.IEnumerable{Guild.Domain.Guild.Role}, System.Collections.Generic.IEnumerable{Guild.Domain.Guild.MemberRole})"/>;
+/// matching <see cref="Domain.Guild.PermissionResolver.Resolve(long, long, IEnumerable{Domain.Guild.Role}, IEnumerable{Domain.Guild.MemberRole})"/>;
 /// the <c>IsOwner</c> flag is the canonical "wins everything" signal.
 /// </summary>
 public sealed record MemberPermissionsResponse(

--- a/services/guild/src/Guild.Application/Features/Membership/JoinByInviteCode/JoinByInviteCodeHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Membership/JoinByInviteCode/JoinByInviteCodeHandler.cs
@@ -16,7 +16,8 @@ internal sealed class JoinByInviteCodeHandler(
 	IEventBus eventBus,
 	IUserService users,
 	IClock clock,
-	ICurrentUser currentUser)
+	ICurrentUser currentUser,
+	IUnitOfWork unitOfWork)
 	: ICommandHandler<JoinByInviteCodeCommand, Result<GuildDto>>
 {
 	public async Task<Result<GuildDto>> HandleAsync(
@@ -75,7 +76,7 @@ internal sealed class JoinByInviteCodeHandler(
 			new GuildMemberJoined(guild.Id, guild.Name, currentUser.Id),
 			cancellationToken);
 
-		await guilds.SaveChangesAsync(cancellationToken);
+		await unitOfWork.SaveChangesAsync(cancellationToken);
 
 		return GuildDto.FromEntity(guild);
 	}

--- a/services/guild/src/Guild.Application/Features/Membership/JoinByInviteCode/JoinByInviteCodeHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Membership/JoinByInviteCode/JoinByInviteCodeHandler.cs
@@ -69,11 +69,14 @@ internal sealed class JoinByInviteCodeHandler(
 
 		invites.Update(invite);
 		guilds.Update(guild);
-		await guilds.SaveChangesAsync(cancellationToken);
 
+		// publish BEFORE SaveChanges so the bus outbox binds the GuildMemberJoined
+		// event to the same transaction as the invite consume + member add
 		await eventBus.PublishAsync(
 			new GuildMemberJoined(guild.Id, guild.Name, currentUser.Id),
 			cancellationToken);
+
+		await guilds.SaveChangesAsync(cancellationToken);
 
 		return GuildDto.FromEntity(guild);
 	}

--- a/services/guild/src/Guild.Application/Features/Membership/JoinByInviteCode/JoinByInviteCodeHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Membership/JoinByInviteCode/JoinByInviteCodeHandler.cs
@@ -68,7 +68,6 @@ internal sealed class JoinByInviteCodeHandler(
 		await users.ExistsAsync(currentUser.Id, cancellationToken);
 
 		invites.Update(invite);
-		guilds.Update(guild);
 
 		// publish BEFORE SaveChanges so the bus outbox binds the GuildMemberJoined
 		// event to the same transaction as the invite consume + member add

--- a/services/guild/src/Guild.Application/Features/Membership/KickMember/KickMemberHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Membership/KickMember/KickMemberHandler.cs
@@ -39,8 +39,6 @@ internal sealed class KickMemberHandler(
 		if (removeResult.IsFailure)
 			return removeResult.Error;
 
-		guilds.Update(guild);
-
 		// publish BEFORE SaveChanges: the bus outbox records the event as an
 		// OutboxMessage row in this same transaction, so the kick and the
 		// GuildMemberLeft event commit atomically (or not at all)

--- a/services/guild/src/Guild.Application/Features/Membership/KickMember/KickMemberHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Membership/KickMember/KickMemberHandler.cs
@@ -2,6 +2,7 @@ using Guild.Application.Abstractions;
 using Guild.Application.Abstractions.Messaging;
 using Guild.Application.Abstractions.Persistence;
 using Guild.Application.Abstractions.Security;
+using Guild.Application.Authorization;
 using Guild.Application.Contracts;
 using Guild.Domain.Guild;
 using Guild.Domain.Results;
@@ -19,20 +20,14 @@ internal sealed class KickMemberHandler(
 		KickMemberCommand command,
 		CancellationToken cancellationToken = default)
 	{
-		var guild = await guilds.GetByIdWithMembershipAsync(command.GuildId, cancellationToken);
-		if (guild is null)
-			return GuildFailures.GuildNotFound;
-
-		if (guild.Members.All(m => m.UserId != currentUser.Id))
-			return GuildFailures.NotAMember;
+		var auth = await AuthorizationContext.LoadAsync(
+			guilds, currentUser, command.GuildId, Permission.KickMembers, cancellationToken);
+		if (auth.IsFailure)
+			return auth.Error;
+		var guild = auth.Value.Guild;
 
 		if (guild.Members.All(m => m.UserId != command.TargetUserId))
 			return GuildFailures.TargetNotAMember;
-
-		var mask = PermissionResolver.Resolve(
-			currentUser.Id, guild.OwnerId, guild.Roles, guild.MemberRoles);
-		if (!PermissionResolver.HasPermission(mask, Permission.KickMembers))
-			return GuildFailures.MissingPermission;
 
 		if (command.TargetUserId == guild.OwnerId)
 			return GuildFailures.CannotKickOwner;

--- a/services/guild/src/Guild.Application/Features/Membership/KickMember/KickMemberHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Membership/KickMember/KickMemberHandler.cs
@@ -13,7 +13,8 @@ internal sealed class KickMemberHandler(
 	IGuildRepository guilds,
 	IEventBus eventBus,
 	IClock clock,
-	ICurrentUser currentUser)
+	ICurrentUser currentUser,
+	IUnitOfWork unitOfWork)
 	: ICommandHandler<KickMemberCommand, Result>
 {
 	public async Task<Result> HandleAsync(
@@ -26,6 +27,9 @@ internal sealed class KickMemberHandler(
 			return auth.Error;
 		var guild = auth.Value.Guild;
 
+		// kick rejects a non-member target up front: you cannot remove someone who
+		// is not in the guild. (BanMember deliberately does NOT do this, because a
+		// pre-emptive ban against a never-joined user is legal - see that handler.)
 		if (guild.Members.All(m => m.UserId != command.TargetUserId))
 			return GuildFailures.TargetNotAMember;
 
@@ -46,7 +50,7 @@ internal sealed class KickMemberHandler(
 			new GuildMemberLeft(guild.Id, command.TargetUserId),
 			cancellationToken);
 
-		await guilds.SaveChangesAsync(cancellationToken);
+		await unitOfWork.SaveChangesAsync(cancellationToken);
 
 		return Result.Ok();
 	}

--- a/services/guild/src/Guild.Application/Features/Membership/KickMember/KickMemberHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Membership/KickMember/KickMemberHandler.cs
@@ -45,11 +45,15 @@ internal sealed class KickMemberHandler(
 			return removeResult.Error;
 
 		guilds.Update(guild);
-		await guilds.SaveChangesAsync(cancellationToken);
 
+		// publish BEFORE SaveChanges: the bus outbox records the event as an
+		// OutboxMessage row in this same transaction, so the kick and the
+		// GuildMemberLeft event commit atomically (or not at all)
 		await eventBus.PublishAsync(
 			new GuildMemberLeft(guild.Id, command.TargetUserId),
 			cancellationToken);
+
+		await guilds.SaveChangesAsync(cancellationToken);
 
 		return Result.Ok();
 	}

--- a/services/guild/src/Guild.Application/Features/Membership/LeaveGuild/LeaveGuildHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Membership/LeaveGuild/LeaveGuildHandler.cs
@@ -11,7 +11,8 @@ internal sealed class LeaveGuildHandler(
 	IGuildRepository guilds,
 	IEventBus eventBus,
 	IClock clock,
-	ICurrentUser currentUser)
+	ICurrentUser currentUser,
+	IUnitOfWork unitOfWork)
 	: ICommandHandler<LeaveGuildCommand, Result>
 {
 	public async Task<Result> HandleAsync(
@@ -32,7 +33,7 @@ internal sealed class LeaveGuildHandler(
 			new GuildMemberLeft(guild.Id, currentUser.Id),
 			cancellationToken);
 
-		await guilds.SaveChangesAsync(cancellationToken);
+		await unitOfWork.SaveChangesAsync(cancellationToken);
 
 		return Result.Ok();
 	}

--- a/services/guild/src/Guild.Application/Features/Membership/LeaveGuild/LeaveGuildHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Membership/LeaveGuild/LeaveGuildHandler.cs
@@ -27,11 +27,14 @@ internal sealed class LeaveGuildHandler(
 			return removeResult.Error;
 
 		guilds.Update(guild);
-		await guilds.SaveChangesAsync(cancellationToken);
 
+		// publish BEFORE SaveChanges so the bus outbox binds the GuildMemberLeft
+		// event to the same transaction as the membership removal
 		await eventBus.PublishAsync(
 			new GuildMemberLeft(guild.Id, currentUser.Id),
 			cancellationToken);
+
+		await guilds.SaveChangesAsync(cancellationToken);
 
 		return Result.Ok();
 	}

--- a/services/guild/src/Guild.Application/Features/Membership/LeaveGuild/LeaveGuildHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Membership/LeaveGuild/LeaveGuildHandler.cs
@@ -26,8 +26,6 @@ internal sealed class LeaveGuildHandler(
 		if (removeResult.IsFailure)
 			return removeResult.Error;
 
-		guilds.Update(guild);
-
 		// publish BEFORE SaveChanges so the bus outbox binds the GuildMemberLeft
 		// event to the same transaction as the membership removal
 		await eventBus.PublishAsync(

--- a/services/guild/src/Guild.Application/Features/Membership/ListMembers/ListMembersHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Membership/ListMembers/ListMembersHandler.cs
@@ -1,9 +1,7 @@
 using Guild.Application.Abstractions.Messaging;
 using Guild.Application.Abstractions.Persistence;
 using Guild.Application.Abstractions.Security;
-using Guild.Application.Authorization;
 using Guild.Application.Features.Membership.Common;
-using Guild.Domain.Guild;
 using Guild.Domain.Results;
 
 namespace Guild.Application.Features.Membership.ListMembers;
@@ -17,28 +15,29 @@ internal sealed class ListMembersHandler(
 		ListMembersQuery query,
 		CancellationToken cancellationToken = default)
 	{
-		var auth = await AuthorizationContext.LoadAsync(
-			guilds, currentUser, query.GuildId, Permission.None, cancellationToken);
-		if (auth.IsFailure)
-			return auth.Error;
-		var guild = auth.Value.Guild;
+		// lightweight gate: listing members never needs the full aggregate or a
+		// permission, just "guild exists" + "caller is a member". the members
+		// themselves are then keyset-paged straight from the DB, so a 10k-member
+		// guild no longer hydrates every row to return one page.
+		var guild = await guilds.GetByIdAsync(query.GuildId, cancellationToken);
+		if (guild is null)
+			return GuildFailures.GuildNotFound;
 
-		var rolesByMember = guild.MemberRoles
-			.GroupBy(mr => mr.UserId)
-			.ToDictionary(g => g.Key, g => g.Select(mr => mr.RoleId.ToString()).ToList());
+		if (!await guilds.IsMemberAsync(query.GuildId, currentUser.Id, cancellationToken))
+			return GuildFailures.NotAMember;
 
-		var page = guild.Members
-			.Where(m => query.After is null || m.UserId > query.After.Value)
-			.OrderBy(m => m.UserId)
-			.Take(query.Limit)
+		var page = await guilds.PageMembersAsync(
+			query.GuildId, query.After, query.Limit, cancellationToken);
+
+		var items = page
 			.Select(m => new MemberResponse(
 				UserId: m.UserId.ToString(),
-				GuildId: guild.Id.ToString(),
+				GuildId: query.GuildId.ToString(),
 				Nickname: m.Nickname,
-				Roles: rolesByMember.TryGetValue(m.UserId, out var ids) ? ids : new List<string>(),
+				Roles: m.RoleIds.Select(id => id.ToString()).ToList(),
 				JoinedAt: m.JoinedAt))
 			.ToList();
 
-		return new MemberListResponse(page);
+		return new MemberListResponse(items);
 	}
 }

--- a/services/guild/src/Guild.Application/Features/Membership/ListMembers/ListMembersHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Membership/ListMembers/ListMembersHandler.cs
@@ -9,9 +9,9 @@ namespace Guild.Application.Features.Membership.ListMembers;
 internal sealed class ListMembersHandler(
 	IGuildRepository guilds,
 	ICurrentUser currentUser)
-	: IQueryHandler<ListMembersQuery, Result<MemberListResponse>>
+	: IQueryHandler<ListMembersQuery, Result<IReadOnlyList<MemberResponse>>>
 {
-	public async Task<Result<MemberListResponse>> HandleAsync(
+	public async Task<Result<IReadOnlyList<MemberResponse>>> HandleAsync(
 		ListMembersQuery query,
 		CancellationToken cancellationToken = default)
 	{
@@ -29,7 +29,7 @@ internal sealed class ListMembersHandler(
 		var page = await guilds.PageMembersAsync(
 			query.GuildId, query.After, query.Limit, cancellationToken);
 
-		var items = page
+		IReadOnlyList<MemberResponse> items = page
 			.Select(m => new MemberResponse(
 				UserId: m.UserId.ToString(),
 				GuildId: query.GuildId.ToString(),
@@ -38,6 +38,6 @@ internal sealed class ListMembersHandler(
 				JoinedAt: m.JoinedAt))
 			.ToList();
 
-		return new MemberListResponse(items);
+		return Result.Ok(items);
 	}
 }

--- a/services/guild/src/Guild.Application/Features/Membership/ListMembers/ListMembersHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Membership/ListMembers/ListMembersHandler.cs
@@ -1,7 +1,9 @@
 using Guild.Application.Abstractions.Messaging;
 using Guild.Application.Abstractions.Persistence;
 using Guild.Application.Abstractions.Security;
+using Guild.Application.Authorization;
 using Guild.Application.Features.Membership.Common;
+using Guild.Domain.Guild;
 using Guild.Domain.Results;
 
 namespace Guild.Application.Features.Membership.ListMembers;
@@ -15,12 +17,11 @@ internal sealed class ListMembersHandler(
 		ListMembersQuery query,
 		CancellationToken cancellationToken = default)
 	{
-		var guild = await guilds.GetByIdWithMembershipAsync(query.GuildId, cancellationToken);
-		if (guild is null)
-			return GuildFailures.GuildNotFound;
-
-		if (guild.Members.All(m => m.UserId != currentUser.Id))
-			return GuildFailures.NotAMember;
+		var auth = await AuthorizationContext.LoadAsync(
+			guilds, currentUser, query.GuildId, Permission.None, cancellationToken);
+		if (auth.IsFailure)
+			return auth.Error;
+		var guild = auth.Value.Guild;
 
 		var rolesByMember = guild.MemberRoles
 			.GroupBy(mr => mr.UserId)

--- a/services/guild/src/Guild.Application/Features/Membership/ListMembers/ListMembersQuery.cs
+++ b/services/guild/src/Guild.Application/Features/Membership/ListMembers/ListMembersQuery.cs
@@ -4,11 +4,5 @@ using Guild.Domain.Results;
 
 namespace Guild.Application.Features.Membership.ListMembers;
 
-public sealed record ListMembersQuery(long GuildId, long? After, int Limit) : IQuery<Result<MemberListResponse>>;
+public sealed record ListMembersQuery(long GuildId, long? After, int Limit) : IQuery<Result<IReadOnlyList<MemberResponse>>>;
 
-/// <summary>
-/// wrapped in a record so the generic <c>IQueryHandler&lt;,&gt;</c> constraint
-/// (<c>TResponse : class</c>) is satisfied; the endpoint unwraps to return
-/// <see cref="Items"/> as a flat JSON array per the contract
-/// </summary>
-public sealed record MemberListResponse(IReadOnlyList<MemberResponse> Items);

--- a/services/guild/src/Guild.Application/Features/Membership/UnassignRole/UnassignRoleHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Membership/UnassignRole/UnassignRoleHandler.cs
@@ -35,7 +35,6 @@ internal sealed class UnassignRoleHandler(
 		if (unassignResult.IsFailure)
 			return unassignResult.Error;
 
-		guilds.Update(guild);
 		await guilds.SaveChangesAsync(cancellationToken);
 
 		return Result.Ok();

--- a/services/guild/src/Guild.Application/Features/Membership/UnassignRole/UnassignRoleHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Membership/UnassignRole/UnassignRoleHandler.cs
@@ -11,7 +11,8 @@ namespace Guild.Application.Features.Membership.UnassignRole;
 internal sealed class UnassignRoleHandler(
 	IGuildRepository guilds,
 	IClock clock,
-	ICurrentUser currentUser)
+	ICurrentUser currentUser,
+	IUnitOfWork unitOfWork)
 	: ICommandHandler<UnassignRoleCommand, Result>
 {
 	public async Task<Result> HandleAsync(
@@ -35,7 +36,7 @@ internal sealed class UnassignRoleHandler(
 		if (unassignResult.IsFailure)
 			return unassignResult.Error;
 
-		await guilds.SaveChangesAsync(cancellationToken);
+		await unitOfWork.SaveChangesAsync(cancellationToken);
 
 		return Result.Ok();
 	}

--- a/services/guild/src/Guild.Application/Features/Membership/UnassignRole/UnassignRoleHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Membership/UnassignRole/UnassignRoleHandler.cs
@@ -2,6 +2,7 @@ using Guild.Application.Abstractions;
 using Guild.Application.Abstractions.Messaging;
 using Guild.Application.Abstractions.Persistence;
 using Guild.Application.Abstractions.Security;
+using Guild.Application.Authorization;
 using Guild.Domain.Guild;
 using Guild.Domain.Results;
 
@@ -17,17 +18,11 @@ internal sealed class UnassignRoleHandler(
 		UnassignRoleCommand command,
 		CancellationToken cancellationToken = default)
 	{
-		var guild = await guilds.GetByIdWithMembershipAsync(command.GuildId, cancellationToken);
-		if (guild is null)
-			return GuildFailures.GuildNotFound;
-
-		if (guild.Members.All(m => m.UserId != currentUser.Id))
-			return GuildFailures.NotAMember;
-
-		var mask = PermissionResolver.Resolve(
-			currentUser.Id, guild.OwnerId, guild.Roles, guild.MemberRoles);
-		if (!PermissionResolver.HasPermission(mask, Permission.ManageRoles))
-			return GuildFailures.MissingPermission;
+		var auth = await AuthorizationContext.LoadAsync(
+			guilds, currentUser, command.GuildId, Permission.ManageRoles, cancellationToken);
+		if (auth.IsFailure)
+			return auth.Error;
+		var guild = auth.Value.Guild;
 
 		var role = guild.Roles.FirstOrDefault(r => r.Id == command.RoleId);
 		if (role is null)

--- a/services/guild/src/Guild.Application/Features/Membership/UpdateNickname/UpdateNicknameHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Membership/UpdateNickname/UpdateNicknameHandler.cs
@@ -1,6 +1,7 @@
 using Guild.Application.Abstractions.Messaging;
 using Guild.Application.Abstractions.Persistence;
 using Guild.Application.Abstractions.Security;
+using Guild.Application.Authorization;
 using Guild.Application.Features.Membership.Common;
 using Guild.Domain.Guild;
 using Guild.Domain.Results;
@@ -16,19 +17,18 @@ internal sealed class UpdateNicknameHandler(
 		UpdateNicknameCommand command,
 		CancellationToken cancellationToken = default)
 	{
-		var guild = await guilds.GetByIdWithMembershipAsync(command.GuildId, cancellationToken);
-		if (guild is null)
-			return GuildFailures.GuildNotFound;
-
-		if (guild.Members.All(m => m.UserId != currentUser.Id))
-			return GuildFailures.NotAMember;
+		// membership-gate only: editing your OWN nickname needs no permission,
+		// editing someone else's needs MANAGE_NICKNAMES plus out-ranking them
+		var auth = await AuthorizationContext.LoadAsync(
+			guilds, currentUser, command.GuildId, Permission.None, cancellationToken);
+		if (auth.IsFailure)
+			return auth.Error;
+		var guild = auth.Value.Guild;
 
 		var isSelf = command.TargetUserId == currentUser.Id;
 		if (!isSelf)
 		{
-			var mask = PermissionResolver.Resolve(
-				currentUser.Id, guild.OwnerId, guild.Roles, guild.MemberRoles);
-			if (!PermissionResolver.HasPermission(mask, Permission.ManageNicknames))
+			if (!PermissionResolver.HasPermission(auth.Value.EffectiveMask, Permission.ManageNicknames))
 				return GuildFailures.MissingPermission;
 
 			if (!PermissionResolver.OutRanks(guild, currentUser.Id, command.TargetUserId))

--- a/services/guild/src/Guild.Application/Features/Membership/UpdateNickname/UpdateNicknameHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Membership/UpdateNickname/UpdateNicknameHandler.cs
@@ -10,7 +10,8 @@ namespace Guild.Application.Features.Membership.UpdateNickname;
 
 internal sealed class UpdateNicknameHandler(
 	IGuildRepository guilds,
-	ICurrentUser currentUser)
+	ICurrentUser currentUser,
+	IUnitOfWork unitOfWork)
 	: ICommandHandler<UpdateNicknameCommand, Result<MemberResponse>>
 {
 	public async Task<Result<MemberResponse>> HandleAsync(
@@ -39,7 +40,7 @@ internal sealed class UpdateNicknameHandler(
 		if (updateResult.IsFailure)
 			return updateResult.Error;
 
-		await guilds.SaveChangesAsync(cancellationToken);
+		await unitOfWork.SaveChangesAsync(cancellationToken);
 
 		var member = updateResult.Value;
 		var assignedRoleIds = guild.MemberRoles

--- a/services/guild/src/Guild.Application/Features/Membership/UpdateNickname/UpdateNicknameHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Membership/UpdateNickname/UpdateNicknameHandler.cs
@@ -39,7 +39,6 @@ internal sealed class UpdateNicknameHandler(
 		if (updateResult.IsFailure)
 			return updateResult.Error;
 
-		guilds.Update(guild);
 		await guilds.SaveChangesAsync(cancellationToken);
 
 		var member = updateResult.Value;

--- a/services/guild/src/Guild.Application/Features/Roles/CreateRole/CreateRoleHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Roles/CreateRole/CreateRoleHandler.cs
@@ -2,6 +2,7 @@ using Guild.Application.Abstractions;
 using Guild.Application.Abstractions.Messaging;
 using Guild.Application.Abstractions.Persistence;
 using Guild.Application.Abstractions.Security;
+using Guild.Application.Authorization;
 using Guild.Application.Features.Roles.Common;
 using Guild.Domain.Guild;
 using Guild.Domain.Results;
@@ -19,17 +20,12 @@ internal sealed class CreateRoleHandler(
 		CreateRoleCommand command,
 		CancellationToken cancellationToken = default)
 	{
-		var guild = await guilds.GetByIdWithMembershipAsync(command.GuildId, cancellationToken);
-		if (guild is null)
-			return GuildFailures.GuildNotFound;
-
-		if (guild.Members.All(m => m.UserId != currentUser.Id))
-			return GuildFailures.NotAMember;
-
-		var mask = PermissionResolver.Resolve(
-			currentUser.Id, guild.OwnerId, guild.Roles, guild.MemberRoles);
-		if (!PermissionResolver.HasPermission(mask, Permission.ManageRoles))
-			return GuildFailures.MissingPermission;
+		var auth = await AuthorizationContext.LoadAsync(
+			guilds, currentUser, command.GuildId, Permission.ManageRoles, cancellationToken);
+		if (auth.IsFailure)
+			return auth.Error;
+		var guild = auth.Value.Guild;
+		var mask = auth.Value.EffectiveMask;
 
 		if (!PermissionResolver.CanGrantPermissions(mask, command.Permissions))
 			return GuildFailures.CannotGrantPermissionsYouLack;

--- a/services/guild/src/Guild.Application/Features/Roles/CreateRole/CreateRoleHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Roles/CreateRole/CreateRoleHandler.cs
@@ -41,7 +41,6 @@ internal sealed class CreateRoleHandler(
 		if (addResult.IsFailure)
 			return addResult.Error;
 
-		guilds.Update(guild);
 		await guilds.SaveChangesAsync(cancellationToken);
 
 		return RoleResponse.From(addResult.Value);

--- a/services/guild/src/Guild.Application/Features/Roles/CreateRole/CreateRoleHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Roles/CreateRole/CreateRoleHandler.cs
@@ -13,7 +13,8 @@ internal sealed class CreateRoleHandler(
 	IGuildRepository guilds,
 	IIdGenerator ids,
 	IClock clock,
-	ICurrentUser currentUser)
+	ICurrentUser currentUser,
+	IUnitOfWork unitOfWork)
 	: ICommandHandler<CreateRoleCommand, Result<RoleResponse>>
 {
 	public async Task<Result<RoleResponse>> HandleAsync(
@@ -41,7 +42,7 @@ internal sealed class CreateRoleHandler(
 		if (addResult.IsFailure)
 			return addResult.Error;
 
-		await guilds.SaveChangesAsync(cancellationToken);
+		await unitOfWork.SaveChangesAsync(cancellationToken);
 
 		return RoleResponse.From(addResult.Value);
 	}

--- a/services/guild/src/Guild.Application/Features/Roles/DeleteRole/DeleteRoleHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Roles/DeleteRole/DeleteRoleHandler.cs
@@ -11,7 +11,8 @@ namespace Guild.Application.Features.Roles.DeleteRole;
 internal sealed class DeleteRoleHandler(
 	IGuildRepository guilds,
 	IClock clock,
-	ICurrentUser currentUser)
+	ICurrentUser currentUser,
+	IUnitOfWork unitOfWork)
 	: ICommandHandler<DeleteRoleCommand, Result>
 {
 	public async Task<Result> HandleAsync(
@@ -41,7 +42,7 @@ internal sealed class DeleteRoleHandler(
 		if (removeResult.IsFailure)
 			return removeResult.Error;
 
-		await guilds.SaveChangesAsync(cancellationToken);
+		await unitOfWork.SaveChangesAsync(cancellationToken);
 
 		return Result.Ok();
 	}

--- a/services/guild/src/Guild.Application/Features/Roles/DeleteRole/DeleteRoleHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Roles/DeleteRole/DeleteRoleHandler.cs
@@ -41,7 +41,6 @@ internal sealed class DeleteRoleHandler(
 		if (removeResult.IsFailure)
 			return removeResult.Error;
 
-		guilds.Update(guild);
 		await guilds.SaveChangesAsync(cancellationToken);
 
 		return Result.Ok();

--- a/services/guild/src/Guild.Application/Features/Roles/DeleteRole/DeleteRoleHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Roles/DeleteRole/DeleteRoleHandler.cs
@@ -2,6 +2,7 @@ using Guild.Application.Abstractions;
 using Guild.Application.Abstractions.Messaging;
 using Guild.Application.Abstractions.Persistence;
 using Guild.Application.Abstractions.Security;
+using Guild.Application.Authorization;
 using Guild.Domain.Guild;
 using Guild.Domain.Results;
 
@@ -17,17 +18,11 @@ internal sealed class DeleteRoleHandler(
 		DeleteRoleCommand command,
 		CancellationToken cancellationToken = default)
 	{
-		var guild = await guilds.GetByIdWithMembershipAsync(command.GuildId, cancellationToken);
-		if (guild is null)
-			return GuildFailures.GuildNotFound;
-
-		if (guild.Members.All(m => m.UserId != currentUser.Id))
-			return GuildFailures.NotAMember;
-
-		var mask = PermissionResolver.Resolve(
-			currentUser.Id, guild.OwnerId, guild.Roles, guild.MemberRoles);
-		if (!PermissionResolver.HasPermission(mask, Permission.ManageRoles))
-			return GuildFailures.MissingPermission;
+		var auth = await AuthorizationContext.LoadAsync(
+			guilds, currentUser, command.GuildId, Permission.ManageRoles, cancellationToken);
+		if (auth.IsFailure)
+			return auth.Error;
+		var guild = auth.Value.Guild;
 
 		var role = guild.Roles.FirstOrDefault(r => r.Id == command.RoleId);
 		if (role is null)

--- a/services/guild/src/Guild.Application/Features/Roles/ListRoles/ListRolesHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Roles/ListRoles/ListRolesHandler.cs
@@ -1,7 +1,9 @@
 using Guild.Application.Abstractions.Messaging;
 using Guild.Application.Abstractions.Persistence;
 using Guild.Application.Abstractions.Security;
+using Guild.Application.Authorization;
 using Guild.Application.Features.Roles.Common;
+using Guild.Domain.Guild;
 using Guild.Domain.Results;
 
 namespace Guild.Application.Features.Roles.ListRoles;
@@ -15,12 +17,11 @@ internal sealed class ListRolesHandler(
 		ListRolesQuery query,
 		CancellationToken cancellationToken = default)
 	{
-		var guild = await guilds.GetByIdWithMembershipAsync(query.GuildId, cancellationToken);
-		if (guild is null)
-			return GuildFailures.GuildNotFound;
-
-		if (guild.Members.All(m => m.UserId != currentUser.Id))
-			return GuildFailures.NotAMember;
+		var auth = await AuthorizationContext.LoadAsync(
+			guilds, currentUser, query.GuildId, Permission.None, cancellationToken);
+		if (auth.IsFailure)
+			return auth.Error;
+		var guild = auth.Value.Guild;
 
 		var items = guild.Roles
 			.OrderBy(r => r.Position)

--- a/services/guild/src/Guild.Application/Features/Roles/ListRoles/ListRolesHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Roles/ListRoles/ListRolesHandler.cs
@@ -18,7 +18,7 @@ internal sealed class ListRolesHandler(
 		CancellationToken cancellationToken = default)
 	{
 		var auth = await AuthorizationContext.LoadAsync(
-			guilds, currentUser, query.GuildId, Permission.None, cancellationToken);
+			guilds, currentUser, query.GuildId, Permission.None, cancellationToken, asNoTracking: true);
 		if (auth.IsFailure)
 			return auth.Error;
 		var guild = auth.Value.Guild;

--- a/services/guild/src/Guild.Application/Features/Roles/ReorderRoles/ReorderRolesHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Roles/ReorderRoles/ReorderRolesHandler.cs
@@ -2,6 +2,7 @@ using Guild.Application.Abstractions;
 using Guild.Application.Abstractions.Messaging;
 using Guild.Application.Abstractions.Persistence;
 using Guild.Application.Abstractions.Security;
+using Guild.Application.Authorization;
 using Guild.Application.Features.Roles.Common;
 using Guild.Application.Features.Roles.ListRoles;
 using Guild.Domain.Guild;
@@ -19,17 +20,11 @@ internal sealed class ReorderRolesHandler(
 		ReorderRolesCommand command,
 		CancellationToken cancellationToken = default)
 	{
-		var guild = await guilds.GetByIdWithMembershipAsync(command.GuildId, cancellationToken);
-		if (guild is null)
-			return GuildFailures.GuildNotFound;
-
-		if (guild.Members.All(m => m.UserId != currentUser.Id))
-			return GuildFailures.NotAMember;
-
-		var mask = PermissionResolver.Resolve(
-			currentUser.Id, guild.OwnerId, guild.Roles, guild.MemberRoles);
-		if (!PermissionResolver.HasPermission(mask, Permission.ManageRoles))
-			return GuildFailures.MissingPermission;
+		var auth = await AuthorizationContext.LoadAsync(
+			guilds, currentUser, command.GuildId, Permission.ManageRoles, cancellationToken);
+		if (auth.IsFailure)
+			return auth.Error;
+		var guild = auth.Value.Guild;
 
 		// hierarchy guard (Discord rule): for every role whose position actually
 		// CHANGES, the caller must strictly out-rank it at both its old and new

--- a/services/guild/src/Guild.Application/Features/Roles/ReorderRoles/ReorderRolesHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Roles/ReorderRoles/ReorderRolesHandler.cs
@@ -54,7 +54,6 @@ internal sealed class ReorderRolesHandler(
 		if (result.IsFailure)
 			return result.Error;
 
-		guilds.Update(guild);
 		await guilds.SaveChangesAsync(cancellationToken);
 
 		var items = result.Value.Select(RoleResponse.From).ToList();

--- a/services/guild/src/Guild.Application/Features/Roles/ReorderRoles/ReorderRolesHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Roles/ReorderRoles/ReorderRolesHandler.cs
@@ -13,7 +13,8 @@ namespace Guild.Application.Features.Roles.ReorderRoles;
 internal sealed class ReorderRolesHandler(
 	IGuildRepository guilds,
 	IClock clock,
-	ICurrentUser currentUser)
+	ICurrentUser currentUser,
+	IUnitOfWork unitOfWork)
 	: ICommandHandler<ReorderRolesCommand, Result<RoleListResponse>>
 {
 	public async Task<Result<RoleListResponse>> HandleAsync(
@@ -54,7 +55,7 @@ internal sealed class ReorderRolesHandler(
 		if (result.IsFailure)
 			return result.Error;
 
-		await guilds.SaveChangesAsync(cancellationToken);
+		await unitOfWork.SaveChangesAsync(cancellationToken);
 
 		var items = result.Value.Select(RoleResponse.From).ToList();
 		return new RoleListResponse(items);

--- a/services/guild/src/Guild.Application/Features/Roles/UpdateRole/UpdateRoleHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Roles/UpdateRole/UpdateRoleHandler.cs
@@ -53,7 +53,6 @@ internal sealed class UpdateRoleHandler(
 		if (updateResult.IsFailure)
 			return updateResult.Error;
 
-		guilds.Update(guild);
 		await guilds.SaveChangesAsync(cancellationToken);
 
 		return RoleResponse.From(updateResult.Value);

--- a/services/guild/src/Guild.Application/Features/Roles/UpdateRole/UpdateRoleHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Roles/UpdateRole/UpdateRoleHandler.cs
@@ -12,7 +12,8 @@ namespace Guild.Application.Features.Roles.UpdateRole;
 internal sealed class UpdateRoleHandler(
 	IGuildRepository guilds,
 	IClock clock,
-	ICurrentUser currentUser)
+	ICurrentUser currentUser,
+	IUnitOfWork unitOfWork)
 	: ICommandHandler<UpdateRoleCommand, Result<RoleResponse>>
 {
 	public async Task<Result<RoleResponse>> HandleAsync(
@@ -53,7 +54,7 @@ internal sealed class UpdateRoleHandler(
 		if (updateResult.IsFailure)
 			return updateResult.Error;
 
-		await guilds.SaveChangesAsync(cancellationToken);
+		await unitOfWork.SaveChangesAsync(cancellationToken);
 
 		return RoleResponse.From(updateResult.Value);
 	}

--- a/services/guild/src/Guild.Application/Features/Roles/UpdateRole/UpdateRoleHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Roles/UpdateRole/UpdateRoleHandler.cs
@@ -2,6 +2,7 @@ using Guild.Application.Abstractions;
 using Guild.Application.Abstractions.Messaging;
 using Guild.Application.Abstractions.Persistence;
 using Guild.Application.Abstractions.Security;
+using Guild.Application.Authorization;
 using Guild.Application.Features.Roles.Common;
 using Guild.Domain.Guild;
 using Guild.Domain.Results;
@@ -18,17 +19,12 @@ internal sealed class UpdateRoleHandler(
 		UpdateRoleCommand command,
 		CancellationToken cancellationToken = default)
 	{
-		var guild = await guilds.GetByIdWithMembershipAsync(command.GuildId, cancellationToken);
-		if (guild is null)
-			return GuildFailures.GuildNotFound;
-
-		if (guild.Members.All(m => m.UserId != currentUser.Id))
-			return GuildFailures.NotAMember;
-
-		var mask = PermissionResolver.Resolve(
-			currentUser.Id, guild.OwnerId, guild.Roles, guild.MemberRoles);
-		if (!PermissionResolver.HasPermission(mask, Permission.ManageRoles))
-			return GuildFailures.MissingPermission;
+		var auth = await AuthorizationContext.LoadAsync(
+			guilds, currentUser, command.GuildId, Permission.ManageRoles, cancellationToken);
+		if (auth.IsFailure)
+			return auth.Error;
+		var guild = auth.Value.Guild;
+		var mask = auth.Value.EffectiveMask;
 
 		var role = guild.Roles.FirstOrDefault(r => r.Id == command.RoleId);
 		if (role is null)

--- a/services/guild/src/Guild.Application/GuildSerialization.cs
+++ b/services/guild/src/Guild.Application/GuildSerialization.cs
@@ -1,0 +1,16 @@
+using System.Text.Json;
+
+namespace Guild.Application;
+
+/// <summary>
+/// the single source of truth for the Guild service's JSON wire format. both the
+/// HTTP pipeline (<c>Program.cs</c> via <c>ConfigureHttpJsonOptions</c>) and the
+/// MassTransit message serializer (<c>Infrastructure/DependencyInjection.cs</c>)
+/// apply <see cref="NamingPolicy"/>, so API responses and event payloads can
+/// never drift apart - cross-service consumers rely on the snake_case property
+/// names matching <c>docs/contracts</c>.
+/// </summary>
+public static class GuildSerialization
+{
+	public static readonly JsonNamingPolicy NamingPolicy = JsonNamingPolicy.SnakeCaseLower;
+}

--- a/services/guild/src/Guild.Domain/Guild.Domain.csproj
+++ b/services/guild/src/Guild.Domain/Guild.Domain.csproj
@@ -7,4 +7,10 @@
         <Nullable>enable</Nullable>
     </PropertyGroup>
 
+    <ItemGroup>
+        <!-- lets the functional tests seed aggregates via the internal domain
+             factories (e.g. MemberRole.Create) instead of reflection -->
+        <InternalsVisibleTo Include="Guild.FunctionalTests" />
+    </ItemGroup>
+
 </Project>

--- a/services/guild/src/Guild.Domain/Guild/ChannelPermissionOverwrite.cs
+++ b/services/guild/src/Guild.Domain/Guild/ChannelPermissionOverwrite.cs
@@ -4,7 +4,7 @@ namespace Guild.Domain.Guild;
 
 /// <summary>
 /// per-channel allow/deny tweak applied on top of role-based permissions.
-/// see <see cref="PermissionResolver.Resolve(Guild,long,Channel,System.Collections.Generic.IReadOnlyList{ChannelPermissionOverwrite})"/>
+/// see <see cref="PermissionResolver.Resolve(Guild,long,Channel,IReadOnlyList{ChannelPermissionOverwrite})"/>
 /// for the precedence order
 /// </summary>
 public sealed class ChannelPermissionOverwrite

--- a/services/guild/src/Guild.Domain/Guild/PermissionResolver.cs
+++ b/services/guild/src/Guild.Domain/Guild/PermissionResolver.cs
@@ -7,28 +7,36 @@ namespace Guild.Domain.Guild;
 /// </summary>
 public static class PermissionResolver
 {
-	public static long Resolve(
-		long userId,
-		long ownerId,
-		IEnumerable<Role> allGuildRoles,
-		IEnumerable<MemberRole> userAssignments)
+	/// <summary>
+	/// guild-scoped resolution for <paramref name="userId"/>. symmetric with the
+	/// channel-scoped overload below: the owner short-circuits to ADMINISTRATOR,
+	/// a non-member resolves to 0, and everyone else gets the union of the
+	/// @everyone role and their explicitly assigned roles. folding the
+	/// membership check in here (rather than leaving every caller to remember a
+	/// separate <c>guild.Members.All(...)</c> guard) removes the footgun where a
+	/// forgotten check leaked @everyone perms to non-members.
+	/// </summary>
+	public static long Resolve(Guild guild, long userId)
 	{
-		if (userId == ownerId)
+		if (userId == guild.OwnerId)
 			return (long)Permission.Administrator;
 
-		// the default (@everyone) role is always granted, regardless of explicit
-		// assignment. it encodes the baseline permissions for all members
-		var mask = allGuildRoles.Where(role => role.IsDefault).Aggregate(0L, (current, role) => current | role.Permissions);
+		if (guild.Members.All(m => m.UserId != userId))
+			return 0L;
 
-		// explicitly assigned roles add to the mask
-		var assignedRoleIds = new HashSet<long>();
-		foreach (var assignment in userAssignments)
+		var assignedRoleIds = guild.MemberRoles
+			.Where(mr => mr.UserId == userId)
+			.Select(mr => mr.RoleId)
+			.ToHashSet();
+
+		var mask = 0L;
+		foreach (var role in guild.Roles)
 		{
-			if (assignment.UserId == userId)
-				assignedRoleIds.Add(assignment.RoleId);
+			if (role.IsDefault || assignedRoleIds.Contains(role.Id))
+				mask |= role.Permissions;
 		}
 
-		return assignedRoleIds.Count <= 0 ? mask : allGuildRoles.Where(role => assignedRoleIds.Contains(role.Id)).Aggregate(mask, (current, role) => current | role.Permissions);
+		return mask;
 	}
 
 	/// <summary>

--- a/services/guild/src/Guild.Domain/Results/Result.cs
+++ b/services/guild/src/Guild.Domain/Results/Result.cs
@@ -17,11 +17,16 @@ public class Result
 
 	public static Result Ok() => new(true, Failure.None);
 	public static Result Fail(Failure error) => new(false, error);
-	public static Result<TValue> Ok<TValue>(TValue value) => new(true, value, Failure.None);
-	public static Result<TValue> Fail<TValue>(Failure error) => new(false, default!, error);
+	public static Result<TValue> Ok<TValue>(TValue value) where TValue : notnull => new(true, value, Failure.None);
+	public static Result<TValue> Fail<TValue>(Failure error) where TValue : notnull => new(false, default!, error);
 }
 
+// TValue is constrained to notnull so a Result can never be Succeeded with a null
+// Value. without this you could silently return Result<GuildDto?> { Succeeded =
+// true, Value = null } via the implicit operator below; the constraint turns that
+// into a compile error instead of a latent null deref for the caller.
 public sealed class Result<TValue>(bool isSuccess, TValue value, Failure error) : Result(isSuccess, error)
+	where TValue : notnull
 {
 	public TValue Value => Succeeded
 		? value

--- a/services/guild/src/Guild.Domain/Results/Result.cs
+++ b/services/guild/src/Guild.Domain/Results/Result.cs
@@ -2,14 +2,24 @@ namespace Guild.Domain.Results;
 
 public class Result
 {
+	private readonly Failure _error;
+
 	private protected Result(bool succeeded, Failure error)
 	{
 		Succeeded = succeeded;
-		Error = error;
+		_error = error;
 	}
 
 	public bool Succeeded { get; }
-	public Failure Error { get; }
+
+	// symmetric with Result<TValue>.Value (which throws on failure): Error throws
+	// on success rather than handing back the Failure.None sentinel, so neither
+	// accessor can be read in the wrong state without it surfacing.
+	public Failure Error => Succeeded
+		? throw new InvalidOperationException(
+			"There is no error on a successful result. Check that IsFailure is true before accessing Error.")
+		: _error;
+
 	public bool IsFailure => !Succeeded;
 
 	public TResult Match<TResult>(Func<TResult> onSuccess, Func<Failure, TResult> onFailure) =>

--- a/services/guild/src/Guild.Infrastructure/DependencyInjection.cs
+++ b/services/guild/src/Guild.Infrastructure/DependencyInjection.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using System.Text.Json;
+using Guild.Application;
 using Guild.Application.Abstractions;
 using Guild.Application.Abstractions.Security;
 using Guild.Application.Abstractions.Users;
@@ -64,7 +65,7 @@ public static class DependencyInjection
 				// apply the same policy or deserialisation will fail
 				cfg.ConfigureJsonSerializerOptions(opts =>
 				{
-					opts.PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower;
+					opts.PropertyNamingPolicy = GuildSerialization.NamingPolicy;
 					return opts;
 				});
 

--- a/services/guild/src/Guild.Infrastructure/DependencyInjection.cs
+++ b/services/guild/src/Guild.Infrastructure/DependencyInjection.cs
@@ -96,7 +96,7 @@ public static class DependencyInjection
 	}
 
 	private static OptionsBuilder<T> ConfigureOptions<T>(IServiceCollection services)
-		where T : class, Options.IOptions
+		where T : class, IOptions
 	{
 		return services.AddOptions<T>()
 			.BindConfiguration(T.SectionName)

--- a/services/guild/src/Guild.Infrastructure/DependencyInjection.cs
+++ b/services/guild/src/Guild.Infrastructure/DependencyInjection.cs
@@ -10,6 +10,7 @@ using Guild.Infrastructure.Security;
 using Guild.Infrastructure.Users;
 using MassTransit;
 using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
@@ -17,7 +18,8 @@ namespace Guild.Infrastructure;
 
 public static class DependencyInjection
 {
-	public static IServiceCollection AddInfrastructure(this IServiceCollection services)
+	public static IServiceCollection AddInfrastructure<TDbContext>(this IServiceCollection services)
+		where TDbContext : DbContext
 	{
 		var optionsTypes = typeof(DependencyInjection).Assembly.GetTypes()
 			.Where(t => t is { IsAbstract: false, IsInterface: false } &&
@@ -34,6 +36,18 @@ public static class DependencyInjection
 
 		services.AddMassTransit(x =>
 		{
+			// transactional bus outbox: a published event is written to the
+			// OutboxMessage table inside the same SaveChanges as the business
+			// change (so a broker outage can no longer drop an event), then the
+			// delivery service ships it to RabbitMQ after the commit. TDbContext
+			// is supplied by the composition root so Infrastructure never has to
+			// reference the Persistence project (LayerDependencyTests forbids it).
+			x.AddEntityFrameworkOutbox<TDbContext>(o =>
+			{
+				o.UsePostgres();
+				o.UseBusOutbox();
+			});
+
 			x.UsingRabbitMq((ctx, cfg) =>
 			{
 				var options = ctx.GetRequiredService<IOptions<RabbitMqOptions>>().Value;

--- a/services/guild/src/Guild.Infrastructure/Guild.Infrastructure.csproj
+++ b/services/guild/src/Guild.Infrastructure/Guild.Infrastructure.csproj
@@ -10,6 +10,7 @@
 
     <ItemGroup>
         <PackageReference Include="MassTransit.RabbitMQ" Version="8.4.1"/>
+        <PackageReference Include="MassTransit.EntityFrameworkCore" Version="8.4.1"/>
     </ItemGroup>
 
     <PropertyGroup>

--- a/services/guild/src/Guild.Persistence/Db/Configurations/GuildBanConfig.cs
+++ b/services/guild/src/Guild.Persistence/Db/Configurations/GuildBanConfig.cs
@@ -11,6 +11,11 @@ internal sealed class GuildBanConfig : IEntityTypeConfiguration<GuildBan>
 	{
 		builder.ToTable("guild_bans");
 
+		// optimistic concurrency via Postgres xmin (no DDL). see GuildConfig.
+		// this is the token that turns the AlreadyBanned race into a clean 409
+		// instead of a 500 on the composite-PK insert.
+		builder.UseXminConcurrencyToken();
+
 		builder.HasKey(b => new { b.GuildId, b.UserId });
 
 		builder.Property(b => b.GuildId).HasColumnName("guild_id").IsRequired();

--- a/services/guild/src/Guild.Persistence/Db/Configurations/GuildBanConfig.cs
+++ b/services/guild/src/Guild.Persistence/Db/Configurations/GuildBanConfig.cs
@@ -12,8 +12,12 @@ internal sealed class GuildBanConfig : IEntityTypeConfiguration<GuildBan>
 		builder.ToTable("guild_bans");
 
 		// optimistic concurrency via Postgres xmin (no DDL). see GuildConfig.
-		// this is the token that turns the AlreadyBanned race into a clean 409
-		// instead of a 500 on the composite-PK insert.
+		// NOTE: xmin only lands in the WHERE of UPDATE/DELETE, so it guards a
+		// concurrent unban (DELETE) race, NOT the insert race. a concurrent
+		// double-ban is two INSERTs on the composite PK; the loser raises a
+		// 23505 unique violation (a DbUpdateException, not a
+		// DbUpdateConcurrencyException) that the global exception handler maps
+		// to a 409 instead of a 500.
 		builder.UseXminConcurrencyToken();
 
 		builder.HasKey(b => new { b.GuildId, b.UserId });

--- a/services/guild/src/Guild.Persistence/Db/Configurations/GuildConfig.cs
+++ b/services/guild/src/Guild.Persistence/Db/Configurations/GuildConfig.cs
@@ -10,6 +10,14 @@ internal sealed class GuildConfig : IEntityTypeConfiguration<GuildEntity>
 	{
 		builder.ToTable("guilds");
 
+		// optimistic concurrency via Postgres' xmin system column. two writers
+		// that loaded the same row version and both commit make the second
+		// SaveChanges throw DbUpdateConcurrencyException (mapped to 409 Conflict
+		// in Program.cs), closing the last-write-wins races (ban, role reorder,
+		// settings). no DDL and no migration column: xmin already exists on every
+		// row, EF just maps a shadow property onto it.
+		builder.UseXminConcurrencyToken();
+
 		builder.HasKey(g => g.Id);
 		builder.Property(g => g.Id)
 			.HasColumnName("id")

--- a/services/guild/src/Guild.Persistence/Db/Configurations/GuildInviteConfig.cs
+++ b/services/guild/src/Guild.Persistence/Db/Configurations/GuildInviteConfig.cs
@@ -11,6 +11,9 @@ internal sealed class GuildInviteConfig : IEntityTypeConfiguration<GuildInvite>
 	{
 		builder.ToTable("guild_invites");
 
+		// optimistic concurrency via Postgres xmin (no DDL). see GuildConfig.
+		builder.UseXminConcurrencyToken();
+
 		builder.HasKey(i => i.Code);
 
 		builder.Property(i => i.Code)

--- a/services/guild/src/Guild.Persistence/Db/Configurations/GuildMemberConfig.cs
+++ b/services/guild/src/Guild.Persistence/Db/Configurations/GuildMemberConfig.cs
@@ -10,6 +10,9 @@ internal sealed class GuildMemberConfig : IEntityTypeConfiguration<GuildMember>
 	{
 		builder.ToTable("guild_members");
 
+		// optimistic concurrency via Postgres xmin (no DDL). see GuildConfig.
+		builder.UseXminConcurrencyToken();
+
 		builder.HasKey(m => new { m.GuildId, m.UserId });
 
 		builder.Property(m => m.GuildId).HasColumnName("guild_id");

--- a/services/guild/src/Guild.Persistence/Db/Configurations/RoleConfig.cs
+++ b/services/guild/src/Guild.Persistence/Db/Configurations/RoleConfig.cs
@@ -10,6 +10,9 @@ internal sealed class RoleConfig : IEntityTypeConfiguration<Role>
 	{
 		builder.ToTable("roles");
 
+		// optimistic concurrency via Postgres xmin (no DDL). see GuildConfig.
+		builder.UseXminConcurrencyToken();
+
 		builder.HasKey(r => r.Id);
 		builder.Property(r => r.Id)
 			.HasColumnName("id")

--- a/services/guild/src/Guild.Persistence/Db/GuildDbContext.cs
+++ b/services/guild/src/Guild.Persistence/Db/GuildDbContext.cs
@@ -1,4 +1,5 @@
 using Guild.Domain.Guild;
+using MassTransit;
 using Microsoft.EntityFrameworkCore;
 using GuildEntity = Guild.Domain.Guild.Guild;
 
@@ -20,6 +21,16 @@ public sealed class GuildDbContext(DbContextOptions<GuildDbContext> options) : D
 	{
 		base.OnModelCreating(modelBuilder);
 		modelBuilder.RegisterPostgresEnums();
+
+		// MassTransit transactional (bus) outbox tables. publishing an event now
+		// writes an OutboxMessage row inside the same SaveChanges as the business
+		// change, so the DB commit and the event can never diverge: a broker
+		// outage no longer drops events, and the delivery service ships them once
+		// the transaction has committed. see Infrastructure AddEntityFrameworkOutbox
+		modelBuilder.AddInboxStateEntity();
+		modelBuilder.AddOutboxStateEntity();
+		modelBuilder.AddOutboxMessageEntity();
+
 		modelBuilder.ApplyConfigurationsFromAssembly(typeof(GuildDbContext).Assembly);
 	}
 }

--- a/services/guild/src/Guild.Persistence/Db/XminConcurrency.cs
+++ b/services/guild/src/Guild.Persistence/Db/XminConcurrency.cs
@@ -1,0 +1,27 @@
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Guild.Persistence.Db;
+
+/// <summary>
+/// adds optimistic-concurrency control backed by Postgres' <c>xmin</c> system
+/// column. <c>xmin</c> holds the id of the transaction that last wrote a row and
+/// Postgres bumps it on every UPDATE, so it works as a row version for free.
+/// </summary>
+/// <remarks>
+/// uses the standard EF <c>IsRowVersion()</c> on a <c>uint</c> shadow property:
+/// the Npgsql provider maps any <c>uint</c> row-version property to <c>xmin</c>
+/// automatically (the PostgreSQL-specific <c>UseXminAsConcurrencyToken()</c>
+/// helper was removed in Npgsql 7.0+). a shadow property keeps the Domain
+/// entities persistence-ignorant. there is no DDL: <c>xmin</c> is an existing
+/// system column, so the migration adds no column and EF simply appends
+/// <c>WHERE xmin = @original</c> to every UPDATE/DELETE, throwing
+/// <c>DbUpdateConcurrencyException</c> when the row was changed underneath it.
+/// </remarks>
+internal static class XminConcurrency
+{
+	public static void UseXminConcurrencyToken<T>(this EntityTypeBuilder<T> builder)
+		where T : class
+	{
+		builder.Property<uint>("Version").IsRowVersion();
+	}
+}

--- a/services/guild/src/Guild.Persistence/DependencyInjection.cs
+++ b/services/guild/src/Guild.Persistence/DependencyInjection.cs
@@ -25,6 +25,7 @@ public static class DependencyInjection
 			config.UseNpgsql(options.ToConnectionString(), o => o.MapPostgresEnums());
 		});
 
+		services.AddScoped<IUnitOfWork, UnitOfWork>();
 		services.AddScoped<IGuildRepository, GuildRepository>();
 		services.AddScoped<IGuildInviteRepository, GuildInviteRepository>();
 		services.AddScoped<IGuildBanRepository, GuildBanRepository>();

--- a/services/guild/src/Guild.Persistence/Guild.Persistence.csproj
+++ b/services/guild/src/Guild.Persistence/Guild.Persistence.csproj
@@ -7,6 +7,7 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.0" />
         <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
+        <PackageReference Include="MassTransit.EntityFrameworkCore" Version="8.4.1" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.1">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/services/guild/src/Guild.Persistence/Maintenance/InviteCleanupService.cs
+++ b/services/guild/src/Guild.Persistence/Maintenance/InviteCleanupService.cs
@@ -1,5 +1,6 @@
 using Guild.Application.Abstractions.Messaging;
 using Guild.Application.Features.Invites.CleanupExpiredInvites;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -43,6 +44,12 @@ internal sealed class InviteCleanupService(
 		catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
 		{
 			// shutting down: let the loop's WaitForNextTickAsync observe the cancellation
+		}
+		catch (DbUpdateException ex)
+		{
+			// a row lock / write conflict on the invite rows is transient; the next
+			// tick retries, so warn rather than error (which implies something broken)
+			logger.LogWarning(ex, "invite cleanup sweep hit a transient DB conflict; retrying next tick");
 		}
 		catch (Exception ex)
 		{

--- a/services/guild/src/Guild.Persistence/Migrations/20260628143938_AddMassTransitOutbox.Designer.cs
+++ b/services/guild/src/Guild.Persistence/Migrations/20260628143938_AddMassTransitOutbox.Designer.cs
@@ -4,6 +4,7 @@ using Guild.Domain.Guild;
 using Guild.Persistence.Db;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Guild.Persistence.Migrations
 {
     [DbContext(typeof(GuildDbContext))]
-    partial class GuildDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260628143938_AddMassTransitOutbox")]
+    partial class AddMassTransitOutbox
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/services/guild/src/Guild.Persistence/Migrations/20260628143938_AddMassTransitOutbox.cs
+++ b/services/guild/src/Guild.Persistence/Migrations/20260628143938_AddMassTransitOutbox.cs
@@ -1,0 +1,142 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace Guild.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddMassTransitOutbox : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "InboxState",
+                columns: table => new
+                {
+                    Id = table.Column<long>(type: "bigint", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    MessageId = table.Column<Guid>(type: "uuid", nullable: false),
+                    ConsumerId = table.Column<Guid>(type: "uuid", nullable: false),
+                    LockId = table.Column<Guid>(type: "uuid", nullable: false),
+                    RowVersion = table.Column<byte[]>(type: "bytea", rowVersion: true, nullable: true),
+                    Received = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    ReceiveCount = table.Column<int>(type: "integer", nullable: false),
+                    ExpirationTime = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    Consumed = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    Delivered = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    LastSequenceNumber = table.Column<long>(type: "bigint", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_InboxState", x => x.Id);
+                    table.UniqueConstraint("AK_InboxState_MessageId_ConsumerId", x => new { x.MessageId, x.ConsumerId });
+                });
+
+            migrationBuilder.CreateTable(
+                name: "OutboxState",
+                columns: table => new
+                {
+                    OutboxId = table.Column<Guid>(type: "uuid", nullable: false),
+                    LockId = table.Column<Guid>(type: "uuid", nullable: false),
+                    RowVersion = table.Column<byte[]>(type: "bytea", rowVersion: true, nullable: true),
+                    Created = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    Delivered = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    LastSequenceNumber = table.Column<long>(type: "bigint", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_OutboxState", x => x.OutboxId);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "OutboxMessage",
+                columns: table => new
+                {
+                    SequenceNumber = table.Column<long>(type: "bigint", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    EnqueueTime = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    SentTime = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    Headers = table.Column<string>(type: "text", nullable: true),
+                    Properties = table.Column<string>(type: "text", nullable: true),
+                    InboxMessageId = table.Column<Guid>(type: "uuid", nullable: true),
+                    InboxConsumerId = table.Column<Guid>(type: "uuid", nullable: true),
+                    OutboxId = table.Column<Guid>(type: "uuid", nullable: true),
+                    MessageId = table.Column<Guid>(type: "uuid", nullable: false),
+                    ContentType = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
+                    MessageType = table.Column<string>(type: "text", nullable: false),
+                    Body = table.Column<string>(type: "text", nullable: false),
+                    ConversationId = table.Column<Guid>(type: "uuid", nullable: true),
+                    CorrelationId = table.Column<Guid>(type: "uuid", nullable: true),
+                    InitiatorId = table.Column<Guid>(type: "uuid", nullable: true),
+                    RequestId = table.Column<Guid>(type: "uuid", nullable: true),
+                    SourceAddress = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true),
+                    DestinationAddress = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true),
+                    ResponseAddress = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true),
+                    FaultAddress = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true),
+                    ExpirationTime = table.Column<DateTime>(type: "timestamp with time zone", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_OutboxMessage", x => x.SequenceNumber);
+                    table.ForeignKey(
+                        name: "FK_OutboxMessage_InboxState_InboxMessageId_InboxConsumerId",
+                        columns: x => new { x.InboxMessageId, x.InboxConsumerId },
+                        principalTable: "InboxState",
+                        principalColumns: new[] { "MessageId", "ConsumerId" });
+                    table.ForeignKey(
+                        name: "FK_OutboxMessage_OutboxState_OutboxId",
+                        column: x => x.OutboxId,
+                        principalTable: "OutboxState",
+                        principalColumn: "OutboxId");
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_InboxState_Delivered",
+                table: "InboxState",
+                column: "Delivered");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OutboxMessage_EnqueueTime",
+                table: "OutboxMessage",
+                column: "EnqueueTime");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OutboxMessage_ExpirationTime",
+                table: "OutboxMessage",
+                column: "ExpirationTime");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OutboxMessage_InboxMessageId_InboxConsumerId_SequenceNumber",
+                table: "OutboxMessage",
+                columns: new[] { "InboxMessageId", "InboxConsumerId", "SequenceNumber" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OutboxMessage_OutboxId_SequenceNumber",
+                table: "OutboxMessage",
+                columns: new[] { "OutboxId", "SequenceNumber" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_OutboxState_Created",
+                table: "OutboxState",
+                column: "Created");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "OutboxMessage");
+
+            migrationBuilder.DropTable(
+                name: "InboxState");
+
+            migrationBuilder.DropTable(
+                name: "OutboxState");
+        }
+    }
+}

--- a/services/guild/src/Guild.Persistence/Migrations/20260628145655_AddXminConcurrencyTokens.Designer.cs
+++ b/services/guild/src/Guild.Persistence/Migrations/20260628145655_AddXminConcurrencyTokens.Designer.cs
@@ -4,6 +4,7 @@ using Guild.Domain.Guild;
 using Guild.Persistence.Db;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Guild.Persistence.Migrations
 {
     [DbContext(typeof(GuildDbContext))]
-    partial class GuildDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260628145655_AddXminConcurrencyTokens")]
+    partial class AddXminConcurrencyTokens
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/services/guild/src/Guild.Persistence/Migrations/20260628145655_AddXminConcurrencyTokens.cs
+++ b/services/guild/src/Guild.Persistence/Migrations/20260628145655_AddXminConcurrencyTokens.cs
@@ -1,0 +1,37 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Guild.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddXminConcurrencyTokens : Migration
+    {
+        // This migration intentionally has NO DDL.
+        //
+        // The Guild/Role/GuildMember/GuildBan/GuildInvite entities now map a uint
+        // shadow property to Postgres' `xmin` system column as an optimistic-
+        // concurrency token (see XminConcurrency + the entity configs). `xmin`
+        // already exists on every table as a system column, so it must NOT be
+        // created. Npgsql removed UseXminAsConcurrencyToken() in 7.0+ and its
+        // IsRowVersion() replacement scaffolds an AddColumn("xmin", "xid") that
+        // PostgreSQL rejects ("column name xmin conflicts with a system column").
+        // See npgsql/efcore.pg issues #2558 and #3539 (both closed "not planned").
+        //
+        // The fix is to keep the model/snapshot mapping (so EF appends
+        // `WHERE xmin = @original` to every UPDATE/DELETE and raises
+        // DbUpdateConcurrencyException on a lost write) while emptying the
+        // generated column DDL here. The model snapshot still records the token,
+        // so later migrations diff cleanly and never re-scaffold these columns.
+
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+        }
+    }
+}

--- a/services/guild/src/Guild.Persistence/Repositories/ChannelCategoryRepository.cs
+++ b/services/guild/src/Guild.Persistence/Repositories/ChannelCategoryRepository.cs
@@ -24,9 +24,9 @@ internal sealed class ChannelCategoryRepository(GuildDbContext context) : IChann
 			.MaxAsync(cancellationToken);
 	}
 
-	public async Task AddAsync(ChannelCategory category, CancellationToken cancellationToken = default)
+	public void Add(ChannelCategory category)
 	{
-		await context.ChannelCategories.AddAsync(category, cancellationToken);
+		context.ChannelCategories.Add(category);
 	}
 
 	public void Update(ChannelCategory category)

--- a/services/guild/src/Guild.Persistence/Repositories/ChannelCategoryRepository.cs
+++ b/services/guild/src/Guild.Persistence/Repositories/ChannelCategoryRepository.cs
@@ -38,9 +38,4 @@ internal sealed class ChannelCategoryRepository(GuildDbContext context) : IChann
 	{
 		context.ChannelCategories.Remove(category);
 	}
-
-	public Task SaveChangesAsync(CancellationToken cancellationToken = default)
-	{
-		return context.SaveChangesAsync(cancellationToken);
-	}
 }

--- a/services/guild/src/Guild.Persistence/Repositories/ChannelPermissionOverwriteRepository.cs
+++ b/services/guild/src/Guild.Persistence/Repositories/ChannelPermissionOverwriteRepository.cs
@@ -55,9 +55,4 @@ internal sealed class ChannelPermissionOverwriteRepository(GuildDbContext contex
 	{
 		context.ChannelPermissionOverwrites.Remove(overwrite);
 	}
-
-	public Task SaveChangesAsync(CancellationToken cancellationToken = default)
-	{
-		return context.SaveChangesAsync(cancellationToken);
-	}
 }

--- a/services/guild/src/Guild.Persistence/Repositories/ChannelPermissionOverwriteRepository.cs
+++ b/services/guild/src/Guild.Persistence/Repositories/ChannelPermissionOverwriteRepository.cs
@@ -41,9 +41,9 @@ internal sealed class ChannelPermissionOverwriteRepository(GuildDbContext contex
 				cancellationToken);
 	}
 
-	public async Task AddAsync(ChannelPermissionOverwrite overwrite, CancellationToken cancellationToken = default)
+	public void Add(ChannelPermissionOverwrite overwrite)
 	{
-		await context.ChannelPermissionOverwrites.AddAsync(overwrite, cancellationToken);
+		context.ChannelPermissionOverwrites.Add(overwrite);
 	}
 
 	public void Update(ChannelPermissionOverwrite overwrite)

--- a/services/guild/src/Guild.Persistence/Repositories/ChannelRepository.cs
+++ b/services/guild/src/Guild.Persistence/Repositories/ChannelRepository.cs
@@ -46,9 +46,4 @@ internal sealed class ChannelRepository(GuildDbContext context) : IChannelReposi
 	{
 		context.Channels.Remove(channel);
 	}
-
-	public Task SaveChangesAsync(CancellationToken cancellationToken = default)
-	{
-		return context.SaveChangesAsync(cancellationToken);
-	}
 }

--- a/services/guild/src/Guild.Persistence/Repositories/ChannelRepository.cs
+++ b/services/guild/src/Guild.Persistence/Repositories/ChannelRepository.cs
@@ -32,9 +32,9 @@ internal sealed class ChannelRepository(GuildDbContext context) : IChannelReposi
 			.MaxAsync(cancellationToken);
 	}
 
-	public async Task AddAsync(Channel channel, CancellationToken cancellationToken = default)
+	public void Add(Channel channel)
 	{
-		await context.Channels.AddAsync(channel, cancellationToken);
+		context.Channels.Add(channel);
 	}
 
 	public void Update(Channel channel)

--- a/services/guild/src/Guild.Persistence/Repositories/GuildBanRepository.cs
+++ b/services/guild/src/Guild.Persistence/Repositories/GuildBanRepository.cs
@@ -13,7 +13,7 @@ internal sealed class GuildBanRepository(GuildDbContext context) : IGuildBanRepo
 		int limit,
 		CancellationToken cancellationToken = default)
 	{
-		var query = context.GuildBans.Where(b => b.GuildId == guildId);
+		var query = context.GuildBans.AsNoTracking().Where(b => b.GuildId == guildId);
 		if (afterUserId is { } cursor)
 			query = query.Where(b => b.UserId > cursor);
 

--- a/services/guild/src/Guild.Persistence/Repositories/GuildBanRepository.cs
+++ b/services/guild/src/Guild.Persistence/Repositories/GuildBanRepository.cs
@@ -29,9 +29,9 @@ internal sealed class GuildBanRepository(GuildDbContext context) : IGuildBanRepo
 			.FirstOrDefaultAsync(b => b.GuildId == guildId && b.UserId == userId, cancellationToken);
 	}
 
-	public async Task AddAsync(GuildBan ban, CancellationToken cancellationToken = default)
+	public void Add(GuildBan ban)
 	{
-		await context.GuildBans.AddAsync(ban, cancellationToken);
+		context.GuildBans.Add(ban);
 	}
 
 	public void Remove(GuildBan ban)

--- a/services/guild/src/Guild.Persistence/Repositories/GuildInviteRepository.cs
+++ b/services/guild/src/Guild.Persistence/Repositories/GuildInviteRepository.cs
@@ -31,11 +31,6 @@ internal sealed class GuildInviteRepository(GuildDbContext context) : IGuildInvi
 		context.GuildInvites.Update(invite);
 	}
 
-	public Task SaveChangesAsync(CancellationToken cancellationToken = default)
-	{
-		return context.SaveChangesAsync(cancellationToken);
-	}
-
 	public Task<int> DeleteRevokedAndExpiredAsync(DateTimeOffset expiredBefore, CancellationToken cancellationToken = default) => context.GuildInvites
 		.Where(i => i.IsRevoked || (i.ExpiresAt != null && i.ExpiresAt < expiredBefore))
 		.ExecuteDeleteAsync(cancellationToken);

--- a/services/guild/src/Guild.Persistence/Repositories/GuildInviteRepository.cs
+++ b/services/guild/src/Guild.Persistence/Repositories/GuildInviteRepository.cs
@@ -21,9 +21,9 @@ internal sealed class GuildInviteRepository(GuildDbContext context) : IGuildInvi
 			.ToListAsync(cancellationToken);
 	}
 
-	public async Task AddAsync(GuildInvite invite, CancellationToken cancellationToken = default)
+	public void Add(GuildInvite invite)
 	{
-		await context.GuildInvites.AddAsync(invite, cancellationToken);
+		context.GuildInvites.Add(invite);
 	}
 
 	public void Update(GuildInvite invite)

--- a/services/guild/src/Guild.Persistence/Repositories/GuildRepository.cs
+++ b/services/guild/src/Guild.Persistence/Repositories/GuildRepository.cs
@@ -110,9 +110,4 @@ internal sealed class GuildRepository(GuildDbContext context) : IGuildRepository
 	{
 		context.Guilds.Remove(guild);
 	}
-
-	public Task SaveChangesAsync(CancellationToken cancellationToken = default)
-	{
-		return context.SaveChangesAsync(cancellationToken);
-	}
 }

--- a/services/guild/src/Guild.Persistence/Repositories/GuildRepository.cs
+++ b/services/guild/src/Guild.Persistence/Repositories/GuildRepository.cs
@@ -29,6 +29,13 @@ internal sealed class GuildRepository(GuildDbContext context) : IGuildRepository
 
 	public Task<GuildEntity?> GetByIdWithMembershipAsNoTrackingAsync(long id, CancellationToken cancellationToken = default)
 	{
+		// KNOWN TRADE-OFF: AsSplitQuery issues one SELECT per collection, not
+		// wrapped in a single snapshot, so a membership change committing between
+		// the Members and MemberRoles selects yields a momentarily inconsistent
+		// read (e.g. member present but their role rows missing). this is an
+		// eventual-consistency read endpoint and the skew is fail-safe -
+		// permissions are under-evaluated, never over-granted - so we accept it
+		// rather than forcing a REPEATABLE READ transaction on a hot read path.
 		return context.Guilds
 			.AsNoTracking()
 			.Include(g => g.Roles)
@@ -57,7 +64,11 @@ internal sealed class GuildRepository(GuildDbContext context) : IGuildRepository
 			return [];
 
 		// second bounded query: role ids for just the members on this page,
-		// grouped in memory (at most `limit` members, not the whole guild)
+		// grouped in memory (at most `limit` members, not the whole guild).
+		// KNOWN TRADE-OFF: this is a separate, non-snapshotted query, so a role
+		// change committing between the two selects can leave a member listed with
+		// stale RoleIds. acceptable eventual consistency for a paginated list; a
+		// fresh page reflects the change.
 		var userIds = members.Select(m => m.UserId).ToList();
 		var assignments = await context.MemberRoles
 			.AsNoTracking()

--- a/services/guild/src/Guild.Persistence/Repositories/GuildRepository.cs
+++ b/services/guild/src/Guild.Persistence/Repositories/GuildRepository.cs
@@ -96,9 +96,9 @@ internal sealed class GuildRepository(GuildDbContext context) : IGuildRepository
 			.AnyAsync(m => m.GuildId == guildId && m.UserId == userId, cancellationToken);
 	}
 
-	public async Task AddAsync(GuildEntity guild, CancellationToken cancellationToken = default)
+	public void Add(GuildEntity guild)
 	{
-		await context.Guilds.AddAsync(guild, cancellationToken);
+		context.Guilds.Add(guild);
 	}
 
 	public void Update(GuildEntity guild)

--- a/services/guild/src/Guild.Persistence/Repositories/GuildRepository.cs
+++ b/services/guild/src/Guild.Persistence/Repositories/GuildRepository.cs
@@ -15,11 +15,67 @@ internal sealed class GuildRepository(GuildDbContext context) : IGuildRepository
 
 	public Task<GuildEntity?> GetByIdWithMembershipAsync(long id, CancellationToken cancellationToken = default)
 	{
+		// AsSplitQuery: three collection Includes on one root would otherwise
+		// produce a cartesian product (members x roles x member-roles) in a
+		// single JOIN. split queries issue one SELECT per collection instead,
+		// which EF 10 actively warns about when omitted here.
 		return context.Guilds
 			.Include(g => g.Roles)
 			.Include(g => g.Members)
 			.Include(g => g.MemberRoles)
+			.AsSplitQuery()
 			.FirstOrDefaultAsync(g => g.Id == id, cancellationToken);
+	}
+
+	public Task<GuildEntity?> GetByIdWithMembershipAsNoTrackingAsync(long id, CancellationToken cancellationToken = default)
+	{
+		return context.Guilds
+			.AsNoTracking()
+			.Include(g => g.Roles)
+			.Include(g => g.Members)
+			.Include(g => g.MemberRoles)
+			.AsSplitQuery()
+			.FirstOrDefaultAsync(g => g.Id == id, cancellationToken);
+	}
+
+	public async Task<IReadOnlyList<MemberPage>> PageMembersAsync(
+		long guildId, long? afterUserId, int limit, CancellationToken cancellationToken = default)
+	{
+		var membersQuery = context.Members
+			.AsNoTracking()
+			.Where(m => m.GuildId == guildId);
+		if (afterUserId is { } cursor)
+			membersQuery = membersQuery.Where(m => m.UserId > cursor);
+
+		var members = await membersQuery
+			.OrderBy(m => m.UserId)
+			.Take(limit)
+			.Select(m => new { m.UserId, m.Nickname, m.JoinedAt })
+			.ToListAsync(cancellationToken);
+
+		if (members.Count == 0)
+			return [];
+
+		// second bounded query: role ids for just the members on this page,
+		// grouped in memory (at most `limit` members, not the whole guild)
+		var userIds = members.Select(m => m.UserId).ToList();
+		var assignments = await context.MemberRoles
+			.AsNoTracking()
+			.Where(mr => mr.GuildId == guildId && userIds.Contains(mr.UserId))
+			.Select(mr => new { mr.UserId, mr.RoleId })
+			.ToListAsync(cancellationToken);
+
+		var rolesByUser = assignments
+			.GroupBy(a => a.UserId)
+			.ToDictionary(g => g.Key, g => (IReadOnlyList<long>)g.Select(a => a.RoleId).ToList());
+
+		return members
+			.Select(m => new MemberPage(
+				m.UserId,
+				m.Nickname,
+				m.JoinedAt,
+				rolesByUser.TryGetValue(m.UserId, out var ids) ? ids : []))
+			.ToList();
 	}
 
 	public Task<int> CountMembersAsync(long guildId, CancellationToken cancellationToken = default)

--- a/services/guild/src/Guild.Persistence/Repositories/UnitOfWork.cs
+++ b/services/guild/src/Guild.Persistence/Repositories/UnitOfWork.cs
@@ -1,0 +1,14 @@
+using Guild.Application.Abstractions.Persistence;
+using Guild.Persistence.Db;
+
+namespace Guild.Persistence.Repositories;
+
+/// <summary>
+/// commits the scoped <see cref="GuildDbContext"/> - the single EF unit of work
+/// that every repository tracks changes against.
+/// </summary>
+internal sealed class UnitOfWork(GuildDbContext context) : IUnitOfWork
+{
+	public Task SaveChangesAsync(CancellationToken cancellationToken = default) =>
+		context.SaveChangesAsync(cancellationToken);
+}

--- a/services/guild/src/Guild.Presentation/Endpoints/BansEndpoint.cs
+++ b/services/guild/src/Guild.Presentation/Endpoints/BansEndpoint.cs
@@ -25,7 +25,7 @@ public sealed class BansEndpoint : ICarterModule
 		long id,
 		string? after,
 		int? limit,
-		IQueryHandler<ListBansQuery, Result<BanListResponse>> handler,
+		IQueryHandler<ListBansQuery, Result<IReadOnlyList<BanResponse>>> handler,
 		CancellationToken cancellationToken)
 	{
 		var (afterCursor, effectiveLimit, error) = Pagination.Parse(after, limit);
@@ -37,7 +37,7 @@ public sealed class BansEndpoint : ICarterModule
 			cancellationToken);
 
 		if (result.Succeeded)
-			return TypedResults.Ok(result.Value.Items);
+			return TypedResults.Ok(result.Value);
 
 		return EndpointResults.Problem(result.Error);
 	}

--- a/services/guild/src/Guild.Presentation/Endpoints/BansEndpoint.cs
+++ b/services/guild/src/Guild.Presentation/Endpoints/BansEndpoint.cs
@@ -12,9 +12,6 @@ namespace Guild.Presentation.Endpoints;
 
 public sealed class BansEndpoint : ICarterModule
 {
-	private const int DefaultListLimit = 50;
-	private const int MaxListLimit = 100;
-
 	public void AddRoutes(IEndpointRouteBuilder endpoints)
 	{
 		var group = endpoints.MapGroup("/guilds/{id:long}/bans");
@@ -31,17 +28,9 @@ public sealed class BansEndpoint : ICarterModule
 		IQueryHandler<ListBansQuery, Result<BanListResponse>> handler,
 		CancellationToken cancellationToken)
 	{
-		long? afterCursor = null;
-		if (after is not null)
-		{
-			if (!long.TryParse(after, out var parsed) || parsed <= 0)
-				return TypedResults.Json(new ErrorBody("after must be a positive snowflake."), statusCode: StatusCodes.Status400BadRequest);
-			afterCursor = parsed;
-		}
-
-		var effectiveLimit = limit ?? DefaultListLimit;
-		if (effectiveLimit <= 0 || effectiveLimit > MaxListLimit)
-			return TypedResults.Json(new ErrorBody($"limit must be between 1 and {MaxListLimit}."), statusCode: StatusCodes.Status400BadRequest);
+		var (afterCursor, effectiveLimit, error) = Pagination.Parse(after, limit);
+		if (error is not null)
+			return error;
 
 		var result = await handler.HandleAsync(
 			new ListBansQuery(id, afterCursor, effectiveLimit),

--- a/services/guild/src/Guild.Presentation/Endpoints/BansEndpoint.cs
+++ b/services/guild/src/Guild.Presentation/Endpoints/BansEndpoint.cs
@@ -15,9 +15,9 @@ public sealed class BansEndpoint : ICarterModule
 	public void AddRoutes(IEndpointRouteBuilder endpoints)
 	{
 		var group = endpoints.MapGroup("/guilds/{id:long}/bans");
-		group.MapGet("/", ListAsync);
-		group.MapPost("/{userId:long}", BanAsync);
-		group.MapDelete("/{userId:long}", UnbanAsync);
+		group.MapGet("/", ListAsync).ProducesGuildErrors();
+		group.MapPost("/{userId:long}", BanAsync).ProducesGuildErrors().ProducesConflict();
+		group.MapDelete("/{userId:long}", UnbanAsync).ProducesGuildErrors();
 	}
 
 	private static async Task<Results<Ok<IReadOnlyList<BanResponse>>, JsonHttpResult<ErrorBody>>>

--- a/services/guild/src/Guild.Presentation/Endpoints/BansEndpoint.cs
+++ b/services/guild/src/Guild.Presentation/Endpoints/BansEndpoint.cs
@@ -23,11 +23,7 @@ public sealed class BansEndpoint : ICarterModule
 		group.MapDelete("/{userId:long}", UnbanAsync);
 	}
 
-	private static async Task<Results<
-		Ok<IReadOnlyList<BanResponse>>,
-		BadRequest<ErrorBody>,
-		NotFound<ErrorBody>,
-		JsonHttpResult<ErrorBody>>>
+	private static async Task<Results<Ok<IReadOnlyList<BanResponse>>, JsonHttpResult<ErrorBody>>>
 	ListAsync(
 		long id,
 		string? after,
@@ -39,13 +35,13 @@ public sealed class BansEndpoint : ICarterModule
 		if (after is not null)
 		{
 			if (!long.TryParse(after, out var parsed) || parsed <= 0)
-				return TypedResults.BadRequest(new ErrorBody("after must be a positive snowflake."));
+				return TypedResults.Json(new ErrorBody("after must be a positive snowflake."), statusCode: StatusCodes.Status400BadRequest);
 			afterCursor = parsed;
 		}
 
 		var effectiveLimit = limit ?? DefaultListLimit;
 		if (effectiveLimit <= 0 || effectiveLimit > MaxListLimit)
-			return TypedResults.BadRequest(new ErrorBody($"limit must be between 1 and {MaxListLimit}."));
+			return TypedResults.Json(new ErrorBody($"limit must be between 1 and {MaxListLimit}."), statusCode: StatusCodes.Status400BadRequest);
 
 		var result = await handler.HandleAsync(
 			new ListBansQuery(id, afterCursor, effectiveLimit),
@@ -54,21 +50,10 @@ public sealed class BansEndpoint : ICarterModule
 		if (result.Succeeded)
 			return TypedResults.Ok(result.Value.Items);
 
-		return result.Error.Code switch
-		{
-			"Guild.GuildNotFound" => TypedResults.NotFound(new ErrorBody(result.Error.Message)),
-			"Guild.NotAMember" => TypedResults.Json(new ErrorBody(result.Error.Message), statusCode: StatusCodes.Status403Forbidden),
-			"Guild.MissingPermission" => TypedResults.Json(new ErrorBody(result.Error.Message), statusCode: StatusCodes.Status403Forbidden),
-			_ => TypedResults.BadRequest(new ErrorBody(result.Error.Message)),
-		};
+		return EndpointResults.Problem(result.Error);
 	}
 
-	private static async Task<Results<
-		NoContent,
-		BadRequest<ErrorBody>,
-		NotFound<ErrorBody>,
-		Conflict<ErrorBody>,
-		JsonHttpResult<ErrorBody>>>
+	private static async Task<Results<NoContent, JsonHttpResult<ErrorBody>>>
 	BanAsync(
 		long id,
 		long userId,
@@ -83,25 +68,10 @@ public sealed class BansEndpoint : ICarterModule
 		if (result.Succeeded)
 			return TypedResults.NoContent();
 
-		return result.Error.Code switch
-		{
-			"Guild.GuildNotFound" => TypedResults.NotFound(new ErrorBody(result.Error.Message)),
-			"Guild.NotAMember" => TypedResults.Json(new ErrorBody(result.Error.Message), statusCode: StatusCodes.Status403Forbidden),
-			"Guild.MissingPermission" => TypedResults.Json(new ErrorBody(result.Error.Message), statusCode: StatusCodes.Status403Forbidden),
-			"Guild.CannotBanOwner" => TypedResults.Json(new ErrorBody(result.Error.Message), statusCode: StatusCodes.Status403Forbidden),
-			"Guild.RoleHierarchyBlocked" => TypedResults.Json(new ErrorBody(result.Error.Message), statusCode: StatusCodes.Status403Forbidden),
-			"Guild.CannotBanSelf" => TypedResults.BadRequest(new ErrorBody(result.Error.Message)),
-			"Guild.BanReasonTooLong" => TypedResults.BadRequest(new ErrorBody(result.Error.Message)),
-			"Guild.AlreadyBanned" => TypedResults.Conflict(new ErrorBody(result.Error.Message)),
-			_ => TypedResults.BadRequest(new ErrorBody(result.Error.Message)),
-		};
+		return EndpointResults.Problem(result.Error);
 	}
 
-	private static async Task<Results<
-		NoContent,
-		BadRequest<ErrorBody>,
-		NotFound<ErrorBody>,
-		JsonHttpResult<ErrorBody>>>
+	private static async Task<Results<NoContent, JsonHttpResult<ErrorBody>>>
 	UnbanAsync(
 		long id,
 		long userId,
@@ -114,14 +84,7 @@ public sealed class BansEndpoint : ICarterModule
 		if (result.Succeeded)
 			return TypedResults.NoContent();
 
-		return result.Error.Code switch
-		{
-			"Guild.GuildNotFound" => TypedResults.NotFound(new ErrorBody(result.Error.Message)),
-			"Guild.BanNotFound" => TypedResults.NotFound(new ErrorBody(result.Error.Message)),
-			"Guild.NotAMember" => TypedResults.Json(new ErrorBody(result.Error.Message), statusCode: StatusCodes.Status403Forbidden),
-			"Guild.MissingPermission" => TypedResults.Json(new ErrorBody(result.Error.Message), statusCode: StatusCodes.Status403Forbidden),
-			_ => TypedResults.BadRequest(new ErrorBody(result.Error.Message)),
-		};
+		return EndpointResults.Problem(result.Error);
 	}
 
 	private sealed record BanRequest(string? Reason);

--- a/services/guild/src/Guild.Presentation/Endpoints/CategoriesEndpoint.cs
+++ b/services/guild/src/Guild.Presentation/Endpoints/CategoriesEndpoint.cs
@@ -20,11 +20,7 @@ public sealed class CategoriesEndpoint : ICarterModule
 		group.MapDelete("/{categoryId:long}", DeleteAsync);
 	}
 
-	private static async Task<Results<
-		Created<CategoryResponse>,
-		BadRequest<ErrorBody>,
-		NotFound<ErrorBody>,
-		JsonHttpResult<ErrorBody>>>
+	private static async Task<Results<Created<CategoryResponse>, JsonHttpResult<ErrorBody>>>
 	CreateAsync(
 		long id,
 		CreateCategoryRequest request,
@@ -37,14 +33,10 @@ public sealed class CategoriesEndpoint : ICarterModule
 
 		return result.Succeeded
 			? TypedResults.Created($"/v1/guilds/{id}/categories/{result.Value.Id}", result.Value)
-			: MapErrorCreate(result.Error);
+			: EndpointResults.Problem(result.Error);
 	}
 
-	private static async Task<Results<
-		Ok<CategoryResponse>,
-		BadRequest<ErrorBody>,
-		NotFound<ErrorBody>,
-		JsonHttpResult<ErrorBody>>>
+	private static async Task<Results<Ok<CategoryResponse>, JsonHttpResult<ErrorBody>>>
 	UpdateAsync(
 		long id,
 		long categoryId,
@@ -56,13 +48,10 @@ public sealed class CategoriesEndpoint : ICarterModule
 			new UpdateCategoryCommand(id, categoryId, request.Name, request.Position),
 			cancellationToken);
 
-		return result.Succeeded ? TypedResults.Ok(result.Value) : MapErrorUpdate(result.Error);
+		return result.Succeeded ? TypedResults.Ok(result.Value) : EndpointResults.Problem(result.Error);
 	}
 
-	private static async Task<Results<
-		NoContent,
-		NotFound<ErrorBody>,
-		JsonHttpResult<ErrorBody>>>
+	private static async Task<Results<NoContent, JsonHttpResult<ErrorBody>>>
 	DeleteAsync(
 		long id,
 		long categoryId,
@@ -73,38 +62,13 @@ public sealed class CategoriesEndpoint : ICarterModule
 			new DeleteCategoryCommand(id, categoryId),
 			cancellationToken);
 
-		return result.Succeeded ? TypedResults.NoContent() : MapErrorDelete(result.Error);
+		return result.Succeeded ? TypedResults.NoContent() : EndpointResults.Problem(result.Error);
 	}
 
 	// ---- error mapping ----
 
-	private static Results<Created<CategoryResponse>, BadRequest<ErrorBody>, NotFound<ErrorBody>, JsonHttpResult<ErrorBody>>
-		MapErrorCreate(Failure failure) => failure.Code switch
-		{
-			"Guild.GuildNotFound" => TypedResults.NotFound(new ErrorBody(failure.Message)),
-			"Guild.NotAMember" => TypedResults.Json(new ErrorBody(failure.Message), statusCode: StatusCodes.Status403Forbidden),
-			"Guild.MissingPermission" => TypedResults.Json(new ErrorBody(failure.Message), statusCode: StatusCodes.Status403Forbidden),
-			_ => TypedResults.BadRequest(new ErrorBody(failure.Message)),
-		};
 
-	private static Results<Ok<CategoryResponse>, BadRequest<ErrorBody>, NotFound<ErrorBody>, JsonHttpResult<ErrorBody>>
-		MapErrorUpdate(Failure failure) => failure.Code switch
-		{
-			"Guild.GuildNotFound" => TypedResults.NotFound(new ErrorBody(failure.Message)),
-			"Guild.CategoryNotFound" => TypedResults.NotFound(new ErrorBody(failure.Message)),
-			"Guild.NotAMember" => TypedResults.Json(new ErrorBody(failure.Message), statusCode: StatusCodes.Status403Forbidden),
-			"Guild.MissingPermission" => TypedResults.Json(new ErrorBody(failure.Message), statusCode: StatusCodes.Status403Forbidden),
-			_ => TypedResults.BadRequest(new ErrorBody(failure.Message)),
-		};
 
-	private static Results<NoContent, NotFound<ErrorBody>, JsonHttpResult<ErrorBody>>
-		MapErrorDelete(Failure failure) => failure.Code switch
-		{
-			"Guild.GuildNotFound" => TypedResults.NotFound(new ErrorBody(failure.Message)),
-			"Guild.CategoryNotFound" => TypedResults.NotFound(new ErrorBody(failure.Message)),
-			"Guild.NotAMember" => TypedResults.Json(new ErrorBody(failure.Message), statusCode: StatusCodes.Status403Forbidden),
-			_ => TypedResults.Json(new ErrorBody(failure.Message), statusCode: StatusCodes.Status403Forbidden),
-		};
 
 	// ---- request shapes (snake_case via ConfigureHttpJsonOptions) ----
 

--- a/services/guild/src/Guild.Presentation/Endpoints/CategoriesEndpoint.cs
+++ b/services/guild/src/Guild.Presentation/Endpoints/CategoriesEndpoint.cs
@@ -15,9 +15,9 @@ public sealed class CategoriesEndpoint : ICarterModule
 	public void AddRoutes(IEndpointRouteBuilder endpoints)
 	{
 		var group = endpoints.MapGroup("/guilds/{id:long}/categories");
-		group.MapPost("/", CreateAsync);
-		group.MapPatch("/{categoryId:long}", UpdateAsync);
-		group.MapDelete("/{categoryId:long}", DeleteAsync);
+		group.MapPost("/", CreateAsync).ProducesGuildErrors();
+		group.MapPatch("/{categoryId:long}", UpdateAsync).ProducesGuildErrors();
+		group.MapDelete("/{categoryId:long}", DeleteAsync).ProducesGuildErrors();
 	}
 
 	private static async Task<Results<Created<CategoryResponse>, JsonHttpResult<ErrorBody>>>

--- a/services/guild/src/Guild.Presentation/Endpoints/ChannelMembershipEndpoint.cs
+++ b/services/guild/src/Guild.Presentation/Endpoints/ChannelMembershipEndpoint.cs
@@ -20,10 +20,7 @@ public static class ChannelMembershipEndpoint
 		endpoints.MapGet("/channels/{channelId:long}/membership", GetAsync);
 	}
 
-	private static async Task<Results<
-		Ok<MembershipResponse>,
-		BadRequest<ErrorBody>,
-		NotFound<ErrorBody>>>
+	private static async Task<Results<Ok<MembershipResponse>, JsonHttpResult<ErrorBody>>>
 	GetAsync(
 		long channelId,
 		string? user_id,
@@ -33,7 +30,7 @@ public static class ChannelMembershipEndpoint
 		// user_id is a snowflake (long). the contract doc lists it as uuid but
 		// snowflakes are the project-wide id format -> parse as long
 		if (string.IsNullOrWhiteSpace(user_id) || !long.TryParse(user_id, out var userId) || userId <= 0)
-			return TypedResults.BadRequest(new ErrorBody("user_id query parameter must be a positive snowflake."));
+			return TypedResults.Json(new ErrorBody("user_id query parameter must be a positive snowflake."), statusCode: StatusCodes.Status400BadRequest);
 
 		var result = await handler.HandleAsync(
 			new GetChannelMembershipQuery(channelId, userId),
@@ -42,11 +39,6 @@ public static class ChannelMembershipEndpoint
 		if (result.Succeeded)
 			return TypedResults.Ok(result.Value);
 
-		return result.Error.Code switch
-		{
-			"Guild.ChannelNotFound" => TypedResults.NotFound(new ErrorBody(result.Error.Message)),
-			"Guild.GuildNotFound" => TypedResults.NotFound(new ErrorBody(result.Error.Message)),
-			_ => TypedResults.BadRequest(new ErrorBody(result.Error.Message)),
-		};
+		return EndpointResults.Problem(result.Error);
 	}
 }

--- a/services/guild/src/Guild.Presentation/Endpoints/ChannelPermissionsEndpoint.cs
+++ b/services/guild/src/Guild.Presentation/Endpoints/ChannelPermissionsEndpoint.cs
@@ -14,9 +14,9 @@ public sealed class ChannelPermissionsEndpoint : ICarterModule
 	public void AddRoutes(IEndpointRouteBuilder endpoints)
 	{
 		var group = endpoints.MapGroup("/channels/{channelId:long}/permissions");
-		group.MapGet("/", ListAsync);
-		group.MapPut("/{targetId:long}", PutAsync);
-		group.MapDelete("/{targetId:long}", DeleteAsync);
+		group.MapGet("/", ListAsync).ProducesGuildErrors();
+		group.MapPut("/{targetId:long}", PutAsync).ProducesGuildErrors();
+		group.MapDelete("/{targetId:long}", DeleteAsync).ProducesGuildErrors();
 	}
 
 	private static async Task<Results<Ok<IReadOnlyList<OverwriteItem>>, JsonHttpResult<ErrorBody>>>

--- a/services/guild/src/Guild.Presentation/Endpoints/ChannelPermissionsEndpoint.cs
+++ b/services/guild/src/Guild.Presentation/Endpoints/ChannelPermissionsEndpoint.cs
@@ -19,10 +19,7 @@ public sealed class ChannelPermissionsEndpoint : ICarterModule
 		group.MapDelete("/{targetId:long}", DeleteAsync);
 	}
 
-	private static async Task<Results<
-		Ok<IReadOnlyList<OverwriteItem>>,
-		NotFound<ErrorBody>,
-		JsonHttpResult<ErrorBody>>>
+	private static async Task<Results<Ok<IReadOnlyList<OverwriteItem>>, JsonHttpResult<ErrorBody>>>
 	ListAsync(
 		long channelId,
 		IQueryHandler<GetOverwritesQuery, Result<OverwritesResponse>> handler,
@@ -31,14 +28,10 @@ public sealed class ChannelPermissionsEndpoint : ICarterModule
 		var result = await handler.HandleAsync(new GetOverwritesQuery(channelId), cancellationToken);
 		return result.Succeeded
 			? TypedResults.Ok(result.Value.Items)
-			: MapErrorList(result.Error);
+			: EndpointResults.Problem(result.Error);
 	}
 
-	private static async Task<Results<
-		NoContent,
-		BadRequest<ErrorBody>,
-		NotFound<ErrorBody>,
-		JsonHttpResult<ErrorBody>>>
+	private static async Task<Results<NoContent, JsonHttpResult<ErrorBody>>>
 	PutAsync(
 		long channelId,
 		long targetId,
@@ -57,13 +50,10 @@ public sealed class ChannelPermissionsEndpoint : ICarterModule
 
 		return result.Succeeded
 			? TypedResults.NoContent()
-			: MapErrorPut(result.Error);
+			: EndpointResults.Problem(result.Error);
 	}
 
-	private static async Task<Results<
-		NoContent,
-		NotFound<ErrorBody>,
-		JsonHttpResult<ErrorBody>>>
+	private static async Task<Results<NoContent, JsonHttpResult<ErrorBody>>>
 	DeleteAsync(
 		long channelId,
 		long targetId,
@@ -74,40 +64,13 @@ public sealed class ChannelPermissionsEndpoint : ICarterModule
 			new DeleteOverwriteCommand(channelId, targetId),
 			cancellationToken);
 
-		return result.Succeeded ? TypedResults.NoContent() : MapErrorDelete(result.Error);
+		return result.Succeeded ? TypedResults.NoContent() : EndpointResults.Problem(result.Error);
 	}
 
 	// ---- error mapping ----
 
-	private static Results<Ok<IReadOnlyList<OverwriteItem>>, NotFound<ErrorBody>, JsonHttpResult<ErrorBody>>
-		MapErrorList(Failure failure) => failure.Code switch
-		{
-			"Guild.ChannelNotFound" => TypedResults.NotFound(new ErrorBody(failure.Message)),
-			"Guild.GuildNotFound" => TypedResults.NotFound(new ErrorBody(failure.Message)),
-			"Guild.NotAMember" => TypedResults.Json(new ErrorBody(failure.Message), statusCode: StatusCodes.Status403Forbidden),
-			"Guild.MissingPermission" => TypedResults.Json(new ErrorBody(failure.Message), statusCode: StatusCodes.Status403Forbidden),
-			_ => TypedResults.Json(new ErrorBody(failure.Message), statusCode: StatusCodes.Status403Forbidden),
-		};
 
-	private static Results<NoContent, BadRequest<ErrorBody>, NotFound<ErrorBody>, JsonHttpResult<ErrorBody>>
-		MapErrorPut(Failure failure) => failure.Code switch
-		{
-			"Guild.ChannelNotFound" => TypedResults.NotFound(new ErrorBody(failure.Message)),
-			"Guild.GuildNotFound" => TypedResults.NotFound(new ErrorBody(failure.Message)),
-			"Guild.NotAMember" => TypedResults.Json(new ErrorBody(failure.Message), statusCode: StatusCodes.Status403Forbidden),
-			"Guild.MissingPermission" => TypedResults.Json(new ErrorBody(failure.Message), statusCode: StatusCodes.Status403Forbidden),
-			_ => TypedResults.BadRequest(new ErrorBody(failure.Message)),
-		};
 
-	private static Results<NoContent, NotFound<ErrorBody>, JsonHttpResult<ErrorBody>>
-		MapErrorDelete(Failure failure) => failure.Code switch
-		{
-			"Guild.ChannelNotFound" => TypedResults.NotFound(new ErrorBody(failure.Message)),
-			"Guild.GuildNotFound" => TypedResults.NotFound(new ErrorBody(failure.Message)),
-			"Guild.OverwriteNotFound" => TypedResults.NotFound(new ErrorBody(failure.Message)),
-			"Guild.NotAMember" => TypedResults.Json(new ErrorBody(failure.Message), statusCode: StatusCodes.Status403Forbidden),
-			_ => TypedResults.Json(new ErrorBody(failure.Message), statusCode: StatusCodes.Status403Forbidden),
-		};
 
 	// ---- request shape ----
 

--- a/services/guild/src/Guild.Presentation/Endpoints/ChannelsEndpoint.cs
+++ b/services/guild/src/Guild.Presentation/Endpoints/ChannelsEndpoint.cs
@@ -16,10 +16,10 @@ public sealed class ChannelsEndpoint : ICarterModule
 	public void AddRoutes(IEndpointRouteBuilder endpoints)
 	{
 		var group = endpoints.MapGroup("/guilds/{id:long}/channels");
-		group.MapGet("/", ListAsync);
-		group.MapPost("/", CreateAsync);
-		group.MapPatch("/{channelId:long}", UpdateAsync);
-		group.MapDelete("/{channelId:long}", DeleteAsync);
+		group.MapGet("/", ListAsync).ProducesGuildErrors();
+		group.MapPost("/", CreateAsync).ProducesGuildErrors();
+		group.MapPatch("/{channelId:long}", UpdateAsync).ProducesGuildErrors();
+		group.MapDelete("/{channelId:long}", DeleteAsync).ProducesGuildErrors();
 	}
 
 	private static async Task<Results<Ok<IReadOnlyList<ChannelResponse>>, JsonHttpResult<ErrorBody>>>

--- a/services/guild/src/Guild.Presentation/Endpoints/ChannelsEndpoint.cs
+++ b/services/guild/src/Guild.Presentation/Endpoints/ChannelsEndpoint.cs
@@ -22,10 +22,7 @@ public sealed class ChannelsEndpoint : ICarterModule
 		group.MapDelete("/{channelId:long}", DeleteAsync);
 	}
 
-	private static async Task<Results<
-		Ok<IReadOnlyList<ChannelResponse>>,
-		NotFound<ErrorBody>,
-		JsonHttpResult<ErrorBody>>>
+	private static async Task<Results<Ok<IReadOnlyList<ChannelResponse>>, JsonHttpResult<ErrorBody>>>
 	ListAsync(
 		long id,
 		IQueryHandler<ListChannelsQuery, Result<ChannelListResponse>> handler,
@@ -34,14 +31,10 @@ public sealed class ChannelsEndpoint : ICarterModule
 		var result = await handler.HandleAsync(new ListChannelsQuery(id), cancellationToken);
 		return result.Succeeded
 			? TypedResults.Ok(result.Value.Items)
-			: MapErrorList(result.Error);
+			: EndpointResults.Problem(result.Error);
 	}
 
-	private static async Task<Results<
-		Created<ChannelResponse>,
-		BadRequest<ErrorBody>,
-		NotFound<ErrorBody>,
-		JsonHttpResult<ErrorBody>>>
+	private static async Task<Results<Created<ChannelResponse>, JsonHttpResult<ErrorBody>>>
 	CreateAsync(
 		long id,
 		CreateChannelRequest request,
@@ -52,7 +45,7 @@ public sealed class ChannelsEndpoint : ICarterModule
 		if (request.CategoryId is { Length: > 0 } raw)
 		{
 			if (!long.TryParse(raw, out var parsed))
-				return TypedResults.BadRequest(new ErrorBody("category_id must be a snowflake string."));
+				return TypedResults.Json(new ErrorBody("category_id must be a snowflake string."), statusCode: StatusCodes.Status400BadRequest);
 			categoryId = parsed;
 		}
 
@@ -70,14 +63,10 @@ public sealed class ChannelsEndpoint : ICarterModule
 
 		return result.Succeeded
 			? TypedResults.Created($"/v1/guilds/{id}/channels/{result.Value.Id}", result.Value)
-			: MapErrorCreate(result.Error);
+			: EndpointResults.Problem(result.Error);
 	}
 
-	private static async Task<Results<
-		Ok<ChannelResponse>,
-		BadRequest<ErrorBody>,
-		NotFound<ErrorBody>,
-		JsonHttpResult<ErrorBody>>>
+	private static async Task<Results<Ok<ChannelResponse>, JsonHttpResult<ErrorBody>>>
 	UpdateAsync(
 		long id,
 		long channelId,
@@ -96,7 +85,7 @@ public sealed class ChannelsEndpoint : ICarterModule
 		if (categoryProvided && request.CategoryId is { Length: > 0 } raw)
 		{
 			if (!long.TryParse(raw, out var parsed))
-				return TypedResults.BadRequest(new ErrorBody("category_id must be a snowflake string or empty to clear."));
+				return TypedResults.Json(new ErrorBody("category_id must be a snowflake string or empty to clear."), statusCode: StatusCodes.Status400BadRequest);
 			categoryId = parsed;
 		}
 
@@ -112,13 +101,10 @@ public sealed class ChannelsEndpoint : ICarterModule
 				TopicProvided: topicProvided),
 			cancellationToken);
 
-		return result.Succeeded ? TypedResults.Ok(result.Value) : MapErrorUpdate(result.Error);
+		return result.Succeeded ? TypedResults.Ok(result.Value) : EndpointResults.Problem(result.Error);
 	}
 
-	private static async Task<Results<
-		NoContent,
-		NotFound<ErrorBody>,
-		JsonHttpResult<ErrorBody>>>
+	private static async Task<Results<NoContent, JsonHttpResult<ErrorBody>>>
 	DeleteAsync(
 		long id,
 		long channelId,
@@ -129,48 +115,14 @@ public sealed class ChannelsEndpoint : ICarterModule
 			new DeleteChannelCommand(id, channelId),
 			cancellationToken);
 
-		return result.Succeeded ? TypedResults.NoContent() : MapErrorDelete(result.Error);
+		return result.Succeeded ? TypedResults.NoContent() : EndpointResults.Problem(result.Error);
 	}
 
 	// ---- error mapping ----
 
-	private static Results<Ok<IReadOnlyList<ChannelResponse>>, NotFound<ErrorBody>, JsonHttpResult<ErrorBody>>
-		MapErrorList(Failure failure) => failure.Code switch
-		{
-			"Guild.GuildNotFound" => TypedResults.NotFound(new ErrorBody(failure.Message)),
-			"Guild.NotAMember" => TypedResults.Json(new ErrorBody(failure.Message), statusCode: StatusCodes.Status403Forbidden),
-			_ => TypedResults.Json(new ErrorBody(failure.Message), statusCode: StatusCodes.Status403Forbidden),
-		};
 
-	private static Results<Created<ChannelResponse>, BadRequest<ErrorBody>, NotFound<ErrorBody>, JsonHttpResult<ErrorBody>>
-		MapErrorCreate(Failure failure) => failure.Code switch
-		{
-			"Guild.GuildNotFound" => TypedResults.NotFound(new ErrorBody(failure.Message)),
-			"Guild.CategoryNotFound" => TypedResults.NotFound(new ErrorBody(failure.Message)),
-			"Guild.NotAMember" => TypedResults.Json(new ErrorBody(failure.Message), statusCode: StatusCodes.Status403Forbidden),
-			"Guild.MissingPermission" => TypedResults.Json(new ErrorBody(failure.Message), statusCode: StatusCodes.Status403Forbidden),
-			_ => TypedResults.BadRequest(new ErrorBody(failure.Message)),
-		};
 
-	private static Results<Ok<ChannelResponse>, BadRequest<ErrorBody>, NotFound<ErrorBody>, JsonHttpResult<ErrorBody>>
-		MapErrorUpdate(Failure failure) => failure.Code switch
-		{
-			"Guild.GuildNotFound" => TypedResults.NotFound(new ErrorBody(failure.Message)),
-			"Guild.ChannelNotFound" => TypedResults.NotFound(new ErrorBody(failure.Message)),
-			"Guild.CategoryNotFound" => TypedResults.NotFound(new ErrorBody(failure.Message)),
-			"Guild.NotAMember" => TypedResults.Json(new ErrorBody(failure.Message), statusCode: StatusCodes.Status403Forbidden),
-			"Guild.MissingPermission" => TypedResults.Json(new ErrorBody(failure.Message), statusCode: StatusCodes.Status403Forbidden),
-			_ => TypedResults.BadRequest(new ErrorBody(failure.Message)),
-		};
 
-	private static Results<NoContent, NotFound<ErrorBody>, JsonHttpResult<ErrorBody>>
-		MapErrorDelete(Failure failure) => failure.Code switch
-		{
-			"Guild.GuildNotFound" => TypedResults.NotFound(new ErrorBody(failure.Message)),
-			"Guild.ChannelNotFound" => TypedResults.NotFound(new ErrorBody(failure.Message)),
-			"Guild.NotAMember" => TypedResults.Json(new ErrorBody(failure.Message), statusCode: StatusCodes.Status403Forbidden),
-			_ => TypedResults.Json(new ErrorBody(failure.Message), statusCode: StatusCodes.Status403Forbidden),
-		};
 
 	// ---- request shapes (snake_case via ConfigureHttpJsonOptions) ----
 

--- a/services/guild/src/Guild.Presentation/Endpoints/EndpointConventions.cs
+++ b/services/guild/src/Guild.Presentation/Endpoints/EndpointConventions.cs
@@ -1,0 +1,26 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+
+namespace Guild.Presentation.Endpoints;
+
+/// <summary>
+/// OpenAPI response metadata for the guild endpoints. collapsing the per-endpoint
+/// typed-results unions into <c>JsonHttpResult&lt;ErrorBody&gt;</c> (so the error
+/// status now comes from the central <see cref="FailureStatus"/> map) removed the
+/// error responses the generated OpenAPI / Scalar doc used to infer from those
+/// unions. these helpers re-declare them so the API reference still lists the
+/// 4xx responses every guild route can return as an <see cref="ErrorBody"/>.
+/// </summary>
+internal static class EndpointConventions
+{
+	/// <summary>the 4xx responses common to authenticated guild routes.</summary>
+	public static RouteHandlerBuilder ProducesGuildErrors(this RouteHandlerBuilder builder) =>
+		builder
+			.Produces<ErrorBody>(StatusCodes.Status400BadRequest)
+			.Produces<ErrorBody>(StatusCodes.Status403Forbidden)
+			.Produces<ErrorBody>(StatusCodes.Status404NotFound);
+
+	/// <summary>adds the 409 response for routes that can conflict (ban, join).</summary>
+	public static RouteHandlerBuilder ProducesConflict(this RouteHandlerBuilder builder) =>
+		builder.Produces<ErrorBody>(StatusCodes.Status409Conflict);
+}

--- a/services/guild/src/Guild.Presentation/Endpoints/FailureStatus.cs
+++ b/services/guild/src/Guild.Presentation/Endpoints/FailureStatus.cs
@@ -1,0 +1,78 @@
+using Guild.Domain.Results;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+
+namespace Guild.Presentation.Endpoints;
+
+/// <summary>
+/// single source of truth mapping a domain <see cref="Failure"/> code to its HTTP
+/// status, derived from <c>docs/contracts/guild.md</c>. replaces the per-endpoint
+/// switch arms that previously drifted (e.g. Leave fell back to 403 instead of
+/// 400). codes absent from the table are request/validation problems and map to
+/// <see cref="StatusCodes.Status400BadRequest"/>.
+/// </summary>
+/// <remarks>
+/// a handful of codes are status-ambiguous because the contract documents them
+/// differently per endpoint (the clearest case: an invalid invite is 400 on
+/// <c>POST /guilds/{id}/join</c> but 404 on <c>POST /invites/{code}/join</c>).
+/// those endpoints pass per-call overrides to <see cref="EndpointResults.Problem"/>;
+/// the table holds the more common status as the default.
+/// </remarks>
+internal static class FailureStatus
+{
+	private static readonly Dictionary<string, int> Map = new(StringComparer.Ordinal)
+	{
+		// 404 Not Found
+		["Guild.GuildNotFound"] = StatusCodes.Status404NotFound,
+		["Guild.CategoryNotFound"] = StatusCodes.Status404NotFound,
+		["Guild.ChannelNotFound"] = StatusCodes.Status404NotFound,
+		["Guild.RoleNotFound"] = StatusCodes.Status404NotFound,
+		["Guild.BanNotFound"] = StatusCodes.Status404NotFound,
+		["Guild.OverwriteNotFound"] = StatusCodes.Status404NotFound,
+		["Guild.RoleAssignmentNotFound"] = StatusCodes.Status404NotFound,
+		["Guild.InviteNotFound"] = StatusCodes.Status404NotFound,
+		["Guild.InviteAlreadyRevoked"] = StatusCodes.Status404NotFound,
+		["Guild.InviteGuildMismatch"] = StatusCodes.Status404NotFound,
+		["Guild.InviteUnusable"] = StatusCodes.Status404NotFound,
+		["Guild.TargetNotAMember"] = StatusCodes.Status404NotFound,
+
+		// 403 Forbidden
+		["Guild.NotAMember"] = StatusCodes.Status403Forbidden,
+		["Guild.MissingPermission"] = StatusCodes.Status403Forbidden,
+		["Guild.RoleHierarchyBlocked"] = StatusCodes.Status403Forbidden,
+		["Guild.CannotGrantPermissionsYouLack"] = StatusCodes.Status403Forbidden,
+		["Guild.NotTheOwner"] = StatusCodes.Status403Forbidden,
+		["Guild.JoinBannedFromGuild"] = StatusCodes.Status403Forbidden,
+		// NOTE: CannotBanOwner is 403 but CannotKickOwner is 400 (per contract,
+		// Ban vs Kick error tables); the latter falls through to the 400 default.
+		["Guild.CannotBanOwner"] = StatusCodes.Status403Forbidden,
+
+		// 409 Conflict
+		["Guild.AlreadyBanned"] = StatusCodes.Status409Conflict,
+		["Guild.AlreadyMember"] = StatusCodes.Status409Conflict,
+	};
+
+	public static int Of(Failure failure) =>
+		Map.GetValueOrDefault(failure.Code, StatusCodes.Status400BadRequest);
+}
+
+/// <summary>
+/// turns a <see cref="Failure"/> into the canonical error response. endpoints
+/// return <c>Results&lt;TSuccess, JsonHttpResult&lt;ErrorBody&gt;&gt;</c> and call
+/// <see cref="Problem"/> on the failure path.
+/// </summary>
+internal static class EndpointResults
+{
+	public static JsonHttpResult<ErrorBody> Problem(
+		Failure failure,
+		params (string Code, int Status)[] overrides)
+	{
+		foreach (var (code, status) in overrides)
+		{
+			if (failure.Code == code)
+				return TypedResults.Json(new ErrorBody(failure.Message), statusCode: status);
+		}
+
+		return TypedResults.Json(new ErrorBody(failure.Message), statusCode: FailureStatus.Of(failure));
+	}
+}

--- a/services/guild/src/Guild.Presentation/Endpoints/GuildInvitesEndpoint.cs
+++ b/services/guild/src/Guild.Presentation/Endpoints/GuildInvitesEndpoint.cs
@@ -15,9 +15,9 @@ public sealed class GuildInvitesEndpoint : ICarterModule
 	public void AddRoutes(IEndpointRouteBuilder endpoints)
 	{
 		var group = endpoints.MapGroup("/guilds/{id:long}/invites");
-		group.MapPost("/", CreateAsync);
-		group.MapGet("/", ListAsync);
-		group.MapDelete("/{code}", DeleteAsync);
+		group.MapPost("/", CreateAsync).ProducesGuildErrors();
+		group.MapGet("/", ListAsync).ProducesGuildErrors();
+		group.MapDelete("/{code}", DeleteAsync).ProducesGuildErrors();
 	}
 
 	private static async Task<Results<Created<InviteDto>, JsonHttpResult<ErrorBody>>>

--- a/services/guild/src/Guild.Presentation/Endpoints/GuildInvitesEndpoint.cs
+++ b/services/guild/src/Guild.Presentation/Endpoints/GuildInvitesEndpoint.cs
@@ -2,7 +2,7 @@ using Carter;
 using Guild.Application.Abstractions.Messaging;
 using Guild.Application.Features.Invites.Common;
 using Guild.Application.Features.Invites.CreateInvite;
-using Guild.Application.Features.Invites.DeleteInvite;
+using Guild.Application.Features.Invites.RevokeInvite;
 using Guild.Application.Features.Invites.ListInvites;
 using Guild.Domain.Results;
 using Microsoft.AspNetCore.Http;
@@ -17,7 +17,9 @@ public sealed class GuildInvitesEndpoint : ICarterModule
 		var group = endpoints.MapGroup("/guilds/{id:long}/invites");
 		group.MapPost("/", CreateAsync).ProducesGuildErrors();
 		group.MapGet("/", ListAsync).ProducesGuildErrors();
-		group.MapDelete("/{code}", DeleteAsync).ProducesGuildErrors();
+		// DELETE here soft-revokes the invite (sets revoked), it does not hard-delete
+		// the row; hard deletion of expired/revoked invites is the cleanup service's job
+		group.MapDelete("/{code}", RevokeAsync).ProducesGuildErrors();
 	}
 
 	private static async Task<Results<Created<InviteDto>, JsonHttpResult<ErrorBody>>>
@@ -52,13 +54,13 @@ public sealed class GuildInvitesEndpoint : ICarterModule
 	}
 
 	private static async Task<Results<NoContent, JsonHttpResult<ErrorBody>>>
-	DeleteAsync(
+	RevokeAsync(
 		long id,
 		string code,
-		ICommandHandler<DeleteInviteCommand, Result> handler,
+		ICommandHandler<RevokeInviteCommand, Result> handler,
 		CancellationToken cancellationToken)
 	{
-		var result = await handler.HandleAsync(new DeleteInviteCommand(id, code), cancellationToken);
+		var result = await handler.HandleAsync(new RevokeInviteCommand(id, code), cancellationToken);
 
 		if (result.Succeeded)
 			return TypedResults.NoContent();

--- a/services/guild/src/Guild.Presentation/Endpoints/GuildInvitesEndpoint.cs
+++ b/services/guild/src/Guild.Presentation/Endpoints/GuildInvitesEndpoint.cs
@@ -20,11 +20,7 @@ public sealed class GuildInvitesEndpoint : ICarterModule
 		group.MapDelete("/{code}", DeleteAsync);
 	}
 
-	private static async Task<Results<
-		Created<InviteDto>,
-		BadRequest<ErrorBody>,
-		NotFound<ErrorBody>,
-		JsonHttpResult<ErrorBody>>>
+	private static async Task<Results<Created<InviteDto>, JsonHttpResult<ErrorBody>>>
 	CreateAsync(
 		long id,
 		CreateInviteRequest request,
@@ -38,19 +34,10 @@ public sealed class GuildInvitesEndpoint : ICarterModule
 		if (result.Succeeded)
 			return TypedResults.Created($"/v1/invites/{result.Value.Code}", result.Value);
 
-		return result.Error.Code switch
-		{
-			"Guild.GuildNotFound" => TypedResults.NotFound(new ErrorBody(result.Error.Message)),
-			"Guild.NotAMember" => TypedResults.Json(new ErrorBody(result.Error.Message), statusCode: StatusCodes.Status403Forbidden),
-			"Guild.MissingPermission" => TypedResults.Json(new ErrorBody(result.Error.Message), statusCode: StatusCodes.Status403Forbidden),
-			_ => TypedResults.BadRequest(new ErrorBody(result.Error.Message)),
-		};
+		return EndpointResults.Problem(result.Error);
 	}
 
-	private static async Task<Results<
-		Ok<IReadOnlyList<InviteDto>>,
-		NotFound<ErrorBody>,
-		JsonHttpResult<ErrorBody>>>
+	private static async Task<Results<Ok<IReadOnlyList<InviteDto>>, JsonHttpResult<ErrorBody>>>
 	ListAsync(
 		long id,
 		IQueryHandler<ListInvitesQuery, Result<IReadOnlyList<InviteDto>>> handler,
@@ -61,17 +48,10 @@ public sealed class GuildInvitesEndpoint : ICarterModule
 		if (result.Succeeded)
 			return TypedResults.Ok(result.Value);
 
-		return result.Error.Code switch
-		{
-			"Guild.GuildNotFound" => TypedResults.NotFound(new ErrorBody(result.Error.Message)),
-			_ => TypedResults.Json(new ErrorBody(result.Error.Message), statusCode: StatusCodes.Status403Forbidden),
-		};
+		return EndpointResults.Problem(result.Error);
 	}
 
-	private static async Task<Results<
-		NoContent,
-		NotFound<ErrorBody>,
-		JsonHttpResult<ErrorBody>>>
+	private static async Task<Results<NoContent, JsonHttpResult<ErrorBody>>>
 	DeleteAsync(
 		long id,
 		string code,
@@ -83,13 +63,7 @@ public sealed class GuildInvitesEndpoint : ICarterModule
 		if (result.Succeeded)
 			return TypedResults.NoContent();
 
-		return result.Error.Code switch
-		{
-			"Guild.InviteNotFound" => TypedResults.NotFound(new ErrorBody(result.Error.Message)),
-			"Guild.InviteGuildMismatch" => TypedResults.NotFound(new ErrorBody(result.Error.Message)),
-			"Guild.GuildNotFound" => TypedResults.NotFound(new ErrorBody(result.Error.Message)),
-			_ => TypedResults.Json(new ErrorBody(result.Error.Message), statusCode: StatusCodes.Status403Forbidden),
-		};
+		return EndpointResults.Problem(result.Error);
 	}
 
 	private sealed record CreateInviteRequest(int? MaxUses, int? ExpiresInHours);

--- a/services/guild/src/Guild.Presentation/Endpoints/GuildsEndpoint.cs
+++ b/services/guild/src/Guild.Presentation/Endpoints/GuildsEndpoint.cs
@@ -24,9 +24,7 @@ public sealed class GuildsEndpoint : ICarterModule
 		group.MapPatch("/{id:long}/owner", TransferOwnershipAsync);
 	}
 
-	private static async Task<Results<
-		Created<GuildDto>,
-		BadRequest<ErrorBody>>>
+	private static async Task<Results<Created<GuildDto>, JsonHttpResult<ErrorBody>>>
 	CreateAsync(
 		CreateGuildRequest request,
 		ICommandHandler<CreateGuildCommand, Result<GuildDto>> handler,
@@ -38,27 +36,20 @@ public sealed class GuildsEndpoint : ICarterModule
 
 		return result.Succeeded
 			? TypedResults.Created($"/v1/guilds/{result.Value.Id}", result.Value)
-			: TypedResults.BadRequest(new ErrorBody(result.Error.Message));
+			: TypedResults.Json(new ErrorBody(result.Error.Message), statusCode: StatusCodes.Status400BadRequest);
 	}
 
-	private static async Task<Results<
-		Ok<GuildDetailsDto>,
-		NotFound<ErrorBody>,
-		JsonHttpResult<ErrorBody>>>
+	private static async Task<Results<Ok<GuildDetailsDto>, JsonHttpResult<ErrorBody>>>
 	GetAsync(
 		long id,
 		IQueryHandler<GetGuildQuery, Result<GuildDetailsDto>> handler,
 		CancellationToken cancellationToken)
 	{
 		var result = await handler.HandleAsync(new GetGuildQuery(id), cancellationToken);
-		return result.Succeeded ? TypedResults.Ok(result.Value) : MapErrorGet(result.Error);
+		return result.Succeeded ? TypedResults.Ok(result.Value) : EndpointResults.Problem(result.Error);
 	}
 
-	private static async Task<Results<
-		Ok<GuildDto>,
-		BadRequest<ErrorBody>,
-		NotFound<ErrorBody>,
-		JsonHttpResult<ErrorBody>>>
+	private static async Task<Results<Ok<GuildDto>, JsonHttpResult<ErrorBody>>>
 	UpdateAsync(
 		long id,
 		UpdateGuildRequest request,
@@ -69,27 +60,20 @@ public sealed class GuildsEndpoint : ICarterModule
 			new UpdateGuildCommand(id, request.Name, request.Description, request.IconUrl, request.BannerUrl),
 			cancellationToken);
 
-		return result.Succeeded ? TypedResults.Ok(result.Value) : MapErrorUpdate(result.Error);
+		return result.Succeeded ? TypedResults.Ok(result.Value) : EndpointResults.Problem(result.Error);
 	}
 
-	private static async Task<Results<
-		NoContent,
-		NotFound<ErrorBody>,
-		JsonHttpResult<ErrorBody>>>
+	private static async Task<Results<NoContent, JsonHttpResult<ErrorBody>>>
 	DeleteAsync(
 		long id,
 		ICommandHandler<DeleteGuildCommand, Result> handler,
 		CancellationToken cancellationToken)
 	{
 		var result = await handler.HandleAsync(new DeleteGuildCommand(id), cancellationToken);
-		return result.Succeeded ? TypedResults.NoContent() : MapErrorDelete(result.Error);
+		return result.Succeeded ? TypedResults.NoContent() : EndpointResults.Problem(result.Error);
 	}
 
-	private static async Task<Results<
-		Ok<GuildDto>,
-		BadRequest<ErrorBody>,
-		NotFound<ErrorBody>,
-		JsonHttpResult<ErrorBody>>>
+	private static async Task<Results<Ok<GuildDto>, JsonHttpResult<ErrorBody>>>
 	TransferOwnershipAsync(
 		long id,
 		TransferOwnershipRequest request,
@@ -97,13 +81,13 @@ public sealed class GuildsEndpoint : ICarterModule
 		CancellationToken cancellationToken)
 	{
 		if (!long.TryParse(request.NewOwnerId, out var newOwnerId))
-			return TypedResults.BadRequest(new ErrorBody("new_owner_id must be a snowflake string."));
+			return TypedResults.Json(new ErrorBody("new_owner_id must be a snowflake string."), statusCode: StatusCodes.Status400BadRequest);
 
 		var result = await handler.HandleAsync(
 			new TransferOwnershipCommand(id, newOwnerId),
 			cancellationToken);
 
-		return result.Succeeded ? TypedResults.Ok(result.Value) : MapErrorTransfer(result.Error);
+		return result.Succeeded ? TypedResults.Ok(result.Value) : EndpointResults.Problem(result.Error);
 	}
 
 	// ---- error mapping ----
@@ -112,41 +96,9 @@ public sealed class GuildsEndpoint : ICarterModule
 	// separate mapper methods so the compiler can pick the correct implicit
 	// conversion to each variant. the mapping logic itself is shared
 
-	private static Results<Ok<GuildDetailsDto>, NotFound<ErrorBody>, JsonHttpResult<ErrorBody>>
-		MapErrorGet(Failure failure) => failure.Code switch
-		{
-			"Guild.GuildNotFound" => TypedResults.NotFound(new ErrorBody(failure.Message)),
-			"Guild.NotAMember" => TypedResults.Json(new ErrorBody(failure.Message), statusCode: StatusCodes.Status403Forbidden),
-			_ => TypedResults.Json(new ErrorBody(failure.Message), statusCode: StatusCodes.Status403Forbidden),
-		};
 
-	private static Results<Ok<GuildDto>, BadRequest<ErrorBody>, NotFound<ErrorBody>, JsonHttpResult<ErrorBody>>
-		MapErrorUpdate(Failure failure) => failure.Code switch
-		{
-			"Guild.GuildNotFound" => TypedResults.NotFound(new ErrorBody(failure.Message)),
-			"Guild.TargetNotAMember" => TypedResults.NotFound(new ErrorBody(failure.Message)),
-			"Guild.NotAMember" => TypedResults.Json(new ErrorBody(failure.Message), statusCode: StatusCodes.Status403Forbidden),
-			"Guild.NotTheOwner" => TypedResults.Json(new ErrorBody(failure.Message), statusCode: StatusCodes.Status403Forbidden),
-			"Guild.MissingPermission" => TypedResults.Json(new ErrorBody(failure.Message), statusCode: StatusCodes.Status403Forbidden),
-			_ => TypedResults.BadRequest(new ErrorBody(failure.Message)),
-		};
 
-	private static Results<NoContent, NotFound<ErrorBody>, JsonHttpResult<ErrorBody>>
-		MapErrorDelete(Failure failure) => failure.Code switch
-		{
-			"Guild.GuildNotFound" => TypedResults.NotFound(new ErrorBody(failure.Message)),
-			"Guild.NotTheOwner" => TypedResults.Json(new ErrorBody(failure.Message), statusCode: StatusCodes.Status403Forbidden),
-			_ => TypedResults.Json(new ErrorBody(failure.Message), statusCode: StatusCodes.Status403Forbidden),
-		};
 
-	private static Results<Ok<GuildDto>, BadRequest<ErrorBody>, NotFound<ErrorBody>, JsonHttpResult<ErrorBody>>
-		MapErrorTransfer(Failure failure) => failure.Code switch
-		{
-			"Guild.GuildNotFound" => TypedResults.NotFound(new ErrorBody(failure.Message)),
-			"Guild.TargetNotAMember" => TypedResults.NotFound(new ErrorBody(failure.Message)),
-			"Guild.NotTheOwner" => TypedResults.Json(new ErrorBody(failure.Message), statusCode: StatusCodes.Status403Forbidden),
-			_ => TypedResults.BadRequest(new ErrorBody(failure.Message)),
-		};
 
 	// ---- request shapes (snake_case via ConfigureHttpJsonOptions) ----
 

--- a/services/guild/src/Guild.Presentation/Endpoints/GuildsEndpoint.cs
+++ b/services/guild/src/Guild.Presentation/Endpoints/GuildsEndpoint.cs
@@ -17,11 +17,11 @@ public sealed class GuildsEndpoint : ICarterModule
 	public void AddRoutes(IEndpointRouteBuilder endpoints)
 	{
 		var group = endpoints.MapGroup("/guilds");
-		group.MapPost("/", CreateAsync);
-		group.MapGet("/{id:long}", GetAsync);
-		group.MapPatch("/{id:long}", UpdateAsync);
-		group.MapDelete("/{id:long}", DeleteAsync);
-		group.MapPatch("/{id:long}/owner", TransferOwnershipAsync);
+		group.MapPost("/", CreateAsync).ProducesGuildErrors();
+		group.MapGet("/{id:long}", GetAsync).ProducesGuildErrors();
+		group.MapPatch("/{id:long}", UpdateAsync).ProducesGuildErrors();
+		group.MapDelete("/{id:long}", DeleteAsync).ProducesGuildErrors();
+		group.MapPatch("/{id:long}/owner", TransferOwnershipAsync).ProducesGuildErrors();
 	}
 
 	private static async Task<Results<Created<GuildDto>, JsonHttpResult<ErrorBody>>>

--- a/services/guild/src/Guild.Presentation/Endpoints/InvitesEndpoint.cs
+++ b/services/guild/src/Guild.Presentation/Endpoints/InvitesEndpoint.cs
@@ -24,9 +24,7 @@ public sealed class InvitesEndpoint : ICarterModule
 		group.MapPost("/join", JoinAsync);
 	}
 
-	private static async Task<Results<
-		Ok<InvitePreviewDto>,
-		NotFound<ErrorBody>>>
+	private static async Task<Results<Ok<InvitePreviewDto>, JsonHttpResult<ErrorBody>>>
 	PreviewAsync(
 		string code,
 		IQueryHandler<GetInvitePreviewQuery, Result<InvitePreviewDto>> handler,
@@ -37,14 +35,10 @@ public sealed class InvitesEndpoint : ICarterModule
 		if (result.Succeeded)
 			return TypedResults.Ok(result.Value);
 
-		return TypedResults.NotFound(new ErrorBody(result.Error.Message));
+		return TypedResults.Json(new ErrorBody(result.Error.Message), statusCode: StatusCodes.Status404NotFound);
 	}
 
-	private static async Task<Results<
-		Ok<GuildDto>,
-		NotFound<ErrorBody>,
-		Conflict<ErrorBody>,
-		JsonHttpResult<ErrorBody>>>
+	private static async Task<Results<Ok<GuildDto>, JsonHttpResult<ErrorBody>>>
 	JoinAsync(
 		string code,
 		ICommandHandler<JoinByInviteCodeCommand, Result<GuildDto>> handler,
@@ -57,11 +51,6 @@ public sealed class InvitesEndpoint : ICarterModule
 		if (result.Succeeded)
 			return TypedResults.Ok(result.Value);
 
-		return result.Error.Code switch
-		{
-			"Guild.AlreadyMember" => TypedResults.Conflict(new ErrorBody(result.Error.Message)),
-			"Guild.JoinBannedFromGuild" => TypedResults.Json(new ErrorBody(result.Error.Message), statusCode: StatusCodes.Status403Forbidden),
-			_ => TypedResults.NotFound(new ErrorBody(result.Error.Message)),
-		};
+		return EndpointResults.Problem(result.Error);
 	}
 }

--- a/services/guild/src/Guild.Presentation/Endpoints/InvitesEndpoint.cs
+++ b/services/guild/src/Guild.Presentation/Endpoints/InvitesEndpoint.cs
@@ -20,8 +20,8 @@ public sealed class InvitesEndpoint : ICarterModule
 	public void AddRoutes(IEndpointRouteBuilder endpoints)
 	{
 		var group = endpoints.MapGroup("/invites/{code}");
-		group.MapGet("/", PreviewAsync);
-		group.MapPost("/join", JoinAsync);
+		group.MapGet("/", PreviewAsync).ProducesGuildErrors();
+		group.MapPost("/join", JoinAsync).ProducesGuildErrors().ProducesConflict();
 	}
 
 	private static async Task<Results<Ok<InvitePreviewDto>, JsonHttpResult<ErrorBody>>>

--- a/services/guild/src/Guild.Presentation/Endpoints/MemberPermissionsEndpoint.cs
+++ b/services/guild/src/Guild.Presentation/Endpoints/MemberPermissionsEndpoint.cs
@@ -16,11 +16,7 @@ public sealed class MemberPermissionsEndpoint : ICarterModule
 			GetAsync);
 	}
 
-	private static async Task<Results<
-		Ok<MemberPermissionsResponse>,
-		BadRequest<ErrorBody>,
-		NotFound<ErrorBody>,
-		JsonHttpResult<ErrorBody>>>
+	private static async Task<Results<Ok<MemberPermissionsResponse>, JsonHttpResult<ErrorBody>>>
 	GetAsync(
 		long id,
 		long userId,
@@ -33,12 +29,6 @@ public sealed class MemberPermissionsEndpoint : ICarterModule
 		if (result.Succeeded)
 			return TypedResults.Ok(result.Value);
 
-		return result.Error.Code switch
-		{
-			"Guild.GuildNotFound" => TypedResults.NotFound(new ErrorBody(result.Error.Message)),
-			"Guild.TargetNotAMember" => TypedResults.NotFound(new ErrorBody(result.Error.Message)),
-			"Guild.NotAMember" => TypedResults.Json(new ErrorBody(result.Error.Message), statusCode: StatusCodes.Status403Forbidden),
-			_ => TypedResults.BadRequest(new ErrorBody(result.Error.Message)),
-		};
+		return EndpointResults.Problem(result.Error);
 	}
 }

--- a/services/guild/src/Guild.Presentation/Endpoints/MemberPermissionsEndpoint.cs
+++ b/services/guild/src/Guild.Presentation/Endpoints/MemberPermissionsEndpoint.cs
@@ -12,8 +12,9 @@ public sealed class MemberPermissionsEndpoint : ICarterModule
 	public void AddRoutes(IEndpointRouteBuilder endpoints)
 	{
 		endpoints.MapGet(
-			"/guilds/{id:long}/members/{userId:long}/permissions",
-			GetAsync);
+				"/guilds/{id:long}/members/{userId:long}/permissions",
+				GetAsync)
+			.ProducesGuildErrors();
 	}
 
 	private static async Task<Results<Ok<MemberPermissionsResponse>, JsonHttpResult<ErrorBody>>>

--- a/services/guild/src/Guild.Presentation/Endpoints/MemberRolesEndpoint.cs
+++ b/services/guild/src/Guild.Presentation/Endpoints/MemberRolesEndpoint.cs
@@ -13,8 +13,8 @@ public sealed class MemberRolesEndpoint : ICarterModule
 	public void AddRoutes(IEndpointRouteBuilder endpoints)
 	{
 		var group = endpoints.MapGroup("/guilds/{id:long}/members/{userId:long}/roles");
-		group.MapPut("/{roleId:long}", AssignAsync);
-		group.MapDelete("/{roleId:long}", UnassignAsync);
+		group.MapPut("/{roleId:long}", AssignAsync).ProducesGuildErrors();
+		group.MapDelete("/{roleId:long}", UnassignAsync).ProducesGuildErrors();
 	}
 
 	private static async Task<Results<NoContent, JsonHttpResult<ErrorBody>>>

--- a/services/guild/src/Guild.Presentation/Endpoints/MemberRolesEndpoint.cs
+++ b/services/guild/src/Guild.Presentation/Endpoints/MemberRolesEndpoint.cs
@@ -17,11 +17,7 @@ public sealed class MemberRolesEndpoint : ICarterModule
 		group.MapDelete("/{roleId:long}", UnassignAsync);
 	}
 
-	private static async Task<Results<
-		NoContent,
-		BadRequest<ErrorBody>,
-		NotFound<ErrorBody>,
-		JsonHttpResult<ErrorBody>>>
+	private static async Task<Results<NoContent, JsonHttpResult<ErrorBody>>>
 	AssignAsync(
 		long id,
 		long userId,
@@ -35,25 +31,10 @@ public sealed class MemberRolesEndpoint : ICarterModule
 		if (result.Succeeded)
 			return TypedResults.NoContent();
 
-		return result.Error.Code switch
-		{
-			"Guild.GuildNotFound" => TypedResults.NotFound(new ErrorBody(result.Error.Message)),
-			"Guild.RoleNotFound" => TypedResults.NotFound(new ErrorBody(result.Error.Message)),
-			"Guild.TargetNotAMember" => TypedResults.NotFound(new ErrorBody(result.Error.Message)),
-			"Guild.NotAMember" => TypedResults.Json(new ErrorBody(result.Error.Message), statusCode: StatusCodes.Status403Forbidden),
-			"Guild.MissingPermission" => TypedResults.Json(new ErrorBody(result.Error.Message), statusCode: StatusCodes.Status403Forbidden),
-			"Guild.RoleHierarchyBlocked" => TypedResults.Json(new ErrorBody(result.Error.Message), statusCode: StatusCodes.Status403Forbidden),
-			"Guild.CannotGrantPermissionsYouLack" => TypedResults.Json(new ErrorBody(result.Error.Message), statusCode: StatusCodes.Status403Forbidden),
-			"Guild.CannotAssignDefaultRole" => TypedResults.BadRequest(new ErrorBody(result.Error.Message)),
-			_ => TypedResults.BadRequest(new ErrorBody(result.Error.Message)),
-		};
+		return EndpointResults.Problem(result.Error);
 	}
 
-	private static async Task<Results<
-		NoContent,
-		BadRequest<ErrorBody>,
-		NotFound<ErrorBody>,
-		JsonHttpResult<ErrorBody>>>
+	private static async Task<Results<NoContent, JsonHttpResult<ErrorBody>>>
 	UnassignAsync(
 		long id,
 		long userId,
@@ -67,17 +48,6 @@ public sealed class MemberRolesEndpoint : ICarterModule
 		if (result.Succeeded)
 			return TypedResults.NoContent();
 
-		return result.Error.Code switch
-		{
-			"Guild.GuildNotFound" => TypedResults.NotFound(new ErrorBody(result.Error.Message)),
-			"Guild.RoleNotFound" => TypedResults.NotFound(new ErrorBody(result.Error.Message)),
-			"Guild.TargetNotAMember" => TypedResults.NotFound(new ErrorBody(result.Error.Message)),
-			"Guild.RoleAssignmentNotFound" => TypedResults.NotFound(new ErrorBody(result.Error.Message)),
-			"Guild.NotAMember" => TypedResults.Json(new ErrorBody(result.Error.Message), statusCode: StatusCodes.Status403Forbidden),
-			"Guild.MissingPermission" => TypedResults.Json(new ErrorBody(result.Error.Message), statusCode: StatusCodes.Status403Forbidden),
-			"Guild.RoleHierarchyBlocked" => TypedResults.Json(new ErrorBody(result.Error.Message), statusCode: StatusCodes.Status403Forbidden),
-			"Guild.CannotUnassignDefaultRole" => TypedResults.BadRequest(new ErrorBody(result.Error.Message)),
-			_ => TypedResults.BadRequest(new ErrorBody(result.Error.Message)),
-		};
+		return EndpointResults.Problem(result.Error);
 	}
 }

--- a/services/guild/src/Guild.Presentation/Endpoints/MembershipEndpoint.cs
+++ b/services/guild/src/Guild.Presentation/Endpoints/MembershipEndpoint.cs
@@ -68,7 +68,7 @@ public sealed class MembershipEndpoint : ICarterModule
 		long id,
 		string? after,
 		int? limit,
-		IQueryHandler<ListMembersQuery, Result<MemberListResponse>> handler,
+		IQueryHandler<ListMembersQuery, Result<IReadOnlyList<MemberResponse>>> handler,
 		CancellationToken cancellationToken)
 	{
 		var (afterCursor, effectiveLimit, error) = Pagination.Parse(after, limit);
@@ -80,7 +80,7 @@ public sealed class MembershipEndpoint : ICarterModule
 			cancellationToken);
 
 		if (result.Succeeded)
-			return TypedResults.Ok(result.Value.Items);
+			return TypedResults.Ok(result.Value);
 
 		return EndpointResults.Problem(result.Error);
 	}

--- a/services/guild/src/Guild.Presentation/Endpoints/MembershipEndpoint.cs
+++ b/services/guild/src/Guild.Presentation/Endpoints/MembershipEndpoint.cs
@@ -15,9 +15,6 @@ namespace Guild.Presentation.Endpoints;
 
 public sealed class MembershipEndpoint : ICarterModule
 {
-	private const int DefaultListLimit = 50;
-	private const int MaxListLimit = 100;
-
 	public void AddRoutes(IEndpointRouteBuilder endpoints)
 	{
 		var group = endpoints.MapGroup("/guilds/{id:long}");
@@ -74,17 +71,9 @@ public sealed class MembershipEndpoint : ICarterModule
 		IQueryHandler<ListMembersQuery, Result<MemberListResponse>> handler,
 		CancellationToken cancellationToken)
 	{
-		long? afterCursor = null;
-		if (after is not null)
-		{
-			if (!long.TryParse(after, out var parsed) || parsed <= 0)
-				return TypedResults.Json(new ErrorBody("after must be a positive snowflake."), statusCode: StatusCodes.Status400BadRequest);
-			afterCursor = parsed;
-		}
-
-		var effectiveLimit = limit ?? DefaultListLimit;
-		if (effectiveLimit <= 0 || effectiveLimit > MaxListLimit)
-			return TypedResults.Json(new ErrorBody($"limit must be between 1 and {MaxListLimit}."), statusCode: StatusCodes.Status400BadRequest);
+		var (afterCursor, effectiveLimit, error) = Pagination.Parse(after, limit);
+		if (error is not null)
+			return error;
 
 		var result = await handler.HandleAsync(
 			new ListMembersQuery(id, afterCursor, effectiveLimit),

--- a/services/guild/src/Guild.Presentation/Endpoints/MembershipEndpoint.cs
+++ b/services/guild/src/Guild.Presentation/Endpoints/MembershipEndpoint.cs
@@ -28,12 +28,7 @@ public sealed class MembershipEndpoint : ICarterModule
 		group.MapDelete("/members/{userId:long}", KickAsync);
 	}
 
-	private static async Task<Results<
-		Ok<GuildDto>,
-		BadRequest<ErrorBody>,
-		NotFound<ErrorBody>,
-		Conflict<ErrorBody>,
-		JsonHttpResult<ErrorBody>>>
+	private static async Task<Results<Ok<GuildDto>, JsonHttpResult<ErrorBody>>>
 	JoinAsync(
 		long id,
 		JoinByPathRequest request,
@@ -47,20 +42,17 @@ public sealed class MembershipEndpoint : ICarterModule
 		if (result.Succeeded)
 			return TypedResults.Ok(result.Value);
 
-		return result.Error.Code switch
-		{
-			"Guild.GuildNotFound" => TypedResults.NotFound(new ErrorBody(result.Error.Message)),
-			"Guild.AlreadyMember" => TypedResults.Conflict(new ErrorBody(result.Error.Message)),
-			"Guild.JoinBannedFromGuild" => TypedResults.Json(new ErrorBody(result.Error.Message), statusCode: StatusCodes.Status403Forbidden),
-			_ => TypedResults.BadRequest(new ErrorBody(result.Error.Message)),
-		};
+		// contract: on POST /guilds/{id}/join an invalid/expired/wrong-guild invite
+		// is a 400 (the body carried a bad code), unlike POST /invites/{code}/join
+		// where the same failures are 404. override the table's 404 default here.
+		return EndpointResults.Problem(
+			result.Error,
+			("Guild.InviteNotFound", StatusCodes.Status400BadRequest),
+			("Guild.InviteUnusable", StatusCodes.Status400BadRequest),
+			("Guild.InviteGuildMismatch", StatusCodes.Status400BadRequest));
 	}
 
-	private static async Task<Results<
-		NoContent,
-		BadRequest<ErrorBody>,
-		NotFound<ErrorBody>,
-		JsonHttpResult<ErrorBody>>>
+	private static async Task<Results<NoContent, JsonHttpResult<ErrorBody>>>
 	LeaveAsync(
 		long id,
 		ICommandHandler<LeaveGuildCommand, Result> handler,
@@ -71,20 +63,10 @@ public sealed class MembershipEndpoint : ICarterModule
 		if (result.Succeeded)
 			return TypedResults.NoContent();
 
-		return result.Error.Code switch
-		{
-			"Guild.GuildNotFound" => TypedResults.NotFound(new ErrorBody(result.Error.Message)),
-			"Guild.OwnerCannotLeave" => TypedResults.BadRequest(new ErrorBody(result.Error.Message)),
-			"Guild.NotAMember" => TypedResults.Json(new ErrorBody(result.Error.Message), statusCode: StatusCodes.Status403Forbidden),
-			_ => TypedResults.Json(new ErrorBody(result.Error.Message), statusCode: StatusCodes.Status403Forbidden),
-		};
+		return EndpointResults.Problem(result.Error);
 	}
 
-	private static async Task<Results<
-		Ok<IReadOnlyList<MemberResponse>>,
-		BadRequest<ErrorBody>,
-		NotFound<ErrorBody>,
-		JsonHttpResult<ErrorBody>>>
+	private static async Task<Results<Ok<IReadOnlyList<MemberResponse>>, JsonHttpResult<ErrorBody>>>
 	ListMembersAsync(
 		long id,
 		string? after,
@@ -96,13 +78,13 @@ public sealed class MembershipEndpoint : ICarterModule
 		if (after is not null)
 		{
 			if (!long.TryParse(after, out var parsed) || parsed <= 0)
-				return TypedResults.BadRequest(new ErrorBody("after must be a positive snowflake."));
+				return TypedResults.Json(new ErrorBody("after must be a positive snowflake."), statusCode: StatusCodes.Status400BadRequest);
 			afterCursor = parsed;
 		}
 
 		var effectiveLimit = limit ?? DefaultListLimit;
 		if (effectiveLimit <= 0 || effectiveLimit > MaxListLimit)
-			return TypedResults.BadRequest(new ErrorBody($"limit must be between 1 and {MaxListLimit}."));
+			return TypedResults.Json(new ErrorBody($"limit must be between 1 and {MaxListLimit}."), statusCode: StatusCodes.Status400BadRequest);
 
 		var result = await handler.HandleAsync(
 			new ListMembersQuery(id, afterCursor, effectiveLimit),
@@ -111,19 +93,10 @@ public sealed class MembershipEndpoint : ICarterModule
 		if (result.Succeeded)
 			return TypedResults.Ok(result.Value.Items);
 
-		return result.Error.Code switch
-		{
-			"Guild.GuildNotFound" => TypedResults.NotFound(new ErrorBody(result.Error.Message)),
-			"Guild.NotAMember" => TypedResults.Json(new ErrorBody(result.Error.Message), statusCode: StatusCodes.Status403Forbidden),
-			_ => TypedResults.BadRequest(new ErrorBody(result.Error.Message)),
-		};
+		return EndpointResults.Problem(result.Error);
 	}
 
-	private static async Task<Results<
-		Ok<MemberResponse>,
-		BadRequest<ErrorBody>,
-		NotFound<ErrorBody>,
-		JsonHttpResult<ErrorBody>>>
+	private static async Task<Results<Ok<MemberResponse>, JsonHttpResult<ErrorBody>>>
 	UpdateNicknameAsync(
 		long id,
 		long userId,
@@ -138,24 +111,10 @@ public sealed class MembershipEndpoint : ICarterModule
 		if (result.Succeeded)
 			return TypedResults.Ok(result.Value);
 
-		return result.Error.Code switch
-		{
-			"Guild.GuildNotFound" => TypedResults.NotFound(new ErrorBody(result.Error.Message)),
-			"Guild.TargetNotAMember" => TypedResults.NotFound(new ErrorBody(result.Error.Message)),
-			"Guild.NotAMember" => TypedResults.Json(new ErrorBody(result.Error.Message), statusCode: StatusCodes.Status403Forbidden),
-			"Guild.MissingPermission" => TypedResults.Json(new ErrorBody(result.Error.Message), statusCode: StatusCodes.Status403Forbidden),
-			"Guild.RoleHierarchyBlocked" => TypedResults.Json(new ErrorBody(result.Error.Message), statusCode: StatusCodes.Status403Forbidden),
-			"Guild.NicknameTooLong" => TypedResults.BadRequest(new ErrorBody(result.Error.Message)),
-			"Guild.NicknameInvalid" => TypedResults.BadRequest(new ErrorBody(result.Error.Message)),
-			_ => TypedResults.BadRequest(new ErrorBody(result.Error.Message)),
-		};
+		return EndpointResults.Problem(result.Error);
 	}
 
-	private static async Task<Results<
-		NoContent,
-		BadRequest<ErrorBody>,
-		NotFound<ErrorBody>,
-		JsonHttpResult<ErrorBody>>>
+	private static async Task<Results<NoContent, JsonHttpResult<ErrorBody>>>
 	KickAsync(
 		long id,
 		long userId,
@@ -167,16 +126,7 @@ public sealed class MembershipEndpoint : ICarterModule
 		if (result.Succeeded)
 			return TypedResults.NoContent();
 
-		return result.Error.Code switch
-		{
-			"Guild.GuildNotFound" => TypedResults.NotFound(new ErrorBody(result.Error.Message)),
-			"Guild.TargetNotAMember" => TypedResults.NotFound(new ErrorBody(result.Error.Message)),
-			"Guild.NotAMember" => TypedResults.Json(new ErrorBody(result.Error.Message), statusCode: StatusCodes.Status403Forbidden),
-			"Guild.MissingPermission" => TypedResults.Json(new ErrorBody(result.Error.Message), statusCode: StatusCodes.Status403Forbidden),
-			"Guild.RoleHierarchyBlocked" => TypedResults.Json(new ErrorBody(result.Error.Message), statusCode: StatusCodes.Status403Forbidden),
-			"Guild.CannotKickOwner" => TypedResults.BadRequest(new ErrorBody(result.Error.Message)),
-			_ => TypedResults.BadRequest(new ErrorBody(result.Error.Message)),
-		};
+		return EndpointResults.Problem(result.Error);
 	}
 
 	private sealed record JoinByPathRequest(string? InviteCode);

--- a/services/guild/src/Guild.Presentation/Endpoints/MembershipEndpoint.cs
+++ b/services/guild/src/Guild.Presentation/Endpoints/MembershipEndpoint.cs
@@ -18,11 +18,11 @@ public sealed class MembershipEndpoint : ICarterModule
 	public void AddRoutes(IEndpointRouteBuilder endpoints)
 	{
 		var group = endpoints.MapGroup("/guilds/{id:long}");
-		group.MapPost("/join", JoinAsync);
-		group.MapPost("/leave", LeaveAsync);
-		group.MapGet("/members", ListMembersAsync);
-		group.MapPatch("/members/{userId:long}", UpdateNicknameAsync);
-		group.MapDelete("/members/{userId:long}", KickAsync);
+		group.MapPost("/join", JoinAsync).ProducesGuildErrors().ProducesConflict();
+		group.MapPost("/leave", LeaveAsync).ProducesGuildErrors();
+		group.MapGet("/members", ListMembersAsync).ProducesGuildErrors();
+		group.MapPatch("/members/{userId:long}", UpdateNicknameAsync).ProducesGuildErrors();
+		group.MapDelete("/members/{userId:long}", KickAsync).ProducesGuildErrors();
 	}
 
 	private static async Task<Results<Ok<GuildDto>, JsonHttpResult<ErrorBody>>>

--- a/services/guild/src/Guild.Presentation/Endpoints/Pagination.cs
+++ b/services/guild/src/Guild.Presentation/Endpoints/Pagination.cs
@@ -1,0 +1,43 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+
+namespace Guild.Presentation.Endpoints;
+
+/// <summary>
+/// shared keyset-pagination query parsing for the list endpoints (members, bans,
+/// ...). validates the <c>after</c> cursor and clamps/checks <c>limit</c> so the
+/// rules and the default/max limits live in one place instead of being copied
+/// into every paginated endpoint.
+/// </summary>
+internal static class Pagination
+{
+	public const int DefaultLimit = 50;
+	public const int MaxLimit = 100;
+
+	/// <summary>
+	/// parses <paramref name="after"/> / <paramref name="limit"/>. on success
+	/// <c>Error</c> is null and the cursor + effective limit are set; on a bad
+	/// input <c>Error</c> is a 400 describing the problem and the other values
+	/// should be ignored.
+	/// </summary>
+	public static (long? After, int Limit, JsonHttpResult<ErrorBody>? Error) Parse(string? after, int? limit)
+	{
+		long? afterCursor = null;
+		if (after is not null)
+		{
+			if (!long.TryParse(after, out var parsed) || parsed <= 0)
+				return (null, 0, TypedResults.Json(
+					new ErrorBody("after must be a positive snowflake."),
+					statusCode: StatusCodes.Status400BadRequest));
+			afterCursor = parsed;
+		}
+
+		var effectiveLimit = limit ?? DefaultLimit;
+		if (effectiveLimit <= 0 || effectiveLimit > MaxLimit)
+			return (null, 0, TypedResults.Json(
+				new ErrorBody($"limit must be between 1 and {MaxLimit}."),
+				statusCode: StatusCodes.Status400BadRequest));
+
+		return (afterCursor, effectiveLimit, null);
+	}
+}

--- a/services/guild/src/Guild.Presentation/Endpoints/RolesEndpoint.cs
+++ b/services/guild/src/Guild.Presentation/Endpoints/RolesEndpoint.cs
@@ -24,10 +24,7 @@ public sealed class RolesEndpoint : ICarterModule
 		group.MapDelete("/{roleId:long}", DeleteAsync);
 	}
 
-	private static async Task<Results<
-		Ok<IReadOnlyList<RoleResponse>>,
-		NotFound<ErrorBody>,
-		JsonHttpResult<ErrorBody>>>
+	private static async Task<Results<Ok<IReadOnlyList<RoleResponse>>, JsonHttpResult<ErrorBody>>>
 	ListAsync(
 		long id,
 		IQueryHandler<ListRolesQuery, Result<RoleListResponse>> handler,
@@ -36,14 +33,10 @@ public sealed class RolesEndpoint : ICarterModule
 		var result = await handler.HandleAsync(new ListRolesQuery(id), cancellationToken);
 		return result.Succeeded
 			? TypedResults.Ok(result.Value.Items)
-			: MapErrorList(result.Error);
+			: EndpointResults.Problem(result.Error);
 	}
 
-	private static async Task<Results<
-		Created<RoleResponse>,
-		BadRequest<ErrorBody>,
-		NotFound<ErrorBody>,
-		JsonHttpResult<ErrorBody>>>
+	private static async Task<Results<Created<RoleResponse>, JsonHttpResult<ErrorBody>>>
 	CreateAsync(
 		long id,
 		CreateRoleRequest request,
@@ -62,14 +55,10 @@ public sealed class RolesEndpoint : ICarterModule
 
 		return result.Succeeded
 			? TypedResults.Created($"/v1/guilds/{id}/roles/{result.Value.Id}", result.Value)
-			: MapErrorCreate(result.Error);
+			: EndpointResults.Problem(result.Error);
 	}
 
-	private static async Task<Results<
-		Ok<RoleResponse>,
-		BadRequest<ErrorBody>,
-		NotFound<ErrorBody>,
-		JsonHttpResult<ErrorBody>>>
+	private static async Task<Results<Ok<RoleResponse>, JsonHttpResult<ErrorBody>>>
 	UpdateAsync(
 		long id,
 		long roleId,
@@ -90,14 +79,10 @@ public sealed class RolesEndpoint : ICarterModule
 
 		return result.Succeeded
 			? TypedResults.Ok(result.Value)
-			: MapErrorUpdate(result.Error);
+			: EndpointResults.Problem(result.Error);
 	}
 
-	private static async Task<Results<
-		Ok<IReadOnlyList<RoleResponse>>,
-		BadRequest<ErrorBody>,
-		NotFound<ErrorBody>,
-		JsonHttpResult<ErrorBody>>>
+	private static async Task<Results<Ok<IReadOnlyList<RoleResponse>>, JsonHttpResult<ErrorBody>>>
 	ReorderAsync(
 		long id,
 		IReadOnlyList<ReorderRoleEntry>? request,
@@ -105,27 +90,23 @@ public sealed class RolesEndpoint : ICarterModule
 		CancellationToken cancellationToken)
 	{
 		if (request is null)
-			return TypedResults.BadRequest(new ErrorBody("Request body must be a JSON array of { id, position }."));
+			return TypedResults.Json(new ErrorBody("Request body must be a JSON array of { id, position }."), statusCode: StatusCodes.Status400BadRequest);
 
 		var moves = new List<RolePositionEntry>(request.Count);
 		foreach (var entry in request)
 		{
 			if (!long.TryParse(entry.Id, out var roleId))
-				return TypedResults.BadRequest(new ErrorBody("Each role id must be a numeric snowflake string."));
+				return TypedResults.Json(new ErrorBody("Each role id must be a numeric snowflake string."), statusCode: StatusCodes.Status400BadRequest);
 			moves.Add(new RolePositionEntry(roleId, entry.Position));
 		}
 
 		var result = await handler.HandleAsync(new ReorderRolesCommand(id, moves), cancellationToken);
 		return result.Succeeded
 			? TypedResults.Ok(result.Value.Items)
-			: MapErrorReorder(result.Error);
+			: EndpointResults.Problem(result.Error);
 	}
 
-	private static async Task<Results<
-		NoContent,
-		BadRequest<ErrorBody>,
-		NotFound<ErrorBody>,
-		JsonHttpResult<ErrorBody>>>
+	private static async Task<Results<NoContent, JsonHttpResult<ErrorBody>>>
 	DeleteAsync(
 		long id,
 		long roleId,
@@ -135,62 +116,15 @@ public sealed class RolesEndpoint : ICarterModule
 		var result = await handler.HandleAsync(new DeleteRoleCommand(id, roleId), cancellationToken);
 		return result.Succeeded
 			? TypedResults.NoContent()
-			: MapErrorDelete(result.Error);
+			: EndpointResults.Problem(result.Error);
 	}
 
 	// ---- error mapping ----
 
-	private static Results<Ok<IReadOnlyList<RoleResponse>>, NotFound<ErrorBody>, JsonHttpResult<ErrorBody>>
-		MapErrorList(Failure failure) => failure.Code switch
-		{
-			"Guild.GuildNotFound" => TypedResults.NotFound(new ErrorBody(failure.Message)),
-			_ => TypedResults.Json(new ErrorBody(failure.Message), statusCode: StatusCodes.Status403Forbidden),
-		};
 
-	private static Results<Created<RoleResponse>, BadRequest<ErrorBody>, NotFound<ErrorBody>, JsonHttpResult<ErrorBody>>
-		MapErrorCreate(Failure failure) => failure.Code switch
-		{
-			"Guild.GuildNotFound" => TypedResults.NotFound(new ErrorBody(failure.Message)),
-			"Guild.NotAMember" => TypedResults.Json(new ErrorBody(failure.Message), statusCode: StatusCodes.Status403Forbidden),
-			"Guild.MissingPermission" => TypedResults.Json(new ErrorBody(failure.Message), statusCode: StatusCodes.Status403Forbidden),
-			"Guild.CannotGrantPermissionsYouLack" => TypedResults.Json(new ErrorBody(failure.Message), statusCode: StatusCodes.Status403Forbidden),
-			_ => TypedResults.BadRequest(new ErrorBody(failure.Message)),
-		};
 
-	private static Results<Ok<RoleResponse>, BadRequest<ErrorBody>, NotFound<ErrorBody>, JsonHttpResult<ErrorBody>>
-		MapErrorUpdate(Failure failure) => failure.Code switch
-		{
-			"Guild.GuildNotFound" => TypedResults.NotFound(new ErrorBody(failure.Message)),
-			"Guild.RoleNotFound" => TypedResults.NotFound(new ErrorBody(failure.Message)),
-			"Guild.NotAMember" => TypedResults.Json(new ErrorBody(failure.Message), statusCode: StatusCodes.Status403Forbidden),
-			"Guild.MissingPermission" => TypedResults.Json(new ErrorBody(failure.Message), statusCode: StatusCodes.Status403Forbidden),
-			"Guild.RoleHierarchyBlocked" => TypedResults.Json(new ErrorBody(failure.Message), statusCode: StatusCodes.Status403Forbidden),
-			"Guild.CannotGrantPermissionsYouLack" => TypedResults.Json(new ErrorBody(failure.Message), statusCode: StatusCodes.Status403Forbidden),
-			_ => TypedResults.BadRequest(new ErrorBody(failure.Message)),
-		};
 
-	private static Results<Ok<IReadOnlyList<RoleResponse>>, BadRequest<ErrorBody>, NotFound<ErrorBody>, JsonHttpResult<ErrorBody>>
-		MapErrorReorder(Failure failure) => failure.Code switch
-		{
-			"Guild.GuildNotFound" => TypedResults.NotFound(new ErrorBody(failure.Message)),
-			"Guild.RoleNotFound" => TypedResults.NotFound(new ErrorBody(failure.Message)),
-			"Guild.NotAMember" => TypedResults.Json(new ErrorBody(failure.Message), statusCode: StatusCodes.Status403Forbidden),
-			"Guild.MissingPermission" => TypedResults.Json(new ErrorBody(failure.Message), statusCode: StatusCodes.Status403Forbidden),
-			"Guild.RoleHierarchyBlocked" => TypedResults.Json(new ErrorBody(failure.Message), statusCode: StatusCodes.Status403Forbidden),
-			_ => TypedResults.BadRequest(new ErrorBody(failure.Message)),
-		};
 
-	private static Results<NoContent, BadRequest<ErrorBody>, NotFound<ErrorBody>, JsonHttpResult<ErrorBody>>
-		MapErrorDelete(Failure failure) => failure.Code switch
-		{
-			"Guild.GuildNotFound" => TypedResults.NotFound(new ErrorBody(failure.Message)),
-			"Guild.RoleNotFound" => TypedResults.NotFound(new ErrorBody(failure.Message)),
-			"Guild.NotAMember" => TypedResults.Json(new ErrorBody(failure.Message), statusCode: StatusCodes.Status403Forbidden),
-			"Guild.MissingPermission" => TypedResults.Json(new ErrorBody(failure.Message), statusCode: StatusCodes.Status403Forbidden),
-			"Guild.RoleHierarchyBlocked" => TypedResults.Json(new ErrorBody(failure.Message), statusCode: StatusCodes.Status403Forbidden),
-			"Guild.CannotDeleteDefaultRole" => TypedResults.BadRequest(new ErrorBody(failure.Message)),
-			_ => TypedResults.BadRequest(new ErrorBody(failure.Message)),
-		};
 
 	// ---- request shapes ----
 

--- a/services/guild/src/Guild.Presentation/Endpoints/RolesEndpoint.cs
+++ b/services/guild/src/Guild.Presentation/Endpoints/RolesEndpoint.cs
@@ -17,11 +17,11 @@ public sealed class RolesEndpoint : ICarterModule
 	public void AddRoutes(IEndpointRouteBuilder endpoints)
 	{
 		var group = endpoints.MapGroup("/guilds/{id:long}/roles");
-		group.MapGet("/", ListAsync);
-		group.MapPost("/", CreateAsync);
-		group.MapPatch("/", ReorderAsync);
-		group.MapPatch("/{roleId:long}", UpdateAsync);
-		group.MapDelete("/{roleId:long}", DeleteAsync);
+		group.MapGet("/", ListAsync).ProducesGuildErrors();
+		group.MapPost("/", CreateAsync).ProducesGuildErrors();
+		group.MapPatch("/", ReorderAsync).ProducesGuildErrors();
+		group.MapPatch("/{roleId:long}", UpdateAsync).ProducesGuildErrors();
+		group.MapDelete("/{roleId:long}", DeleteAsync).ProducesGuildErrors();
 	}
 
 	private static async Task<Results<Ok<IReadOnlyList<RoleResponse>>, JsonHttpResult<ErrorBody>>>

--- a/services/guild/src/Guild.Presentation/Program.cs
+++ b/services/guild/src/Guild.Presentation/Program.cs
@@ -85,6 +85,15 @@ app.UseExceptionHandler(exApp => exApp.Run(async ctx =>
 	}
 	else
 	{
+		// genuinely unexpected: log it (with the exception) before returning an
+		// opaque 500. previously the error was read and silently swallowed, so
+		// production failures left no trace.
+		var logger = ctx.RequestServices
+			.GetRequiredService<ILoggerFactory>()
+			.CreateLogger("Guild.GlobalExceptionHandler");
+		logger.LogError(err, "Unhandled exception processing {Method} {Path}",
+			ctx.Request.Method, ctx.Request.Path);
+
 		ctx.Response.StatusCode = 500;
 		await ctx.Response.WriteAsJsonAsync(new ErrorBody("internal_server_error"));
 	}

--- a/services/guild/src/Guild.Presentation/Program.cs
+++ b/services/guild/src/Guild.Presentation/Program.cs
@@ -73,6 +73,16 @@ app.UseExceptionHandler(exApp => exApp.Run(async ctx =>
 			: "bad request";
 		await ctx.Response.WriteAsJsonAsync(new ErrorBody(message));
 	}
+	else if (err is Microsoft.EntityFrameworkCore.DbUpdateConcurrencyException)
+	{
+		// optimistic-concurrency conflict: another request modified the same row
+		// version between our read and write (xmin token, see the entity configs).
+		// surface a retryable 409 instead of a 500 so the client can re-fetch and
+		// retry rather than treating it as a server fault
+		ctx.Response.StatusCode = StatusCodes.Status409Conflict;
+		await ctx.Response.WriteAsJsonAsync(
+			new ErrorBody("the resource was modified by another request; please retry"));
+	}
 	else
 	{
 		ctx.Response.StatusCode = 500;

--- a/services/guild/src/Guild.Presentation/Program.cs
+++ b/services/guild/src/Guild.Presentation/Program.cs
@@ -66,7 +66,7 @@ app.UseExceptionHandler(exApp => exApp.Run(async ctx =>
 	if (err is BadHttpRequestException bad)
 	{
 		ctx.Response.StatusCode = bad.StatusCode;
-		var jsonEx = bad.InnerException as System.Text.Json.JsonException;
+		var jsonEx = bad.InnerException as JsonException;
 		var path = jsonEx?.Path?.TrimStart('$', '.');
 		var message = path is not null
 			? $"invalid value for field '{path}'"
@@ -82,6 +82,18 @@ app.UseExceptionHandler(exApp => exApp.Run(async ctx =>
 		ctx.Response.StatusCode = StatusCodes.Status409Conflict;
 		await ctx.Response.WriteAsJsonAsync(
 			new ErrorBody("the resource was modified by another request; please retry"));
+	}
+	else if (err is Microsoft.EntityFrameworkCore.DbUpdateException
+		{ InnerException: Npgsql.PostgresException { SqlState: Npgsql.PostgresErrorCodes.UniqueViolation } })
+	{
+		// lost a race to insert a row with a unique/PK that already exists - e.g.
+		// two concurrent double-bans both pass the FindAsync guard then both INSERT
+		// on guild_bans' composite PK. xmin does not cover inserts, so EF raises a
+		// plain DbUpdateException (not the concurrency variant above). 23505 is a
+		// genuine conflict, so map it to 409 rather than letting it fall to a 500.
+		ctx.Response.StatusCode = StatusCodes.Status409Conflict;
+		await ctx.Response.WriteAsJsonAsync(
+			new ErrorBody("the resource already exists"));
 	}
 	else
 	{

--- a/services/guild/src/Guild.Presentation/Program.cs
+++ b/services/guild/src/Guild.Presentation/Program.cs
@@ -4,6 +4,7 @@ using Carter;
 using Guild.Application;
 using Guild.Infrastructure;
 using Guild.Persistence;
+using Guild.Persistence.Db;
 using Guild.Presentation.Endpoints;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
@@ -22,7 +23,7 @@ builder.Services.AddHealthChecks()
 	.AddPersistenceHealthChecks();
 
 builder.Services.AddApplication()
-	.AddInfrastructure()
+	.AddInfrastructure<GuildDbContext>()
 	.AddPersistence();
 
 builder.Services.AddCarter();

--- a/services/guild/src/Guild.Presentation/Program.cs
+++ b/services/guild/src/Guild.Presentation/Program.cs
@@ -16,7 +16,7 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Host.ConfigureHostOptions(o => o.ShutdownTimeout = TimeSpan.FromSeconds(5));
 
 builder.Services.ConfigureHttpJsonOptions(o =>
-	o.SerializerOptions.PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower);
+	o.SerializerOptions.PropertyNamingPolicy = GuildSerialization.NamingPolicy);
 
 builder.Services.AddOpenApi();
 builder.Services.AddHealthChecks()

--- a/services/guild/tests/Guild.FunctionalTests/Endpoints/ListInvitesTests.cs
+++ b/services/guild/tests/Guild.FunctionalTests/Endpoints/ListInvitesTests.cs
@@ -67,7 +67,7 @@ public sealed class ListInvitesTests(GuildApiFactory factory) : IClassFixture<Gu
 	private async Task RevokeAsync(long guildId, string code)
 	{
 		using var scope = factory.Services.CreateScope();
-		var db = scope.ServiceProvider.GetRequiredService<Guild.Persistence.Db.GuildDbContext>();
+		var db = scope.ServiceProvider.GetRequiredService<Persistence.Db.GuildDbContext>();
 		var invite = await Microsoft.EntityFrameworkCore.EntityFrameworkQueryableExtensions
 			.FirstAsync(db.GuildInvites, i => i.Code == code);
 		invite.Revoke();

--- a/services/guild/tests/Guild.FunctionalTests/Endpoints/RevokeInviteTests.cs
+++ b/services/guild/tests/Guild.FunctionalTests/Endpoints/RevokeInviteTests.cs
@@ -4,7 +4,7 @@ using Xunit;
 
 namespace Guild.FunctionalTests.Endpoints;
 
-public sealed class DeleteInviteTests(GuildApiFactory factory) : IClassFixture<GuildApiFactory>
+public sealed class RevokeInviteTests(GuildApiFactory factory) : IClassFixture<GuildApiFactory>
 {
 	[Fact]
 	public async Task Without_Token_Returns_401()

--- a/services/guild/tests/Guild.FunctionalTests/Infrastructure/GuildApiFactory.cs
+++ b/services/guild/tests/Guild.FunctionalTests/Infrastructure/GuildApiFactory.cs
@@ -1,5 +1,4 @@
 using System.Net.Http.Headers;
-using System.Reflection;
 using Guild.Application.Abstractions;
 using Guild.Application.Abstractions.Users;
 using Guild.Persistence.Db;
@@ -239,9 +238,6 @@ public sealed class GuildApiFactory : WebApplicationFactory<Program>
 	/// </summary>
 	public async Task AddMemberWithPermissionsAsync(long guildId, long userId, long permissions)
 	{
-		const BindingFlags AnyInstance =
-			BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
-
 		using var scope = Services.CreateScope();
 		var db = scope.ServiceProvider.GetRequiredService<GuildDbContext>();
 		var ids = scope.ServiceProvider.GetRequiredService<IIdGenerator>();
@@ -261,22 +257,8 @@ public sealed class GuildApiFactory : WebApplicationFactory<Program>
 		db.Roles.Add(roleResult.Value);
 		await db.SaveChangesAsync();
 
-		var memberRole = (Guild.Domain.Guild.MemberRole)Activator.CreateInstance(
-			typeof(Guild.Domain.Guild.MemberRole), AnyInstance,
-			binder: null, args: null, culture: null)!;
-		typeof(Guild.Domain.Guild.MemberRole)
-			.GetProperty(nameof(Guild.Domain.Guild.MemberRole.GuildId), AnyInstance)!
-			.SetValue(memberRole, guildId);
-		typeof(Guild.Domain.Guild.MemberRole)
-			.GetProperty(nameof(Guild.Domain.Guild.MemberRole.UserId), AnyInstance)!
-			.SetValue(memberRole, userId);
-		typeof(Guild.Domain.Guild.MemberRole)
-			.GetProperty(nameof(Guild.Domain.Guild.MemberRole.RoleId), AnyInstance)!
-			.SetValue(memberRole, roleResult.Value.Id);
-		typeof(Guild.Domain.Guild.MemberRole)
-			.GetProperty(nameof(Guild.Domain.Guild.MemberRole.AssignedAt), AnyInstance)!
-			.SetValue(memberRole, now);
-		db.MemberRoles.Add(memberRole);
+		db.MemberRoles.Add(
+			Guild.Domain.Guild.MemberRole.Create(guildId, userId, roleResult.Value.Id, now));
 		await db.SaveChangesAsync();
 	}
 
@@ -285,34 +267,14 @@ public sealed class GuildApiFactory : WebApplicationFactory<Program>
 	/// <c>MemberRole</c> row directly. used by tests that need to construct
 	/// role hierarchies the public API cannot natively produce (e.g. assigning
 	/// a high-position role to a target so the caller is out-ranked).
-	/// uses reflection because <see cref="Guild.Domain.Guild.MemberRole.Create"/>
-	/// is <c>internal</c> and the functional-tests assembly does not have
-	/// <c>InternalsVisibleTo</c> access to the Domain project.
 	/// </summary>
 	public async Task AssignRoleDirectAsync(long guildId, long userId, long roleId)
 	{
-		const BindingFlags AnyInstance =
-			BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic;
-
 		using var scope = Services.CreateScope();
 		var db = scope.ServiceProvider.GetRequiredService<GuildDbContext>();
 
-		var memberRole = (Guild.Domain.Guild.MemberRole)Activator.CreateInstance(
-			typeof(Guild.Domain.Guild.MemberRole), AnyInstance,
-			binder: null, args: null, culture: null)!;
-		typeof(Guild.Domain.Guild.MemberRole)
-			.GetProperty(nameof(Guild.Domain.Guild.MemberRole.GuildId), AnyInstance)!
-			.SetValue(memberRole, guildId);
-		typeof(Guild.Domain.Guild.MemberRole)
-			.GetProperty(nameof(Guild.Domain.Guild.MemberRole.UserId), AnyInstance)!
-			.SetValue(memberRole, userId);
-		typeof(Guild.Domain.Guild.MemberRole)
-			.GetProperty(nameof(Guild.Domain.Guild.MemberRole.RoleId), AnyInstance)!
-			.SetValue(memberRole, roleId);
-		typeof(Guild.Domain.Guild.MemberRole)
-			.GetProperty(nameof(Guild.Domain.Guild.MemberRole.AssignedAt), AnyInstance)!
-			.SetValue(memberRole, DateTimeOffset.UtcNow);
-		db.MemberRoles.Add(memberRole);
+		db.MemberRoles.Add(
+			Guild.Domain.Guild.MemberRole.Create(guildId, userId, roleId, DateTimeOffset.UtcNow));
 		await db.SaveChangesAsync();
 	}
 

--- a/services/guild/tests/Guild.FunctionalTests/Infrastructure/GuildApiFactory.cs
+++ b/services/guild/tests/Guild.FunctionalTests/Infrastructure/GuildApiFactory.cs
@@ -171,7 +171,7 @@ public sealed class GuildApiFactory : WebApplicationFactory<Program>
 	{
 		using var scope = Services.CreateScope();
 		var db = scope.ServiceProvider.GetRequiredService<GuildDbContext>();
-		var ids = scope.ServiceProvider.GetRequiredService<Guild.Application.Abstractions.IIdGenerator>();
+		var ids = scope.ServiceProvider.GetRequiredService<IIdGenerator>();
 		var id = channelId ?? ids.NextId();
 		var channelResult = Guild.Domain.Guild.Channel.Create(
 			id: id,
@@ -206,14 +206,14 @@ public sealed class GuildApiFactory : WebApplicationFactory<Program>
 
 	public async Task AddChannelOverwriteAsync(
 		long channelId,
-		Guild.Domain.Guild.OverwriteTargetType type,
+		Domain.Guild.OverwriteTargetType type,
 		long targetId,
 		long allow,
 		long deny)
 	{
 		using var scope = Services.CreateScope();
 		var db = scope.ServiceProvider.GetRequiredService<GuildDbContext>();
-		var ids = scope.ServiceProvider.GetRequiredService<Guild.Application.Abstractions.IIdGenerator>();
+		var ids = scope.ServiceProvider.GetRequiredService<IIdGenerator>();
 		var channel = await db.Channels.FindAsync(channelId)
 			?? throw new InvalidOperationException($"Channel {channelId} not found");
 		var owResult = Guild.Domain.Guild.ChannelPermissionOverwrite.Create(

--- a/services/guild/tests/Guild.UnitTests/Application/AssignRoleHandlerTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/AssignRoleHandlerTests.cs
@@ -97,7 +97,7 @@ public sealed class AssignRoleHandlerTests
 		var guild = GuildEntity.Create(
 			id: 100, name: "Test", description: null, iconUrl: null, bannerUrl: null,
 			ownerId: 1, everyoneRoleId: 101, adminRoleId: 102, now: Now).Value;
-		guilds.AddAsync(guild).GetAwaiter().GetResult();
+		guilds.Add(guild);
 
 		var handler = HandlerFactory.CreateCommand<AssignRoleCommand, Result>(
 			guilds, clock, new FakeCurrentUser { Id = currentUser });

--- a/services/guild/tests/Guild.UnitTests/Application/AssignRoleHandlerTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/AssignRoleHandlerTests.cs
@@ -1,0 +1,106 @@
+using Guild.Application.Abstractions.Messaging;
+using Guild.Application.Features.Membership.AssignRole;
+using Guild.Domain.Guild;
+using Guild.Domain.Results;
+using Guild.UnitTests.Fakes;
+using Xunit;
+using GuildEntity = Guild.Domain.Guild.Guild;
+
+namespace Guild.UnitTests.Application;
+
+public sealed class AssignRoleHandlerTests
+{
+	private static readonly DateTimeOffset Now =
+		new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+	[Fact]
+	public async Task UnknownGuild_Returns_GuildNotFound()
+	{
+		var (handler, _) = MakeHandler(currentUser: 1);
+
+		var result = await handler.HandleAsync(new AssignRoleCommand(999, TargetUserId: 3, RoleId: 500));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal("Guild.GuildNotFound", result.Error.Code);
+	}
+
+	[Fact]
+	public async Task CallerNotMember_Returns_NotAMember()
+	{
+		var (handler, _) = MakeHandler(currentUser: 99);
+
+		var result = await handler.HandleAsync(new AssignRoleCommand(100, TargetUserId: 3, RoleId: 500));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal("Guild.NotAMember", result.Error.Code);
+	}
+
+	[Fact]
+	public async Task CallerWithoutManageRoles_Returns_MissingPermission()
+	{
+		var (handler, guilds) = MakeHandler(currentUser: 2);
+		var guild = guilds.Store[100];
+		DomainSeed.AddCustomRole(guild, roleId: 500, name: "Role", permissions: 0, position: 5, now: Now);
+		DomainSeed.AddMember(guild, userId: 2, joinedAt: Now);
+		DomainSeed.AddMember(guild, userId: 3, joinedAt: Now);
+
+		var result = await handler.HandleAsync(new AssignRoleCommand(100, TargetUserId: 3, RoleId: 500));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal("Guild.MissingPermission", result.Error.Code);
+	}
+
+	[Fact]
+	public async Task UnknownRole_Returns_RoleNotFound()
+	{
+		var (handler, _) = MakeHandler(currentUser: 1);
+
+		var result = await handler.HandleAsync(new AssignRoleCommand(100, TargetUserId: 3, RoleId: 999));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal("Guild.RoleNotFound", result.Error.Code);
+	}
+
+	[Fact]
+	public async Task TargetNotAMember_Returns_TargetNotAMember()
+	{
+		var (handler, guilds) = MakeHandler(currentUser: 1);
+		DomainSeed.AddCustomRole(guilds.Store[100], roleId: 500, name: "Role",
+			permissions: (long)Permission.SendMessages, position: 5, now: Now);
+
+		var result = await handler.HandleAsync(new AssignRoleCommand(100, TargetUserId: 555, RoleId: 500));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal("Guild.TargetNotAMember", result.Error.Code);
+	}
+
+	[Fact]
+	public async Task HappyPath_AssignsRole()
+	{
+		var (handler, guilds) = MakeHandler(currentUser: 1);
+		var guild = guilds.Store[100];
+		DomainSeed.AddCustomRole(guild, roleId: 500, name: "Role",
+			permissions: (long)Permission.SendMessages, position: 5, now: Now);
+		DomainSeed.AddMember(guild, userId: 3, joinedAt: Now);
+
+		var result = await handler.HandleAsync(new AssignRoleCommand(100, TargetUserId: 3, RoleId: 500));
+
+		Assert.True(result.Succeeded);
+		Assert.Contains(guild.MemberRoles, mr => mr.UserId == 3 && mr.RoleId == 500);
+	}
+
+	private static (ICommandHandler<AssignRoleCommand, Result> Handler, FakeGuildRepository Guilds)
+		MakeHandler(long currentUser)
+	{
+		var guilds = new FakeGuildRepository();
+		var clock = new FakeClock(Now);
+		var guild = GuildEntity.Create(
+			id: 100, name: "Test", description: null, iconUrl: null, bannerUrl: null,
+			ownerId: 1, everyoneRoleId: 101, adminRoleId: 102, now: Now).Value;
+		guilds.AddAsync(guild).GetAwaiter().GetResult();
+
+		var handler = HandlerFactory.CreateCommand<AssignRoleCommand, Result>(
+			guilds, clock, new FakeCurrentUser { Id = currentUser });
+		return (handler, guilds);
+	}
+}

--- a/services/guild/tests/Guild.UnitTests/Application/BanMemberHandlerTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/BanMemberHandlerTests.cs
@@ -169,7 +169,7 @@ public sealed class BanMemberHandlerTests
 		var guild = GuildEntity.Create(
 			id: 100, name: "Test", description: null, iconUrl: null, bannerUrl: null,
 			ownerId: 1, everyoneRoleId: 101, adminRoleId: 102, now: Now).Value;
-		guilds.AddAsync(guild).GetAwaiter().GetResult();
+		guilds.Add(guild);
 
 		var handler = HandlerFactory.CreateCommand<BanMemberCommand, Result>(
 			guilds, bans, events, clock, new FakeCurrentUser { Id = currentUser });

--- a/services/guild/tests/Guild.UnitTests/Application/BanMemberHandlerTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/BanMemberHandlerTests.cs
@@ -1,0 +1,178 @@
+using Guild.Application.Abstractions.Messaging;
+using Guild.Application.Contracts;
+using Guild.Application.Features.Bans.BanMember;
+using Guild.Domain.Guild;
+using Guild.Domain.Results;
+using Guild.UnitTests.Fakes;
+using Xunit;
+using GuildEntity = Guild.Domain.Guild.Guild;
+
+namespace Guild.UnitTests.Application;
+
+public sealed class BanMemberHandlerTests
+{
+	private static readonly DateTimeOffset Now =
+		new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+	[Fact]
+	public async Task UnknownGuild_Returns_GuildNotFound()
+	{
+		var (handler, _, _, _) = MakeHandler(currentUser: 1);
+
+		var result = await handler.HandleAsync(new BanMemberCommand(999, TargetUserId: 2, Reason: null));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal("Guild.GuildNotFound", result.Error.Code);
+	}
+
+	[Fact]
+	public async Task CallerNotMember_Returns_NotAMember()
+	{
+		var (handler, _, _, _) = MakeHandler(currentUser: 99);
+
+		var result = await handler.HandleAsync(new BanMemberCommand(100, TargetUserId: 2, Reason: null));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal("Guild.NotAMember", result.Error.Code);
+	}
+
+	[Fact]
+	public async Task CallerWithoutBanMembers_Returns_MissingPermission()
+	{
+		var (handler, guilds, _, _) = MakeHandler(currentUser: 2);
+		DomainSeed.AddMember(guilds.Store[100], userId: 2, joinedAt: Now);
+		DomainSeed.AddMember(guilds.Store[100], userId: 3, joinedAt: Now);
+
+		var result = await handler.HandleAsync(new BanMemberCommand(100, TargetUserId: 3, Reason: null));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal("Guild.MissingPermission", result.Error.Code);
+	}
+
+	[Fact]
+	public async Task SelfBan_Returns_CannotBanSelf()
+	{
+		// owner has BAN_MEMBERS via Administrator; the self check precedes the
+		// owner check, so banning yourself surfaces CannotBanSelf even as owner
+		var (handler, _, _, _) = MakeHandler(currentUser: 1);
+
+		var result = await handler.HandleAsync(new BanMemberCommand(100, TargetUserId: 1, Reason: null));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal("Guild.CannotBanSelf", result.Error.Code);
+	}
+
+	[Fact]
+	public async Task OwnerAsTarget_Returns_CannotBanOwner()
+	{
+		// caller is a non-owner mod with BAN_MEMBERS, target is the owner
+		var (handler, guilds, _, _) = MakeHandler(currentUser: 2);
+		var guild = guilds.Store[100];
+		var mod = DomainSeed.AddCustomRole(guild, roleId: 500, name: "Mod",
+			permissions: (long)Permission.BanMembers, position: 5, now: Now);
+		DomainSeed.AddMember(guild, userId: 2, joinedAt: Now);
+		DomainSeed.AssignRole(guild, userId: 2, roleId: mod.Id, now: Now);
+
+		var result = await handler.HandleAsync(new BanMemberCommand(100, TargetUserId: 1, Reason: null));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal("Guild.CannotBanOwner", result.Error.Code);
+	}
+
+	[Fact]
+	public async Task SameRank_Returns_RoleHierarchyBlocked()
+	{
+		var (handler, guilds, _, _) = MakeHandler(currentUser: 2);
+		var guild = guilds.Store[100];
+		var mod = DomainSeed.AddCustomRole(guild, roleId: 500, name: "Mod",
+			permissions: (long)Permission.BanMembers, position: 5, now: Now);
+		DomainSeed.AddMember(guild, userId: 2, joinedAt: Now);
+		DomainSeed.AssignRole(guild, userId: 2, roleId: mod.Id, now: Now);
+		DomainSeed.AddMember(guild, userId: 3, joinedAt: Now);
+		DomainSeed.AssignRole(guild, userId: 3, roleId: mod.Id, now: Now);
+
+		var result = await handler.HandleAsync(new BanMemberCommand(100, TargetUserId: 3, Reason: null));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal("Guild.RoleHierarchyBlocked", result.Error.Code);
+	}
+
+	[Fact]
+	public async Task AlreadyBanned_Returns_AlreadyBanned()
+	{
+		var (handler, guilds, bans, _) = MakeHandler(currentUser: 1);
+		DomainSeed.AddMember(guilds.Store[100], userId: 3, joinedAt: Now);
+		bans.Seed(GuildBan.Create(guildId: 100, userId: 3, bannedBy: 1, reason: null, now: Now).Value);
+
+		var result = await handler.HandleAsync(new BanMemberCommand(100, TargetUserId: 3, Reason: null));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal("Guild.AlreadyBanned", result.Error.Code);
+	}
+
+	[Fact]
+	public async Task ReasonTooLong_Returns_BanReasonTooLong()
+	{
+		var (handler, guilds, bans, _) = MakeHandler(currentUser: 1);
+		DomainSeed.AddMember(guilds.Store[100], userId: 3, joinedAt: Now);
+		var reason = new string('x', GuildBan.MaxReasonLen + 1);
+
+		var result = await handler.HandleAsync(new BanMemberCommand(100, TargetUserId: 3, Reason: reason));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal("Guild.BanReasonTooLong", result.Error.Code);
+		Assert.Empty(bans.Store);
+	}
+
+	[Fact]
+	public async Task HappyPath_Member_BansAndRemovesMember_AndPublishesGuildMemberLeft()
+	{
+		var (handler, guilds, bans, events) = MakeHandler(currentUser: 1);
+		var guild = guilds.Store[100];
+		DomainSeed.AddMember(guild, userId: 3, joinedAt: Now);
+
+		var result = await handler.HandleAsync(new BanMemberCommand(100, TargetUserId: 3, Reason: "spam"));
+
+		Assert.True(result.Succeeded);
+		Assert.True(bans.Store.ContainsKey((100, 3)));
+		Assert.DoesNotContain(guild.Members, m => m.UserId == 3);
+		var ev = events.Single<GuildMemberLeft>();
+		Assert.Equal(100L, ev.GuildId);
+		Assert.Equal(3L, ev.UserId);
+	}
+
+	[Fact]
+	public async Task HappyPath_PreEmptive_BansNonMember_WithoutPublishingLeft()
+	{
+		// pre-emptive ban: target has never been a member, so no member is
+		// removed and no GuildMemberLeft is published
+		var (handler, guilds, bans, events) = MakeHandler(currentUser: 1);
+
+		var result = await handler.HandleAsync(new BanMemberCommand(100, TargetUserId: 555, Reason: null));
+
+		Assert.True(result.Succeeded);
+		Assert.True(bans.Store.ContainsKey((100, 555)));
+		Assert.False(events.Has<GuildMemberLeft>());
+	}
+
+	private static (
+		ICommandHandler<BanMemberCommand, Result> Handler,
+		FakeGuildRepository Guilds,
+		FakeGuildBanRepository Bans,
+		FakeEventBus Events)
+		MakeHandler(long currentUser)
+	{
+		var guilds = new FakeGuildRepository();
+		var bans = new FakeGuildBanRepository();
+		var events = new FakeEventBus();
+		var clock = new FakeClock(Now);
+		var guild = GuildEntity.Create(
+			id: 100, name: "Test", description: null, iconUrl: null, bannerUrl: null,
+			ownerId: 1, everyoneRoleId: 101, adminRoleId: 102, now: Now).Value;
+		guilds.AddAsync(guild).GetAwaiter().GetResult();
+
+		var handler = HandlerFactory.CreateCommand<BanMemberCommand, Result>(
+			guilds, bans, events, clock, new FakeCurrentUser { Id = currentUser });
+		return (handler, guilds, bans, events);
+	}
+}

--- a/services/guild/tests/Guild.UnitTests/Application/CountOwnedGuildsHandlerTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/CountOwnedGuildsHandlerTests.cs
@@ -67,7 +67,7 @@ public sealed class CountOwnedGuildsHandlerTests
 		var guild = GuildEntity.Create(
 			id: guildId, name: $"g{guildId}", description: null, iconUrl: null, bannerUrl: null,
 			ownerId: ownerId, everyoneRoleId: guildId + 1, adminRoleId: guildId + 2, now: Now).Value;
-		guilds.AddAsync(guild).GetAwaiter().GetResult();
+		guilds.Add(guild);
 	}
 
 	private static (

--- a/services/guild/tests/Guild.UnitTests/Application/CreateCategoryHandlerTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/CreateCategoryHandlerTests.cs
@@ -51,7 +51,7 @@ public sealed class CreateCategoryHandlerTests
 		var guildRepo = new FakeGuildRepository();
 		var catRepo = new FakeChannelCategoryRepository();
 		var guild = CreateGuildWithBareMember(memberId: 2, ownerId: 1);
-		await guildRepo.AddAsync(guild);
+		guildRepo.Add(guild);
 
 		var handler = HandlerFactory.CreateCommand<CreateCategoryCommand, Result<CategoryResponse>>(
 			guildRepo, catRepo, new FakeIdGenerator(), new FakeClock(), new FakeCurrentUser { Id = 2 });
@@ -152,7 +152,7 @@ public sealed class CreateCategoryHandlerTests
 			id: 100, name: "Test", description: null, iconUrl: null, bannerUrl: null,
 			ownerId: 1, everyoneRoleId: 101, adminRoleId: 102, now: Now).Value;
 		DomainSeed.AddMember(guild, userId: 2, joinedAt: Now);
-		await guildRepo.AddAsync(guild);
+		guildRepo.Add(guild);
 
 		var handler = HandlerFactory.CreateCommand<CreateCategoryCommand, Result<CategoryResponse>>(
 			guildRepo, catRepo, new FakeIdGenerator(), new FakeClock(), new FakeCurrentUser { Id = 1 });
@@ -168,7 +168,7 @@ public sealed class CreateCategoryHandlerTests
 		var guild = GuildEntity.Create(
 			id: 100, name: "Test", description: null, iconUrl: null, bannerUrl: null,
 			ownerId: ownerId, everyoneRoleId: 101, adminRoleId: 102, now: Now).Value;
-		repo.AddAsync(guild).GetAwaiter().GetResult();
+		repo.Add(guild);
 	}
 
 	private static GuildEntity CreateGuildWithBareMember(long memberId, long ownerId)

--- a/services/guild/tests/Guild.UnitTests/Application/CreateChannelHandlerTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/CreateChannelHandlerTests.cs
@@ -48,7 +48,7 @@ public sealed class CreateChannelHandlerTests
 		var channelRepo = new FakeChannelRepository();
 		var categoryRepo = new FakeChannelCategoryRepository();
 		var guild = CreateGuildWithBareMember(memberId: 2, ownerId: 1);
-		await guildRepo.AddAsync(guild);
+		guildRepo.Add(guild);
 
 		var handler = HandlerFactory.CreateCommand<CreateChannelCommand, Result<ChannelResponse>>(
 			guildRepo, channelRepo, categoryRepo,
@@ -194,7 +194,7 @@ public sealed class CreateChannelHandlerTests
 			id: 100, name: "Test", description: null, iconUrl: null, bannerUrl: null,
 			ownerId: 1, everyoneRoleId: 101, adminRoleId: 102, now: Now).Value;
 		DomainSeed.AddMember(guild, userId: 2, joinedAt: Now);
-		await guilds.AddAsync(guild);
+		guilds.Add(guild);
 
 		var handler = HandlerFactory.CreateCommand<CreateChannelCommand, Result<ChannelResponse>>(
 			guilds, channels, cats,
@@ -224,7 +224,7 @@ public sealed class CreateChannelHandlerTests
 			var guild = GuildEntity.Create(
 				id: 100, name: "Test", description: null, iconUrl: null, bannerUrl: null,
 				ownerId: ownerId, everyoneRoleId: 101, adminRoleId: 102, now: Now).Value;
-			guilds.AddAsync(guild).GetAwaiter().GetResult();
+			guilds.Add(guild);
 		}
 
 		return HandlerFactory.CreateCommand<CreateChannelCommand, Result<ChannelResponse>>(

--- a/services/guild/tests/Guild.UnitTests/Application/CreateInviteHandlerTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/CreateInviteHandlerTests.cs
@@ -79,7 +79,6 @@ public sealed class CreateInviteHandlerTests
 		Assert.NotNull(result.Value.ExpiresAt);
 
 		Assert.Equal(1, i.AddCount);
-		Assert.Equal(1, i.SaveChangesCount);
 
 		var evt = b.Single<GuildInviteCreated>();
 		Assert.Equal(guild.Id, evt.GuildId);

--- a/services/guild/tests/Guild.UnitTests/Application/CreateInviteHandlerTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/CreateInviteHandlerTests.cs
@@ -137,7 +137,7 @@ public sealed class CreateInviteHandlerTests
 		var guild = GuildEntity.Create(
 			id: 100, name: "Test", description: null, iconUrl: null, bannerUrl: null,
 			ownerId: ownerId, everyoneRoleId: 101, adminRoleId: 102, now: Now).Value;
-		repo.AddAsync(guild).GetAwaiter().GetResult();
+		repo.Add(guild);
 		return guild;
 	}
 }

--- a/services/guild/tests/Guild.UnitTests/Application/CreateRoleHandlerTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/CreateRoleHandlerTests.cs
@@ -122,7 +122,7 @@ public sealed class CreateRoleHandlerTests
 		var guild = GuildEntity.Create(
 			id: 100, name: "Test", description: null, iconUrl: null, bannerUrl: null,
 			ownerId: 1, everyoneRoleId: 101, adminRoleId: 102, now: Now).Value;
-		guilds.AddAsync(guild).GetAwaiter().GetResult();
+		guilds.Add(guild);
 		var handler = HandlerFactory.CreateCommand<CreateRoleCommand, Result<RoleResponse>>(
 			guilds, new FakeIdGenerator(seed: 1000), new FakeClock(Now),
 			new FakeCurrentUser { Id = currentUser });

--- a/services/guild/tests/Guild.UnitTests/Application/DeleteCategoryHandlerTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/DeleteCategoryHandlerTests.cs
@@ -51,7 +51,7 @@ public sealed class DeleteCategoryHandlerTests
 		var guildRepo = new FakeGuildRepository();
 		var catRepo = new FakeChannelCategoryRepository();
 		var guild = CreateGuildWithBareMember(memberId: 2, ownerId: 1);
-		await guildRepo.AddAsync(guild);
+		guildRepo.Add(guild);
 		SeedCategory(catRepo, id: 500);
 
 		var handler = HandlerFactory.CreateCommand<DeleteCategoryCommand, Result>(
@@ -109,7 +109,7 @@ public sealed class DeleteCategoryHandlerTests
 			id: 100, name: "Test", description: null, iconUrl: null, bannerUrl: null,
 			ownerId: 1, everyoneRoleId: 101, adminRoleId: 102, now: Now).Value;
 		DomainSeed.AddMember(guild, userId: 2, joinedAt: Now);
-		await guildRepo.AddAsync(guild);
+		guildRepo.Add(guild);
 		SeedCategory(catRepo, id: 500);
 
 		var handler = HandlerFactory.CreateCommand<DeleteCategoryCommand, Result>(
@@ -130,7 +130,7 @@ public sealed class DeleteCategoryHandlerTests
 		var guild = GuildEntity.Create(
 			id: 100, name: "Test", description: null, iconUrl: null, bannerUrl: null,
 			ownerId: ownerId, everyoneRoleId: 101, adminRoleId: 102, now: Now).Value;
-		guildRepo.AddAsync(guild).GetAwaiter().GetResult();
+		guildRepo.Add(guild);
 		if (seedCategory)
 			SeedCategory(catRepo, id: 500);
 	}

--- a/services/guild/tests/Guild.UnitTests/Application/DeleteChannelHandlerTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/DeleteChannelHandlerTests.cs
@@ -71,7 +71,7 @@ public sealed class DeleteChannelHandlerTests
 		var guild = GuildEntity.Create(
 			id: 100, name: "Test", description: null, iconUrl: null, bannerUrl: null,
 			ownerId: 1, everyoneRoleId: 101, adminRoleId: 102, now: Now).Value;
-		guilds.AddAsync(guild).GetAwaiter().GetResult();
+		guilds.Add(guild);
 
 		var handler = HandlerFactory.CreateCommand<DeleteChannelCommand, Result>(
 			guilds, channels, new FakeCurrentUser { Id = currentUser });

--- a/services/guild/tests/Guild.UnitTests/Application/DeleteGuildHandlerTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/DeleteGuildHandlerTests.cs
@@ -64,6 +64,6 @@ public sealed class DeleteGuildHandlerTests
 			everyoneRoleId: 101,
 			adminRoleId: 102,
 			now: Now).Value;
-		repo.AddAsync(guild).GetAwaiter().GetResult();
+		repo.Add(guild);
 	}
 }

--- a/services/guild/tests/Guild.UnitTests/Application/DeleteInviteHandlerTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/DeleteInviteHandlerTests.cs
@@ -129,7 +129,7 @@ public sealed class DeleteInviteHandlerTests
 		var guild = GuildEntity.Create(
 			id: 100, name: "Test", description: null, iconUrl: null, bannerUrl: null,
 			ownerId: ownerId, everyoneRoleId: 101, adminRoleId: 102, now: Now).Value;
-		repo.AddAsync(guild).GetAwaiter().GetResult();
+		repo.Add(guild);
 		return guild;
 	}
 

--- a/services/guild/tests/Guild.UnitTests/Application/DeleteInviteHandlerTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/DeleteInviteHandlerTests.cs
@@ -82,7 +82,6 @@ public sealed class DeleteInviteHandlerTests
 		Assert.True(result.Succeeded);
 		Assert.True(invite.IsRevoked);
 		Assert.Equal(1, i.UpdateCount);
-		Assert.Equal(1, i.SaveChangesCount);
 	}
 
 	[Fact]

--- a/services/guild/tests/Guild.UnitTests/Application/DeleteOverwriteHandlerTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/DeleteOverwriteHandlerTests.cs
@@ -108,7 +108,7 @@ public sealed class DeleteOverwriteHandlerTests
 		var guild = GuildEntity.Create(
 			id: 100, name: "Test", description: null, iconUrl: null, bannerUrl: null,
 			ownerId: 1, everyoneRoleId: 101, adminRoleId: 102, now: Now).Value;
-		guilds.AddAsync(guild).GetAwaiter().GetResult();
+		guilds.Add(guild);
 
 		var handler = HandlerFactory.CreateCommand<DeleteOverwriteCommand, Result>(
 			guilds, channels, overwrites, new FakeCurrentUser { Id = currentUser });

--- a/services/guild/tests/Guild.UnitTests/Application/DeleteOverwriteHandlerTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/DeleteOverwriteHandlerTests.cs
@@ -48,7 +48,6 @@ public sealed class DeleteOverwriteHandlerTests
 		Assert.True(result.Succeeded);
 		Assert.Empty(overwrites.Store);
 		Assert.Equal(1, overwrites.RemoveCount);
-		Assert.Equal(1, overwrites.SaveChangesCount);
 	}
 
 	[Fact]

--- a/services/guild/tests/Guild.UnitTests/Application/DeleteRoleHandlerTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/DeleteRoleHandlerTests.cs
@@ -113,7 +113,7 @@ public sealed class DeleteRoleHandlerTests
 		var guild = GuildEntity.Create(
 			id: 100, name: "Test", description: null, iconUrl: null, bannerUrl: null,
 			ownerId: 1, everyoneRoleId: 101, adminRoleId: 102, now: Now).Value;
-		guilds.AddAsync(guild).GetAwaiter().GetResult();
+		guilds.Add(guild);
 		var handler = HandlerFactory.CreateCommand<DeleteRoleCommand, Result>(
 			guilds, new FakeClock(Now), new FakeCurrentUser { Id = currentUser });
 		return (handler, guilds);

--- a/services/guild/tests/Guild.UnitTests/Application/GetChannelMembershipHandlerTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/GetChannelMembershipHandlerTests.cs
@@ -84,7 +84,7 @@ public sealed class GetChannelMembershipHandlerTests
 		var guild = GuildEntity.Create(
 			id: 100, name: "Test", description: null, iconUrl: null, bannerUrl: null,
 			ownerId: 1, everyoneRoleId: 101, adminRoleId: 102, now: Now).Value;
-		guilds.AddAsync(guild).GetAwaiter().GetResult();
+		guilds.Add(guild);
 
 		var handler = HandlerFactory.CreateQuery<GetChannelMembershipQuery, Result<MembershipResponse>>(
 			guilds, channels, overwrites);

--- a/services/guild/tests/Guild.UnitTests/Application/GetGuildHandlerTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/GetGuildHandlerTests.cs
@@ -68,6 +68,6 @@ public sealed class GetGuildHandlerTests
 			everyoneRoleId: 101,
 			adminRoleId: 102,
 			now: Now).Value;
-		repo.AddAsync(guild).GetAwaiter().GetResult();
+		repo.Add(guild);
 	}
 }

--- a/services/guild/tests/Guild.UnitTests/Application/GetInvitePreviewHandlerTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/GetInvitePreviewHandlerTests.cs
@@ -124,7 +124,7 @@ public sealed class GetInvitePreviewHandlerTests
 		var guild = GuildEntity.Create(
 			id: 100, name: "Test", description: null, iconUrl: null, bannerUrl: null,
 			ownerId: 1, everyoneRoleId: 101, adminRoleId: 102, now: Now).Value;
-		repo.AddAsync(guild).GetAwaiter().GetResult();
+		repo.Add(guild);
 		return guild;
 	}
 

--- a/services/guild/tests/Guild.UnitTests/Application/GetMemberPermissionsHandlerTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/GetMemberPermissionsHandlerTests.cs
@@ -1,0 +1,92 @@
+using Guild.Application.Abstractions.Messaging;
+using Guild.Application.Features.Membership.GetMemberPermissions;
+using Guild.Domain.Guild;
+using Guild.Domain.Results;
+using Guild.UnitTests.Fakes;
+using Xunit;
+using GuildEntity = Guild.Domain.Guild.Guild;
+
+namespace Guild.UnitTests.Application;
+
+public sealed class GetMemberPermissionsHandlerTests
+{
+	private static readonly DateTimeOffset Now =
+		new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+	[Fact]
+	public async Task UnknownGuild_Returns_GuildNotFound()
+	{
+		var (handler, _) = MakeHandler(currentUser: 1);
+
+		var result = await handler.HandleAsync(new GetMemberPermissionsQuery(999, TargetUserId: 1));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal("Guild.GuildNotFound", result.Error.Code);
+	}
+
+	[Fact]
+	public async Task CallerNotMember_Returns_NotAMember()
+	{
+		var (handler, _) = MakeHandler(currentUser: 99);
+
+		var result = await handler.HandleAsync(new GetMemberPermissionsQuery(100, TargetUserId: 1));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal("Guild.NotAMember", result.Error.Code);
+	}
+
+	[Fact]
+	public async Task TargetNotAMember_Returns_TargetNotAMember()
+	{
+		var (handler, _) = MakeHandler(currentUser: 1);
+
+		var result = await handler.HandleAsync(new GetMemberPermissionsQuery(100, TargetUserId: 555));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal("Guild.TargetNotAMember", result.Error.Code);
+	}
+
+	[Fact]
+	public async Task Owner_ReportsIsOwner_WithAdministrator()
+	{
+		var (handler, _) = MakeHandler(currentUser: 1);
+
+		var result = await handler.HandleAsync(new GetMemberPermissionsQuery(100, TargetUserId: 1));
+
+		Assert.True(result.Succeeded);
+		Assert.True(result.Value.IsOwner);
+		Assert.NotEqual(0, result.Value.EffectivePermissions & (long)Permission.Administrator);
+	}
+
+	[Fact]
+	public async Task Member_ReportsAssignedRolePermissions_WithoutOwnerFlag()
+	{
+		var (handler, guilds) = MakeHandler(currentUser: 1);
+		var guild = guilds.Store[100];
+		DomainSeed.AddCustomRole(guild, roleId: 500, name: "Mod",
+			permissions: (long)Permission.BanMembers, position: 5, now: Now);
+		DomainSeed.AddMember(guild, userId: 3, joinedAt: Now);
+		DomainSeed.AssignRole(guild, userId: 3, roleId: 500, now: Now);
+
+		var result = await handler.HandleAsync(new GetMemberPermissionsQuery(100, TargetUserId: 3));
+
+		Assert.True(result.Succeeded);
+		Assert.False(result.Value.IsOwner);
+		Assert.NotEqual(0, result.Value.EffectivePermissions & (long)Permission.BanMembers);
+		Assert.Contains(result.Value.Roles, r => r.Id == "500");
+	}
+
+	private static (IQueryHandler<GetMemberPermissionsQuery, Result<MemberPermissionsResponse>> Handler, FakeGuildRepository Guilds)
+		MakeHandler(long currentUser)
+	{
+		var guilds = new FakeGuildRepository();
+		var guild = GuildEntity.Create(
+			id: 100, name: "Test", description: null, iconUrl: null, bannerUrl: null,
+			ownerId: 1, everyoneRoleId: 101, adminRoleId: 102, now: Now).Value;
+		guilds.AddAsync(guild).GetAwaiter().GetResult();
+
+		var handler = HandlerFactory.CreateQuery<GetMemberPermissionsQuery, Result<MemberPermissionsResponse>>(
+			guilds, new FakeCurrentUser { Id = currentUser });
+		return (handler, guilds);
+	}
+}

--- a/services/guild/tests/Guild.UnitTests/Application/GetMemberPermissionsHandlerTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/GetMemberPermissionsHandlerTests.cs
@@ -83,7 +83,7 @@ public sealed class GetMemberPermissionsHandlerTests
 		var guild = GuildEntity.Create(
 			id: 100, name: "Test", description: null, iconUrl: null, bannerUrl: null,
 			ownerId: 1, everyoneRoleId: 101, adminRoleId: 102, now: Now).Value;
-		guilds.AddAsync(guild).GetAwaiter().GetResult();
+		guilds.Add(guild);
 
 		var handler = HandlerFactory.CreateQuery<GetMemberPermissionsQuery, Result<MemberPermissionsResponse>>(
 			guilds, new FakeCurrentUser { Id = currentUser });

--- a/services/guild/tests/Guild.UnitTests/Application/GetOverwritesQueryHandlerTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/GetOverwritesQueryHandlerTests.cs
@@ -191,7 +191,7 @@ public sealed class GetOverwritesQueryHandlerTests
 		var guild = GuildEntity.Create(
 			id: 100, name: "Test", description: null, iconUrl: null, bannerUrl: null,
 			ownerId: 1, everyoneRoleId: 101, adminRoleId: 102, now: Now).Value;
-		guilds.AddAsync(guild).GetAwaiter().GetResult();
+		guilds.Add(guild);
 
 		var handler = HandlerFactory.CreateQuery<GetOverwritesQuery, Result<OverwritesResponse>>(
 			guilds, channels, overwrites, new FakeCurrentUser { Id = currentUser });

--- a/services/guild/tests/Guild.UnitTests/Application/JoinByInviteCodeHandlerTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/JoinByInviteCodeHandlerTests.cs
@@ -189,7 +189,7 @@ public sealed class JoinByInviteCodeHandlerTests
 		var guild = GuildEntity.Create(
 			id: 100, name: "Test", description: null, iconUrl: null, bannerUrl: null,
 			ownerId: ownerId, everyoneRoleId: 101, adminRoleId: 102, now: Now).Value;
-		repo.AddAsync(guild).GetAwaiter().GetResult();
+		repo.Add(guild);
 		return guild;
 	}
 

--- a/services/guild/tests/Guild.UnitTests/Application/JoinByInviteCodeHandlerTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/JoinByInviteCodeHandlerTests.cs
@@ -145,7 +145,6 @@ public sealed class JoinByInviteCodeHandlerTests
 		Assert.Contains(guild.Members, m => m.UserId == 99);
 		Assert.Equal(1, invite.Uses);
 		Assert.Equal(1, i.UpdateCount);
-		Assert.Equal(1, g.SaveChangesCount);
 		Assert.Equal(1, u.ExistsCallCount);
 
 		var evt = b.Single<GuildMemberJoined>();

--- a/services/guild/tests/Guild.UnitTests/Application/JoinByInviteCodeHandlerTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/JoinByInviteCodeHandlerTests.cs
@@ -145,7 +145,6 @@ public sealed class JoinByInviteCodeHandlerTests
 		Assert.Contains(guild.Members, m => m.UserId == 99);
 		Assert.Equal(1, invite.Uses);
 		Assert.Equal(1, i.UpdateCount);
-		Assert.Equal(1, g.UpdateCount);
 		Assert.Equal(1, g.SaveChangesCount);
 		Assert.Equal(1, u.ExistsCallCount);
 

--- a/services/guild/tests/Guild.UnitTests/Application/JoinByInviteCodeHandlerTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/JoinByInviteCodeHandlerTests.cs
@@ -83,6 +83,25 @@ public sealed class JoinByInviteCodeHandlerTests
 	}
 
 	[Fact]
+	public async Task BannedUser_ReturnsJoinBannedFromGuild()
+	{
+		// caller is not a member (so the AlreadyMember check passes) but is banned;
+		// a valid invite code must not let a banned user back in
+		var (g, i, bans, b, u) = NewFakes();
+		var guild = SeedGuild(g, ownerId: 1);
+		var invite = SeedInvite(i, guildId: guild.Id, creator: 1);
+		bans.Seed(GuildBan.Create(guildId: guild.Id, userId: 99, bannedBy: 1, reason: null, now: Now).Value);
+		var handler = NewHandler(g, i, bans, b, u, callerId: 99);
+
+		var result = await handler.HandleAsync(new JoinByInviteCodeCommand(invite.Code, ExpectedGuildId: null));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal("Guild.JoinBannedFromGuild", result.Error.Code);
+		Assert.DoesNotContain(guild.Members, m => m.UserId == 99);
+		Assert.False(b.Has<GuildMemberJoined>());
+	}
+
+	[Fact]
 	public async Task RevokedInvite_ReturnsInviteUnusable()
 	{
 		var (g, i, bans, b, u) = NewFakes();

--- a/services/guild/tests/Guild.UnitTests/Application/KickMemberHandlerTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/KickMemberHandlerTests.cs
@@ -143,7 +143,7 @@ public sealed class KickMemberHandlerTests
 		var guild = GuildEntity.Create(
 			id: 100, name: "Test", description: null, iconUrl: null, bannerUrl: null,
 			ownerId: 1, everyoneRoleId: 101, adminRoleId: 102, now: Now).Value;
-		guilds.AddAsync(guild).GetAwaiter().GetResult();
+		guilds.Add(guild);
 
 		var handler = HandlerFactory.CreateCommand<KickMemberCommand, Result>(
 			guilds, events, clock, new FakeCurrentUser { Id = currentUser });

--- a/services/guild/tests/Guild.UnitTests/Application/LeaveGuildHandlerTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/LeaveGuildHandlerTests.cs
@@ -70,7 +70,6 @@ public sealed class LeaveGuildHandlerTests
 
 		Assert.True(result.Succeeded);
 		Assert.DoesNotContain(guild.Members, m => m.UserId == 99);
-		Assert.Equal(1, repo.UpdateCount);
 		Assert.Equal(1, repo.SaveChangesCount);
 
 		var evt = bus.Single<GuildMemberLeft>();

--- a/services/guild/tests/Guild.UnitTests/Application/LeaveGuildHandlerTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/LeaveGuildHandlerTests.cs
@@ -39,7 +39,6 @@ public sealed class LeaveGuildHandlerTests
 		Assert.True(result.IsFailure);
 		Assert.Equal("Guild.OwnerCannotLeave", result.Error.Code);
 		Assert.Empty(bus.Published);
-		Assert.Equal(0, repo.SaveChangesCount);
 	}
 
 	[Fact]
@@ -70,7 +69,6 @@ public sealed class LeaveGuildHandlerTests
 
 		Assert.True(result.Succeeded);
 		Assert.DoesNotContain(guild.Members, m => m.UserId == 99);
-		Assert.Equal(1, repo.SaveChangesCount);
 
 		var evt = bus.Single<GuildMemberLeft>();
 		Assert.Equal(guild.Id, evt.GuildId);

--- a/services/guild/tests/Guild.UnitTests/Application/LeaveGuildHandlerTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/LeaveGuildHandlerTests.cs
@@ -80,7 +80,7 @@ public sealed class LeaveGuildHandlerTests
 		var guild = GuildEntity.Create(
 			id: 100, name: "Test", description: null, iconUrl: null, bannerUrl: null,
 			ownerId: ownerId, everyoneRoleId: 101, adminRoleId: 102, now: Now).Value;
-		repo.AddAsync(guild).GetAwaiter().GetResult();
+		repo.Add(guild);
 		return guild;
 	}
 }

--- a/services/guild/tests/Guild.UnitTests/Application/ListBansHandlerTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/ListBansHandlerTests.cs
@@ -56,7 +56,7 @@ public sealed class ListBansHandlerTests
 		var result = await handler.HandleAsync(new ListBansQuery(100, After: null, Limit: 50));
 
 		Assert.True(result.Succeeded);
-		Assert.Empty(result.Value.Items);
+		Assert.Empty(result.Value);
 	}
 
 	[Fact]
@@ -69,11 +69,11 @@ public sealed class ListBansHandlerTests
 		var result = await handler.HandleAsync(new ListBansQuery(100, After: null, Limit: 50));
 
 		Assert.True(result.Succeeded);
-		Assert.Collection(result.Value.Items,
+		Assert.Collection(result.Value,
 			b => Assert.Equal("3", b.UserId),
 			b => Assert.Equal("5", b.UserId));
-		Assert.Equal("1", result.Value.Items[0].BannedBy);
-		Assert.Equal("a", result.Value.Items[0].Reason);
+		Assert.Equal("1", result.Value[0].BannedBy);
+		Assert.Equal("a", result.Value[0].Reason);
 	}
 
 	[Fact]
@@ -87,12 +87,12 @@ public sealed class ListBansHandlerTests
 		var result = await handler.HandleAsync(new ListBansQuery(100, After: 3, Limit: 1));
 
 		Assert.True(result.Succeeded);
-		var only = Assert.Single(result.Value.Items);
+		var only = Assert.Single(result.Value);
 		Assert.Equal("5", only.UserId);
 	}
 
 	private static (
-		IQueryHandler<ListBansQuery, Result<BanListResponse>> Handler,
+		IQueryHandler<ListBansQuery, Result<IReadOnlyList<BanResponse>>> Handler,
 		FakeGuildRepository Guilds,
 		FakeGuildBanRepository Bans)
 		MakeHandler(long currentUser)
@@ -102,9 +102,9 @@ public sealed class ListBansHandlerTests
 		var guild = GuildEntity.Create(
 			id: 100, name: "Test", description: null, iconUrl: null, bannerUrl: null,
 			ownerId: 1, everyoneRoleId: 101, adminRoleId: 102, now: Now).Value;
-		guilds.AddAsync(guild).GetAwaiter().GetResult();
+		guilds.Add(guild);
 
-		var handler = HandlerFactory.CreateQuery<ListBansQuery, Result<BanListResponse>>(
+		var handler = HandlerFactory.CreateQuery<ListBansQuery, Result<IReadOnlyList<BanResponse>>>(
 			guilds, bans, new FakeCurrentUser { Id = currentUser });
 		return (handler, guilds, bans);
 	}

--- a/services/guild/tests/Guild.UnitTests/Application/ListBansHandlerTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/ListBansHandlerTests.cs
@@ -1,0 +1,111 @@
+using Guild.Application.Abstractions.Messaging;
+using Guild.Application.Features.Bans.Common;
+using Guild.Application.Features.Bans.ListBans;
+using Guild.Domain.Guild;
+using Guild.Domain.Results;
+using Guild.UnitTests.Fakes;
+using Xunit;
+using GuildEntity = Guild.Domain.Guild.Guild;
+
+namespace Guild.UnitTests.Application;
+
+public sealed class ListBansHandlerTests
+{
+	private static readonly DateTimeOffset Now =
+		new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+	[Fact]
+	public async Task UnknownGuild_Returns_GuildNotFound()
+	{
+		var (handler, _, _) = MakeHandler(currentUser: 1);
+
+		var result = await handler.HandleAsync(new ListBansQuery(999, After: null, Limit: 50));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal("Guild.GuildNotFound", result.Error.Code);
+	}
+
+	[Fact]
+	public async Task CallerNotMember_Returns_NotAMember()
+	{
+		var (handler, _, _) = MakeHandler(currentUser: 99);
+
+		var result = await handler.HandleAsync(new ListBansQuery(100, After: null, Limit: 50));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal("Guild.NotAMember", result.Error.Code);
+	}
+
+	[Fact]
+	public async Task CallerWithoutBanMembers_Returns_MissingPermission()
+	{
+		var (handler, guilds, _) = MakeHandler(currentUser: 2);
+		DomainSeed.AddMember(guilds.Store[100], userId: 2, joinedAt: Now);
+
+		var result = await handler.HandleAsync(new ListBansQuery(100, After: null, Limit: 50));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal("Guild.MissingPermission", result.Error.Code);
+	}
+
+	[Fact]
+	public async Task HappyPath_NoBans_Returns_EmptyList()
+	{
+		var (handler, _, _) = MakeHandler(currentUser: 1);
+
+		var result = await handler.HandleAsync(new ListBansQuery(100, After: null, Limit: 50));
+
+		Assert.True(result.Succeeded);
+		Assert.Empty(result.Value.Items);
+	}
+
+	[Fact]
+	public async Task HappyPath_ReturnsBans_OrderedByUserId_AndMapped()
+	{
+		var (handler, _, bans) = MakeHandler(currentUser: 1);
+		bans.Seed(GuildBan.Create(guildId: 100, userId: 5, bannedBy: 1, reason: "b", now: Now).Value);
+		bans.Seed(GuildBan.Create(guildId: 100, userId: 3, bannedBy: 1, reason: "a", now: Now).Value);
+
+		var result = await handler.HandleAsync(new ListBansQuery(100, After: null, Limit: 50));
+
+		Assert.True(result.Succeeded);
+		Assert.Collection(result.Value.Items,
+			b => Assert.Equal("3", b.UserId),
+			b => Assert.Equal("5", b.UserId));
+		Assert.Equal("1", result.Value.Items[0].BannedBy);
+		Assert.Equal("a", result.Value.Items[0].Reason);
+	}
+
+	[Fact]
+	public async Task HappyPath_RespectsAfterAndLimit()
+	{
+		var (handler, _, bans) = MakeHandler(currentUser: 1);
+		bans.Seed(GuildBan.Create(guildId: 100, userId: 3, bannedBy: 1, reason: null, now: Now).Value);
+		bans.Seed(GuildBan.Create(guildId: 100, userId: 5, bannedBy: 1, reason: null, now: Now).Value);
+		bans.Seed(GuildBan.Create(guildId: 100, userId: 7, bannedBy: 1, reason: null, now: Now).Value);
+
+		var result = await handler.HandleAsync(new ListBansQuery(100, After: 3, Limit: 1));
+
+		Assert.True(result.Succeeded);
+		var only = Assert.Single(result.Value.Items);
+		Assert.Equal("5", only.UserId);
+	}
+
+	private static (
+		IQueryHandler<ListBansQuery, Result<BanListResponse>> Handler,
+		FakeGuildRepository Guilds,
+		FakeGuildBanRepository Bans)
+		MakeHandler(long currentUser)
+	{
+		var guilds = new FakeGuildRepository();
+		var bans = new FakeGuildBanRepository();
+		var guild = GuildEntity.Create(
+			id: 100, name: "Test", description: null, iconUrl: null, bannerUrl: null,
+			ownerId: 1, everyoneRoleId: 101, adminRoleId: 102, now: Now).Value;
+		guilds.AddAsync(guild).GetAwaiter().GetResult();
+
+		var handler = HandlerFactory.CreateQuery<ListBansQuery, Result<BanListResponse>>(
+			guilds, bans, new FakeCurrentUser { Id = currentUser });
+		return (handler, guilds, bans);
+	}
+}

--- a/services/guild/tests/Guild.UnitTests/Application/ListChannelsHandlerTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/ListChannelsHandlerTests.cs
@@ -67,6 +67,6 @@ public sealed class ListChannelsHandlerTests
 		var guild = GuildEntity.Create(
 			id: 100, name: "Test", description: null, iconUrl: null, bannerUrl: null,
 			ownerId: ownerId, everyoneRoleId: 101, adminRoleId: 102, now: Now).Value;
-		repo.AddAsync(guild).GetAwaiter().GetResult();
+		repo.Add(guild);
 	}
 }

--- a/services/guild/tests/Guild.UnitTests/Application/ListInvitesHandlerTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/ListInvitesHandlerTests.cs
@@ -99,7 +99,7 @@ public sealed class ListInvitesHandlerTests
 		var guild = GuildEntity.Create(
 			id: 100, name: "Test", description: null, iconUrl: null, bannerUrl: null,
 			ownerId: ownerId, everyoneRoleId: 101, adminRoleId: 102, now: Now).Value;
-		repo.AddAsync(guild).GetAwaiter().GetResult();
+		repo.Add(guild);
 		return guild;
 	}
 }

--- a/services/guild/tests/Guild.UnitTests/Application/ListMembersHandlerTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/ListMembersHandlerTests.cs
@@ -42,8 +42,8 @@ public sealed class ListMembersHandlerTests
 		var result = await handler.HandleAsync(new ListMembersQuery(100, After: null, Limit: 50));
 
 		Assert.True(result.Succeeded);
-		Assert.Single(result.Value.Items);
-		Assert.Equal("1", result.Value.Items[0].UserId);
+		Assert.Single(result.Value);
+		Assert.Equal("1", result.Value[0].UserId);
 	}
 
 	[Fact]
@@ -57,7 +57,7 @@ public sealed class ListMembersHandlerTests
 		var result = await handler.HandleAsync(new ListMembersQuery(100, After: 5, Limit: 50));
 
 		Assert.True(result.Succeeded);
-		Assert.Equal(new[] { "7", "9" }, result.Value.Items.Select(m => m.UserId).ToArray());
+		Assert.Equal(new[] { "7", "9" }, result.Value.Select(m => m.UserId).ToArray());
 	}
 
 	[Fact]
@@ -70,9 +70,9 @@ public sealed class ListMembersHandlerTests
 		var result = await handler.HandleAsync(new ListMembersQuery(100, After: null, Limit: 2));
 
 		Assert.True(result.Succeeded);
-		Assert.Equal(2, result.Value.Items.Count);
-		Assert.Equal("1", result.Value.Items[0].UserId);
-		Assert.Equal("2", result.Value.Items[1].UserId);
+		Assert.Equal(2, result.Value.Count);
+		Assert.Equal("1", result.Value[0].UserId);
+		Assert.Equal("2", result.Value[1].UserId);
 	}
 
 	[Fact]
@@ -87,14 +87,14 @@ public sealed class ListMembersHandlerTests
 		var result = await handler.HandleAsync(new ListMembersQuery(100, After: null, Limit: 50));
 
 		Assert.True(result.Succeeded);
-		var member2 = result.Value.Items.Single(m => m.UserId == "2");
+		var member2 = result.Value.Single(m => m.UserId == "2");
 		Assert.Equal(new[] { "500" }, member2.Roles.ToArray());
-		var owner = result.Value.Items.Single(m => m.UserId == "1");
+		var owner = result.Value.Single(m => m.UserId == "1");
 		Assert.Single(owner.Roles);
 	}
 
 	private static (
-		Guild.Application.Abstractions.Messaging.IQueryHandler<ListMembersQuery, Result<MemberListResponse>> Handler,
+		Guild.Application.Abstractions.Messaging.IQueryHandler<ListMembersQuery, Result<IReadOnlyList<MemberResponse>>> Handler,
 		FakeGuildRepository Guilds)
 		MakeHandler(long currentUser)
 	{
@@ -102,9 +102,9 @@ public sealed class ListMembersHandlerTests
 		var guild = GuildEntity.Create(
 			id: 100, name: "Test", description: null, iconUrl: null, bannerUrl: null,
 			ownerId: 1, everyoneRoleId: 101, adminRoleId: 102, now: Now).Value;
-		guilds.AddAsync(guild).GetAwaiter().GetResult();
+		guilds.Add(guild);
 
-		var handler = HandlerFactory.CreateQuery<ListMembersQuery, Result<MemberListResponse>>(
+		var handler = HandlerFactory.CreateQuery<ListMembersQuery, Result<IReadOnlyList<MemberResponse>>>(
 			guilds, new FakeCurrentUser { Id = currentUser });
 		return (handler, guilds);
 	}

--- a/services/guild/tests/Guild.UnitTests/Application/ListRolesHandlerTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/ListRolesHandlerTests.cs
@@ -73,7 +73,7 @@ public sealed class ListRolesHandlerTests
 		var guild = GuildEntity.Create(
 			id: 100, name: "Test", description: null, iconUrl: null, bannerUrl: null,
 			ownerId: 1, everyoneRoleId: 101, adminRoleId: 102, now: Now).Value;
-		guilds.AddAsync(guild).GetAwaiter().GetResult();
+		guilds.Add(guild);
 		var handler = HandlerFactory.CreateQuery<ListRolesQuery, Result<RoleListResponse>>(
 			guilds, new FakeCurrentUser { Id = currentUser });
 		return (handler, guilds);

--- a/services/guild/tests/Guild.UnitTests/Application/PutOverwriteHandlerTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/PutOverwriteHandlerTests.cs
@@ -82,7 +82,6 @@ public sealed class PutOverwriteHandlerTests
 		Assert.Single(overwrites.Store);
 		Assert.Equal(OverwriteTargetType.Role, overwrites.Store.Values.Single().TargetType);
 		Assert.Equal(1, overwrites.AddCount);
-		Assert.Equal(1, overwrites.SaveChangesCount);
 	}
 
 	[Fact]
@@ -101,7 +100,6 @@ public sealed class PutOverwriteHandlerTests
 		Assert.Equal(8L, only.Deny);
 		Assert.Equal(1, overwrites.AddCount);
 		Assert.Equal(1, overwrites.UpdateCount);
-		Assert.Equal(2, overwrites.SaveChangesCount);
 	}
 
 	[Fact]

--- a/services/guild/tests/Guild.UnitTests/Application/PutOverwriteHandlerTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/PutOverwriteHandlerTests.cs
@@ -223,7 +223,7 @@ public sealed class PutOverwriteHandlerTests
 		var guild = GuildEntity.Create(
 			id: 100, name: "Test", description: null, iconUrl: null, bannerUrl: null,
 			ownerId: 1, everyoneRoleId: 101, adminRoleId: 102, now: Now).Value;
-		guilds.AddAsync(guild).GetAwaiter().GetResult();
+		guilds.Add(guild);
 
 		var handler = HandlerFactory.CreateCommand<PutOverwriteCommand, Result>(
 			guilds, channels, overwrites,

--- a/services/guild/tests/Guild.UnitTests/Application/ReorderRolesHandlerTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/ReorderRolesHandlerTests.cs
@@ -134,7 +134,7 @@ public sealed class ReorderRolesHandlerTests
 		var guild = GuildEntity.Create(
 			id: 100, name: "Test", description: null, iconUrl: null, bannerUrl: null,
 			ownerId: 1, everyoneRoleId: 101, adminRoleId: 102, now: Now).Value;
-		guilds.AddAsync(guild).GetAwaiter().GetResult();
+		guilds.Add(guild);
 		var handler = HandlerFactory.CreateCommand<ReorderRolesCommand, Result<RoleListResponse>>(
 			guilds, new FakeClock(Now), new FakeCurrentUser { Id = currentUser });
 		return (handler, guilds);

--- a/services/guild/tests/Guild.UnitTests/Application/RevokeInviteHandlerTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/RevokeInviteHandlerTests.cs
@@ -1,5 +1,5 @@
 using Guild.Application.Abstractions.Messaging;
-using Guild.Application.Features.Invites.DeleteInvite;
+using Guild.Application.Features.Invites.RevokeInvite;
 using Guild.Domain.Guild;
 using Guild.Domain.Results;
 using Guild.UnitTests.Fakes;
@@ -8,7 +8,7 @@ using GuildEntity = Guild.Domain.Guild.Guild;
 
 namespace Guild.UnitTests.Application;
 
-public sealed class DeleteInviteHandlerTests
+public sealed class RevokeInviteHandlerTests
 {
 	private static readonly DateTimeOffset Now =
 		new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
@@ -19,7 +19,7 @@ public sealed class DeleteInviteHandlerTests
 		var (g, i) = NewFakes();
 		var handler = NewHandler(g, i, callerId: 1);
 
-		var result = await handler.HandleAsync(new DeleteInviteCommand(GuildId: 1, Code: "ghost"));
+		var result = await handler.HandleAsync(new RevokeInviteCommand(GuildId: 1, Code: "ghost"));
 
 		Assert.True(result.IsFailure);
 		Assert.Equal("Guild.InviteNotFound", result.Error.Code);
@@ -34,7 +34,7 @@ public sealed class DeleteInviteHandlerTests
 		invite.Revoke();
 		var handler = NewHandler(g, i, callerId: 1);
 
-		var result = await handler.HandleAsync(new DeleteInviteCommand(guild.Id, invite.Code));
+		var result = await handler.HandleAsync(new RevokeInviteCommand(guild.Id, invite.Code));
 
 		Assert.True(result.IsFailure);
 		Assert.Equal("Guild.InviteNotFound", result.Error.Code);
@@ -48,7 +48,7 @@ public sealed class DeleteInviteHandlerTests
 		var invite = SeedInvite(i, guild.Id, creator: 1);
 		var handler = NewHandler(g, i, callerId: 1);
 
-		var result = await handler.HandleAsync(new DeleteInviteCommand(GuildId: guild.Id + 1, Code: invite.Code));
+		var result = await handler.HandleAsync(new RevokeInviteCommand(GuildId: guild.Id + 1, Code: invite.Code));
 
 		Assert.True(result.IsFailure);
 		Assert.Equal("Guild.InviteGuildMismatch", result.Error.Code);
@@ -62,7 +62,7 @@ public sealed class DeleteInviteHandlerTests
 		var invite = SeedInvite(i, guild.Id, creator: 1);
 		var handler = NewHandler(g, i, callerId: 99);
 
-		var result = await handler.HandleAsync(new DeleteInviteCommand(guild.Id, invite.Code));
+		var result = await handler.HandleAsync(new RevokeInviteCommand(guild.Id, invite.Code));
 
 		Assert.True(result.IsFailure);
 		Assert.Equal("Guild.NotAMember", result.Error.Code);
@@ -77,7 +77,7 @@ public sealed class DeleteInviteHandlerTests
 		var invite = SeedInvite(i, guild.Id, creator: 99);
 
 		var handler = NewHandler(g, i, callerId: 99);
-		var result = await handler.HandleAsync(new DeleteInviteCommand(guild.Id, invite.Code));
+		var result = await handler.HandleAsync(new RevokeInviteCommand(guild.Id, invite.Code));
 
 		Assert.True(result.Succeeded);
 		Assert.True(invite.IsRevoked);
@@ -93,7 +93,7 @@ public sealed class DeleteInviteHandlerTests
 		var invite = SeedInvite(i, guild.Id, creator: 1);
 		var handler = NewHandler(g, i, callerId: 99);
 
-		var result = await handler.HandleAsync(new DeleteInviteCommand(guild.Id, invite.Code));
+		var result = await handler.HandleAsync(new RevokeInviteCommand(guild.Id, invite.Code));
 
 		Assert.True(result.IsFailure);
 		Assert.Equal("Guild.MissingPermission", result.Error.Code);
@@ -108,7 +108,7 @@ public sealed class DeleteInviteHandlerTests
 		var invite = SeedInvite(i, guild.Id, creator: 42);
 		var handler = NewHandler(g, i, callerId: 1);
 
-		var result = await handler.HandleAsync(new DeleteInviteCommand(guild.Id, invite.Code));
+		var result = await handler.HandleAsync(new RevokeInviteCommand(guild.Id, invite.Code));
 
 		Assert.True(result.Succeeded);
 		Assert.True(invite.IsRevoked);
@@ -117,10 +117,10 @@ public sealed class DeleteInviteHandlerTests
 	private static (FakeGuildRepository, FakeGuildInviteRepository) NewFakes()
 		=> (new FakeGuildRepository(), new FakeGuildInviteRepository());
 
-	private static ICommandHandler<DeleteInviteCommand, Result> NewHandler(
+	private static ICommandHandler<RevokeInviteCommand, Result> NewHandler(
 		FakeGuildRepository guilds, FakeGuildInviteRepository invites, long callerId)
 	{
-		return HandlerFactory.CreateCommand<DeleteInviteCommand, Result>(
+		return HandlerFactory.CreateCommand<RevokeInviteCommand, Result>(
 			guilds, invites, new FakeCurrentUser { Id = callerId });
 	}
 

--- a/services/guild/tests/Guild.UnitTests/Application/TransferOwnershipHandlerTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/TransferOwnershipHandlerTests.cs
@@ -71,7 +71,6 @@ public sealed class TransferOwnershipHandlerTests
 		Assert.True(result.Succeeded);
 		Assert.Equal("2", result.Value.OwnerId);
 		Assert.Equal(2L, repo.Store[100].OwnerId);
-		Assert.Equal(1, repo.SaveChangesCount);
 	}
 
 	private static void Seed(FakeGuildRepository repo, long ownerId)

--- a/services/guild/tests/Guild.UnitTests/Application/TransferOwnershipHandlerTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/TransferOwnershipHandlerTests.cs
@@ -71,7 +71,6 @@ public sealed class TransferOwnershipHandlerTests
 		Assert.True(result.Succeeded);
 		Assert.Equal("2", result.Value.OwnerId);
 		Assert.Equal(2L, repo.Store[100].OwnerId);
-		Assert.Equal(1, repo.UpdateCount);
 		Assert.Equal(1, repo.SaveChangesCount);
 	}
 

--- a/services/guild/tests/Guild.UnitTests/Application/TransferOwnershipHandlerTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/TransferOwnershipHandlerTests.cs
@@ -61,7 +61,7 @@ public sealed class TransferOwnershipHandlerTests
 			id: 100, name: "Test", description: null, iconUrl: null, bannerUrl: null,
 			ownerId: 1, everyoneRoleId: 101, adminRoleId: 102, now: Now).Value;
 		DomainSeed.AddMember(guild, userId: 2, joinedAt: Now);
-		await repo.AddAsync(guild);
+		repo.Add(guild);
 
 		var handler = HandlerFactory.CreateCommand<TransferOwnershipCommand, Result<GuildDto>>(
 			repo, new FakeClock(), new FakeCurrentUser { Id = 1 });
@@ -85,6 +85,6 @@ public sealed class TransferOwnershipHandlerTests
 			everyoneRoleId: 101,
 			adminRoleId: 102,
 			now: Now).Value;
-		repo.AddAsync(guild).GetAwaiter().GetResult();
+		repo.Add(guild);
 	}
 }

--- a/services/guild/tests/Guild.UnitTests/Application/UnassignRoleHandlerTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/UnassignRoleHandlerTests.cs
@@ -1,0 +1,110 @@
+using Guild.Application.Abstractions.Messaging;
+using Guild.Application.Features.Membership.UnassignRole;
+using Guild.Domain.Guild;
+using Guild.Domain.Results;
+using Guild.UnitTests.Fakes;
+using Xunit;
+using GuildEntity = Guild.Domain.Guild.Guild;
+
+namespace Guild.UnitTests.Application;
+
+public sealed class UnassignRoleHandlerTests
+{
+	private static readonly DateTimeOffset Now =
+		new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+	[Fact]
+	public async Task UnknownGuild_Returns_GuildNotFound()
+	{
+		var (handler, _) = MakeHandler(currentUser: 1);
+
+		var result = await handler.HandleAsync(new UnassignRoleCommand(999, TargetUserId: 3, RoleId: 500));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal("Guild.GuildNotFound", result.Error.Code);
+	}
+
+	[Fact]
+	public async Task CallerNotMember_Returns_NotAMember()
+	{
+		var (handler, _) = MakeHandler(currentUser: 99);
+
+		var result = await handler.HandleAsync(new UnassignRoleCommand(100, TargetUserId: 3, RoleId: 500));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal("Guild.NotAMember", result.Error.Code);
+	}
+
+	[Fact]
+	public async Task CallerWithoutManageRoles_Returns_MissingPermission()
+	{
+		var (handler, guilds) = MakeHandler(currentUser: 2);
+		var guild = guilds.Store[100];
+		DomainSeed.AddCustomRole(guild, roleId: 500, name: "Role", permissions: 0, position: 5, now: Now);
+		DomainSeed.AddMember(guild, userId: 2, joinedAt: Now);
+		DomainSeed.AddMember(guild, userId: 3, joinedAt: Now);
+		DomainSeed.AssignRole(guild, userId: 3, roleId: 500, now: Now);
+
+		var result = await handler.HandleAsync(new UnassignRoleCommand(100, TargetUserId: 3, RoleId: 500));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal("Guild.MissingPermission", result.Error.Code);
+	}
+
+	[Fact]
+	public async Task UnknownRole_Returns_RoleNotFound()
+	{
+		var (handler, _) = MakeHandler(currentUser: 1);
+
+		var result = await handler.HandleAsync(new UnassignRoleCommand(100, TargetUserId: 3, RoleId: 999));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal("Guild.RoleNotFound", result.Error.Code);
+	}
+
+	[Fact]
+	public async Task RoleNotAssigned_Returns_RoleAssignmentNotFound()
+	{
+		var (handler, guilds) = MakeHandler(currentUser: 1);
+		var guild = guilds.Store[100];
+		DomainSeed.AddCustomRole(guild, roleId: 500, name: "Role",
+			permissions: (long)Permission.SendMessages, position: 5, now: Now);
+		DomainSeed.AddMember(guild, userId: 3, joinedAt: Now);
+
+		var result = await handler.HandleAsync(new UnassignRoleCommand(100, TargetUserId: 3, RoleId: 500));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal("Guild.RoleAssignmentNotFound", result.Error.Code);
+	}
+
+	[Fact]
+	public async Task HappyPath_RemovesAssignment()
+	{
+		var (handler, guilds) = MakeHandler(currentUser: 1);
+		var guild = guilds.Store[100];
+		DomainSeed.AddCustomRole(guild, roleId: 500, name: "Role",
+			permissions: (long)Permission.SendMessages, position: 5, now: Now);
+		DomainSeed.AddMember(guild, userId: 3, joinedAt: Now);
+		DomainSeed.AssignRole(guild, userId: 3, roleId: 500, now: Now);
+
+		var result = await handler.HandleAsync(new UnassignRoleCommand(100, TargetUserId: 3, RoleId: 500));
+
+		Assert.True(result.Succeeded);
+		Assert.DoesNotContain(guild.MemberRoles, mr => mr.UserId == 3 && mr.RoleId == 500);
+	}
+
+	private static (ICommandHandler<UnassignRoleCommand, Result> Handler, FakeGuildRepository Guilds)
+		MakeHandler(long currentUser)
+	{
+		var guilds = new FakeGuildRepository();
+		var clock = new FakeClock(Now);
+		var guild = GuildEntity.Create(
+			id: 100, name: "Test", description: null, iconUrl: null, bannerUrl: null,
+			ownerId: 1, everyoneRoleId: 101, adminRoleId: 102, now: Now).Value;
+		guilds.AddAsync(guild).GetAwaiter().GetResult();
+
+		var handler = HandlerFactory.CreateCommand<UnassignRoleCommand, Result>(
+			guilds, clock, new FakeCurrentUser { Id = currentUser });
+		return (handler, guilds);
+	}
+}

--- a/services/guild/tests/Guild.UnitTests/Application/UnassignRoleHandlerTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/UnassignRoleHandlerTests.cs
@@ -101,7 +101,7 @@ public sealed class UnassignRoleHandlerTests
 		var guild = GuildEntity.Create(
 			id: 100, name: "Test", description: null, iconUrl: null, bannerUrl: null,
 			ownerId: 1, everyoneRoleId: 101, adminRoleId: 102, now: Now).Value;
-		guilds.AddAsync(guild).GetAwaiter().GetResult();
+		guilds.Add(guild);
 
 		var handler = HandlerFactory.CreateCommand<UnassignRoleCommand, Result>(
 			guilds, clock, new FakeCurrentUser { Id = currentUser });

--- a/services/guild/tests/Guild.UnitTests/Application/UnbanMemberHandlerTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/UnbanMemberHandlerTests.cs
@@ -96,7 +96,7 @@ public sealed class UnbanMemberHandlerTests
 		var guild = GuildEntity.Create(
 			id: 100, name: "Test", description: null, iconUrl: null, bannerUrl: null,
 			ownerId: 1, everyoneRoleId: 101, adminRoleId: 102, now: Now).Value;
-		guilds.AddAsync(guild).GetAwaiter().GetResult();
+		guilds.Add(guild);
 
 		var handler = HandlerFactory.CreateCommand<UnbanMemberCommand, Result>(
 			guilds, bans, new FakeCurrentUser { Id = currentUser });

--- a/services/guild/tests/Guild.UnitTests/Application/UnbanMemberHandlerTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/UnbanMemberHandlerTests.cs
@@ -1,0 +1,105 @@
+using Guild.Application.Abstractions.Messaging;
+using Guild.Application.Features.Bans.UnbanMember;
+using Guild.Domain.Guild;
+using Guild.Domain.Results;
+using Guild.UnitTests.Fakes;
+using Xunit;
+using GuildEntity = Guild.Domain.Guild.Guild;
+
+namespace Guild.UnitTests.Application;
+
+public sealed class UnbanMemberHandlerTests
+{
+	private static readonly DateTimeOffset Now =
+		new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+	[Fact]
+	public async Task UnknownGuild_Returns_GuildNotFound()
+	{
+		var (handler, _, _) = MakeHandler(currentUser: 1);
+
+		var result = await handler.HandleAsync(new UnbanMemberCommand(999, TargetUserId: 2));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal("Guild.GuildNotFound", result.Error.Code);
+	}
+
+	[Fact]
+	public async Task CallerNotMember_Returns_NotAMember()
+	{
+		var (handler, _, _) = MakeHandler(currentUser: 99);
+
+		var result = await handler.HandleAsync(new UnbanMemberCommand(100, TargetUserId: 2));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal("Guild.NotAMember", result.Error.Code);
+	}
+
+	[Fact]
+	public async Task CallerWithoutBanMembers_Returns_MissingPermission()
+	{
+		var (handler, guilds, bans) = MakeHandler(currentUser: 2);
+		DomainSeed.AddMember(guilds.Store[100], userId: 2, joinedAt: Now);
+		bans.Seed(GuildBan.Create(guildId: 100, userId: 3, bannedBy: 1, reason: null, now: Now).Value);
+
+		var result = await handler.HandleAsync(new UnbanMemberCommand(100, TargetUserId: 3));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal("Guild.MissingPermission", result.Error.Code);
+	}
+
+	[Fact]
+	public async Task NoSuchBan_Returns_BanNotFound()
+	{
+		var (handler, _, _) = MakeHandler(currentUser: 1);
+
+		var result = await handler.HandleAsync(new UnbanMemberCommand(100, TargetUserId: 3));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal("Guild.BanNotFound", result.Error.Code);
+	}
+
+	[Fact]
+	public async Task NegativeTargetId_Returns_BanNotFound()
+	{
+		// characterization of the known ID-validation gap: there is no invariant
+		// check on TargetUserId, so a negative id simply finds no ban and the
+		// handler emits BanNotFound rather than InvalidId (see cleanup plan 0.3)
+		var (handler, _, _) = MakeHandler(currentUser: 1);
+
+		var result = await handler.HandleAsync(new UnbanMemberCommand(100, TargetUserId: -1));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal("Guild.BanNotFound", result.Error.Code);
+	}
+
+	[Fact]
+	public async Task HappyPath_RemovesBan()
+	{
+		var (handler, _, bans) = MakeHandler(currentUser: 1);
+		bans.Seed(GuildBan.Create(guildId: 100, userId: 3, bannedBy: 1, reason: null, now: Now).Value);
+
+		var result = await handler.HandleAsync(new UnbanMemberCommand(100, TargetUserId: 3));
+
+		Assert.True(result.Succeeded);
+		Assert.False(bans.Store.ContainsKey((100, 3)));
+	}
+
+	private static (
+		ICommandHandler<UnbanMemberCommand, Result> Handler,
+		FakeGuildRepository Guilds,
+		FakeGuildBanRepository Bans)
+		MakeHandler(long currentUser)
+	{
+		var guilds = new FakeGuildRepository();
+		var bans = new FakeGuildBanRepository();
+		var guild = GuildEntity.Create(
+			id: 100, name: "Test", description: null, iconUrl: null, bannerUrl: null,
+			ownerId: 1, everyoneRoleId: 101, adminRoleId: 102, now: Now).Value;
+		guilds.AddAsync(guild).GetAwaiter().GetResult();
+
+		var handler = HandlerFactory.CreateCommand<UnbanMemberCommand, Result>(
+			guilds, bans, new FakeCurrentUser { Id = currentUser });
+		return (handler, guilds, bans);
+	}
+}

--- a/services/guild/tests/Guild.UnitTests/Application/UpdateCategoryHandlerTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/UpdateCategoryHandlerTests.cs
@@ -155,7 +155,6 @@ public sealed class UpdateCategoryHandlerTests
 		Assert.Equal("New", result.Value.Name);
 		Assert.Equal(12, result.Value.Position);
 		Assert.Equal(1, catRepo.UpdateCount);
-		Assert.Equal(1, catRepo.SaveChangesCount);
 	}
 
 	[Fact]

--- a/services/guild/tests/Guild.UnitTests/Application/UpdateCategoryHandlerTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/UpdateCategoryHandlerTests.cs
@@ -52,7 +52,7 @@ public sealed class UpdateCategoryHandlerTests
 		var guildRepo = new FakeGuildRepository();
 		var catRepo = new FakeChannelCategoryRepository();
 		var guild = CreateGuildWithBareMember(memberId: 2, ownerId: 1);
-		await guildRepo.AddAsync(guild);
+		guildRepo.Add(guild);
 		SeedCategory(catRepo, id: 500);
 
 		var handler = HandlerFactory.CreateCommand<UpdateCategoryCommand, Result<CategoryResponse>>(
@@ -188,7 +188,7 @@ public sealed class UpdateCategoryHandlerTests
 			id: 100, name: "Test", description: null, iconUrl: null, bannerUrl: null,
 			ownerId: 1, everyoneRoleId: 101, adminRoleId: 102, now: Now).Value;
 		DomainSeed.AddMember(guild, userId: 2, joinedAt: Now);
-		await guildRepo.AddAsync(guild);
+		guildRepo.Add(guild);
 		SeedCategory(catRepo, id: 500);
 
 		var handler = HandlerFactory.CreateCommand<UpdateCategoryCommand, Result<CategoryResponse>>(
@@ -209,7 +209,7 @@ public sealed class UpdateCategoryHandlerTests
 		var guild = GuildEntity.Create(
 			id: 100, name: "Test", description: null, iconUrl: null, bannerUrl: null,
 			ownerId: ownerId, everyoneRoleId: 101, adminRoleId: 102, now: Now).Value;
-		guildRepo.AddAsync(guild).GetAwaiter().GetResult();
+		guildRepo.Add(guild);
 		if (seedCategory)
 			SeedCategory(catRepo, id: 500);
 	}

--- a/services/guild/tests/Guild.UnitTests/Application/UpdateChannelHandlerTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/UpdateChannelHandlerTests.cs
@@ -189,7 +189,7 @@ public sealed class UpdateChannelHandlerTests
 			var guild = GuildEntity.Create(
 				id: 100, name: "Test", description: null, iconUrl: null, bannerUrl: null,
 				ownerId: ownerId, everyoneRoleId: 101, adminRoleId: 102, now: Now).Value;
-			guilds.AddAsync(guild).GetAwaiter().GetResult();
+			guilds.Add(guild);
 		}
 
 		var handler = HandlerFactory.CreateCommand<UpdateChannelCommand, Result<ChannelResponse>>(

--- a/services/guild/tests/Guild.UnitTests/Application/UpdateChannelHandlerTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/UpdateChannelHandlerTests.cs
@@ -68,7 +68,6 @@ public sealed class UpdateChannelHandlerTests
 		Assert.Equal("new", result.Value.Name);
 		Assert.Equal(4, result.Value.Position);
 		Assert.Equal(1, channels.UpdateCount);
-		Assert.Equal(1, channels.SaveChangesCount);
 	}
 
 	[Fact]

--- a/services/guild/tests/Guild.UnitTests/Application/UpdateGuildHandlerTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/UpdateGuildHandlerTests.cs
@@ -84,7 +84,6 @@ public sealed class UpdateGuildHandlerTests
 		Assert.True(result.Succeeded);
 		Assert.Equal("Renamed", result.Value.Name);
 		Assert.Equal("Renamed", repo.Store[100].Name);
-		Assert.Equal(1, repo.UpdateCount);
 		Assert.Equal(1, repo.SaveChangesCount);
 	}
 

--- a/services/guild/tests/Guild.UnitTests/Application/UpdateGuildHandlerTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/UpdateGuildHandlerTests.cs
@@ -58,7 +58,7 @@ public sealed class UpdateGuildHandlerTests
 			BindingFlags.Instance | BindingFlags.NonPublic)!;
 		var list = (List<MemberRole>)memberRolesField.GetValue(guild)!;
 		list.Clear();
-		await repo.AddAsync(guild);
+		repo.Add(guild);
 
 		var handler = HandlerFactory.CreateCommand<UpdateGuildCommand, Result<GuildDto>>(
 			repo, new FakeClock(), new FakeCurrentUser { Id = 2 });
@@ -98,7 +98,7 @@ public sealed class UpdateGuildHandlerTests
 			guild, roleId: 200, name: "Manager", permissions: (long)Permission.ManageGuild,
 			position: 2, now: Now);
 		DomainSeed.AssignRole(guild, userId: 2, roleId: modRole.Id, now: Now);
-		await repo.AddAsync(guild);
+		repo.Add(guild);
 
 		var handler = HandlerFactory.CreateCommand<UpdateGuildCommand, Result<GuildDto>>(
 			repo, new FakeClock(), new FakeCurrentUser { Id = 2 });
@@ -122,6 +122,6 @@ public sealed class UpdateGuildHandlerTests
 			everyoneRoleId: 101,
 			adminRoleId: 102,
 			now: Now).Value;
-		repo.AddAsync(guild).GetAwaiter().GetResult();
+		repo.Add(guild);
 	}
 }

--- a/services/guild/tests/Guild.UnitTests/Application/UpdateGuildHandlerTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/UpdateGuildHandlerTests.cs
@@ -84,7 +84,6 @@ public sealed class UpdateGuildHandlerTests
 		Assert.True(result.Succeeded);
 		Assert.Equal("Renamed", result.Value.Name);
 		Assert.Equal("Renamed", repo.Store[100].Name);
-		Assert.Equal(1, repo.SaveChangesCount);
 	}
 
 	[Fact]

--- a/services/guild/tests/Guild.UnitTests/Application/UpdateNicknameHandlerTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/UpdateNicknameHandlerTests.cs
@@ -184,7 +184,7 @@ public sealed class UpdateNicknameHandlerTests
 		var guild = GuildEntity.Create(
 			id: 100, name: "Test", description: null, iconUrl: null, bannerUrl: null,
 			ownerId: 1, everyoneRoleId: 101, adminRoleId: 102, now: Now).Value;
-		guilds.AddAsync(guild).GetAwaiter().GetResult();
+		guilds.Add(guild);
 
 		var handler = HandlerFactory.CreateCommand<UpdateNicknameCommand, Result<MemberResponse>>(
 			guilds, new FakeCurrentUser { Id = currentUser });

--- a/services/guild/tests/Guild.UnitTests/Application/UpdateRoleHandlerTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/UpdateRoleHandlerTests.cs
@@ -159,7 +159,7 @@ public sealed class UpdateRoleHandlerTests
 		var guild = GuildEntity.Create(
 			id: 100, name: "Test", description: null, iconUrl: null, bannerUrl: null,
 			ownerId: 1, everyoneRoleId: 101, adminRoleId: 102, now: Now).Value;
-		guilds.AddAsync(guild).GetAwaiter().GetResult();
+		guilds.Add(guild);
 		var handler = HandlerFactory.CreateCommand<UpdateRoleCommand, Result<RoleResponse>>(
 			guilds, new FakeClock(Now), new FakeCurrentUser { Id = currentUser });
 		return (handler, guilds);

--- a/services/guild/tests/Guild.UnitTests/Domain/GuildAssignRoleTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Domain/GuildAssignRoleTests.cs
@@ -1,0 +1,80 @@
+using Guild.Domain.Guild;
+using Guild.UnitTests.Fakes;
+using Xunit;
+using GuildEntity = Guild.Domain.Guild.Guild;
+
+namespace Guild.UnitTests.Domain;
+
+public sealed class GuildAssignRoleTests
+{
+	private static readonly DateTimeOffset Now =
+		new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+	// guild seeded by Create with @everyone(101, default) + Administrator(102),
+	// owner 1, plus member 2 and a custom non-default role 500
+	private static GuildEntity MakeGuild()
+	{
+		var guild = GuildEntity.Create(
+			id: 100, name: "Test", description: null, iconUrl: null, bannerUrl: null,
+			ownerId: 1, everyoneRoleId: 101, adminRoleId: 102, now: Now).Value;
+		DomainSeed.AddMember(guild, userId: 2, joinedAt: Now);
+		DomainSeed.AddCustomRole(guild, roleId: 500, name: "Mod", permissions: 0, position: 2, now: Now);
+		return guild;
+	}
+
+	[Fact]
+	public void TargetNotAMember_Returns_TargetNotAMember()
+	{
+		var guild = MakeGuild();
+
+		var result = guild.AssignRole(userId: 555, roleId: 500, Now);
+
+		Assert.True(result.IsFailure);
+		Assert.Equal("Guild.TargetNotAMember", result.Error.Code);
+	}
+
+	[Fact]
+	public void UnknownRole_Returns_RoleNotFound()
+	{
+		var guild = MakeGuild();
+
+		var result = guild.AssignRole(userId: 2, roleId: 999, Now);
+
+		Assert.True(result.IsFailure);
+		Assert.Equal("Guild.RoleNotFound", result.Error.Code);
+	}
+
+	[Fact]
+	public void DefaultRole_Returns_CannotAssignDefaultRole()
+	{
+		var guild = MakeGuild();
+
+		var result = guild.AssignRole(userId: 2, roleId: 101, Now); // @everyone
+
+		Assert.True(result.IsFailure);
+		Assert.Equal("Guild.CannotAssignDefaultRole", result.Error.Code);
+	}
+
+	[Fact]
+	public void AlreadyAssigned_IsIdempotent_NoDuplicate()
+	{
+		var guild = MakeGuild();
+		DomainSeed.AssignRole(guild, userId: 2, roleId: 500, now: Now);
+
+		var result = guild.AssignRole(userId: 2, roleId: 500, Now);
+
+		Assert.True(result.Succeeded);
+		Assert.Single(guild.MemberRoles, mr => mr.UserId == 2 && mr.RoleId == 500);
+	}
+
+	[Fact]
+	public void HappyPath_AddsMemberRole()
+	{
+		var guild = MakeGuild();
+
+		var result = guild.AssignRole(userId: 2, roleId: 500, Now);
+
+		Assert.True(result.Succeeded);
+		Assert.Contains(guild.MemberRoles, mr => mr.UserId == 2 && mr.RoleId == 500);
+	}
+}

--- a/services/guild/tests/Guild.UnitTests/Domain/GuildBanTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Domain/GuildBanTests.cs
@@ -1,0 +1,70 @@
+using Guild.Domain.Guild;
+using Xunit;
+
+namespace Guild.UnitTests.Domain;
+
+public sealed class GuildBanTests
+{
+	private static readonly DateTimeOffset Now =
+		new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+	[Fact]
+	public void Create_WithValidArgs_SetsAllFields()
+	{
+		var result = GuildBan.Create(guildId: 100, userId: 3, bannedBy: 1, reason: "spam", now: Now);
+
+		Assert.True(result.Succeeded);
+		var ban = result.Value;
+		Assert.Equal(100, ban.GuildId);
+		Assert.Equal(3, ban.UserId);
+		Assert.Equal(1, ban.BannedBy);
+		Assert.Equal("spam", ban.Reason);
+		Assert.Equal(Now, ban.BannedAt);
+	}
+
+	[Fact]
+	public void Create_WithNullReason_Succeeds()
+	{
+		var result = GuildBan.Create(guildId: 100, userId: 3, bannedBy: 1, reason: null, now: Now);
+
+		Assert.True(result.Succeeded);
+		Assert.Null(result.Value.Reason);
+	}
+
+	[Fact]
+	public void Create_WithReasonAtMaxLen_Succeeds()
+	{
+		var reason = new string('x', GuildBan.MaxReasonLen);
+
+		var result = GuildBan.Create(guildId: 100, userId: 3, bannedBy: 1, reason: reason, now: Now);
+
+		Assert.True(result.Succeeded);
+		Assert.Equal(GuildBan.MaxReasonLen, result.Value.Reason!.Length);
+	}
+
+	[Fact]
+	public void Create_WithReasonOverMaxLen_Returns_BanReasonTooLong()
+	{
+		var reason = new string('x', GuildBan.MaxReasonLen + 1);
+
+		var result = GuildBan.Create(guildId: 100, userId: 3, bannedBy: 1, reason: reason, now: Now);
+
+		Assert.True(result.IsFailure);
+		Assert.Equal("Guild.BanReasonTooLong", result.Error.Code);
+	}
+
+	[Theory]
+	[InlineData(0, 3, 1)]
+	[InlineData(-1, 3, 1)]
+	[InlineData(100, 0, 1)]
+	[InlineData(100, -1, 1)]
+	[InlineData(100, 3, 0)]
+	[InlineData(100, 3, -1)]
+	public void Create_WithNonPositiveId_Returns_InvalidId(long guildId, long userId, long bannedBy)
+	{
+		var result = GuildBan.Create(guildId, userId, bannedBy, reason: null, now: Now);
+
+		Assert.True(result.IsFailure);
+		Assert.Equal("Guild.InvalidId", result.Error.Code);
+	}
+}

--- a/services/guild/tests/Guild.UnitTests/Domain/GuildUnassignRoleTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Domain/GuildUnassignRoleTests.cs
@@ -1,0 +1,79 @@
+using Guild.Domain.Guild;
+using Guild.UnitTests.Fakes;
+using Xunit;
+using GuildEntity = Guild.Domain.Guild.Guild;
+
+namespace Guild.UnitTests.Domain;
+
+public sealed class GuildUnassignRoleTests
+{
+	private static readonly DateTimeOffset Now =
+		new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+	// guild with owner 1, member 2, and a custom non-default role 500
+	private static GuildEntity MakeGuild()
+	{
+		var guild = GuildEntity.Create(
+			id: 100, name: "Test", description: null, iconUrl: null, bannerUrl: null,
+			ownerId: 1, everyoneRoleId: 101, adminRoleId: 102, now: Now).Value;
+		DomainSeed.AddMember(guild, userId: 2, joinedAt: Now);
+		DomainSeed.AddCustomRole(guild, roleId: 500, name: "Mod", permissions: 0, position: 2, now: Now);
+		return guild;
+	}
+
+	[Fact]
+	public void TargetNotAMember_Returns_TargetNotAMember()
+	{
+		var guild = MakeGuild();
+
+		var result = guild.UnassignRole(userId: 555, roleId: 500, Now);
+
+		Assert.True(result.IsFailure);
+		Assert.Equal("Guild.TargetNotAMember", result.Error.Code);
+	}
+
+	[Fact]
+	public void UnknownRole_Returns_RoleNotFound()
+	{
+		var guild = MakeGuild();
+
+		var result = guild.UnassignRole(userId: 2, roleId: 999, Now);
+
+		Assert.True(result.IsFailure);
+		Assert.Equal("Guild.RoleNotFound", result.Error.Code);
+	}
+
+	[Fact]
+	public void DefaultRole_Returns_CannotUnassignDefaultRole()
+	{
+		var guild = MakeGuild();
+
+		var result = guild.UnassignRole(userId: 2, roleId: 101, Now); // @everyone
+
+		Assert.True(result.IsFailure);
+		Assert.Equal("Guild.CannotUnassignDefaultRole", result.Error.Code);
+	}
+
+	[Fact]
+	public void NotAssigned_Returns_RoleAssignmentNotFound()
+	{
+		var guild = MakeGuild();
+
+		var result = guild.UnassignRole(userId: 2, roleId: 500, Now);
+
+		Assert.True(result.IsFailure);
+		Assert.Equal("Guild.RoleAssignmentNotFound", result.Error.Code);
+	}
+
+	[Fact]
+	public void HappyPath_RemovesMemberRole()
+	{
+		var guild = MakeGuild();
+		DomainSeed.AssignRole(guild, userId: 2, roleId: 500, now: Now);
+
+		var result = guild.UnassignRole(userId: 2, roleId: 500, Now);
+
+		Assert.True(result.Succeeded);
+		Assert.DoesNotContain(guild.MemberRoles, mr => mr.UserId == 2 && mr.RoleId == 500);
+	}
+}

--- a/services/guild/tests/Guild.UnitTests/Domain/PermissionResolverTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Domain/PermissionResolverTests.cs
@@ -10,68 +10,69 @@ public sealed class PermissionResolverTests
 	private static readonly DateTimeOffset Now =
 		new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
 
+	// @everyone baseline = SendMessages(1) | ReadMessages(2) | CreateInvite(512)
+	private const long EveryoneMask = 515L;
+
 	[Fact]
 	public void Owner_AlwaysResolvesToAdministrator_RegardlessOfRoles()
 	{
 		var guild = CreateGuild(ownerId: 42);
 
-		var mask = PermissionResolver.Resolve(
-			userId: 42,
-			ownerId: 42,
-			allGuildRoles: guild.Roles,
-			userAssignments: guild.MemberRoles);
+		var mask = PermissionResolver.Resolve(guild, userId: 42);
 
 		Assert.Equal((long)Permission.Administrator, mask);
 	}
 
 	[Fact]
-	public void NonOwner_NoAssignedRoles_GetsOnlyDefaultRoleMask()
+	public void NonMember_ResolvesToZero()
 	{
+		// user 2 is not in the guild's member list. the guild-scoped resolver
+		// folds the membership check in, so a non-member gets no permissions
+		// (previously it leaked the @everyone mask to outsiders)
 		var guild = CreateGuild(ownerId: 1);
 
-		// user 2 is not a member, but the resolver itself only checks
-		// assignments; @everyone applies unconditionally
-		var mask = PermissionResolver.Resolve(
-			userId: 2,
-			ownerId: 1,
-			allGuildRoles: guild.Roles,
-			userAssignments: Array.Empty<MemberRole>());
+		var mask = PermissionResolver.Resolve(guild, userId: 2);
 
-		Assert.Equal(515L, mask);
+		Assert.Equal(0L, mask);
 	}
 
 	[Fact]
-	public void NonOwner_WithAssignedRole_OrsTogetherDefaultAndAssigned()
+	public void Member_NoAssignedRoles_GetsOnlyDefaultRoleMask()
 	{
 		var guild = CreateGuild(ownerId: 1);
+		DomainSeed.AddMember(guild, userId: 2, joinedAt: Now);
+
+		var mask = PermissionResolver.Resolve(guild, userId: 2);
+
+		Assert.Equal(EveryoneMask, mask);
+	}
+
+	[Fact]
+	public void Member_WithAssignedRole_OrsTogetherDefaultAndAssigned()
+	{
+		var guild = CreateGuild(ownerId: 1);
+		DomainSeed.AddMember(guild, userId: 2, joinedAt: Now);
 		long modPerms = (long)Permission.KickMembers | (long)Permission.BanMembers;
 		var modRole = DomainSeed.AddCustomRole(
 			guild, roleId: 100, name: "Moderator", permissions: modPerms, position: 2, now: Now);
 		DomainSeed.AssignRole(guild, userId: 2, roleId: modRole.Id, now: Now);
 
-		var mask = PermissionResolver.Resolve(
-			userId: 2,
-			ownerId: 1,
-			allGuildRoles: guild.Roles,
-			userAssignments: guild.MemberRoles);
+		var mask = PermissionResolver.Resolve(guild, userId: 2);
 
-		Assert.Equal(515L | modPerms, mask);
+		Assert.Equal(EveryoneMask | modPerms, mask);
 		Assert.Equal(563L, mask);
 	}
 
 	[Fact]
-	public void NonOwner_AdministratorRoleAssigned_MaskIncludesAdministratorBit()
+	public void Member_AdministratorRoleAssigned_MaskIncludesAdministratorBit()
 	{
 		var guild = CreateGuild(ownerId: 1);
+		DomainSeed.AddMember(guild, userId: 2, joinedAt: Now);
 		// the seeded admin role for the owner. assign it explicitly to user 2.
 		var adminRole = guild.Roles.Single(r => r.Name == "Administrator");
 		DomainSeed.AssignRole(guild, userId: 2, roleId: adminRole.Id, now: Now);
 
-		var mask = PermissionResolver.Resolve(
-			userId: 2,
-			ownerId: 1,
-			allGuildRoles: guild.Roles,
-			userAssignments: guild.MemberRoles);
+		var mask = PermissionResolver.Resolve(guild, userId: 2);
 
 		Assert.NotEqual(0L, mask & (long)Permission.Administrator);
 	}
@@ -103,11 +104,12 @@ public sealed class PermissionResolverTests
 	}
 
 	[Fact]
-	public void NonOwner_TwoRolesGrantingSameBit_BitIsGrantedNotXored()
+	public void Member_TwoRolesGrantingSameBit_BitIsGrantedNotXored()
 	{
 		// if perms were accumulated with ^= instead of |=, a bit shared by two
 		// assigned roles would cancel back to 0; this test catches that mutation
 		var guild = CreateGuild(ownerId: 1);
+		DomainSeed.AddMember(guild, userId: 2, joinedAt: Now);
 		long sharedBit = (long)Permission.ManageGuild;
 		var role1 = DomainSeed.AddCustomRole(
 			guild, roleId: 100, name: "R1", permissions: sharedBit, position: 2, now: Now);
@@ -116,11 +118,7 @@ public sealed class PermissionResolverTests
 		DomainSeed.AssignRole(guild, userId: 2, roleId: role1.Id, now: Now);
 		DomainSeed.AssignRole(guild, userId: 2, roleId: role2.Id, now: Now);
 
-		var mask = PermissionResolver.Resolve(
-			userId: 2,
-			ownerId: 1,
-			allGuildRoles: guild.Roles,
-			userAssignments: guild.MemberRoles);
+		var mask = PermissionResolver.Resolve(guild, userId: 2);
 
 		Assert.NotEqual(0L, mask & sharedBit);
 	}
@@ -129,19 +127,16 @@ public sealed class PermissionResolverTests
 	public void Resolver_IgnoresAssignmentsForOtherUsers()
 	{
 		var guild = CreateGuild(ownerId: 1);
+		DomainSeed.AddMember(guild, userId: 42, joinedAt: Now);
 		long modPerms = (long)Permission.KickMembers;
 		var modRole = DomainSeed.AddCustomRole(
 			guild, roleId: 100, name: "Moderator", permissions: modPerms, position: 2, now: Now);
 		// assignment belongs to user 99, not 42; should be ignored
 		DomainSeed.AssignRole(guild, userId: 99, roleId: modRole.Id, now: Now);
 
-		var mask = PermissionResolver.Resolve(
-			userId: 42,
-			ownerId: 1,
-			allGuildRoles: guild.Roles,
-			userAssignments: guild.MemberRoles);
+		var mask = PermissionResolver.Resolve(guild, userId: 42);
 
-		Assert.Equal(515L, mask);
+		Assert.Equal(EveryoneMask, mask);
 	}
 
 	private static GuildEntity CreateGuild(long ownerId) =>

--- a/services/guild/tests/Guild.UnitTests/Fakes/FakeChannelCategoryRepository.cs
+++ b/services/guild/tests/Guild.UnitTests/Fakes/FakeChannelCategoryRepository.cs
@@ -34,11 +34,10 @@ internal sealed class FakeChannelCategoryRepository : IChannelCategoryRepository
 		return Task.FromResult(result);
 	}
 
-	public Task AddAsync(ChannelCategory category, CancellationToken cancellationToken = default)
+	public void Add(ChannelCategory category)
 	{
 		_store[category.Id] = category;
 		AddCount++;
-		return Task.CompletedTask;
 	}
 
 	public void Update(ChannelCategory category)

--- a/services/guild/tests/Guild.UnitTests/Fakes/FakeChannelCategoryRepository.cs
+++ b/services/guild/tests/Guild.UnitTests/Fakes/FakeChannelCategoryRepository.cs
@@ -12,7 +12,6 @@ internal sealed class FakeChannelCategoryRepository : IChannelCategoryRepository
 	public int AddCount { get; private set; }
 	public int UpdateCount { get; private set; }
 	public int RemoveCount { get; private set; }
-	public int SaveChangesCount { get; private set; }
 
 	public Task<ChannelCategory?> GetByIdAsync(
 		long guildId,
@@ -52,12 +51,6 @@ internal sealed class FakeChannelCategoryRepository : IChannelCategoryRepository
 	{
 		_store.Remove(category.Id);
 		RemoveCount++;
-	}
-
-	public Task SaveChangesAsync(CancellationToken cancellationToken = default)
-	{
-		SaveChangesCount++;
-		return Task.CompletedTask;
 	}
 
 	internal void Seed(ChannelCategory category) => _store[category.Id] = category;

--- a/services/guild/tests/Guild.UnitTests/Fakes/FakeChannelPermissionOverwriteRepository.cs
+++ b/services/guild/tests/Guild.UnitTests/Fakes/FakeChannelPermissionOverwriteRepository.cs
@@ -12,7 +12,6 @@ internal sealed class FakeChannelPermissionOverwriteRepository : IChannelPermiss
 	public int AddCount { get; private set; }
 	public int UpdateCount { get; private set; }
 	public int RemoveCount { get; private set; }
-	public int SaveChangesCount { get; private set; }
 
 	public Task<IReadOnlyList<ChannelPermissionOverwrite>> GetForChannelAsync(
 		long channelId,
@@ -64,12 +63,6 @@ internal sealed class FakeChannelPermissionOverwriteRepository : IChannelPermiss
 	{
 		_store.Remove(overwrite.Id);
 		RemoveCount++;
-	}
-
-	public Task SaveChangesAsync(CancellationToken cancellationToken = default)
-	{
-		SaveChangesCount++;
-		return Task.CompletedTask;
 	}
 
 	internal void Seed(ChannelPermissionOverwrite overwrite) => _store[overwrite.Id] = overwrite;

--- a/services/guild/tests/Guild.UnitTests/Fakes/FakeChannelPermissionOverwriteRepository.cs
+++ b/services/guild/tests/Guild.UnitTests/Fakes/FakeChannelPermissionOverwriteRepository.cs
@@ -46,11 +46,10 @@ internal sealed class FakeChannelPermissionOverwriteRepository : IChannelPermiss
 		return Task.FromResult(match);
 	}
 
-	public Task AddAsync(ChannelPermissionOverwrite overwrite, CancellationToken cancellationToken = default)
+	public void Add(ChannelPermissionOverwrite overwrite)
 	{
 		_store[overwrite.Id] = overwrite;
 		AddCount++;
-		return Task.CompletedTask;
 	}
 
 	public void Update(ChannelPermissionOverwrite overwrite)

--- a/services/guild/tests/Guild.UnitTests/Fakes/FakeChannelRepository.cs
+++ b/services/guild/tests/Guild.UnitTests/Fakes/FakeChannelRepository.cs
@@ -12,7 +12,6 @@ internal sealed class FakeChannelRepository : IChannelRepository
 	public int AddCount { get; private set; }
 	public int UpdateCount { get; private set; }
 	public int RemoveCount { get; private set; }
-	public int SaveChangesCount { get; private set; }
 
 	public Task<Channel?> GetByIdAsync(long channelId, CancellationToken cancellationToken = default)
 	{
@@ -59,12 +58,6 @@ internal sealed class FakeChannelRepository : IChannelRepository
 	{
 		_store.Remove(channel.Id);
 		RemoveCount++;
-	}
-
-	public Task SaveChangesAsync(CancellationToken cancellationToken = default)
-	{
-		SaveChangesCount++;
-		return Task.CompletedTask;
 	}
 
 	internal void Seed(Channel channel) => _store[channel.Id] = channel;

--- a/services/guild/tests/Guild.UnitTests/Fakes/FakeChannelRepository.cs
+++ b/services/guild/tests/Guild.UnitTests/Fakes/FakeChannelRepository.cs
@@ -41,11 +41,10 @@ internal sealed class FakeChannelRepository : IChannelRepository
 		return Task.FromResult(result);
 	}
 
-	public Task AddAsync(Channel channel, CancellationToken cancellationToken = default)
+	public void Add(Channel channel)
 	{
 		_store[channel.Id] = channel;
 		AddCount++;
-		return Task.CompletedTask;
 	}
 
 	public void Update(Channel channel)

--- a/services/guild/tests/Guild.UnitTests/Fakes/FakeGuildBanRepository.cs
+++ b/services/guild/tests/Guild.UnitTests/Fakes/FakeGuildBanRepository.cs
@@ -32,6 +32,10 @@ internal sealed class FakeGuildBanRepository : IGuildBanRepository
 
 	public Task AddAsync(GuildBan ban, CancellationToken cancellationToken = default)
 	{
+		if (_store.ContainsKey((ban.GuildId, ban.UserId)))
+			throw new InvalidOperationException(
+				$"A GuildBan with key ({ban.GuildId}, {ban.UserId}) is already tracked.");
+
 		_store[(ban.GuildId, ban.UserId)] = ban;
 		AddCount++;
 		return Task.CompletedTask;

--- a/services/guild/tests/Guild.UnitTests/Fakes/FakeGuildBanRepository.cs
+++ b/services/guild/tests/Guild.UnitTests/Fakes/FakeGuildBanRepository.cs
@@ -30,7 +30,7 @@ internal sealed class FakeGuildBanRepository : IGuildBanRepository
 		return Task.FromResult(ban);
 	}
 
-	public Task AddAsync(GuildBan ban, CancellationToken cancellationToken = default)
+	public void Add(GuildBan ban)
 	{
 		if (_store.ContainsKey((ban.GuildId, ban.UserId)))
 			throw new InvalidOperationException(
@@ -38,7 +38,6 @@ internal sealed class FakeGuildBanRepository : IGuildBanRepository
 
 		_store[(ban.GuildId, ban.UserId)] = ban;
 		AddCount++;
-		return Task.CompletedTask;
 	}
 
 	public void Remove(GuildBan ban)

--- a/services/guild/tests/Guild.UnitTests/Fakes/FakeGuildInviteRepository.cs
+++ b/services/guild/tests/Guild.UnitTests/Fakes/FakeGuildInviteRepository.cs
@@ -27,11 +27,10 @@ internal sealed class FakeGuildInviteRepository : IGuildInviteRepository
 		return Task.FromResult(rows);
 	}
 
-	public Task AddAsync(GuildInvite invite, CancellationToken cancellationToken = default)
+	public void Add(GuildInvite invite)
 	{
 		_store[invite.Code] = invite;
 		AddCount++;
-		return Task.CompletedTask;
 	}
 
 	public void Update(GuildInvite invite)

--- a/services/guild/tests/Guild.UnitTests/Fakes/FakeGuildInviteRepository.cs
+++ b/services/guild/tests/Guild.UnitTests/Fakes/FakeGuildInviteRepository.cs
@@ -11,7 +11,6 @@ internal sealed class FakeGuildInviteRepository : IGuildInviteRepository
 
 	public int AddCount { get; private set; }
 	public int UpdateCount { get; private set; }
-	public int SaveChangesCount { get; private set; }
 
 	public Task<GuildInvite?> GetByCodeAsync(string code, CancellationToken cancellationToken = default)
 	{
@@ -39,12 +38,6 @@ internal sealed class FakeGuildInviteRepository : IGuildInviteRepository
 	{
 		_store[invite.Code] = invite;
 		UpdateCount++;
-	}
-
-	public Task SaveChangesAsync(CancellationToken cancellationToken = default)
-	{
-		SaveChangesCount++;
-		return Task.CompletedTask;
 	}
 
 	public Task<int> DeleteRevokedAndExpiredAsync(DateTimeOffset expiredBefore, CancellationToken cancellationToken = default)

--- a/services/guild/tests/Guild.UnitTests/Fakes/FakeGuildRepository.cs
+++ b/services/guild/tests/Guild.UnitTests/Fakes/FakeGuildRepository.cs
@@ -26,9 +26,41 @@ internal sealed class FakeGuildRepository : IGuildRepository
 		return Task.FromResult(guild);
 	}
 
+	public Task<GuildEntity?> GetByIdWithMembershipAsNoTrackingAsync(long id, CancellationToken cancellationToken = default)
+	{
+		// the fake holds entities by reference and does no change tracking, so
+		// tracked vs no-tracking is the same object here
+		_store.TryGetValue(id, out var guild);
+		return Task.FromResult(guild);
+	}
+
 	public Task<int> CountMembersAsync(long guildId, CancellationToken cancellationToken = default)
 	{
 		return Task.FromResult(_store.TryGetValue(guildId, out var guild) ? guild.Members.Count : 0);
+	}
+
+	public Task<IReadOnlyList<MemberPage>> PageMembersAsync(
+		long guildId, long? afterUserId, int limit, CancellationToken cancellationToken = default)
+	{
+		if (!_store.TryGetValue(guildId, out var guild))
+			return Task.FromResult<IReadOnlyList<MemberPage>>([]);
+
+		var rolesByUser = guild.MemberRoles
+			.GroupBy(mr => mr.UserId)
+			.ToDictionary(g => g.Key, g => (IReadOnlyList<long>)g.Select(mr => mr.RoleId).ToList());
+
+		var page = guild.Members
+			.Where(m => afterUserId is null || m.UserId > afterUserId.Value)
+			.OrderBy(m => m.UserId)
+			.Take(limit)
+			.Select(m => new MemberPage(
+				m.UserId,
+				m.Nickname,
+				m.JoinedAt,
+				rolesByUser.TryGetValue(m.UserId, out var ids) ? ids : []))
+			.ToList();
+
+		return Task.FromResult<IReadOnlyList<MemberPage>>(page);
 	}
 
 	public Task<int> CountOwnedByAsync(long userId, CancellationToken cancellationToken = default)

--- a/services/guild/tests/Guild.UnitTests/Fakes/FakeGuildRepository.cs
+++ b/services/guild/tests/Guild.UnitTests/Fakes/FakeGuildRepository.cs
@@ -12,7 +12,6 @@ internal sealed class FakeGuildRepository : IGuildRepository
 	public int AddCount { get; private set; }
 	public int UpdateCount { get; private set; }
 	public int RemoveCount { get; private set; }
-	public int SaveChangesCount { get; private set; }
 
 	public Task<GuildEntity?> GetByIdAsync(long id, CancellationToken cancellationToken = default)
 	{
@@ -93,11 +92,5 @@ internal sealed class FakeGuildRepository : IGuildRepository
 	{
 		_store.Remove(guild.Id);
 		RemoveCount++;
-	}
-
-	public Task SaveChangesAsync(CancellationToken cancellationToken = default)
-	{
-		SaveChangesCount++;
-		return Task.CompletedTask;
 	}
 }

--- a/services/guild/tests/Guild.UnitTests/Fakes/FakeGuildRepository.cs
+++ b/services/guild/tests/Guild.UnitTests/Fakes/FakeGuildRepository.cs
@@ -75,11 +75,10 @@ internal sealed class FakeGuildRepository : IGuildRepository
 		return Task.FromResult(guild.Members.Any(m => m.UserId == userId));
 	}
 
-	public Task AddAsync(GuildEntity guild, CancellationToken cancellationToken = default)
+	public void Add(GuildEntity guild)
 	{
 		_store[guild.Id] = guild;
 		AddCount++;
-		return Task.CompletedTask;
 	}
 
 	public void Update(GuildEntity guild)

--- a/services/guild/tests/Guild.UnitTests/Fakes/FakeUnitOfWork.cs
+++ b/services/guild/tests/Guild.UnitTests/Fakes/FakeUnitOfWork.cs
@@ -1,0 +1,14 @@
+using Guild.Application.Abstractions.Persistence;
+
+namespace Guild.UnitTests.Fakes;
+
+internal sealed class FakeUnitOfWork : IUnitOfWork
+{
+	public int SaveChangesCount { get; private set; }
+
+	public Task SaveChangesAsync(CancellationToken cancellationToken = default)
+	{
+		SaveChangesCount++;
+		return Task.CompletedTask;
+	}
+}

--- a/services/guild/tests/Guild.UnitTests/Fakes/FakeUserService.cs
+++ b/services/guild/tests/Guild.UnitTests/Fakes/FakeUserService.cs
@@ -23,6 +23,6 @@ internal sealed class FakeUserService : IUserService
 	{
 		GetSummaryCallCount++;
 		_summaries.TryGetValue(userId, out var summary);
-		return Task.FromResult<UserSummary?>(summary);
+		return Task.FromResult(summary);
 	}
 }

--- a/services/guild/tests/Guild.UnitTests/Fakes/HandlerFactory.cs
+++ b/services/guild/tests/Guild.UnitTests/Fakes/HandlerFactory.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 using Guild.Application;
 using Guild.Application.Abstractions.Messaging;
+using Guild.Application.Abstractions.Persistence;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 
@@ -72,6 +73,14 @@ internal static class HandlerFactory
 				// exposes it as a property), so reach for the field here
 				var nullLogger = typeof(NullLogger<>).MakeGenericType(type.GetGenericArguments()[0]);
 				args[i] = nullLogger.GetField("Instance")!.GetValue(null)!;
+			}
+			else if (type == typeof(IUnitOfWork))
+			{
+				// committing handlers take an IUnitOfWork; like ILogger it is plumbing,
+				// not behaviour under test, so auto-fill it and let callers keep their
+				// existing arg lists. the real commit path is covered by the functional
+				// tests, which resolve the production UnitOfWork over the DbContext
+				args[i] = new FakeUnitOfWork();
 			}
 			else
 			{

--- a/services/guild/tests/Guild.UnitTests/Serialization/ErrorBodySerializationTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Serialization/ErrorBodySerializationTests.cs
@@ -1,0 +1,39 @@
+using System.Text.Json;
+using Guild.Presentation.Endpoints;
+using Xunit;
+
+namespace Guild.UnitTests.Serialization;
+
+/// <summary>
+/// locks the on-the-wire shape of <see cref="ErrorBody"/>. every client parses
+/// the <c>"error"</c> field; a serializer-policy change or a property rename
+/// would silently break all of them, so the shape is pinned here rather than
+/// discovered in production. mirrors the snake_case policy applied in
+/// <c>Program.cs</c> via <c>ConfigureHttpJsonOptions</c>
+/// </summary>
+public sealed class ErrorBodySerializationTests
+{
+	private static readonly JsonSerializerOptions SnakeCase = new()
+	{
+		PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+	};
+
+	[Fact]
+	public void ErrorBody_SerializesTo_SingleSnakeCaseErrorField()
+	{
+		var json = JsonSerializer.Serialize(new ErrorBody("Guild not found."), SnakeCase);
+
+		Assert.Equal("{\"error\":\"Guild not found.\"}", json);
+	}
+
+	[Fact]
+	public void ErrorBody_RoundTrips()
+	{
+		var original = new ErrorBody("Caller is missing the required permission.");
+
+		var json = JsonSerializer.Serialize(original, SnakeCase);
+		var restored = JsonSerializer.Deserialize<ErrorBody>(json, SnakeCase);
+
+		Assert.Equal(original, restored);
+	}
+}

--- a/services/guild/tests/Guild.UnitTests/Serialization/EventSerializationTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Serialization/EventSerializationTests.cs
@@ -1,0 +1,84 @@
+using System.Text.Json;
+using Guild.Application.Contracts;
+using Xunit;
+
+namespace Guild.UnitTests.Serialization;
+
+/// <summary>
+/// pins the JSON shape of the three RabbitMQ events Guild publishes. cross-service
+/// consumers (Notification, Chat) deserialize these by snake_case property name,
+/// so a rename or a serializer-policy drift breaks them silently at runtime. the
+/// options here mirror the MassTransit config in
+/// <c>Infrastructure/DependencyInjection.cs</c> (<c>ConfigureJsonSerializerOptions</c>
+/// with <c>JsonNamingPolicy.SnakeCaseLower</c>).
+/// </summary>
+public sealed class EventSerializationTests
+{
+	private static readonly JsonSerializerOptions SnakeCase = new()
+	{
+		PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+	};
+
+	[Fact]
+	public void GuildMemberJoined_SerializesWith_SnakeCaseFields()
+	{
+		var json = JsonSerializer.Serialize(new GuildMemberJoined(100, "Test", 3), SnakeCase);
+
+		Assert.Equal("{\"guild_id\":100,\"guild_name\":\"Test\",\"user_id\":3}", json);
+	}
+
+	[Fact]
+	public void GuildMemberLeft_SerializesWith_SnakeCaseFields()
+	{
+		var json = JsonSerializer.Serialize(new GuildMemberLeft(100, 3), SnakeCase);
+
+		Assert.Equal("{\"guild_id\":100,\"user_id\":3}", json);
+	}
+
+	[Fact]
+	public void GuildInviteCreated_SerializesWith_SnakeCaseFields()
+	{
+		var json = JsonSerializer.Serialize(new GuildInviteCreated(100, "Test", 1, 7), SnakeCase);
+
+		Assert.Equal(
+			"{\"guild_id\":100,\"guild_name\":\"Test\",\"invited_by_user_id\":1,\"invited_user_id\":7}",
+			json);
+	}
+
+	[Fact]
+	public void GuildInviteCreated_WithNullTarget_EmitsNullInvitedUserId()
+	{
+		var json = JsonSerializer.Serialize(new GuildInviteCreated(100, "Test", 1, null), SnakeCase);
+
+		Assert.Equal(
+			"{\"guild_id\":100,\"guild_name\":\"Test\",\"invited_by_user_id\":1,\"invited_user_id\":null}",
+			json);
+	}
+
+	[Fact]
+	public void GuildMemberJoined_RoundTrips()
+	{
+		var original = new GuildMemberJoined(100, "Test", 3);
+		var json = JsonSerializer.Serialize(original, SnakeCase);
+
+		Assert.Equal(original, JsonSerializer.Deserialize<GuildMemberJoined>(json, SnakeCase));
+	}
+
+	[Fact]
+	public void GuildMemberLeft_RoundTrips()
+	{
+		var original = new GuildMemberLeft(100, 3);
+		var json = JsonSerializer.Serialize(original, SnakeCase);
+
+		Assert.Equal(original, JsonSerializer.Deserialize<GuildMemberLeft>(json, SnakeCase));
+	}
+
+	[Fact]
+	public void GuildInviteCreated_RoundTrips()
+	{
+		var original = new GuildInviteCreated(100, "Test", 1, null);
+		var json = JsonSerializer.Serialize(original, SnakeCase);
+
+		Assert.Equal(original, JsonSerializer.Deserialize<GuildInviteCreated>(json, SnakeCase));
+	}
+}


### PR DESCRIPTION
# Guild Service cleanup: reliability, consolidation, performance

*don't look at the diff don't look at the diff don't loo-*

Works through a reliability/refactor backlog for the Guild Service, Phases 0 to 5 plus the cross-cutting items. No new product behaviour: this is reliability, consolidation, and read-path performance, all behind a comprehensive test net written up front.

**Tests: 438 unit / 254 functional / 12 architecture, green throughout.** The outbox, xmin concurrency, and member pagination were additionally smoke-tested against the live Postgres + RabbitMQ stack.

## Phase 0: safety net first
Before touching a handler, locked current behaviour down so the structural work could be aggressive:
- Unit tests for the 6 previously-untested handlers (Ban, Unban, ListBans, AssignRole, UnassignRole, GetMemberPermissions) plus `GuildBanTests`.
- `ErrorBody` JSON snapshot + snake_case round-trip tests for the three published events (drift detectors for the cross-service wire contract).
- Fixed `FakeGuildBanRepository.AddAsync` to throw on duplicate keys like the real `DbSet`, so concurrency tests can't silently pass.

## Phase 1: reliability foundations
- **MassTransit EF outbox.** Event publishes are now written to an `OutboxMessage` row inside the same `SaveChanges` as the business change, so a broker outage can no longer drop an event. `AddInfrastructure<TDbContext>()` is generic so Infrastructure never references Persistence (the layer rule holds). The 5 affected handlers publish before `SaveChanges` so the event commits with the transaction.
- **`xmin` optimistic concurrency** on every aggregate. Closes the AlreadyBanned race and the role-reorder race; conflicts surface as a retryable `409` instead of a `500`. (Npgsql 10 dropped `UseXminAsConcurrencyToken`; uses the standard `IsRowVersion()` on a shadow property, with a deliberately-empty migration since `xmin` is a system column.)

## Phase 2: domain consolidation
- Folded the membership check into `PermissionResolver.Resolve(guild, userId)` (non-member now resolves to 0, symmetric with the channel overload) and deleted the old overload that leaked `@everyone` perms to non-members.
- Extracted `AuthorizationContext.LoadAsync(...)`; **27 handlers** now run one call instead of an 8-line preamble.
- Dropped 13 redundant `guilds.Update(guild)` calls on tracked aggregates.

## Phase 3: read-path performance
- `AsSplitQuery()` on the membership load (kills the cartesian explosion) plus a no-tracking sibling for read handlers.
- `ListMembers` now keyset-pages straight from the DB (`PageMembersAsync`) instead of hydrating the whole guild; `ListBans` reads no-tracking.

## Phase 4: HTTP surface
- **Global `Failure -> status` map** built from the contract: 136 hand-written switch arms collapsed to one source of truth (~500 lines of boilerplate gone), with the documented per-endpoint overrides (e.g. invalid invite is 400 on `POST /guilds/{id}/join` but 404 on `POST /invites/{code}/join`).
- Fixed `LeaveAsync`'s 403 fallback (now 400). Restored the OpenAPI/Scalar error-response docs that the union collapse would have dropped (verified against the live spec). Shared `Pagination` parser; structured logging of unhandled exceptions.

## Phase 5: renames and small cleanups
- `DeleteInvite` -> `RevokeInvite` (it soft-revokes; hard deletion is the cleanup service's job).
- `InternalsVisibleTo` on Domain + `MemberRole.Create` instead of reflection in the test factory.
- `Result<T>` constrained to `notnull` so a success can never carry a null value; `Result.Error` now throws on success, symmetric with `Result<T>.Value`.
- Single-sourced the snake_case JSON naming policy for both the HTTP pipeline and MassTransit.

## Cross-cutting backlog
`IUnitOfWork` extracted as the commit boundary (`SaveChangesAsync` removed from all 5 repos); repository `Add()` made synchronous to match `Remove()`; unnecessary `BanListResponse`/`MemberListResponse` wrappers removed; `RemoveAllForUserAsync` consolidated; Kick/Ban `TargetNotAMember` ordering documented; plus the mop-up tests (ban-on-join, `AssignRole`/`UnassignRole` domain coverage).

## Contract-driven decisions
- `InviteUnusable` stays **404 / 400** per `docs/contracts/guild.md`.
- Error bodies stay `{ "error": "..." }` (`ErrorBody`); did **not** switch to RFC-7807 ProblemDetails.
- `UnbanMember` keeps returning **404** for a non-existent/invalid id ("user is not banned" per contract); the ban-vs-unban asymmetry is semantically correct.
