### PR TITLE
Feat(guild): publish channel.access_revoked

### DIFF
--- a/docs/contracts/guild.md
+++ b/docs/contracts/guild.md
@@ -988,6 +988,7 @@ Check if a user is a member of the guild that owns this channel, and get their e
 | `guild.invite_created` | `{ guild_id, guild_name, invited_by_user_id, invited_user_id? }` | Invite created; `invited_user_id` present only for targeted invites |
 | `guild.deleted` | `{ guild_id }` | Guild deleted by its owner. Downstream services cascade their own cleanup by `guild_id` (Chat channels/messages, Notification rows, membership references). |
 | `guild.owner_transferred` | `{ guild_id, old_owner_id, new_owner_id }` | Ownership transferred to another member. At least Notification reacts (notify old and/or new owner). |
+| `channel.access_revoked` | `{ channel_id, user_id }` | A member lost `READ_MESSAGES` on a channel via a role or overwrite change (role permission update, role assignment or unassignment, role deletion, or a channel-overwrite put/delete). One event per (channel, member) whose effective read flipped from allowed to denied. Chat consumes it to evict the member's live SignalR subscription (`EvictFromChannelAsync`). |
 
 ## RabbitMQ Events Consumed
 

--- a/services/guild/src/Guild.Application/Abstractions/Persistence/IChannelPermissionOverwriteRepository.cs
+++ b/services/guild/src/Guild.Application/Abstractions/Persistence/IChannelPermissionOverwriteRepository.cs
@@ -8,21 +8,8 @@ public interface IChannelPermissionOverwriteRepository
 		long channelId,
 		CancellationToken cancellationToken = default);
 
