### PR TITLE
Feat(guild): consume user deleted

### DIFF
--- a/docs/contracts/guild.md
+++ b/docs/contracts/guild.md
@@ -296,6 +296,8 @@ List banned users. Caller must be a member and have `BAN_MEMBERS` permission. Ba
 ]
 ```
 
+`banned_by` is nullable: it becomes `null` once the moderator who issued the ban has deleted their account (GDPR erasure scrubs the reference while the ban stays in force). See the `user.deleted` consumer below.
+
 **Errors:**
 | Status | Reason |
 |--------|--------|
@@ -985,7 +987,9 @@ Check if a user is a member of the guild that owns this channel, and get their e
 
 ## RabbitMQ Events Consumed
 
-| Event | Action |
-|-------|--------|
-| `user.deleted` | Delete all `guild_members`, `member_roles`, `guild_bans`, and `guild_invites` rows referencing the deleted user. Auth Service has already enforced (via 409 on `DELETE /auth/me`) that the user does not own any guilds, so no ownership transfer is needed here. |
+| Event | Payload | Action |
+|-------|---------|--------|
+| `user.deleted` | `{ user_id }` | GDPR erasure cascade. Deletes every row whose subject (or sole artifact) is the user: `guild_members` and `member_roles` (`user_id`), `guild_bans` (`user_id`, bans against them), `guild_invites` (`created_by`, their invite codes), and `channel_permission_overwrites` (`target_id` where `target_type = 'user'`, their per-channel overwrites). Additionally scrubs `guild_bans.banned_by` to `null` for bans the user *issued* against others: the ban stays in force, only the moderator reference is erased. Auth has already enforced (via 409 on `DELETE /auth/me`) that the user owns no guilds, so no ownership transfer is needed here. |
+
+Published by Auth on `Auth.Application.Contracts:UserDeleted` (exchange `user.deleted`, snake_case payload). The consumer's steps are idempotent bulk statements, so redelivery is safe.
 

--- a/docs/schema/guild.sql
+++ b/docs/schema/guild.sql
@@ -86,7 +86,7 @@ CREATE INDEX idx_guild_members_user ON guild_members (user_id);
 CREATE TABLE guild_bans (
     guild_id    BIGINT      NOT NULL REFERENCES guilds (id) ON DELETE CASCADE,
     user_id     BIGINT      NOT NULL,   -- logical ref → users_profile.id
-    banned_by   BIGINT      NOT NULL,   -- logical ref → users_profile.id
+    banned_by   BIGINT,                 -- logical ref → users_profile.id; NULL once the moderator is GDPR-erased (ban stays, reference scrubbed)
     reason      TEXT,
     banned_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     PRIMARY KEY (guild_id, user_id)

--- a/services/auth/src/Auth.Application/Auth.Application.csproj
+++ b/services/auth/src/Auth.Application/Auth.Application.csproj
@@ -5,7 +5,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0"/>
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
     </ItemGroup>
 
     <PropertyGroup>

--- a/services/auth/src/Auth.Application/Contracts/Events.cs
+++ b/services/auth/src/Auth.Application/Contracts/Events.cs
@@ -1,0 +1,22 @@
+using Auth.Application.Abstractions.Events;
+
+namespace Auth.Application.Contracts;
+
+// own-source events published by Auth. namespace + type name form the default
+// MassTransit URN ("Auth.Application.Contracts:UserDeleted") that consumers bind
+// to; no [MessageUrn] attribute here keeps MassTransit out of Application (see
+// DomainPurityTests). exchange names are set in Auth.Infrastructure.
+public sealed record UserRegistered(long UserId, string Email) : IEvent
+{
+    public string EventType => "user.registered";
+}
+
+public sealed record UserLoggedOut(long UserId) : IEvent
+{
+    public string EventType => "user.logged_out";
+}
+
+public sealed record UserDeleted(long UserId) : IEvent
+{
+    public string EventType => "user.deleted";
+}

--- a/services/auth/src/Auth.Application/Events/UserDeletedEvent.cs
+++ b/services/auth/src/Auth.Application/Events/UserDeletedEvent.cs
@@ -1,8 +1,0 @@
-using Auth.Application.Abstractions.Events;
-
-namespace Auth.Application.Events;
-
-public sealed record UserDeletedEvent(long UserId) : IEvent
-{
-    public string EventType => "user.deleted";
-}

--- a/services/auth/src/Auth.Application/Events/UserLoggedOutEvent.cs
+++ b/services/auth/src/Auth.Application/Events/UserLoggedOutEvent.cs
@@ -1,8 +1,0 @@
-using Auth.Application.Abstractions.Events;
-
-namespace Auth.Application.Events;
-
-public sealed record UserLoggedOutEvent(long UserId): IEvent
-{
-    public string EventType => "user.logged_out";
-}

--- a/services/auth/src/Auth.Application/Events/UserRegisteredEvent.cs
+++ b/services/auth/src/Auth.Application/Events/UserRegisteredEvent.cs
@@ -1,8 +1,0 @@
-using Auth.Application.Abstractions.Events;
-
-namespace Auth.Application.Events;
-
-public sealed record UserRegisteredEvent(long UserId, string Email) : IEvent
-{
-    public string EventType => "user.registered";
-}

--- a/services/auth/src/Auth.Application/Features/DeleteMe/DeleteMeHandler.cs
+++ b/services/auth/src/Auth.Application/Features/DeleteMe/DeleteMeHandler.cs
@@ -2,7 +2,7 @@ using Auth.Application.Abstractions;
 using Auth.Application.Abstractions.Events;
 using Auth.Application.Abstractions.Messaging;
 using Auth.Application.Abstractions.Persistence;
-using Auth.Application.Events;
+using Auth.Application.Contracts;
 using Auth.Domain.Results;
 
 namespace Auth.Application.Features.DeleteMe;
@@ -31,7 +31,7 @@ internal sealed class DeleteMeHandler(
         user.RevokeRefreshToken(clock.UtcNow);
 
         await userRepository.SaveChangesAsync(cancellationToken);
-        await eventBus.PublishAsync(new UserDeletedEvent(command.UserId), cancellationToken);
+        await eventBus.PublishAsync(new UserDeleted(command.UserId), cancellationToken);
 
         return Result.Ok();
     }

--- a/services/auth/src/Auth.Application/Features/Logout/LogoutHandler.cs
+++ b/services/auth/src/Auth.Application/Features/Logout/LogoutHandler.cs
@@ -2,7 +2,7 @@ using Auth.Application.Abstractions;
 using Auth.Application.Abstractions.Events;
 using Auth.Application.Abstractions.Messaging;
 using Auth.Application.Abstractions.Persistence;
-using Auth.Application.Events;
+using Auth.Application.Contracts;
 using Auth.Domain.Results;
 
 namespace Auth.Application.Features.Logout;
@@ -25,7 +25,7 @@ internal sealed class LogoutHandler(
         user.RevokeRefreshToken(clock.UtcNow);
         await userRepository.SaveChangesAsync(cancellationToken);
 
-        await eventBus.PublishAsync(new UserLoggedOutEvent(command.UserId), cancellationToken);
+        await eventBus.PublishAsync(new UserLoggedOut(command.UserId), cancellationToken);
 
         return Result.Ok();
     }

--- a/services/auth/src/Auth.Application/Features/OAuth/OAuthCallbackHandler.cs
+++ b/services/auth/src/Auth.Application/Features/OAuth/OAuthCallbackHandler.cs
@@ -4,7 +4,7 @@ using Auth.Application.Abstractions.Messaging;
 using Auth.Application.Abstractions.OAuth;
 using Auth.Application.Abstractions.Persistence;
 using Auth.Application.Abstractions.Security;
-using Auth.Application.Events;
+using Auth.Application.Contracts;
 using Auth.Domain.AuthUser;
 using Auth.Domain.Results;
 using Microsoft.Extensions.DependencyInjection;
@@ -67,7 +67,7 @@ internal sealed class OAuthCallbackHandler(
         await repository.SaveChangesAsync(cancellationToken);
         if (isNewUser)
             await eventBus.PublishAsync(
-                new UserRegisteredEvent(user.Id, userInfo.Email ?? string.Empty), cancellationToken);
+                new UserRegistered(user.Id, userInfo.Email ?? string.Empty), cancellationToken);
 
         var accessToken = tokenGenerator.GenerateAccessToken(user.Id);
         return new OAuthCallbackResult(accessToken, rawRefreshToken, isNewUser);

--- a/services/auth/src/Auth.Application/Features/Register/RegisterHandler.cs
+++ b/services/auth/src/Auth.Application/Features/Register/RegisterHandler.cs
@@ -3,7 +3,7 @@ using Auth.Application.Abstractions.Events;
 using Auth.Application.Abstractions.Messaging;
 using Auth.Application.Abstractions.Persistence;
 using Auth.Application.Abstractions.Security;
-using Auth.Application.Events;
+using Auth.Application.Contracts;
 using Auth.Domain.AuthUser;
 using Auth.Domain.Results;
 
@@ -51,7 +51,7 @@ internal sealed class RegisterHandler(
         await userRepository.SaveChangesAsync(cancellationToken);
 
         var email = newUser.Value.Email!.Value;
-        await eventBus.PublishAsync(new UserRegisteredEvent(uid, email), cancellationToken);
+        await eventBus.PublishAsync(new UserRegistered(uid, email), cancellationToken);
 
         return new RegisterResult(uid, accessTk, refreshTk);
     }

--- a/services/auth/src/Auth.Infrastructure/Auth.Infrastructure.csproj
+++ b/services/auth/src/Auth.Infrastructure/Auth.Infrastructure.csproj
@@ -9,9 +9,10 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="BCrypt.Net-Next" Version="4.1.0" />
+        <PackageReference Include="BCrypt.Net-Next" Version="4.2.0" />
+        <!-- 8.x is the last free/OSS line; 9+ requires a paid commercial license. -->
         <PackageReference Include="MassTransit.RabbitMQ" Version="8.4.1" />
-        <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.3.0" />
+        <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.19.1" />
     </ItemGroup>
 
     <PropertyGroup>

--- a/services/auth/src/Auth.Infrastructure/DependencyInjection.cs
+++ b/services/auth/src/Auth.Infrastructure/DependencyInjection.cs
@@ -1,6 +1,8 @@
 using System.Reflection;
+using System.Text.Json;
 using Auth.Application.Abstractions;
 using Auth.Application.Abstractions.Events;
+using Auth.Application.Contracts;
 using Auth.Application.Abstractions.OAuth;
 using Auth.Application.Abstractions.Security;
 using Auth.Infrastructure.Http;
@@ -34,6 +36,20 @@ public static class DependencyInjection
                     h.Username(options.Username);
                     h.Password(options.Password);
                 });
+
+                // contracts document snake_case payloads; MassTransit defaults to
+                // camelCase, so without this consumers read {"user_id":..} and bind nothing.
+                conf.ConfigureJsonSerializerOptions(opts =>
+                {
+                    opts.PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower;
+                    return opts;
+                });
+
+                // exchange names consumers bind to; must match their SetEntityName.
+                conf.Message<UserRegistered>(m => m.SetEntityName("user.registered"));
+                conf.Message<UserLoggedOut>(m => m.SetEntityName("user.logged_out"));
+                conf.Message<UserDeleted>(m => m.SetEntityName("user.deleted"));
+
                 conf.ConfigureEndpoints(ctx);
             })
         );

--- a/services/auth/src/Auth.Persistence/Auth.Persistence.csproj
+++ b/services/auth/src/Auth.Persistence/Auth.Persistence.csproj
@@ -5,16 +5,16 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.1">
+        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.2" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.9">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <!-- pin transitive to a non-vulnerable version (ef design 10.0.1 pulls 9.0.0, that's a shame) -->
-        <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.7" />
-        <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.0"/>
-        <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.0"/>
+        <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.9" />
+        <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.9" />
+        <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.9" />
+        <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.9" />
     </ItemGroup>
 
     <PropertyGroup>

--- a/services/auth/src/Auth.Presentation/Auth.Presentation.csproj
+++ b/services/auth/src/Auth.Presentation/Auth.Presentation.csproj
@@ -9,11 +9,14 @@
 
     <ItemGroup>
         <PackageReference Include="Carter" Version="10.0.0"/>
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.2"/>
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.2"/>
-        <PackageReference Include="Scalar.AspNetCore" Version="2.6.0"/>
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.9" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.9" />
+        <!-- pin patched 2.x (advisory GHSA-v5pm-xwqc-g5wc affects <= 2.7.4); stays on the
+             2.x API AspNetCore.OpenApi 10.x needs (3.x breaks its source generator). -->
+        <PackageReference Include="Microsoft.OpenApi" Version="2.7.5" />
+        <PackageReference Include="Scalar.AspNetCore" Version="2.16.7" />
         <!-- Needed by dotnet-ef for migrations generation -->
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.1">
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.9">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/services/auth/tests/Auth.ArchitectureTests/Auth.ArchitectureTests.csproj
+++ b/services/auth/tests/Auth.ArchitectureTests/Auth.ArchitectureTests.csproj
@@ -14,9 +14,9 @@
 
     <ItemGroup>
         <PackageReference Include="Carter"                     Version="10.0.0"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk"    Version="17.12.0"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
         <PackageReference Include="xunit"                     Version="2.9.3"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/services/auth/tests/Auth.FunctionalTests/Auth.FunctionalTests.csproj
+++ b/services/auth/tests/Auth.FunctionalTests/Auth.FunctionalTests.csproj
@@ -13,11 +13,11 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing"       Version="10.0.1"/>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.1"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk"                 Version="17.12.0"/>
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.9" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
         <PackageReference Include="xunit"                                  Version="2.9.3"/>
-        <PackageReference Include="xunit.runner.visualstudio"              Version="2.8.2">
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/services/auth/tests/Auth.UnitTests/Application/DeleteMeHandlerTests.cs
+++ b/services/auth/tests/Auth.UnitTests/Application/DeleteMeHandlerTests.cs
@@ -1,4 +1,4 @@
-using Auth.Application.Events;
+using Auth.Application.Contracts;
 using Auth.Application.Features.DeleteMe;
 using Auth.Domain.AuthUser;
 using Auth.Domain.Results;
@@ -110,12 +110,12 @@ public sealed class DeleteMeHandlerTests
     }
 
     [Fact]
-    public async Task ValidUser_PublishesUserDeletedEvent()
+    public async Task ValidUser_PublishesUserDeleted()
     {
         var user = await SeedEmailUser();
         await Handle(user.Id);
 
-        var evt = Assert.Single(_eventBus.Published.OfType<UserDeletedEvent>());
+        var evt = Assert.Single(_eventBus.Published.OfType<UserDeleted>());
         Assert.Equal(user.Id, evt.UserId);
     }
 }

--- a/services/auth/tests/Auth.UnitTests/Application/LogoutHandlerTests.cs
+++ b/services/auth/tests/Auth.UnitTests/Application/LogoutHandlerTests.cs
@@ -1,4 +1,4 @@
-using Auth.Application.Events;
+using Auth.Application.Contracts;
 using Auth.Application.Features.Logout;
 using Auth.Domain.AuthUser;
 using Auth.Domain.Results;
@@ -59,14 +59,14 @@ public sealed class LogoutHandlerTests
     }
 
     [Fact]
-    public async Task ValidUser_PublishesUserLoggedOutEvent()
+    public async Task ValidUser_PublishesUserLoggedOut()
     {
         var user = await SeedUser();
 
         await Handle(user.Id);
 
         var evt = Assert.Single(_eventBus.Published);
-        var loggedOut = Assert.IsType<UserLoggedOutEvent>(evt);
+        var loggedOut = Assert.IsType<UserLoggedOut>(evt);
         Assert.Equal(user.Id, loggedOut.UserId);
     }
 

--- a/services/auth/tests/Auth.UnitTests/Application/OAuthCallbackHandlerTests.cs
+++ b/services/auth/tests/Auth.UnitTests/Application/OAuthCallbackHandlerTests.cs
@@ -1,5 +1,5 @@
 using Auth.Application.Abstractions.Messaging;
-using Auth.Application.Events;
+using Auth.Application.Contracts;
 using Auth.Application.Features.OAuth;
 using Auth.Domain.AuthUser;
 using Auth.Domain.Results;
@@ -50,7 +50,7 @@ public sealed class OAuthCallbackHandlerTests
         Assert.True(result.Value.IsNewUser);
         Assert.Single(repo.Store);
         Assert.Single(eventBus.Published);
-        Assert.IsType<UserRegisteredEvent>(eventBus.Published[0]);
+        Assert.IsType<UserRegistered>(eventBus.Published[0]);
     }
 
     [Fact]

--- a/services/auth/tests/Auth.UnitTests/Application/RegisterHandlerTests.cs
+++ b/services/auth/tests/Auth.UnitTests/Application/RegisterHandlerTests.cs
@@ -1,4 +1,4 @@
-using Auth.Application.Events;
+using Auth.Application.Contracts;
 using Auth.Application.Features.Register;
 using Auth.Domain.Results;
 using Auth.UnitTests.Fakes;
@@ -55,12 +55,12 @@ public sealed class RegisterHandlerTests
     }
 
     [Fact]
-    public async Task ValidRegistration_PublishesUserRegisteredEvent()
+    public async Task ValidRegistration_PublishesUserRegistered()
     {
         await Handle("user@example.com", "password123");
 
         var evt = Assert.Single(_eventBus.Published);
-        var registered = Assert.IsType<UserRegisteredEvent>(evt);
+        var registered = Assert.IsType<UserRegistered>(evt);
         Assert.Equal(1_000_000_000_000_000_001L, registered.UserId);
         Assert.Equal("user@example.com", registered.Email);
     }

--- a/services/auth/tests/Auth.UnitTests/Auth.UnitTests.csproj
+++ b/services/auth/tests/Auth.UnitTests/Auth.UnitTests.csproj
@@ -13,9 +13,9 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk"               Version="17.12.0"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
         <PackageReference Include="xunit"                                Version="2.9.3"/>
-        <PackageReference Include="xunit.runner.visualstudio"            Version="2.8.2">
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/services/guild/src/Guild.Application/Abstractions/Persistence/IChannelPermissionOverwriteRepository.cs
+++ b/services/guild/src/Guild.Application/Abstractions/Persistence/IChannelPermissionOverwriteRepository.cs
@@ -25,6 +25,14 @@ public interface IChannelPermissionOverwriteRepository
 		long targetId,
 		CancellationToken cancellationToken = default);
 
+	/// <summary>
+	/// deletes every member-target overwrite (<c>target_type = 'user'</c>) whose
+	/// <c>target_id</c> is <paramref name="userId"/>, across all channels, in one
+	/// bulk statement. used by the <c>user.deleted</c> GDPR cascade to drop a
+	/// deleted user's per-channel permission rows.
+	/// </summary>
+	Task RemoveAllForMemberAsync(long userId, CancellationToken cancellationToken = default);
+
 	void Add(ChannelPermissionOverwrite overwrite);
 	void Update(ChannelPermissionOverwrite overwrite);
 	void Remove(ChannelPermissionOverwrite overwrite);

--- a/services/guild/src/Guild.Application/Abstractions/Persistence/IGuildBanRepository.cs
+++ b/services/guild/src/Guild.Application/Abstractions/Persistence/IGuildBanRepository.cs
@@ -23,12 +23,19 @@ public interface IGuildBanRepository
 	void Remove(GuildBan ban);
 
 	/// <summary>
-	/// deletes every ban row referencing <paramref name="userId"/> across all
-	/// guilds in one SQL statement (bypasses the change tracker). pre-staged
-	/// for the upcoming <c>user.deleted</c> consumer in issue #147; no current
-	/// caller in this commit. note: <c>ExecuteDeleteAsync</c> is unsupported by
-	/// the InMemory provider, so functional tests cannot exercise this path
-	/// without a real database.
+	/// deletes every ban whose <c>user_id</c> (the banned subject) is
+	/// <paramref name="userId"/>, across all guilds, in one SQL statement
+	/// (bypasses the change tracker). used by the <c>user.deleted</c> GDPR cascade.
+	/// note: <c>ExecuteDeleteAsync</c> is unsupported by the InMemory provider, so
+	/// functional tests cannot exercise this path without a real database.
 	/// </summary>
 	Task RemoveAllForUserAsync(long userId, CancellationToken cancellationToken = default);
+
+	/// <summary>
+	/// GDPR erasure: nulls <c>banned_by</c> on every ban issued by
+	/// <paramref name="moderatorUserId"/> (a ban against someone still present).
+	/// the ban stays in force; only the reference to the now-deleted moderator is
+	/// scrubbed. one bulk <c>ExecuteUpdateAsync</c> statement.
+	/// </summary>
+	Task ScrubModeratorAsync(long moderatorUserId, CancellationToken cancellationToken = default);
 }

--- a/services/guild/src/Guild.Application/Abstractions/Persistence/IGuildInviteRepository.cs
+++ b/services/guild/src/Guild.Application/Abstractions/Persistence/IGuildInviteRepository.cs
@@ -16,6 +16,14 @@ public interface IGuildInviteRepository
 	/// </summary>
 	Task<int> DeleteRevokedAndExpiredAsync(DateTimeOffset expiredBefore, CancellationToken cancellationToken = default);
 
+	/// <summary>
+	/// deletes every invite created by <paramref name="creatorUserId"/> across all
+	/// guilds in one bulk statement. used by the <c>user.deleted</c> GDPR cascade:
+	/// an invite has no subject other than its creator, so erasing the creator
+	/// removes the invite (invalidating the code).
+	/// </summary>
+	Task RemoveAllByCreatorAsync(long creatorUserId, CancellationToken cancellationToken = default);
+
 	void Add(GuildInvite invite);
 	void Update(GuildInvite invite);
 }

--- a/services/guild/src/Guild.Application/Abstractions/Persistence/IGuildRepository.cs
+++ b/services/guild/src/Guild.Application/Abstractions/Persistence/IGuildRepository.cs
@@ -22,6 +22,15 @@ public interface IGuildRepository
 	Task<bool> IsMemberAsync(long guildId, long userId, CancellationToken cancellationToken = default);
 
 	/// <summary>
+	/// deletes a user's <c>member_roles</c> and <c>guild_members</c> rows across all
+	/// guilds in bulk statements. used by the <c>user.deleted</c> GDPR cascade.
+	/// role rows go first so no membership is ever observed without its role links.
+	/// Auth's 409 gate guarantees the user owns no guilds, so no ownership handling
+	/// is needed here.
+	/// </summary>
+	Task PurgeMembershipForUserAsync(long userId, CancellationToken cancellationToken = default);
+
+	/// <summary>
 	/// keyset page of members (ordered by user id, cursor = <paramref name="afterUserId"/>)
 	/// projected straight to <see cref="MemberPage"/> in the database, so listing
 	/// members never hydrates the whole guild aggregate into memory.

--- a/services/guild/src/Guild.Application/Features/Bans/Common/BanResponse.cs
+++ b/services/guild/src/Guild.Application/Features/Bans/Common/BanResponse.cs
@@ -8,13 +8,15 @@ namespace Guild.Application.Features.Bans.Common;
 /// </summary>
 public sealed record BanResponse(
 	string UserId,
-	string BannedBy,
+	string? BannedBy,
 	string? Reason,
 	DateTimeOffset BannedAt)
 {
 	public static BanResponse From(GuildBan ban) => new(
 		UserId: ban.UserId.ToString(),
-		BannedBy: ban.BannedBy.ToString(),
+		// null once the moderator's account has been GDPR-erased (banned_by scrubbed)
+		// we love introducing new concepts that some establishments never heard of :3
+		BannedBy: ban.BannedBy?.ToString(),
 		Reason: ban.Reason,
 		BannedAt: ban.BannedAt);
 }

--- a/services/guild/src/Guild.Application/Features/Users/PurgeUserData/PurgeUserDataCommand.cs
+++ b/services/guild/src/Guild.Application/Features/Users/PurgeUserData/PurgeUserDataCommand.cs
@@ -1,0 +1,11 @@
+using Guild.Application.Abstractions.Messaging;
+
+namespace Guild.Application.Features.Users.PurgeUserData;
+
+/// <summary>
+/// GDPR erasure cascade for a deleted account, dispatched by the
+/// <c>user.deleted</c> consumer. removes rows referencing <see cref="UserId"/> as
+/// a subject or sole artifact, and scrubs <c>banned_by</c> on bans they issued.
+/// Auth's 409 ownership gate guarantees the user owns no guilds.
+/// </summary>
+public sealed record PurgeUserDataCommand(long UserId) : ICommand;

--- a/services/guild/src/Guild.Application/Features/Users/PurgeUserData/PurgeUserDataHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Users/PurgeUserData/PurgeUserDataHandler.cs
@@ -1,0 +1,41 @@
+using Guild.Application.Abstractions.Messaging;
+using Guild.Application.Abstractions.Persistence;
+using Microsoft.Extensions.Logging;
+
+namespace Guild.Application.Features.Users.PurgeUserData;
+
+/// <summary>
+/// runs the <c>user.deleted</c> GDPR cascade. each step is a single bulk SQL
+/// statement (ExecuteDelete / ExecuteUpdate) that bypasses the change tracker, so
+/// there is no SaveChanges follow-up. every step is idempotent (deleting or
+/// scrubbing already-gone rows is a no-op), which makes the whole handler safe to
+/// re-run if the consumer redelivers the event.
+/// </summary>
+internal sealed partial class PurgeUserDataHandler(
+	IGuildRepository guilds,
+	IGuildBanRepository bans,
+	IGuildInviteRepository invites,
+	IChannelPermissionOverwriteRepository overwrites,
+	ILogger<PurgeUserDataHandler> logger)
+	: ICommandHandler<PurgeUserDataCommand>
+{
+	public async Task HandleAsync(PurgeUserDataCommand command, CancellationToken cancellationToken = default)
+	{
+		var userId = command.UserId;
+
+		// subject / sole-artifact rows: remove outright
+		await guilds.PurgeMembershipForUserAsync(userId, cancellationToken);
+		await bans.RemoveAllForUserAsync(userId, cancellationToken);
+		await invites.RemoveAllByCreatorAsync(userId, cancellationToken);
+		await overwrites.RemoveAllForMemberAsync(userId, cancellationToken);
+
+		// bans this user issued against others stay in force; only the reference to
+		// the now-erased moderator is nulled
+		await bans.ScrubModeratorAsync(userId, cancellationToken);
+
+		LogPurged(userId);
+	}
+
+	[LoggerMessage(Level = LogLevel.Information, Message = "purged Guild data for deleted user {UserId}")]
+	private partial void LogPurged(long userId);
+}

--- a/services/guild/src/Guild.Application/Guild.Application.csproj
+++ b/services/guild/src/Guild.Application/Guild.Application.csproj
@@ -5,8 +5,8 @@
     </ItemGroup>
 
     <ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.0"/>
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
     </ItemGroup>
 
     <PropertyGroup>

--- a/services/guild/src/Guild.Domain/Guild/GuildBan.cs
+++ b/services/guild/src/Guild.Domain/Guild/GuildBan.cs
@@ -27,7 +27,13 @@ public sealed class GuildBan
 
 	public long GuildId { get; private set; }
 	public long UserId { get; private set; }
-	public long BannedBy { get; private set; }
+
+	/// <summary>
+	/// the moderator who issued the ban. always set at creation; nulled only by the
+	/// user.deleted GDPR cascade when that moderator's account is erased (the ban
+	/// stays in force, the reference is scrubbed).
+	/// </summary>
+	public long? BannedBy { get; private set; }
 	public string? Reason { get; private set; }
 	public DateTimeOffset BannedAt { get; private set; }
 

--- a/services/guild/src/Guild.Infrastructure/DependencyInjection.cs
+++ b/services/guild/src/Guild.Infrastructure/DependencyInjection.cs
@@ -6,6 +6,8 @@ using Guild.Application.Abstractions.Security;
 using Guild.Application.Abstractions.Users;
 using Guild.Application.Contracts;
 using Guild.Infrastructure.Messaging;
+using Guild.Infrastructure.Messaging.Consumers;
+using Guild.Infrastructure.Messaging.Contracts;
 using Guild.Infrastructure.Options;
 using Guild.Infrastructure.Security;
 using Guild.Infrastructure.Users;
@@ -49,6 +51,9 @@ public static class DependencyInjection
 				o.UseBusOutbox();
 			});
 
+			// consumes Auth's user.deleted to run the GDPR erasure cascade (#147)
+			x.AddConsumer<UserDeletedConsumer>();
+
 			x.UsingRabbitMq((ctx, cfg) =>
 			{
 				var options = ctx.GetRequiredService<IOptions<RabbitMqOptions>>().Value;
@@ -72,6 +77,10 @@ public static class DependencyInjection
 				cfg.Message<GuildMemberJoined>(m => m.SetEntityName("guild.member_joined"));
 				cfg.Message<GuildMemberLeft>(m => m.SetEntityName("guild.member_left"));
 				cfg.Message<GuildInviteCreated>(m => m.SetEntityName("guild.invite_created"));
+
+				// inbound: bind the consumer's receive endpoint to Auth's user.deleted
+				// exchange. must match the SetEntityName Auth publishes under.
+				cfg.Message<UserDeleted>(m => m.SetEntityName("user.deleted"));
 
 				cfg.ConfigureEndpoints(ctx);
 			});

--- a/services/guild/src/Guild.Infrastructure/Guild.Infrastructure.csproj
+++ b/services/guild/src/Guild.Infrastructure/Guild.Infrastructure.csproj
@@ -9,8 +9,11 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="MassTransit.RabbitMQ" Version="8.4.1"/>
-        <PackageReference Include="MassTransit.EntityFrameworkCore" Version="8.4.1"/>
+        <!-- do not bump to 9.x: MassTransit 9+ requires a paid commercial license
+             and refuses to configure the bus at runtime without one. 8.x is the last
+             free/OSS line. fuck MT -->
+        <PackageReference Include="MassTransit.RabbitMQ" Version="8.4.1" />
+        <PackageReference Include="MassTransit.EntityFrameworkCore" Version="8.4.1" />
     </ItemGroup>
 
     <PropertyGroup>

--- a/services/guild/src/Guild.Infrastructure/Messaging/Consumers/UserDeletedConsumer.cs
+++ b/services/guild/src/Guild.Infrastructure/Messaging/Consumers/UserDeletedConsumer.cs
@@ -1,0 +1,27 @@
+using Guild.Application.Abstractions.Messaging;
+using Guild.Application.Features.Users.PurgeUserData;
+using Guild.Infrastructure.Messaging.Contracts;
+using MassTransit;
+using Microsoft.Extensions.Logging;
+
+namespace Guild.Infrastructure.Messaging.Consumers;
+
+/// <summary>
+/// consumes Auth's <c>user.deleted</c> and dispatches the Guild-side GDPR erasure
+/// cascade. thin adapter over <see cref="PurgeUserDataCommand"/>; the handler owns
+/// the policy and its steps are idempotent, so redelivery is safe.
+/// </summary>
+public sealed class UserDeletedConsumer(
+	ICommandHandler<PurgeUserDataCommand> handler,
+	ILogger<UserDeletedConsumer> logger)
+	: IConsumer<UserDeleted>
+{
+	public async Task Consume(ConsumeContext<UserDeleted> context)
+	{
+		var userId = context.Message.UserId;
+
+		await handler.HandleAsync(new PurgeUserDataCommand(userId), context.CancellationToken);
+
+		logger.LogInformation("user.deleted consumed: purged Guild data for user_id={UserId}", userId);
+	}
+}

--- a/services/guild/src/Guild.Infrastructure/Messaging/Contracts/InboundEvents.cs
+++ b/services/guild/src/Guild.Infrastructure/Messaging/Contracts/InboundEvents.cs
@@ -1,0 +1,12 @@
+using MassTransit;
+
+namespace Guild.Infrastructure.Messaging.Contracts;
+
+// cross-service events Guild consumes but does not publish. the [MessageUrn]
+// must match the publisher's URN or the message routes to *_skipped; it lives in
+// Infrastructure to keep MassTransit out of the Application layer. exchange names
+// are bound via SetEntityName in DependencyInjection.
+
+// published by Auth on DELETE /auth/me (exchange user.deleted).
+[MessageUrn("Auth.Application.Contracts:UserDeleted")]
+public sealed record UserDeleted(long UserId);

--- a/services/guild/src/Guild.Persistence/Db/Configurations/GuildBanConfig.cs
+++ b/services/guild/src/Guild.Persistence/Db/Configurations/GuildBanConfig.cs
@@ -24,7 +24,8 @@ internal sealed class GuildBanConfig : IEntityTypeConfiguration<GuildBan>
 
 		builder.Property(b => b.GuildId).HasColumnName("guild_id").IsRequired();
 		builder.Property(b => b.UserId).HasColumnName("user_id").IsRequired();
-		builder.Property(b => b.BannedBy).HasColumnName("banned_by").IsRequired();
+		// nullable: scrubbed to null by the user.deleted cascade (see GuildBan.BannedBy)
+		builder.Property(b => b.BannedBy).HasColumnName("banned_by");
 
 		builder.Property(b => b.Reason)
 			.HasColumnName("reason")

--- a/services/guild/src/Guild.Persistence/Guild.Persistence.csproj
+++ b/services/guild/src/Guild.Persistence/Guild.Persistence.csproj
@@ -5,18 +5,23 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.0" />
-        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
+        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.2" />
+        <!-- Npgsql 10.0.2 only advertises a >=10.0.4 floor for EF Core Relational, but
+             Design 10.0.9 compiles this assembly against 10.0.9; pin Relational explicitly
+             so the 10.0.9 requirement propagates to referencing projects (fixes CS1705). -->
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.9" />
+        <!-- 8.x is the last free/OSS line; 9+ requires a paid license (see Infrastructure). -->
         <PackageReference Include="MassTransit.EntityFrameworkCore" Version="8.4.1" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.1">
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.9">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.7" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.0" />
+        <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.9" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.9" />
+        <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="10.0.9" />
+        <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.9" />
+        <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="10.0.9" />
     </ItemGroup>
 
     <PropertyGroup>

--- a/services/guild/src/Guild.Persistence/Migrations/20260701125541_MakeBanBannedByNullable.Designer.cs
+++ b/services/guild/src/Guild.Persistence/Migrations/20260701125541_MakeBanBannedByNullable.Designer.cs
@@ -4,6 +4,7 @@ using Guild.Domain.Guild;
 using Guild.Persistence.Db;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Guild.Persistence.Migrations
 {
     [DbContext(typeof(GuildDbContext))]
-    partial class GuildDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260701125541_MakeBanBannedByNullable")]
+    partial class MakeBanBannedByNullable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/services/guild/src/Guild.Persistence/Migrations/20260701125541_MakeBanBannedByNullable.cs
+++ b/services/guild/src/Guild.Persistence/Migrations/20260701125541_MakeBanBannedByNullable.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Guild.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class MakeBanBannedByNullable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<long>(
+                name: "banned_by",
+                table: "guild_bans",
+                type: "bigint",
+                nullable: true,
+                oldClrType: typeof(long),
+                oldType: "bigint");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<long>(
+                name: "banned_by",
+                table: "guild_bans",
+                type: "bigint",
+                nullable: false,
+                defaultValue: 0L,
+                oldClrType: typeof(long),
+                oldType: "bigint",
+                oldNullable: true);
+        }
+    }
+}

--- a/services/guild/src/Guild.Persistence/Repositories/ChannelPermissionOverwriteRepository.cs
+++ b/services/guild/src/Guild.Persistence/Repositories/ChannelPermissionOverwriteRepository.cs
@@ -41,6 +41,14 @@ internal sealed class ChannelPermissionOverwriteRepository(GuildDbContext contex
 				cancellationToken);
 	}
 
+	public Task RemoveAllForMemberAsync(long userId, CancellationToken cancellationToken = default)
+	{
+		// constrain on target type so a role overwrite sharing the id space is never touched
+		return context.ChannelPermissionOverwrites
+			.Where(o => o.TargetType == OverwriteTargetType.Member && o.TargetId == userId)
+			.ExecuteDeleteAsync(cancellationToken);
+	}
+
 	public void Add(ChannelPermissionOverwrite overwrite)
 	{
 		context.ChannelPermissionOverwrites.Add(overwrite);

--- a/services/guild/src/Guild.Persistence/Repositories/GuildBanRepository.cs
+++ b/services/guild/src/Guild.Persistence/Repositories/GuildBanRepository.cs
@@ -45,4 +45,13 @@ internal sealed class GuildBanRepository(GuildDbContext context) : IGuildBanRepo
 			.Where(b => b.UserId == userId)
 			.ExecuteDeleteAsync(cancellationToken);
 	}
+
+	public Task ScrubModeratorAsync(long moderatorUserId, CancellationToken cancellationToken = default)
+	{
+		return context.GuildBans
+			.Where(b => b.BannedBy == moderatorUserId)
+			.ExecuteUpdateAsync(
+				s => s.SetProperty(b => b.BannedBy, (long?)null),
+				cancellationToken);
+	}
 }

--- a/services/guild/src/Guild.Persistence/Repositories/GuildInviteRepository.cs
+++ b/services/guild/src/Guild.Persistence/Repositories/GuildInviteRepository.cs
@@ -34,4 +34,8 @@ internal sealed class GuildInviteRepository(GuildDbContext context) : IGuildInvi
 	public Task<int> DeleteRevokedAndExpiredAsync(DateTimeOffset expiredBefore, CancellationToken cancellationToken = default) => context.GuildInvites
 		.Where(i => i.IsRevoked || (i.ExpiresAt != null && i.ExpiresAt < expiredBefore))
 		.ExecuteDeleteAsync(cancellationToken);
+
+	public Task RemoveAllByCreatorAsync(long creatorUserId, CancellationToken cancellationToken = default) => context.GuildInvites
+		.Where(i => i.CreatedBy == creatorUserId)
+		.ExecuteDeleteAsync(cancellationToken);
 }

--- a/services/guild/src/Guild.Persistence/Repositories/GuildRepository.cs
+++ b/services/guild/src/Guild.Persistence/Repositories/GuildRepository.cs
@@ -107,6 +107,17 @@ internal sealed class GuildRepository(GuildDbContext context) : IGuildRepository
 			.AnyAsync(m => m.GuildId == guildId && m.UserId == userId, cancellationToken);
 	}
 
+	public async Task PurgeMembershipForUserAsync(long userId, CancellationToken cancellationToken = default)
+	{
+		await context.MemberRoles
+			.Where(mr => mr.UserId == userId)
+			.ExecuteDeleteAsync(cancellationToken);
+
+		await context.Members
+			.Where(m => m.UserId == userId)
+			.ExecuteDeleteAsync(cancellationToken);
+	}
+
 	public void Add(GuildEntity guild)
 	{
 		context.Guilds.Add(guild);

--- a/services/guild/src/Guild.Presentation/Guild.Presentation.csproj
+++ b/services/guild/src/Guild.Presentation/Guild.Presentation.csproj
@@ -9,21 +9,25 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Carter" Version="10.0.0"/>
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.2"/>
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.2"/>
-        <PackageReference Include="Scalar.AspNetCore" Version="2.6.0"/>
+        <PackageReference Include="Carter" Version="10.0.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.9" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.9" />
+        <!-- pinned to the patched 2.x line (advisory GHSA-v5pm-xwqc-g5wc affects <= 2.7.4).
+             must stay on 2.x: AspNetCore.OpenApi 10.x targets Microsoft.OpenApi 2.x, and 3.x
+             makes IOpenApiMediaType.Example read-only, breaking its source generator. -->
+        <PackageReference Include="Microsoft.OpenApi" Version="2.7.5" />
+        <PackageReference Include="Scalar.AspNetCore" Version="2.16.7" />
         <!-- Needed by dotnet-ef for migrations generation -->
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.1">
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.9">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\Guild.Application\Guild.Application.csproj"/>
-        <ProjectReference Include="..\Guild.Infrastructure\Guild.Infrastructure.csproj"/>
-        <ProjectReference Include="..\Guild.Persistence\Guild.Persistence.csproj"/>
+        <ProjectReference Include="..\Guild.Application\Guild.Application.csproj" />
+        <ProjectReference Include="..\Guild.Infrastructure\Guild.Infrastructure.csproj" />
+        <ProjectReference Include="..\Guild.Persistence\Guild.Persistence.csproj" />
     </ItemGroup>
 
 </Project>

--- a/services/guild/tests/Guild.ArchitectureTests/Guild.ArchitectureTests.csproj
+++ b/services/guild/tests/Guild.ArchitectureTests/Guild.ArchitectureTests.csproj
@@ -14,9 +14,9 @@
 
     <ItemGroup>
         <PackageReference Include="Carter"                     Version="10.0.0"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk"    Version="17.12.0"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
         <PackageReference Include="xunit"                     Version="2.9.3"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/services/guild/tests/Guild.FunctionalTests/Guild.FunctionalTests.csproj
+++ b/services/guild/tests/Guild.FunctionalTests/Guild.FunctionalTests.csproj
@@ -13,11 +13,11 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing"      Version="10.0.1"/>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.1"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk"                Version="17.12.0"/>
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.9" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
         <PackageReference Include="xunit"                                 Version="2.9.3"/>
-        <PackageReference Include="xunit.runner.visualstudio"             Version="2.8.2">
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/services/guild/tests/Guild.UnitTests/Application/PurgeUserDataHandlerTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/PurgeUserDataHandlerTests.cs
@@ -1,0 +1,91 @@
+using Guild.Application.Features.Users.PurgeUserData;
+using Guild.Domain.Guild;
+using Guild.UnitTests.Fakes;
+using Xunit;
+
+namespace Guild.UnitTests.Application;
+
+public sealed class PurgeUserDataHandlerTests
+{
+	private static readonly DateTimeOffset Now =
+		new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+	private const long DeletedUser = 42;
+	private const long OtherUser = 7;
+
+	[Fact]
+	public async Task Purge_InvokesEveryCascadeStep_ForTheDeletedUser()
+	{
+		var guilds = new FakeGuildRepository();
+		var bans = new FakeGuildBanRepository();
+		var invites = new FakeGuildInviteRepository();
+		var overwrites = new FakeChannelPermissionOverwriteRepository();
+		var handler = HandlerFactory.CreateCommand<PurgeUserDataCommand>(guilds, bans, invites, overwrites);
+
+		await handler.HandleAsync(new PurgeUserDataCommand(DeletedUser));
+
+		Assert.Equal(1, guilds.PurgeMembershipCount);
+		Assert.Equal(DeletedUser, guilds.LastPurgedMember);
+		Assert.Equal(1, bans.RemoveAllForUserCount);
+		Assert.Equal(1, invites.RemoveAllByCreatorCount);
+		Assert.Equal(1, overwrites.RemoveAllForMemberCount);
+		Assert.Equal(1, bans.ScrubModeratorCount);
+		Assert.Equal(DeletedUser, bans.LastScrubbedModerator);
+	}
+
+	[Fact]
+	public async Task Purge_RemovesTheUsersInvites_KeepsOthers()
+	{
+		var invites = new FakeGuildInviteRepository();
+		invites.Seed(GuildInvite.Create("MINE01", guildId: 100, createdBy: DeletedUser, maxUses: null, expiresAt: null, now: Now).Value);
+		invites.Seed(GuildInvite.Create("THEIRS", guildId: 100, createdBy: OtherUser, maxUses: null, expiresAt: null, now: Now).Value);
+
+		var handler = HandlerFactory.CreateCommand<PurgeUserDataCommand>(
+			new FakeGuildRepository(), new FakeGuildBanRepository(), invites, new FakeChannelPermissionOverwriteRepository());
+
+		await handler.HandleAsync(new PurgeUserDataCommand(DeletedUser));
+
+		Assert.False(invites.Store.ContainsKey("MINE01"));
+		Assert.True(invites.Store.ContainsKey("THEIRS"));
+	}
+
+	[Fact]
+	public async Task Purge_RemovesUsersMemberOverwrites_KeepsRoleOverwriteWithSameId_AndOtherUsers()
+	{
+		var overwrites = new FakeChannelPermissionOverwriteRepository();
+		// member overwrite for the deleted user -> removed
+		overwrites.Seed(ChannelPermissionOverwrite.Create(1, 100, 200, OverwriteTargetType.Member, DeletedUser, 0, 0, Now).Value);
+		// member overwrite for another user -> kept
+		overwrites.Seed(ChannelPermissionOverwrite.Create(2, 100, 200, OverwriteTargetType.Member, OtherUser, 0, 0, Now).Value);
+		// role overwrite whose target_id equals the deleted user's id -> kept (type guard)
+		overwrites.Seed(ChannelPermissionOverwrite.Create(3, 100, 200, OverwriteTargetType.Role, DeletedUser, 0, 0, Now).Value);
+
+		var handler = HandlerFactory.CreateCommand<PurgeUserDataCommand>(
+			new FakeGuildRepository(), new FakeGuildBanRepository(), new FakeGuildInviteRepository(), overwrites);
+
+		await handler.HandleAsync(new PurgeUserDataCommand(DeletedUser));
+
+		Assert.False(overwrites.Store.ContainsKey(1)); // member overwrite gone
+		Assert.True(overwrites.Store.ContainsKey(2));   // other user's kept
+		Assert.True(overwrites.Store.ContainsKey(3));   // role overwrite kept despite shared id
+	}
+
+	[Fact]
+	public async Task Purge_RemovesBansAgainstUser_KeepsBansTheyIssued()
+	{
+		var bans = new FakeGuildBanRepository();
+		// ban against the deleted user -> removed
+		bans.Seed(GuildBan.Create(guildId: 100, userId: DeletedUser, bannedBy: OtherUser, reason: null, now: Now).Value);
+		// ban the deleted user issued against someone else -> kept (banned_by scrubbed by the real repo)
+		bans.Seed(GuildBan.Create(guildId: 100, userId: OtherUser, bannedBy: DeletedUser, reason: null, now: Now).Value);
+
+		var handler = HandlerFactory.CreateCommand<PurgeUserDataCommand>(
+			new FakeGuildRepository(), bans, new FakeGuildInviteRepository(), new FakeChannelPermissionOverwriteRepository());
+
+		await handler.HandleAsync(new PurgeUserDataCommand(DeletedUser));
+
+		Assert.False(bans.Store.ContainsKey((100, DeletedUser))); // ban against them gone
+		Assert.True(bans.Store.ContainsKey((100, OtherUser)));     // ban they issued stays in force
+		Assert.Equal(DeletedUser, bans.LastScrubbedModerator);     // and their moderator ref was scrubbed
+	}
+}

--- a/services/guild/tests/Guild.UnitTests/Fakes/FakeChannelPermissionOverwriteRepository.cs
+++ b/services/guild/tests/Guild.UnitTests/Fakes/FakeChannelPermissionOverwriteRepository.cs
@@ -58,6 +58,18 @@ internal sealed class FakeChannelPermissionOverwriteRepository : IChannelPermiss
 		UpdateCount++;
 	}
 
+	public int RemoveAllForMemberCount { get; private set; }
+
+	public Task RemoveAllForMemberAsync(long userId, CancellationToken cancellationToken = default)
+	{
+		var doomed = _store.Values
+			.Where(o => o.TargetType == OverwriteTargetType.Member && o.TargetId == userId)
+			.Select(o => o.Id).ToList();
+		foreach (var id in doomed) _store.Remove(id);
+		RemoveAllForMemberCount++;
+		return Task.CompletedTask;
+	}
+
 	public void Remove(ChannelPermissionOverwrite overwrite)
 	{
 		_store.Remove(overwrite.Id);

--- a/services/guild/tests/Guild.UnitTests/Fakes/FakeGuildBanRepository.cs
+++ b/services/guild/tests/Guild.UnitTests/Fakes/FakeGuildBanRepository.cs
@@ -12,6 +12,8 @@ internal sealed class FakeGuildBanRepository : IGuildBanRepository
 	public int AddCount { get; private set; }
 	public int RemoveCount { get; private set; }
 	public int RemoveAllForUserCount { get; private set; }
+	public int ScrubModeratorCount { get; private set; }
+	public long? LastScrubbedModerator { get; private set; }
 
 	public Task<IReadOnlyList<GuildBan>> ListByGuildAsync(
 		long guildId, long? afterUserId, int limit, CancellationToken cancellationToken = default)
@@ -52,6 +54,16 @@ internal sealed class FakeGuildBanRepository : IGuildBanRepository
 		foreach (var key in keys)
 			_store.Remove(key);
 		RemoveAllForUserCount++;
+		return Task.CompletedTask;
+	}
+
+	public Task ScrubModeratorAsync(long moderatorUserId, CancellationToken cancellationToken = default)
+	{
+		// the real repo nulls banned_by via bulk ExecuteUpdate; GuildBan.BannedBy is
+		// private-set so the fake records the invocation for orchestration assertions
+		// rather than mutating entities.
+		ScrubModeratorCount++;
+		LastScrubbedModerator = moderatorUserId;
 		return Task.CompletedTask;
 	}
 

--- a/services/guild/tests/Guild.UnitTests/Fakes/FakeGuildInviteRepository.cs
+++ b/services/guild/tests/Guild.UnitTests/Fakes/FakeGuildInviteRepository.cs
@@ -48,5 +48,15 @@ internal sealed class FakeGuildInviteRepository : IGuildInviteRepository
 		return Task.FromResult(doomed.Count);
 	}
 
+	public int RemoveAllByCreatorCount { get; private set; }
+
+	public Task RemoveAllByCreatorAsync(long creatorUserId, CancellationToken cancellationToken = default)
+	{
+		var doomed = _store.Values.Where(i => i.CreatedBy == creatorUserId).Select(i => i.Code).ToList();
+		foreach (var code in doomed) _store.Remove(code);
+		RemoveAllByCreatorCount++;
+		return Task.CompletedTask;
+	}
+
 	internal void Seed(GuildInvite invite) => _store[invite.Code] = invite;
 }

--- a/services/guild/tests/Guild.UnitTests/Fakes/FakeGuildRepository.cs
+++ b/services/guild/tests/Guild.UnitTests/Fakes/FakeGuildRepository.cs
@@ -92,4 +92,16 @@ internal sealed class FakeGuildRepository : IGuildRepository
 		_store.Remove(guild.Id);
 		RemoveCount++;
 	}
+
+	public int PurgeMembershipCount { get; private set; }
+	public long? LastPurgedMember { get; private set; }
+
+	public Task PurgeMembershipForUserAsync(long userId, CancellationToken cancellationToken = default)
+	{
+		// the real repo issues bulk deletes on Members + MemberRoles; the fake holds
+		// whole guild aggregates so it records the call for orchestration assertions.
+		PurgeMembershipCount++;
+		LastPurgedMember = userId;
+		return Task.CompletedTask;
+	}
 }

--- a/services/guild/tests/Guild.UnitTests/Guild.UnitTests.csproj
+++ b/services/guild/tests/Guild.UnitTests/Guild.UnitTests.csproj
@@ -13,10 +13,10 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk"               Version="17.12.0"/>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.1"/>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.9" />
         <PackageReference Include="xunit"                                Version="2.9.3"/>
-        <PackageReference Include="xunit.runner.visualstudio"            Version="2.8.2">
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/services/guild/tests/Guild.UnitTests/Serialization/UserDeletedContractTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Serialization/UserDeletedContractTests.cs
@@ -1,0 +1,52 @@
+using System.Linq;
+using System.Text.Json;
+using Guild.Infrastructure.Messaging.Contracts;
+using Xunit;
+
+namespace Guild.UnitTests.Serialization;
+
+/// <summary>
+/// pins the wire identity of the inbound <c>user.deleted</c> event. Auth publishes
+/// its <c>UserDeleted</c> type (namespace <c>Auth.Application.Contracts</c>) under
+/// the URN and snake_case payload asserted here; if Guild's inbound binding drifts
+/// from that, MassTransit silently routes the message to the *_skipped queue and
+/// the GDPR cascade never runs. these tests fail loudly instead.
+/// </summary>
+public sealed class UserDeletedContractTests
+{
+	private static readonly JsonSerializerOptions SnakeCase = new()
+	{
+		PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+	};
+
+	[Fact]
+	public void UserDeleted_BindsTo_AuthPublisherUrn()
+	{
+		// read the [MessageUrn] via reflection to avoid a compile-time MassTransit
+		// reference in the test assembly. the full urn is "urn:message:" + value.
+		var attribute = typeof(UserDeleted)
+			.GetCustomAttributes(inherit: false)
+			.Single(a => a.GetType().Name == "MessageUrnAttribute");
+
+		var urn = attribute.GetType().GetProperty("Urn")!.GetValue(attribute)!;
+
+		Assert.Equal("urn:message:Auth.Application.Contracts:UserDeleted", urn.ToString());
+	}
+
+	[Fact]
+	public void UserDeleted_DeserializesFrom_SnakeCasePayload()
+	{
+		var evt = JsonSerializer.Deserialize<UserDeleted>("{\"user_id\":123}", SnakeCase);
+
+		Assert.NotNull(evt);
+		Assert.Equal(123, evt!.UserId);
+	}
+
+	[Fact]
+	public void UserDeleted_SerializesWith_SnakeCaseField()
+	{
+		var json = JsonSerializer.Serialize(new UserDeleted(123), SnakeCase);
+
+		Assert.Equal("{\"user_id\":123}", json);
+	}
+}


### PR DESCRIPTION
Resolves #147 

## Consume `user.deleted` for GDPR erasure

Implements Guild's `user.deleted` consumer so a deleted account's data is purged from the Guild service, and fixes the Auth publisher that was silently preventing any of it from being delivered.

### Why this touches Auth
Building the consumer surfaced that Auth's event publishing was not contract-compliant and had never worked against a real broker (Auth's tests fake the event bus). Three mismatches, all on the same bus:
- **camelCase payloads** (MassTransit default) vs the snake_case every consumer and `docs/contracts` expect.
- **No exchange names** (`SetEntityName`), so events published to a namespace-derived exchange instead of `user.deleted`.
- **URN/namespace drift**: events lived in `Auth.Application.Events` as `...Event`, so their URN never matched the `Auth.Application.Contracts:*` convention consumers bind to.

### What changed
**Auth publisher** (`feat(auth)`)
- Events consolidated into `Auth.Application.Contracts` (plain records, default URN `Auth.Application.Contracts:UserDeleted`), keeping MassTransit out of the Application layer (`DomainPurityTests`).
- Bus configured with snake_case serialization and `SetEntityName` for `user.registered` / `user.logged_out` / `user.deleted`.

**Guild consumer + cascade** (`feat(guild)`)
- `UserDeletedConsumer` dispatches `PurgeUserDataCommand`, which deletes rows referencing the user as subject or sole artifact: memberships, role assignments, bans against them, invites they created, and their per-channel (`target_type='user'`) overwrites.
- `guild_bans.banned_by` made nullable (+ migration); bans the user *issued* against others stay in force with `banned_by` scrubbed to `null`. Ban wire contract (`banned_by`) is now nullable.
- All cascade steps are idempotent bulk statements, so redelivery is safe.

**Deps** (`chore(deps)`)
- Pins `Microsoft.OpenApi` to the patched `2.7.5` (advisory `GHSA-v5pm-xwqc-g5wc` affects `<= 2.7.4`); stays on the 2.x API the .NET 10 OpenAPI stack needs, since 3.x makes `IOpenApiMediaType.Example` read-only and breaks the source generator. Includes EF Core version alignment and package bumps across both solutions.

### Testing
- Auth: 12 arch / 74 unit / 46 functional passing.
- Guild: 12 arch / 445 unit / 254 functional passing, including handler-orchestration tests and a URN + snake_case contract guard against the silent-skip failure mode.
- End-to-end smoke test against the live stack: registered a user, had them banned in a guild plus seeded a ban they issued, deleted the account, and confirmed the ban against them was removed and the `banned_by` they set was scrubbed to `null`. Also confirmed the 409 ownership gate blocks deleting a guild owner. `ExecuteDelete`/`ExecuteUpdate` are not supported by the InMemory provider, so the SQL paths are covered by this smoke test rather than functional tests.