-	Task<ChannelPermissionOverwrite?> GetForChannelAndTargetAsync(
-		long channelId,
-		OverwriteTargetType targetType,
-		long targetId,
-		CancellationToken cancellationToken = default);
-
-	/// <summary>
-	/// snowflake IDs are unique across roles and members, so a single
-	/// <c>(channel_id, target_id)</c> probe is sufficient to find the row
-	/// regardless of its target_type. used by the DELETE handler where the URL
-	/// only carries target_id
-	/// </summary>
-	Task<ChannelPermissionOverwrite?> GetForChannelByTargetIdAsync(
-		long channelId,
-		long targetId,
+	Task<IReadOnlyList<ChannelPermissionOverwrite>> GetForGuildAsync(
+		long guildId,
 		CancellationToken cancellationToken = default);
 
 	/// <summary>

--- a/services/guild/src/Guild.Application/Authorization/ChannelAccess.cs
+++ b/services/guild/src/Guild.Application/Authorization/ChannelAccess.cs
@@ -1,0 +1,124 @@
+using Guild.Application.Abstractions;
+using Guild.Application.Abstractions.Persistence;
+using Guild.Application.Contracts;
+using Guild.Domain.Guild;
+using GuildEntity = Guild.Domain.Guild.Guild;
+
+namespace Guild.Application.Authorization;
+
+// read-access captured before a mutation, diffed against the after-state by
+// PublishRevocationsAsync to emit revocations.
+internal readonly record struct ChannelReadSnapshot(
+	HashSet<(long ChannelId, long UserId)> Before,
+	IReadOnlyDictionary<long, IReadOnlyList<ChannelPermissionOverwrite>> Overwrites);
+
+internal static class ChannelAccess
+{
+	// role mutations reach every channel (base perms apply everywhere) but leave
+	// overwrites unchanged, so the captured set also feeds the after-diff.
+	public static async Task<ChannelReadSnapshot> CaptureAsync(
+		GuildEntity guild,
+		IReadOnlyCollection<long> affectedUserIds,
+		IChannelRepository channels,
+		IChannelPermissionOverwriteRepository overwrites,
+		CancellationToken cancellationToken)
+	{
+		var guildChannels = await channels.GetByGuildAsync(guild.Id, cancellationToken);
+		var allOverwrites = await overwrites.GetForGuildAsync(guild.Id, cancellationToken);
+		var byChannel = allOverwrites
+			.GroupBy(o => o.ChannelId)
+			.ToDictionary(g => g.Key, g => (IReadOnlyList<ChannelPermissionOverwrite>)g.ToList());
+
+		return Capture(guild, Pairs(guildChannels.Select(c => c.Id), affectedUserIds), byChannel);
+	}
+
+	// overwrite mutations touch a single channel; the caller supplies the changed
+	// after-overwrites when publishing.
+	public static ChannelReadSnapshot CaptureForChannel(
+		GuildEntity guild,
+		long channelId,
+		IEnumerable<long> affectedUserIds,
+		IReadOnlyList<ChannelPermissionOverwrite> channelOverwrites) =>
+		Capture(guild, Pairs([channelId], affectedUserIds), Group(channelId, channelOverwrites));
+
+	// role mutations: overwrites are unchanged, so the snapshot's set is the after-state.
+	public static Task PublishRevocationsAsync(
+		IEventBus eventBus, GuildEntity guild, ChannelReadSnapshot snapshot, CancellationToken cancellationToken) =>
+		PublishRevocationsAsync(eventBus, guild, snapshot, snapshot.Overwrites, cancellationToken);
+
+	// overwrite mutations: one channel's overwrites changed.
+	public static Task PublishRevocationsAsync(
+		IEventBus eventBus, GuildEntity guild, ChannelReadSnapshot snapshot,
+		long channelId, IReadOnlyList<ChannelPermissionOverwrite> afterChannelOverwrites,
+		CancellationToken cancellationToken) =>
+		PublishRevocationsAsync(eventBus, guild, snapshot, Group(channelId, afterChannelOverwrites), cancellationToken);
+
+	public static IEnumerable<long> MembersAffectedBy(
+		GuildEntity guild, OverwriteTargetType targetType, long targetId)
+	{
+		if (targetType == OverwriteTargetType.Member)
+			return [targetId];
+
+		var role = guild.Roles.FirstOrDefault(r => r.Id == targetId);
+		if (role is null)
+			return [];
+
+		return role.IsDefault
+			? guild.Members.Select(m => m.UserId)
+			: guild.MemberRoles.Where(mr => mr.RoleId == targetId).Select(mr => mr.UserId);
+	}
+
+	private static async Task PublishRevocationsAsync(
+		IEventBus eventBus, GuildEntity guild, ChannelReadSnapshot snapshot,
+		IReadOnlyDictionary<long, IReadOnlyList<ChannelPermissionOverwrite>> afterOverwrites,
+		CancellationToken cancellationToken)
+	{
+		// a revocation can only come from a pair that could read before; re-resolve
+		// each once and publish the moment it has flipped to denied.
+		foreach (var (channelId, userId) in snapshot.Before)
+		{
+			if (!CanRead(guild, channelId, userId, afterOverwrites))
+				await eventBus.PublishAsync(new ChannelAccessRevoked(channelId, userId), cancellationToken);
+		}
+	}
+
+	private static ChannelReadSnapshot Capture(
+		GuildEntity guild,
+		IEnumerable<(long ChannelId, long UserId)> candidates,
+		IReadOnlyDictionary<long, IReadOnlyList<ChannelPermissionOverwrite>> overwrites) =>
+		new(ReadableIn(guild, candidates, overwrites), overwrites);
+
+	private static HashSet<(long ChannelId, long UserId)> ReadableIn(
+		GuildEntity guild,
+		IEnumerable<(long ChannelId, long UserId)> candidates,
+		IReadOnlyDictionary<long, IReadOnlyList<ChannelPermissionOverwrite>> overwritesByChannel)
+	{
+		var readable = new HashSet<(long, long)>();
+		foreach (var (channelId, userId) in candidates)
+		{
+			if (CanRead(guild, channelId, userId, overwritesByChannel))
+				readable.Add((channelId, userId));
+		}
+
+		return readable;
+	}
+
+	private static bool CanRead(
+		GuildEntity guild, long channelId, long userId,
+		IReadOnlyDictionary<long, IReadOnlyList<ChannelPermissionOverwrite>> overwritesByChannel)
+	{
+		var overwrites = overwritesByChannel.TryGetValue(channelId, out var list) ? list : [];
+		return PermissionResolver.HasPermission(
+			PermissionResolver.Resolve(guild, userId, overwrites), Permission.ReadMessages);
+	}
+
+	// lazy: role mutations on @everyone span (all channels x all members); streaming
+	// avoids materializing the full cartesian product just to fold it into a set.
+	private static IEnumerable<(long ChannelId, long UserId)> Pairs(
+		IEnumerable<long> channelIds, IEnumerable<long> userIds) =>
+		channelIds.SelectMany(c => userIds.Select(u => (c, u)));
+
+	private static Dictionary<long, IReadOnlyList<ChannelPermissionOverwrite>> Group(
+		long channelId, IReadOnlyList<ChannelPermissionOverwrite> overwrites) =>
+		new() { [channelId] = overwrites };
+}

--- a/services/guild/src/Guild.Application/Contracts/Events.cs
+++ b/services/guild/src/Guild.Application/Contracts/Events.cs
@@ -5,3 +5,4 @@ public sealed record GuildMemberLeft(long GuildId, long UserId);
 public sealed record GuildInviteCreated(long GuildId, string GuildName, long InvitedByUserId, long? InvitedUserId);
 public sealed record GuildDeleted(long GuildId);
 public sealed record GuildOwnerTransferred(long GuildId, long OldOwnerId, long NewOwnerId);
+public sealed record ChannelAccessRevoked(long ChannelId, long UserId);

--- a/services/guild/src/Guild.Application/Features/Channels/Permissions/DeleteOverwrite/DeleteOverwriteHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Channels/Permissions/DeleteOverwrite/DeleteOverwriteHandler.cs
@@ -1,3 +1,4 @@
+using Guild.Application.Abstractions;
 using Guild.Application.Abstractions.Messaging;
 using Guild.Application.Abstractions.Persistence;
 using Guild.Application.Abstractions.Security;
@@ -11,6 +12,7 @@ internal sealed class DeleteOverwriteHandler(
 	IGuildRepository guilds,
 	IChannelRepository channels,
 	IChannelPermissionOverwriteRepository overwrites,
+	IEventBus eventBus,
 	ICurrentUser currentUser,
 	IUnitOfWork unitOfWork)
 	: ICommandHandler<DeleteOverwriteCommand, Result>
@@ -29,15 +31,23 @@ internal sealed class DeleteOverwriteHandler(
 			return auth.Error;
 		var guild = auth.Value.Guild;
 
-		// the URL carries only (channel_id, target_id); since snowflake ids are
-		// unique across roles and members, a single server-side probe by
-		// (channel_id, target_id) finds the row regardless of target_type
-		var match = await overwrites.GetForChannelByTargetIdAsync(
-			channel.Id, command.TargetId, cancellationToken);
+		var channelOverwrites = await overwrites.GetForChannelAsync(channel.Id, cancellationToken);
+		// the URL carries only (channel_id, target_id); snowflake ids are unique
+		// across roles and members, so target_id alone finds the row
+		var match = channelOverwrites.FirstOrDefault(o => o.TargetId == command.TargetId);
 		if (match is null)
 			return GuildFailures.OverwriteNotFound;
 
+		var snapshot = ChannelAccess.CaptureForChannel(
+			guild, channel.Id,
+			ChannelAccess.MembersAffectedBy(guild, match.TargetType, match.TargetId),
+			channelOverwrites);
+
 		overwrites.Remove(match);
+
+		var after = channelOverwrites.Where(o => o.Id != match.Id).ToList();
+		await ChannelAccess.PublishRevocationsAsync(eventBus, guild, snapshot, channel.Id, after, cancellationToken);
+
 		await unitOfWork.SaveChangesAsync(cancellationToken);
 
 		return Result.Ok();

--- a/services/guild/src/Guild.Application/Features/Channels/Permissions/PutOverwrite/PutOverwriteHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Channels/Permissions/PutOverwrite/PutOverwriteHandler.cs
@@ -12,6 +12,7 @@ internal sealed class PutOverwriteHandler(
 	IGuildRepository guilds,
 	IChannelRepository channels,
 	IChannelPermissionOverwriteRepository overwrites,
+	IEventBus eventBus,
 	IIdGenerator ids,
 	IClock clock,
 	ICurrentUser currentUser,
@@ -47,10 +48,17 @@ internal sealed class PutOverwriteHandler(
 				return GuildFailures.OverwriteInvalidTarget;
 		}
 
-		var existing = await overwrites.GetForChannelAndTargetAsync(
-			channel.Id, targetType, command.TargetId, cancellationToken);
+		var channelOverwrites = await overwrites.GetForChannelAsync(channel.Id, cancellationToken);
+		var existing = channelOverwrites.FirstOrDefault(
+			o => o.TargetType == targetType && o.TargetId == command.TargetId);
+
+		var snapshot = ChannelAccess.CaptureForChannel(
+			guild, channel.Id,
+			ChannelAccess.MembersAffectedBy(guild, targetType, command.TargetId),
+			channelOverwrites);
 
 		var now = clock.UtcNow;
+		IReadOnlyList<ChannelPermissionOverwrite> after;
 
 		if (existing is not null)
 		{
@@ -59,24 +67,29 @@ internal sealed class PutOverwriteHandler(
 				return updateResult.Error;
 
 			overwrites.Update(existing);
-			await unitOfWork.SaveChangesAsync(cancellationToken);
-			return Result.Ok();
+			after = channelOverwrites; // existing is the same tracked instance, now updated in place
+		}
+		else
+		{
+			var createResult = ChannelPermissionOverwrite.Create(
+				id: ids.NextId(),
+				guildId: channel.GuildId,
+				channelId: channel.Id,
+				targetType: targetType,
+				targetId: command.TargetId,
+				allow: command.Allow,
+				deny: command.Deny,
+				now: now);
+
+			if (createResult.IsFailure)
+				return createResult.Error;
+
+			overwrites.Add(createResult.Value);
+			after = [.. channelOverwrites, createResult.Value];
 		}
 
-		var createResult = ChannelPermissionOverwrite.Create(
-			id: ids.NextId(),
-			guildId: channel.GuildId,
-			channelId: channel.Id,
-			targetType: targetType,
-			targetId: command.TargetId,
-			allow: command.Allow,
-			deny: command.Deny,
-			now: now);
+		await ChannelAccess.PublishRevocationsAsync(eventBus, guild, snapshot, channel.Id, after, cancellationToken);
 
-		if (createResult.IsFailure)
-			return createResult.Error;
-
-		overwrites.Add(createResult.Value);
 		await unitOfWork.SaveChangesAsync(cancellationToken);
 
 		return Result.Ok();

--- a/services/guild/src/Guild.Application/Features/Membership/AssignRole/AssignRoleHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Membership/AssignRole/AssignRoleHandler.cs
@@ -10,6 +10,9 @@ namespace Guild.Application.Features.Membership.AssignRole;
 
 internal sealed class AssignRoleHandler(
 	IGuildRepository guilds,
+	IChannelRepository channels,
+	IChannelPermissionOverwriteRepository overwrites,
+	IEventBus eventBus,
 	IClock clock,
 	ICurrentUser currentUser,
 	IUnitOfWork unitOfWork)
@@ -36,9 +39,16 @@ internal sealed class AssignRoleHandler(
 		if (!PermissionResolver.CanGrantPermissions(mask, role.Permissions))
 			return GuildFailures.CannotGrantPermissionsYouLack;
 
+		// assigning a role adds its deny-overwrites to the member, which can revoke
+		// read on channels the role denies (base perms only ever add)
+		var snapshot = await ChannelAccess.CaptureAsync(
+			guild, [command.TargetUserId], channels, overwrites, cancellationToken);
+
 		var assignResult = guild.AssignRole(command.TargetUserId, command.RoleId, clock.UtcNow);
 		if (assignResult.IsFailure)
 			return assignResult.Error;
+
+		await ChannelAccess.PublishRevocationsAsync(eventBus, guild, snapshot, cancellationToken);
 
 		await unitOfWork.SaveChangesAsync(cancellationToken);
 

--- a/services/guild/src/Guild.Application/Features/Membership/UnassignRole/UnassignRoleHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Membership/UnassignRole/UnassignRoleHandler.cs
@@ -10,6 +10,9 @@ namespace Guild.Application.Features.Membership.UnassignRole;
 
 internal sealed class UnassignRoleHandler(
 	IGuildRepository guilds,
+	IChannelRepository channels,
+	IChannelPermissionOverwriteRepository overwrites,
+	IEventBus eventBus,
 	IClock clock,
 	ICurrentUser currentUser,
 	IUnitOfWork unitOfWork)
@@ -32,9 +35,14 @@ internal sealed class UnassignRoleHandler(
 		if (!PermissionResolver.OutRanksRole(guild, currentUser.Id, role))
 			return GuildFailures.RoleHierarchyBlocked;
 
+		var snapshot = await ChannelAccess.CaptureAsync(
+			guild, [command.TargetUserId], channels, overwrites, cancellationToken);
+
 		var unassignResult = guild.UnassignRole(command.TargetUserId, command.RoleId, clock.UtcNow);
 		if (unassignResult.IsFailure)
 			return unassignResult.Error;
+
+		await ChannelAccess.PublishRevocationsAsync(eventBus, guild, snapshot, cancellationToken);
 
 		await unitOfWork.SaveChangesAsync(cancellationToken);
 

--- a/services/guild/src/Guild.Application/Features/Roles/DeleteRole/DeleteRoleHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Roles/DeleteRole/DeleteRoleHandler.cs
@@ -10,6 +10,9 @@ namespace Guild.Application.Features.Roles.DeleteRole;
 
 internal sealed class DeleteRoleHandler(
 	IGuildRepository guilds,
+	IChannelRepository channels,
+	IChannelPermissionOverwriteRepository overwrites,
+	IEventBus eventBus,
 	IClock clock,
 	ICurrentUser currentUser,
 	IUnitOfWork unitOfWork)
@@ -38,9 +41,22 @@ internal sealed class DeleteRoleHandler(
 		if (!PermissionResolver.OutRanksRole(guild, currentUser.Id, role))
 			return GuildFailures.RoleHierarchyBlocked;
 
+		// no holders -> deleting the role can't change any member's read
+		var holders = guild.MemberRoles
+			.Where(mr => mr.RoleId == command.RoleId)
+			.Select(mr => mr.UserId)
+			.Distinct()
+			.ToList();
+		ChannelReadSnapshot? snapshot = holders.Count > 0
+			? await ChannelAccess.CaptureAsync(guild, holders, channels, overwrites, cancellationToken)
+			: null;
+
 		var removeResult = guild.RemoveRole(command.RoleId, clock.UtcNow);
 		if (removeResult.IsFailure)
 			return removeResult.Error;
+
+		if (snapshot is { } snap)
+			await ChannelAccess.PublishRevocationsAsync(eventBus, guild, snap, cancellationToken);
 
 		await unitOfWork.SaveChangesAsync(cancellationToken);
 

--- a/services/guild/src/Guild.Application/Features/Roles/UpdateRole/UpdateRoleHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Roles/UpdateRole/UpdateRoleHandler.cs
@@ -11,6 +11,9 @@ namespace Guild.Application.Features.Roles.UpdateRole;
 
 internal sealed class UpdateRoleHandler(
 	IGuildRepository guilds,
+	IChannelRepository channels,
+	IChannelPermissionOverwriteRepository overwrites,
+	IEventBus eventBus,
 	IClock clock,
 	ICurrentUser currentUser,
 	IUnitOfWork unitOfWork)
@@ -43,6 +46,19 @@ internal sealed class UpdateRoleHandler(
 		    && !PermissionResolver.CanGrantPermissions(mask, newPerms))
 			return GuildFailures.CannotGrantPermissionsYouLack;
 
+		// read can only be revoked when the role loses READ_MESSAGES or ADMINISTRATOR
+		// (base perms are additive, so a grant never removes read)
+		const long readAffecting = (long)Permission.ReadMessages | (long)Permission.Administrator;
+		ChannelReadSnapshot? snapshot = null;
+		if (command.Permissions is long updatedPerms && (role.Permissions & ~updatedPerms & readAffecting) != 0)
+		{
+			var affected = role.IsDefault
+				? guild.Members.Select(m => m.UserId).ToList()
+				: guild.MemberRoles.Where(mr => mr.RoleId == command.RoleId).Select(mr => mr.UserId).Distinct().ToList();
+			if (affected.Count > 0)
+				snapshot = await ChannelAccess.CaptureAsync(guild, affected, channels, overwrites, cancellationToken);
+		}
+
 		var updateResult = guild.UpdateRole(
 			roleId: command.RoleId,
 			name: command.Name,
@@ -53,6 +69,9 @@ internal sealed class UpdateRoleHandler(
 			now: clock.UtcNow);
 		if (updateResult.IsFailure)
 			return updateResult.Error;
+
+		if (snapshot is { } snap)
+			await ChannelAccess.PublishRevocationsAsync(eventBus, guild, snap, cancellationToken);
 
 		await unitOfWork.SaveChangesAsync(cancellationToken);
 

--- a/services/guild/src/Guild.Infrastructure/DependencyInjection.cs
+++ b/services/guild/src/Guild.Infrastructure/DependencyInjection.cs
@@ -79,6 +79,7 @@ public static class DependencyInjection
 				cfg.Message<GuildInviteCreated>(m => m.SetEntityName("guild.invite_created"));
 				cfg.Message<GuildDeleted>(m => m.SetEntityName("guild.deleted"));
 				cfg.Message<GuildOwnerTransferred>(m => m.SetEntityName("guild.owner_transferred"));
+				cfg.Message<ChannelAccessRevoked>(m => m.SetEntityName("channel.access_revoked"));
 
 				// inbound: bind the consumer's receive endpoint to Auth's user.deleted
 				// exchange. must match the SetEntityName Auth publishes under.

--- a/services/guild/src/Guild.Persistence/Repositories/ChannelPermissionOverwriteRepository.cs
+++ b/services/guild/src/Guild.Persistence/Repositories/ChannelPermissionOverwriteRepository.cs
@@ -16,29 +16,15 @@ internal sealed class ChannelPermissionOverwriteRepository(GuildDbContext contex
 			.ToListAsync(cancellationToken);
 	}
 
-	public Task<ChannelPermissionOverwrite?> GetForChannelAndTargetAsync(
-		long channelId,
-		OverwriteTargetType targetType,
-		long targetId,
+	public async Task<IReadOnlyList<ChannelPermissionOverwrite>> GetForGuildAsync(
+		long guildId,
 		CancellationToken cancellationToken = default)
 	{
-		return context.ChannelPermissionOverwrites
-			.FirstOrDefaultAsync(
-				o => o.ChannelId == channelId
-					&& o.TargetType == targetType
-					&& o.TargetId == targetId,
-				cancellationToken);
-	}
-
-	public Task<ChannelPermissionOverwrite?> GetForChannelByTargetIdAsync(
-		long channelId,
-		long targetId,
-		CancellationToken cancellationToken = default)
-	{
-		return context.ChannelPermissionOverwrites
-			.FirstOrDefaultAsync(
-				o => o.ChannelId == channelId && o.TargetId == targetId,
-				cancellationToken);
+		// read-only: only feeds the channel.access_revoked read-diff, never mutated
+		return await context.ChannelPermissionOverwrites
+			.AsNoTracking()
+			.Where(o => o.GuildId == guildId)
+			.ToListAsync(cancellationToken);
 	}
 
 	public Task RemoveAllForMemberAsync(long userId, CancellationToken cancellationToken = default)

--- a/services/guild/tests/Guild.UnitTests/Application/AssignRoleHandlerTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/AssignRoleHandlerTests.cs
@@ -100,7 +100,7 @@ public sealed class AssignRoleHandlerTests
 		guilds.Add(guild);
 
 		var handler = HandlerFactory.CreateCommand<AssignRoleCommand, Result>(
-			guilds, clock, new FakeCurrentUser { Id = currentUser });
+			guilds, new FakeChannelRepository(), new FakeChannelPermissionOverwriteRepository(), new FakeEventBus(), clock, new FakeCurrentUser { Id = currentUser });
 		return (handler, guilds);
 	}
 }

--- a/services/guild/tests/Guild.UnitTests/Application/ChannelAccessRevokedTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/ChannelAccessRevokedTests.cs
@@ -1,0 +1,243 @@
+using Guild.Application.Contracts;
+using Guild.Application.Features.Channels.Permissions.DeleteOverwrite;
+using Guild.Application.Features.Channels.Permissions.PutOverwrite;
+using Guild.Application.Features.Membership.AssignRole;
+using Guild.Application.Features.Membership.UnassignRole;
+using Guild.Application.Features.Roles.Common;
+using Guild.Application.Features.Roles.DeleteRole;
+using Guild.Application.Features.Roles.UpdateRole;
+using Guild.Domain.Guild;
+using Guild.Domain.Results;
+using Guild.UnitTests.Fakes;
+using Xunit;
+using GuildEntity = Guild.Domain.Guild.Guild;
+
+namespace Guild.UnitTests.Application;
+
+/// <summary>
+/// covers channel.access_revoked emission: a revocation fires exactly when a
+/// member could read a channel before a mutation but not after, and stays silent
+/// when read access survives via another role or overwrite.
+/// </summary>
+public sealed class ChannelAccessRevokedTests
+{
+	private static readonly DateTimeOffset Now = new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+	private const long Read = (long)Permission.ReadMessages;
+	private const long Owner = 1;
+	private const long Member = 2;
+	private const long ChannelId = 500;
+
+	// builds guild 100 with owner 1, a channel, and member 2. everyonePerms sets
+	// what the @everyone role grants (Read by default; 0 to force role/overwrite-only read).
+	private static (FakeGuildRepository Guilds, FakeChannelRepository Channels, FakeChannelPermissionOverwriteRepository Overwrites, GuildEntity Guild)
+		Setup(long everyonePerms = Read)
+	{
+		var guilds = new FakeGuildRepository();
+		var guild = GuildEntity.Create(
+			id: 100, name: "T", description: null, iconUrl: null, bannerUrl: null,
+			ownerId: Owner, everyoneRoleId: 101, adminRoleId: 102, now: Now).Value;
+		DomainSeed.AddMember(guild, Member, Now);
+		DomainSeed.SetRolePermissions(guild.Roles.First(r => r.IsDefault), everyonePerms);
+		guilds.Add(guild);
+
+		var channels = new FakeChannelRepository();
+		channels.Seed(Channel.Create(ChannelId, 100, null, "general", null, ChannelType.Text, 0, Now).Value);
+
+		return (guilds, channels, new FakeChannelPermissionOverwriteRepository(), guild);
+	}
+
+	private static void SeedMemberOverwrite(FakeChannelPermissionOverwriteRepository ow, long userId, long allow, long deny) =>
+		ow.Seed(ChannelPermissionOverwrite.Create(900 + userId, 100, ChannelId, OverwriteTargetType.Member, userId, allow, deny, Now).Value);
+
+	[Fact]
+	public async Task PutOverwrite_DenyReadToMember_EmitsRevocation()
+	{
+		var (guilds, channels, ow, _) = Setup(); // member reads via @everyone
+		var bus = new FakeEventBus();
+		var handler = HandlerFactory.CreateCommand<PutOverwriteCommand, Result>(
+			guilds, channels, ow, bus, new FakeIdGenerator(), new FakeClock(), new FakeCurrentUser { Id = Owner });
+
+		var result = await handler.HandleAsync(
+			new PutOverwriteCommand(ChannelId, Member, "member", Allow: 0, Deny: Read));
+
+		Assert.True(result.Succeeded);
+		var evt = bus.Single<ChannelAccessRevoked>();
+		Assert.Equal((ChannelId, Member), (evt.ChannelId, evt.UserId));
+	}
+
+	[Fact]
+	public async Task DeleteOverwrite_ReadStillGrantedByEveryone_NoRevocation()
+	{
+		var (guilds, channels, ow, _) = Setup(); // @everyone grants read
+		SeedMemberOverwrite(ow, Member, allow: Read, deny: 0); // redundant allow
+		var bus = new FakeEventBus();
+		var handler = HandlerFactory.CreateCommand<DeleteOverwriteCommand, Result>(
+			guilds, channels, ow, bus, new FakeCurrentUser { Id = Owner });
+
+		var result = await handler.HandleAsync(new DeleteOverwriteCommand(ChannelId, Member));
+
+		Assert.True(result.Succeeded);
+		Assert.Empty(bus.Published);
+	}
+
+	[Fact]
+	public async Task DeleteOverwrite_SoleReadSourceRemoved_EmitsRevocation()
+	{
+		var (guilds, channels, ow, _) = Setup(everyonePerms: 0); // no base read
+		SeedMemberOverwrite(ow, Member, allow: Read, deny: 0); // only read source
+		var bus = new FakeEventBus();
+		var handler = HandlerFactory.CreateCommand<DeleteOverwriteCommand, Result>(
+			guilds, channels, ow, bus, new FakeCurrentUser { Id = Owner });
+
+		var result = await handler.HandleAsync(new DeleteOverwriteCommand(ChannelId, Member));
+
+		Assert.True(result.Succeeded);
+		var evt = bus.Single<ChannelAccessRevoked>();
+		Assert.Equal((ChannelId, Member), (evt.ChannelId, evt.UserId));
+	}
+
+	[Fact]
+	public async Task AssignRole_WithDenyReadOverwrite_EmitsRevocation()
+	{
+		var (guilds, channels, ow, guild) = Setup(); // member reads via @everyone
+		DomainSeed.AddCustomRole(guild, 200, "R", permissions: 0, position: 1, Now);
+		// R denies read on the channel via an overwrite; assigning R applies that deny to the member
+		ow.Seed(ChannelPermissionOverwrite.Create(800, 100, ChannelId, OverwriteTargetType.Role, 200, allow: 0, deny: Read, Now).Value);
+		var bus = new FakeEventBus();
+		var handler = HandlerFactory.CreateCommand<AssignRoleCommand, Result>(
+			guilds, channels, ow, bus, new FakeClock(Now), new FakeCurrentUser { Id = Owner });
+
+		var result = await handler.HandleAsync(new AssignRoleCommand(100, Member, 200));
+
+		Assert.True(result.Succeeded);
+		var evt = bus.Single<ChannelAccessRevoked>();
+		Assert.Equal((ChannelId, Member), (evt.ChannelId, evt.UserId));
+	}
+
+	[Fact]
+	public async Task AssignRole_DenyOverwrite_ButAllowOverwriteOnAnotherRoleWins_NoRevocation()
+	{
+		// Skaf holds "Astral Freak" (id 201) with an allow-read overwrite, sitting
+		// BELOW the "Cone of shame" (id 200) deny-read overwrite being assigned.
+		// at the role-overwrite tier allow wins regardless of position, so read survives.
+		var (guilds, channels, ow, guild) = Setup(everyonePerms: 0);
+		DomainSeed.AddCustomRole(guild, 201, "Astral Freak", permissions: 0, position: 1, Now);
+		DomainSeed.AssignRole(guild, Member, 201, Now);
+		ow.Seed(ChannelPermissionOverwrite.Create(801, 100, ChannelId, OverwriteTargetType.Role, 201, allow: Read, deny: 0, Now).Value);
+
+		DomainSeed.AddCustomRole(guild, 200, "Cone of shame", permissions: 0, position: 2, Now);
+		ow.Seed(ChannelPermissionOverwrite.Create(800, 100, ChannelId, OverwriteTargetType.Role, 200, allow: 0, deny: Read, Now).Value);
+
+		var bus = new FakeEventBus();
+		var handler = HandlerFactory.CreateCommand<AssignRoleCommand, Result>(
+			guilds, channels, ow, bus, new FakeClock(Now), new FakeCurrentUser { Id = Owner });
+
+		var result = await handler.HandleAsync(new AssignRoleCommand(100, Member, 200));
+
+		Assert.True(result.Succeeded);
+		Assert.Empty(bus.Published);
+	}
+
+	[Fact]
+	public async Task UnassignRole_SoleReadRole_EmitsRevocation()
+	{
+		var (guilds, channels, ow, guild) = Setup(everyonePerms: 0);
+		DomainSeed.AddCustomRole(guild, 200, "R", Read, 1, Now);
+		DomainSeed.AssignRole(guild, Member, 200, Now);
+		var bus = new FakeEventBus();
+		var handler = HandlerFactory.CreateCommand<UnassignRoleCommand, Result>(
+			guilds, channels, ow, bus, new FakeClock(Now), new FakeCurrentUser { Id = Owner });
+
+		var result = await handler.HandleAsync(new UnassignRoleCommand(100, Member, 200));
+
+		Assert.True(result.Succeeded);
+		var evt = bus.Single<ChannelAccessRevoked>();
+		Assert.Equal((ChannelId, Member), (evt.ChannelId, evt.UserId));
+	}
+
+	[Fact]
+	public async Task UnassignRole_ReadRetainedBySecondRole_NoRevocation()
+	{
+		var (guilds, channels, ow, guild) = Setup(everyonePerms: 0);
+		DomainSeed.AddCustomRole(guild, 200, "R1", Read, 1, Now);
+		DomainSeed.AddCustomRole(guild, 201, "R2", Read, 2, Now);
+		DomainSeed.AssignRole(guild, Member, 200, Now);
+		DomainSeed.AssignRole(guild, Member, 201, Now);
+		var bus = new FakeEventBus();
+		var handler = HandlerFactory.CreateCommand<UnassignRoleCommand, Result>(
+			guilds, channels, ow, bus, new FakeClock(Now), new FakeCurrentUser { Id = Owner });
+
+		var result = await handler.HandleAsync(new UnassignRoleCommand(100, Member, 200));
+
+		Assert.True(result.Succeeded);
+		Assert.Empty(bus.Published);
+	}
+
+	[Fact]
+	public async Task DeleteRole_SoleReadRole_EmitsRevocation()
+	{
+		var (guilds, channels, ow, guild) = Setup(everyonePerms: 0);
+		DomainSeed.AddCustomRole(guild, 200, "R", Read, 1, Now);
+		DomainSeed.AssignRole(guild, Member, 200, Now);
+		var bus = new FakeEventBus();
+		var handler = HandlerFactory.CreateCommand<DeleteRoleCommand, Result>(
+			guilds, channels, ow, bus, new FakeClock(Now), new FakeCurrentUser { Id = Owner });
+
+		var result = await handler.HandleAsync(new DeleteRoleCommand(100, 200));
+
+		Assert.True(result.Succeeded);
+		var evt = bus.Single<ChannelAccessRevoked>();
+		Assert.Equal((ChannelId, Member), (evt.ChannelId, evt.UserId));
+	}
+
+	[Fact]
+	public async Task UpdateRole_RemovesReadBit_EmitsRevocation()
+	{
+		var (guilds, channels, ow, guild) = Setup(everyonePerms: 0);
+		DomainSeed.AddCustomRole(guild, 200, "R", Read, 1, Now);
+		DomainSeed.AssignRole(guild, Member, 200, Now);
+		var bus = new FakeEventBus();
+		var handler = HandlerFactory.CreateCommand<UpdateRoleCommand, Result<RoleResponse>>(
+			guilds, channels, ow, bus, new FakeClock(Now), new FakeCurrentUser { Id = Owner });
+
+		var result = await handler.HandleAsync(new UpdateRoleCommand(
+			100, 200, Name: null, Color: null, Permissions: 0, IsHoisted: null, IsMentionable: null));
+
+		Assert.True(result.Succeeded);
+		var evt = bus.Single<ChannelAccessRevoked>();
+		Assert.Equal((ChannelId, Member), (evt.ChannelId, evt.UserId));
+	}
+
+	[Fact]
+	public async Task UpdateRole_GrantsReadBit_NoRevocation()
+	{
+		// a grant can never revoke (base perms are additive), so no event
+		var (guilds, channels, ow, guild) = Setup(everyonePerms: 0);
+		DomainSeed.AddCustomRole(guild, 200, "R", permissions: 0, position: 1, Now);
+		DomainSeed.AssignRole(guild, Member, 200, Now);
+		var bus = new FakeEventBus();
+		var handler = HandlerFactory.CreateCommand<UpdateRoleCommand, Result<RoleResponse>>(
+			guilds, channels, ow, bus, new FakeClock(Now), new FakeCurrentUser { Id = Owner });
+
+		var result = await handler.HandleAsync(new UpdateRoleCommand(
+			100, 200, Name: null, Color: null, Permissions: Read, IsHoisted: null, IsMentionable: null));
+
+		Assert.True(result.Succeeded);
+		Assert.Empty(bus.Published);
+	}
+
+	[Fact]
+	public async Task DeleteRole_NoHolders_NoRevocation()
+	{
+		var (guilds, channels, ow, guild) = Setup(everyonePerms: 0);
+		DomainSeed.AddCustomRole(guild, 200, "R", permissions: Read, position: 1, Now); // nobody assigned
+		var bus = new FakeEventBus();
+		var handler = HandlerFactory.CreateCommand<DeleteRoleCommand, Result>(
+			guilds, channels, ow, bus, new FakeClock(Now), new FakeCurrentUser { Id = Owner });
+
+		var result = await handler.HandleAsync(new DeleteRoleCommand(100, 200));
+
+		Assert.True(result.Succeeded);
+		Assert.Empty(bus.Published);
+	}
+}

--- a/services/guild/tests/Guild.UnitTests/Application/DeleteOverwriteHandlerTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/DeleteOverwriteHandlerTests.cs
@@ -111,7 +111,7 @@ public sealed class DeleteOverwriteHandlerTests
 		guilds.Add(guild);
 
 		var handler = HandlerFactory.CreateCommand<DeleteOverwriteCommand, Result>(
-			guilds, channels, overwrites, new FakeCurrentUser { Id = currentUser });
+			guilds, channels, overwrites, new FakeEventBus(), new FakeCurrentUser { Id = currentUser });
 		return (handler, guilds, channels, overwrites);
 	}
 }

--- a/services/guild/tests/Guild.UnitTests/Application/DeleteRoleHandlerTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/DeleteRoleHandlerTests.cs
@@ -115,7 +115,7 @@ public sealed class DeleteRoleHandlerTests
 			ownerId: 1, everyoneRoleId: 101, adminRoleId: 102, now: Now).Value;
 		guilds.Add(guild);
 		var handler = HandlerFactory.CreateCommand<DeleteRoleCommand, Result>(
-			guilds, new FakeClock(Now), new FakeCurrentUser { Id = currentUser });
+			guilds, new FakeChannelRepository(), new FakeChannelPermissionOverwriteRepository(), new FakeEventBus(), new FakeClock(Now), new FakeCurrentUser { Id = currentUser });
 		return (handler, guilds);
 	}
 }

--- a/services/guild/tests/Guild.UnitTests/Application/PutOverwriteHandlerTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/PutOverwriteHandlerTests.cs
@@ -226,7 +226,7 @@ public sealed class PutOverwriteHandlerTests
 		guilds.Add(guild);
 
 		var handler = HandlerFactory.CreateCommand<PutOverwriteCommand, Result>(
-			guilds, channels, overwrites,
+			guilds, channels, overwrites, new FakeEventBus(),
 			new FakeIdGenerator(), new FakeClock(), new FakeCurrentUser { Id = currentUser });
 		return (handler, guilds, channels, overwrites);
 	}

--- a/services/guild/tests/Guild.UnitTests/Application/UnassignRoleHandlerTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/UnassignRoleHandlerTests.cs
@@ -104,7 +104,7 @@ public sealed class UnassignRoleHandlerTests
 		guilds.Add(guild);
 
 		var handler = HandlerFactory.CreateCommand<UnassignRoleCommand, Result>(
-			guilds, clock, new FakeCurrentUser { Id = currentUser });
+			guilds, new FakeChannelRepository(), new FakeChannelPermissionOverwriteRepository(), new FakeEventBus(), clock, new FakeCurrentUser { Id = currentUser });
 		return (handler, guilds);
 	}
 }

--- a/services/guild/tests/Guild.UnitTests/Application/UpdateRoleHandlerTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/UpdateRoleHandlerTests.cs
@@ -161,7 +161,7 @@ public sealed class UpdateRoleHandlerTests
 			ownerId: 1, everyoneRoleId: 101, adminRoleId: 102, now: Now).Value;
 		guilds.Add(guild);
 		var handler = HandlerFactory.CreateCommand<UpdateRoleCommand, Result<RoleResponse>>(
-			guilds, new FakeClock(Now), new FakeCurrentUser { Id = currentUser });
+			guilds, new FakeChannelRepository(), new FakeChannelPermissionOverwriteRepository(), new FakeEventBus(), new FakeClock(Now), new FakeCurrentUser { Id = currentUser });
 		return (handler, guilds);
 	}
 }

--- a/services/guild/tests/Guild.UnitTests/Fakes/FakeChannelPermissionOverwriteRepository.cs
+++ b/services/guild/tests/Guild.UnitTests/Fakes/FakeChannelPermissionOverwriteRepository.cs
@@ -23,27 +23,14 @@ internal sealed class FakeChannelPermissionOverwriteRepository : IChannelPermiss
 		return Task.FromResult(list);
 	}
 
-	public Task<ChannelPermissionOverwrite?> GetForChannelAndTargetAsync(
-		long channelId,
-		OverwriteTargetType targetType,
-		long targetId,
+	public Task<IReadOnlyList<ChannelPermissionOverwrite>> GetForGuildAsync(
+		long guildId,
 		CancellationToken cancellationToken = default)
 	{
-		var match = _store.Values.FirstOrDefault(o =>
-			o.ChannelId == channelId
-			&& o.TargetType == targetType
-			&& o.TargetId == targetId);
-		return Task.FromResult(match);
-	}
-
-	public Task<ChannelPermissionOverwrite?> GetForChannelByTargetIdAsync(
-		long channelId,
-		long targetId,
-		CancellationToken cancellationToken = default)
-	{
-		var match = _store.Values.FirstOrDefault(o =>
-			o.ChannelId == channelId && o.TargetId == targetId);
-		return Task.FromResult(match);
+		IReadOnlyList<ChannelPermissionOverwrite> list = _store.Values
+			.Where(o => o.GuildId == guildId)
+			.ToList();
+		return Task.FromResult(list);
 	}
 
 	public void Add(ChannelPermissionOverwrite overwrite)

--- a/services/guild/tests/Guild.UnitTests/Serialization/EventSerializationTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Serialization/EventSerializationTests.cs
@@ -115,4 +115,21 @@ public sealed class EventSerializationTests
 
 		Assert.Equal(original, JsonSerializer.Deserialize<GuildOwnerTransferred>(json, SnakeCase));
 	}
+
+	[Fact]
+	public void ChannelAccessRevoked_SerializesWith_SnakeCaseFields()
+	{
+		var json = JsonSerializer.Serialize(new ChannelAccessRevoked(500, 2), SnakeCase);
+
+		Assert.Equal("{\"channel_id\":500,\"user_id\":2}", json);
+	}
+
+	[Fact]
+	public void ChannelAccessRevoked_RoundTrips()
+	{
+		var original = new ChannelAccessRevoked(500, 2);
+		var json = JsonSerializer.Serialize(original, SnakeCase);
+
+		Assert.Equal(original, JsonSerializer.Deserialize<ChannelAccessRevoked>(json, SnakeCase));
+	}
 }


### PR DESCRIPTION
Resolves #263 

Guild now emits `channel.access_revoked { channel_id, user_id }` whenever a role or overwrite change removes a member's effective `READ_MESSAGES` on a channel, so Chat can evict that member's live SignalR subscription (`EvictFromChannelAsync`, already shipped in #226).

### The core constraint
"Who lost access" can't be shortcut to "react to the deny signal": a member can hold read via multiple paths (two roles, a role + a member allow-overwrite, etc.), so removing one path doesn't necessarily revoke read. Correctness requires computing effective `READ_MESSAGES` **before and after** the mutation and diffing. This runs through the existing `PermissionResolver.Resolve` (the same resolver behind `GET /internal/channels/{id}/membership` that Chat already queries), so the event fires **exactly** when the resolver says read flipped `true -> false`, and never on grants or when access survives another path.

### Approach (scoped diff)
A shared `ChannelAccess` helper captures a before-snapshot of read for a scoped candidate set, then diffs against the after-state and publishes one event per revoked `(channel, member)`:
- **Overwrite mutations** scope to the single channel; candidates are the overwrite target (a member, a role's holders, or all members for `@everyone`).
- **Role mutations** scope the affected member set but span all channels, since a base-permission change reaches everywhere. Overwrites are unchanged by role mutations, so the same set feeds the after-diff.

Both handler families read identically: `compute affected -> capture -> mutate -> publish (before SaveChanges, so it binds to the bus outbox)`.

### Mutation surface
`UnassignRole`, `DeleteRole`, `UpdateRole` (permission change only), `PutOverwrite`, `DeleteOverwrite` from the issue, plus **`AssignRole`** (beyond the issue): assigning a role that carries a deny-read overwrite genuinely revokes read, so it gets the same treatment. Membership removal (kick/ban/leave) is already covered by `guild.member_left` and is out of scope.

### Correctness properties locked in by tests
`ChannelAccessRevokedTests` covers every handler's revoke path plus the "retained -> no event" cases that make the diff worth doing:
- read retained via `@everyone` base,
- retained via a second role's base grant,
- **retained via a lower role's allow-overwrite beating a higher role's deny-overwrite** at the role tier (allow wins, role position is irrelevant to overwrite resolution).

### Testing
- Guild: 12 arch / 456 unit / 254 functional passing, including the 9 revocation tests above and snake_case serialization/roundtrip for the event.
- End-to-end smoke test on the live stack: denied a member's read via a channel overwrite and confirmed `channel.access_revoked` published on the correct exchange (`SetEntityName`). Test data cleaned up.
- Contract updated (`Events Published` row documenting the trigger set and Chat's consumer).

`AssignRole` correctly does nothing when the assigned role merely lacks READ in its base bitmask (base permissions are additive; the member keeps `@everyone`'s read) - it only fires on a genuine deny-overwrite.

Too much to read? Yeah I get it (my brain's burning like a forest fire rn)... Anyway here's a nicely crafted diagram to help you understand how the flow works and when we decide someone doesn't get to see a channel anymore

<img width="1154" height="737" alt="image" src="https://github.com/user-attachments/assets/213d3110-a333-45c2-93df-e7138276c60d" />
