### PR TITLE
Feat(chat): webrtc signaling

### DIFF
--- a/services/chat/src/Chat.Presentation/Chat.Presentation.csproj
+++ b/services/chat/src/Chat.Presentation/Chat.Presentation.csproj
@@ -22,6 +22,7 @@
         <PackageReference Include="Carter" Version="10.0.0"/>
         <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.2"/>
         <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.2"/>
+        <PackageReference Include="Microsoft.OpenApi" Version="2.7.5"/>
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3"/>
         <PackageReference Include="Scalar.AspNetCore" Version="2.6.0"/>
     </ItemGroup>

--- a/services/chat/src/Chat.Presentation/Hubs/CallRegistry.cs
+++ b/services/chat/src/Chat.Presentation/Hubs/CallRegistry.cs
@@ -70,12 +70,16 @@ public sealed class CallRegistry(
 	// ---- call lifecycle ----
 
 	// registers a ringing call. returns false (user_busy) if either participant is
-	// already in a call, which keeps the one-call-per-user invariant intact.
+	// already in a call, which keeps the one-call-per-user invariant intact. a
+	// call_id already in use is also rejected: the id is client-supplied, so a
+	// collision would otherwise overwrite the live call and strand its participants.
 	public bool TryOffer(CallInfo info)
 	{
 		lock (_gate)
 		{
-			if (_userCall.ContainsKey(info.CallerId) || _userCall.ContainsKey(info.CalleeId))
+			if (_userCall.ContainsKey(info.CallerId)
+				|| _userCall.ContainsKey(info.CalleeId)
+				|| _byCall.ContainsKey(info.CallId))
 				return false;
 
 			var entry = new Entry { Info = info };
@@ -155,10 +159,11 @@ public sealed class CallRegistry(
 
 		if (timedOut is not null)
 		{
-			logger.LogInformation("Call {CallId}: unanswered after {Seconds}s, failing both parties",
+			// per docs/contracts/chat.md, an unanswered call fails the caller only;
+			// the callee's ringing UI times out client-side.
+			logger.LogInformation("Call {CallId}: unanswered after {Seconds}s, failing the caller",
 				timedOut.CallId, _answerTimeout.TotalSeconds);
-			_ = hub.Clients
-				.Users([timedOut.CallerId.ToString(), timedOut.CalleeId.ToString()])
+			_ = hub.Clients.User(timedOut.CallerId.ToString())
 				.CallFailed(new CallFailedEvent(timedOut.CallId.ToString(), "timeout"));
 		}
 	}

--- a/services/chat/src/Chat.Presentation/Hubs/CallRegistry.cs
+++ b/services/chat/src/Chat.Presentation/Hubs/CallRegistry.cs
@@ -1,0 +1,159 @@
+using Chat.Presentation.Hubs.Signaling;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Options;
+
+namespace Chat.Presentation.Hubs;
+
+public sealed record CallInfo(long CallId, long CallerId, long CalleeId, string CallType, string Sdp);
+
+/// <summary>
+/// in-memory state for 1-on-1 WebRTC calls: signaling-hub presence, pending/active
+/// call bookkeeping (a user is in at most one call), and the unanswered-call
+/// timeout. single-node only, matching the peer-to-peer, et pour le meilleur
+/// </summary>
+public sealed class CallRegistry(
+	IHubContext<SignalingHub, ISignalingClient> hub,
+	IOptions<SignalingOptions> options)
+{
+	private sealed class Entry
+	{
+		public required CallInfo Info { get; init; }
+		public bool Ringing { get; set; } = true;
+		public Timer? Timer { get; set; }
+	}
+
+	private readonly TimeSpan _answerTimeout = TimeSpan.FromSeconds(options.Value.AnswerTimeoutSeconds);
+	private readonly Lock _gate = new();
+	private readonly Dictionary<long, Entry> _byCall = [];
+	private readonly Dictionary<long, long> _userCall = [];   // participant userId -> callId
+	private readonly Dictionary<long, int> _connected = [];   // signaling-hub connection counts
+
+	// ---- signaling-hub presence ----
+
+	public void Connect(long userId)
+	{
+		lock (_gate)
+			_connected[userId] = _connected.GetValueOrDefault(userId) + 1;
+	}
+
+	public void Disconnect(long userId)
+	{
+		lock (_gate)
+		{
+			if (!_connected.TryGetValue(userId, out var count))
+				return;
+			if (count <= 1)
+				_connected.Remove(userId);
+			else
+				_connected[userId] = count - 1;
+		}
+	}
+
+	public bool IsConnected(long userId)
+	{
+		lock (_gate)
+			return _connected.ContainsKey(userId);
+	}
+
+	// ringing calls where the user is the callee, delivered as IncomingCall when
+	// they (re)connect to the signaling hub.
+	public IReadOnlyList<CallInfo> PendingFor(long calleeId)
+	{
+		lock (_gate)
+			return _byCall.Values
+				.Where(e => e.Ringing && e.Info.CalleeId == calleeId)
+				.Select(e => e.Info)
+				.ToList();
+	}
+
+	// ---- call lifecycle ----
+
+	// registers a ringing call. returns false (user_busy) if either participant is
+	// already in a call, which keeps the one-call-per-user invariant intact.
+	public bool TryOffer(CallInfo info)
+	{
+		lock (_gate)
+		{
+			if (_userCall.ContainsKey(info.CallerId) || _userCall.ContainsKey(info.CalleeId))
+				return false;
+
+			var entry = new Entry { Info = info };
+			_byCall[info.CallId] = entry;
+			_userCall[info.CallerId] = info.CallId;
+			_userCall[info.CalleeId] = info.CallId;
+			entry.Timer = new Timer(OnTimeout, info.CallId, _answerTimeout, Timeout.InfiniteTimeSpan);
+			return true;
+		}
+	}
+
+	// callee accepts: cancels the timeout and marks the call active. returns the
+	// call (to relay CallAnswered to the caller), or null if the answer is invalid.
+	public CallInfo? Answer(long callId, long byUserId)
+	{
+		lock (_gate)
+		{
+			if (!_byCall.TryGetValue(callId, out var entry) || !entry.Ringing || entry.Info.CalleeId != byUserId)
+				return null;
+
+			entry.Ringing = false;
+			entry.Timer?.Dispose();
+			entry.Timer = null;
+			return entry.Info;
+		}
+	}
+
+	// ends a call (hangup or reject) by a participant and clears its state. returns
+	// the call so the caller can notify the other party, or null if invalid.
+	public CallInfo? End(long callId, long byUserId)
+	{
+		lock (_gate)
+		{
+			if (!_byCall.TryGetValue(callId, out var entry) ||
+				(entry.Info.CallerId != byUserId && entry.Info.CalleeId != byUserId))
+				return null;
+
+			RemoveLocked(callId);
+			return entry.Info;
+		}
+	}
+
+	// for ICE relay: returns the call only if the user is one of its participants.
+	public CallInfo? ForParticipant(long callId, long userId)
+	{
+		lock (_gate)
+		{
+			if (!_byCall.TryGetValue(callId, out var entry) ||
+				(entry.Info.CallerId != userId && entry.Info.CalleeId != userId))
+				return null;
+
+			return entry.Info;
+		}
+	}
+
+	private void RemoveLocked(long callId)
+	{
+		if (!_byCall.Remove(callId, out var entry))
+			return;
+		entry.Timer?.Dispose();
+		_userCall.Remove(entry.Info.CallerId);
+		_userCall.Remove(entry.Info.CalleeId);
+	}
+
+	private void OnTimeout(object? state)
+	{
+		var callId = (long)state!;
+		CallInfo? timedOut = null;
+		lock (_gate)
+		{
+			if (_byCall.TryGetValue(callId, out var entry) && entry.Ringing)
+			{
+				timedOut = entry.Info;
+				RemoveLocked(callId);
+			}
+		}
+
+		if (timedOut is not null)
+			_ = hub.Clients.User(timedOut.CallerId.ToString())
+				.CallFailed(new CallFailedEvent(timedOut.CallId.ToString(), "timeout"));
+	}
+}

--- a/services/chat/src/Chat.Presentation/Hubs/CallRegistry.cs
+++ b/services/chat/src/Chat.Presentation/Hubs/CallRegistry.cs
@@ -13,7 +13,8 @@ public sealed record CallInfo(long CallId, long CallerId, long CalleeId, string 
 /// </summary>
 public sealed class CallRegistry(
 	IHubContext<SignalingHub, ISignalingClient> hub,
-	IOptions<SignalingOptions> options)
+	IOptions<SignalingOptions> options,
+	ILogger<CallRegistry> logger)
 {
 	private sealed class Entry
 	{
@@ -153,7 +154,12 @@ public sealed class CallRegistry(
 		}
 
 		if (timedOut is not null)
-			_ = hub.Clients.User(timedOut.CallerId.ToString())
+		{
+			logger.LogInformation("Call {CallId}: unanswered after {Seconds}s, failing both parties",
+				timedOut.CallId, _answerTimeout.TotalSeconds);
+			_ = hub.Clients
+				.Users([timedOut.CallerId.ToString(), timedOut.CalleeId.ToString()])
 				.CallFailed(new CallFailedEvent(timedOut.CallId.ToString(), "timeout"));
+		}
 	}
 }

--- a/services/chat/src/Chat.Presentation/Hubs/ISignalingClient.cs
+++ b/services/chat/src/Chat.Presentation/Hubs/ISignalingClient.cs
@@ -1,8 +1,13 @@
+using Chat.Presentation.Hubs.Signaling;
+
 namespace Chat.Presentation.Hubs;
 
 public interface ISignalingClient
 {
-	Task Offer(string? from, string sdp);
-	Task Answer(string? from, string sdp);
-	Task IceCandidate(string? from, string candidate);
+	Task IncomingCall(IncomingCallEvent evt);
+	Task CallAnswered(CallAnsweredEvent evt);
+	Task CallRejected(CallIdEvent evt);
+	Task CallHungUp(CallIdEvent evt);
+	Task CallFailed(CallFailedEvent evt);
+	Task IceCandidate(IceCandidateEvent evt);
 }

--- a/services/chat/src/Chat.Presentation/Hubs/Signaling/SignalingMessages.cs
+++ b/services/chat/src/Chat.Presentation/Hubs/Signaling/SignalingMessages.cs
@@ -1,0 +1,53 @@
+using System.Text.Json.Serialization;
+
+namespace Chat.Presentation.Hubs.Signaling;
+
+// wire shapes for WebRTC signaling. snowflake ids are quoted strings and fields
+// are snake_case to match docs/contracts/chat.md (SignalR's default protocol is
+// camelCase, so the names are pinned explicitly).
+
+// ---- Client -> Server (invocation arguments) ----
+
+public sealed record CallOfferArgs(
+	[property: JsonPropertyName("callee_id")] string CalleeId,
+	[property: JsonPropertyName("call_id")] string CallId,
+	[property: JsonPropertyName("call_type")] string CallType,
+	[property: JsonPropertyName("sdp")] string Sdp);
+
+public sealed record CallAnswerArgs(
+	[property: JsonPropertyName("call_id")] string CallId,
+	[property: JsonPropertyName("sdp")] string Sdp);
+
+public sealed record CallIdArgs(
+	[property: JsonPropertyName("call_id")] string CallId);
+
+public sealed record IceCandidateArgs(
+	[property: JsonPropertyName("call_id")] string CallId,
+	[property: JsonPropertyName("candidate")] string Candidate,
+	[property: JsonPropertyName("sdp_mid")] string? SdpMid,
+	[property: JsonPropertyName("sdp_mline_index")] int SdpMlineIndex);
+
+// ---- Server -> Client (event payloads) ----
+
+public sealed record IncomingCallEvent(
+	[property: JsonPropertyName("call_id")] string CallId,
+	[property: JsonPropertyName("caller_id")] string CallerId,
+	[property: JsonPropertyName("call_type")] string CallType,
+	[property: JsonPropertyName("sdp")] string Sdp);
+
+public sealed record CallAnsweredEvent(
+	[property: JsonPropertyName("call_id")] string CallId,
+	[property: JsonPropertyName("sdp")] string Sdp);
+
+public sealed record CallIdEvent(
+	[property: JsonPropertyName("call_id")] string CallId);
+
+public sealed record CallFailedEvent(
+	[property: JsonPropertyName("call_id")] string CallId,
+	[property: JsonPropertyName("reason")] string Reason);
+
+public sealed record IceCandidateEvent(
+	[property: JsonPropertyName("call_id")] string CallId,
+	[property: JsonPropertyName("candidate")] string Candidate,
+	[property: JsonPropertyName("sdp_mid")] string? SdpMid,
+	[property: JsonPropertyName("sdp_mline_index")] int SdpMlineIndex);

--- a/services/chat/src/Chat.Presentation/Hubs/Signaling/SignalingOptions.cs
+++ b/services/chat/src/Chat.Presentation/Hubs/Signaling/SignalingOptions.cs
@@ -1,0 +1,9 @@
+namespace Chat.Presentation.Hubs.Signaling;
+
+public sealed class SignalingOptions
+{
+	public const string SectionName = "Signaling";
+
+	// how long a call may ring unanswered before the caller gets CallFailed:timeout
+	public int AnswerTimeoutSeconds { get; set; } = 120;
+}

--- a/services/chat/src/Chat.Presentation/Hubs/SignalingHub.cs
+++ b/services/chat/src/Chat.Presentation/Hubs/SignalingHub.cs
@@ -11,11 +11,13 @@ namespace Chat.Presentation.Hubs;
 public sealed class SignalingHub(
 	ICurrentUser currentUser,
 	CallRegistry calls,
-	IEventBus eventBus) : Hub<ISignalingClient>
+	IEventBus eventBus,
+	ILogger<SignalingHub> logger) : Hub<ISignalingClient>
 {
 	public override async Task OnConnectedAsync()
 	{
 		calls.Connect(currentUser.UserId);
+		logger.LogDebug("Signaling: {User} connected", currentUser.UserId);
 		foreach (var call in calls.PendingFor(currentUser.UserId))
 			await Clients.Caller.IncomingCall(new IncomingCallEvent(
 				call.CallId.ToString(), call.CallerId.ToString(), call.CallType, call.Sdp));
@@ -25,6 +27,7 @@ public sealed class SignalingHub(
 	public override async Task OnDisconnectedAsync(Exception? exception)
 	{
 		calls.Disconnect(currentUser.UserId);
+		logger.LogDebug("Signaling: {User} disconnected", currentUser.UserId);
 		await base.OnDisconnectedAsync(exception);
 	}
 
@@ -38,16 +41,23 @@ public sealed class SignalingHub(
 
 		if (!calls.TryOffer(info))
 		{
+			logger.LogInformation("Call {CallId}: {Caller} -> {Callee} rejected, peer busy", callId, callerId, calleeId);
 			await Clients.Caller.CallFailed(new CallFailedEvent(args.CallId, "user_busy"));
 			return;
 		}
 
 		if (calls.IsConnected(calleeId))
+		{
+			logger.LogInformation("Call {CallId}: relaying offer {Caller} -> {Callee} (callee online)", callId, callerId, calleeId);
 			await Clients.User(calleeId.ToString()).IncomingCall(new IncomingCallEvent(
 				args.CallId, callerId.ToString(), args.CallType, args.Sdp));
+		}
 		else
+		{
+			logger.LogInformation("Call {CallId}: {Callee} offline, publishing call.incoming", callId, calleeId);
 			await eventBus.PublishAsync(
 				new CallIncoming(callId, callerId, calleeId, args.CallType), Context.ConnectionAborted);
+		}
 	}
 
 	public async Task CallAnswer(CallAnswerArgs args)
@@ -59,6 +69,7 @@ public sealed class SignalingHub(
 		if (call is null)
 			return;
 
+		logger.LogInformation("Call {CallId}: answered by {Callee}", callId, currentUser.UserId);
 		await Clients.User(call.CallerId.ToString()).CallAnswered(new CallAnsweredEvent(args.CallId, args.Sdp));
 	}
 
@@ -71,6 +82,7 @@ public sealed class SignalingHub(
 		if (call is null)
 			return;
 
+		logger.LogInformation("Call {CallId}: rejected by {User}", callId, currentUser.UserId);
 		await Clients.User(Other(call, currentUser.UserId).ToString())
 			.CallRejected(new CallIdEvent(args.CallId));
 	}
@@ -84,6 +96,7 @@ public sealed class SignalingHub(
 		if (call is null)
 			return;
 
+		logger.LogInformation("Call {CallId}: hung up by {User}", callId, currentUser.UserId);
 		await Clients.User(Other(call, currentUser.UserId).ToString())
 			.CallHungUp(new CallIdEvent(args.CallId));
 	}

--- a/services/chat/src/Chat.Presentation/Hubs/SignalingHub.cs
+++ b/services/chat/src/Chat.Presentation/Hubs/SignalingHub.cs
@@ -1,20 +1,106 @@
+using Chat.Application.Abstractions;
+using Chat.Application.Abstractions.Authentication;
+using Chat.Application.Contracts;
+using Chat.Presentation.Hubs.Signaling;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.SignalR;
 
 namespace Chat.Presentation.Hubs;
 
 [Authorize]
-public sealed class SignalingHub : Hub<ISignalingClient>
+public sealed class SignalingHub(
+	ICurrentUser currentUser,
+	CallRegistry calls,
+	IEventBus eventBus) : Hub<ISignalingClient>
 {
-	public Task SendOffer(long targetUserId, string sdp) =>
-		Clients.User(targetUserId.ToString())
-			.Offer(Context.UserIdentifier, sdp);
+	public override async Task OnConnectedAsync()
+	{
+		calls.Connect(currentUser.UserId);
+		foreach (var call in calls.PendingFor(currentUser.UserId))
+			await Clients.Caller.IncomingCall(new IncomingCallEvent(
+				call.CallId.ToString(), call.CallerId.ToString(), call.CallType, call.Sdp));
+		await base.OnConnectedAsync();
+	}
 
-	public Task SendAnswer(long targetUserId, string sdp) =>
-		Clients.User(targetUserId.ToString())
-			.Answer(Context.UserIdentifier, sdp);
+	public override async Task OnDisconnectedAsync(Exception? exception)
+	{
+		calls.Disconnect(currentUser.UserId);
+		await base.OnDisconnectedAsync(exception);
+	}
 
-	public Task SendIceCandidate(long targetUserId, string candidate) =>
-		Clients.User(targetUserId.ToString())
-			.IceCandidate(Context.UserIdentifier, candidate);
+	public async Task CallOffer(CallOfferArgs args)
+	{
+		if (!long.TryParse(args.CalleeId, out var calleeId) || !long.TryParse(args.CallId, out var callId))
+			return;
+
+		var callerId = currentUser.UserId;
+		var info = new CallInfo(callId, callerId, calleeId, args.CallType, args.Sdp);
+
+		if (!calls.TryOffer(info))
+		{
+			await Clients.Caller.CallFailed(new CallFailedEvent(args.CallId, "user_busy"));
+			return;
+		}
+
+		if (calls.IsConnected(calleeId))
+			await Clients.User(calleeId.ToString()).IncomingCall(new IncomingCallEvent(
+				args.CallId, callerId.ToString(), args.CallType, args.Sdp));
+		else
+			await eventBus.PublishAsync(
+				new CallIncoming(callId, callerId, calleeId, args.CallType), Context.ConnectionAborted);
+	}
+
+	public async Task CallAnswer(CallAnswerArgs args)
+	{
+		if (!long.TryParse(args.CallId, out var callId))
+			return;
+
+		var call = calls.Answer(callId, currentUser.UserId);
+		if (call is null)
+			return;
+
+		await Clients.User(call.CallerId.ToString()).CallAnswered(new CallAnsweredEvent(args.CallId, args.Sdp));
+	}
+
+	public async Task CallReject(CallIdArgs args)
+	{
+		if (!long.TryParse(args.CallId, out var callId))
+			return;
+
+		var call = calls.End(callId, currentUser.UserId);
+		if (call is null)
+			return;
+
+		await Clients.User(Other(call, currentUser.UserId).ToString())
+			.CallRejected(new CallIdEvent(args.CallId));
+	}
+
+	public async Task CallHangup(CallIdArgs args)
+	{
+		if (!long.TryParse(args.CallId, out var callId))
+			return;
+
+		var call = calls.End(callId, currentUser.UserId);
+		if (call is null)
+			return;
+
+		await Clients.User(Other(call, currentUser.UserId).ToString())
+			.CallHungUp(new CallIdEvent(args.CallId));
+	}
+
+	public async Task IceCandidate(IceCandidateArgs args)
+	{
+		if (!long.TryParse(args.CallId, out var callId))
+			return;
+
+		var call = calls.ForParticipant(callId, currentUser.UserId);
+		if (call is null)
+			return;
+
+		await Clients.User(Other(call, currentUser.UserId).ToString())
+			.IceCandidate(new IceCandidateEvent(args.CallId, args.Candidate, args.SdpMid, args.SdpMlineIndex));
+	}
+
+	private static long Other(CallInfo call, long self) =>
+		call.CallerId == self ? call.CalleeId : call.CallerId;
 }

--- a/services/chat/src/Chat.Presentation/Program.cs
+++ b/services/chat/src/Chat.Presentation/Program.cs
@@ -6,6 +6,7 @@ using Chat.Application.Abstractions;
 using Chat.Infrastructure;
 using Chat.Persistence;
 using Chat.Presentation.Hubs;
+using Chat.Presentation.Hubs.Signaling;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.Extensions.DependencyInjection;
@@ -27,6 +28,8 @@ builder.Services.AddApplication()
 	.AddInfrastructure()
 	.AddPersistence();
 builder.Services.AddSingleton<UserConnectionTracker>();
+builder.Services.AddSingleton<CallRegistry>();
+builder.Services.Configure<SignalingOptions>(builder.Configuration.GetSection(SignalingOptions.SectionName));
 builder.Services.AddScoped<IChannelBroadcaster, SignalRChannelBroadcaster>();
 builder.Services.AddScoped<IUserBroadcaster, SignalRUserBroadcaster>();
 builder.Services.AddCarter();

--- a/services/chat/tests/Chat.FunctionalTests/Features/SignalingHubTests.cs
+++ b/services/chat/tests/Chat.FunctionalTests/Features/SignalingHubTests.cs
@@ -1,0 +1,184 @@
+using Chat.Application.Contracts;
+using Chat.FunctionalTests.Infrastructure;
+using Chat.Presentation.Hubs.Signaling;
+using Microsoft.AspNetCore.SignalR.Client;
+using Xunit;
+
+namespace Chat.FunctionalTests.Features;
+
+// WebRTC signaling relay via /v1/hubs/signaling. Each test uses unique user/call
+// ids so the process-wide CallRegistry singleton can't leak state between tests.
+public sealed class SignalingHubTests(ChatApiFactory factory)
+	: IClassFixture<ChatApiFactory>, IAsyncLifetime
+{
+	private const string SignalingPath = "/v1/hubs/signaling";
+	private static readonly TimeSpan Wait = TimeSpan.FromSeconds(3);
+
+	public Task InitializeAsync()
+	{
+		factory.EventBus.Reset();
+		return Task.CompletedTask;
+	}
+
+	public Task DisposeAsync() => Task.CompletedTask;
+
+	private HubConnection Connect(long userId) =>
+		HubConnectionHelper.Build(factory, TestTokens.Issue(ChatApiFactory.JwtSecret, userId), SignalingPath);
+
+	[Fact]
+	public async Task Offer_WhenCalleeConnected_CalleeReceivesIncomingCall()
+	{
+		const long caller = 8_001, callee = 8_002, callId = 90_001;
+		await using var callerConn = Connect(caller);
+		await using var calleeConn = Connect(callee);
+
+		var incoming = new TaskCompletionSource<IncomingCallEvent>();
+		calleeConn.On<IncomingCallEvent>("IncomingCall", e => incoming.TrySetResult(e));
+
+		await calleeConn.StartAsync();
+		await callerConn.StartAsync();
+		await callerConn.InvokeAsync("CallOffer",
+			new CallOfferArgs(callee.ToString(), callId.ToString(), "video", "sdp-offer"));
+
+		var e = await incoming.Task.WaitAsync(Wait);
+		Assert.Equal(callId.ToString(), e.CallId);
+		Assert.Equal(caller.ToString(), e.CallerId);
+		Assert.Equal("video", e.CallType);
+		Assert.Equal("sdp-offer", e.Sdp);
+	}
+
+	[Fact]
+	public async Task Answer_CallerReceivesCallAnswered()
+	{
+		const long caller = 8_011, callee = 8_012, callId = 90_011;
+		await using var callerConn = Connect(caller);
+		await using var calleeConn = Connect(callee);
+
+		var answered = new TaskCompletionSource<CallAnsweredEvent>();
+		callerConn.On<CallAnsweredEvent>("CallAnswered", e => answered.TrySetResult(e));
+
+		await callerConn.StartAsync();
+		await calleeConn.StartAsync();
+		await callerConn.InvokeAsync("CallOffer",
+			new CallOfferArgs(callee.ToString(), callId.ToString(), "audio", "offer"));
+		await calleeConn.InvokeAsync("CallAnswer", new CallAnswerArgs(callId.ToString(), "sdp-answer"));
+
+		var e = await answered.Task.WaitAsync(Wait);
+		Assert.Equal(callId.ToString(), e.CallId);
+		Assert.Equal("sdp-answer", e.Sdp);
+	}
+
+	[Fact]
+	public async Task Reject_CallerReceivesCallRejected()
+	{
+		const long caller = 8_021, callee = 8_022, callId = 90_021;
+		await using var callerConn = Connect(caller);
+		await using var calleeConn = Connect(callee);
+
+		var rejected = new TaskCompletionSource<CallIdEvent>();
+		callerConn.On<CallIdEvent>("CallRejected", e => rejected.TrySetResult(e));
+
+		await callerConn.StartAsync();
+		await calleeConn.StartAsync();
+		await callerConn.InvokeAsync("CallOffer",
+			new CallOfferArgs(callee.ToString(), callId.ToString(), "video", "offer"));
+		await calleeConn.InvokeAsync("CallReject", new CallIdArgs(callId.ToString()));
+
+		var e = await rejected.Task.WaitAsync(Wait);
+		Assert.Equal(callId.ToString(), e.CallId);
+	}
+
+	[Fact]
+	public async Task Hangup_OtherPartyReceivesCallHungUp()
+	{
+		const long caller = 8_031, callee = 8_032, callId = 90_031;
+		await using var callerConn = Connect(caller);
+		await using var calleeConn = Connect(callee);
+
+		var hungUp = new TaskCompletionSource<CallIdEvent>();
+		calleeConn.On<CallIdEvent>("CallHungUp", e => hungUp.TrySetResult(e));
+
+		await callerConn.StartAsync();
+		await calleeConn.StartAsync();
+		await callerConn.InvokeAsync("CallOffer",
+			new CallOfferArgs(callee.ToString(), callId.ToString(), "video", "offer"));
+		await callerConn.InvokeAsync("CallHangup", new CallIdArgs(callId.ToString()));
+
+		var e = await hungUp.Task.WaitAsync(Wait);
+		Assert.Equal(callId.ToString(), e.CallId);
+	}
+
+	[Fact]
+	public async Task IceCandidate_RelayedToOtherParty()
+	{
+		const long caller = 8_041, callee = 8_042, callId = 90_041;
+		await using var callerConn = Connect(caller);
+		await using var calleeConn = Connect(callee);
+
+		var ice = new TaskCompletionSource<IceCandidateEvent>();
+		calleeConn.On<IceCandidateEvent>("IceCandidate", e => ice.TrySetResult(e));
+
+		await callerConn.StartAsync();
+		await calleeConn.StartAsync();
+		await callerConn.InvokeAsync("CallOffer",
+			new CallOfferArgs(callee.ToString(), callId.ToString(), "video", "offer"));
+		await callerConn.InvokeAsync("IceCandidate",
+			new IceCandidateArgs(callId.ToString(), "candidate:1", "0", 0));
+
+		var e = await ice.Task.WaitAsync(Wait);
+		Assert.Equal(callId.ToString(), e.CallId);
+		Assert.Equal("candidate:1", e.Candidate);
+		Assert.Equal("0", e.SdpMid);
+		Assert.Equal(0, e.SdpMlineIndex);
+	}
+
+	[Fact]
+	public async Task Offer_WhenCalleeBusy_CallerReceivesUserBusy()
+	{
+		const long a = 8_051, b = 8_052, c = 8_053, call1 = 90_051, call2 = 90_052;
+		await using var connA = Connect(a);
+		await using var connB = Connect(b);
+		await using var connC = Connect(c);
+
+		var busy = new TaskCompletionSource<CallFailedEvent>();
+		connC.On<CallFailedEvent>("CallFailed", e => busy.TrySetResult(e));
+
+		await connA.StartAsync();
+		await connB.StartAsync();
+		await connC.StartAsync();
+
+		await connA.InvokeAsync("CallOffer", new CallOfferArgs(b.ToString(), call1.ToString(), "video", "offer"));
+		await connC.InvokeAsync("CallOffer", new CallOfferArgs(b.ToString(), call2.ToString(), "video", "offer"));
+
+		var e = await busy.Task.WaitAsync(Wait);
+		Assert.Equal(call2.ToString(), e.CallId);
+		Assert.Equal("user_busy", e.Reason);
+	}
+
+	[Fact]
+	public async Task Offer_WhenCalleeOffline_PublishesCallIncoming_AndDeliversOnConnect()
+	{
+		const long caller = 8_061, callee = 8_062, callId = 90_061;
+		await using var callerConn = Connect(caller);
+		await callerConn.StartAsync();
+
+		// callee is not connected -> offline path
+		await callerConn.InvokeAsync("CallOffer",
+			new CallOfferArgs(callee.ToString(), callId.ToString(), "audio", "offer"));
+
+		var published = Assert.Single(factory.EventBus.PublishedOf<CallIncoming>());
+		Assert.Equal(callId, published.CallId);
+		Assert.Equal(caller, published.CallerId);
+		Assert.Equal(callee, published.CalleeId);
+
+		// when the callee finally connects, the pending call is delivered
+		await using var calleeConn = Connect(callee);
+		var incoming = new TaskCompletionSource<IncomingCallEvent>();
+		calleeConn.On<IncomingCallEvent>("IncomingCall", e => incoming.TrySetResult(e));
+		await calleeConn.StartAsync();
+
+		var e = await incoming.Task.WaitAsync(Wait);
+		Assert.Equal(callId.ToString(), e.CallId);
+		Assert.Equal(caller.ToString(), e.CallerId);
+	}
+}

--- a/services/chat/tests/Chat.FunctionalTests/Infrastructure/HubConnectionHelper.cs
+++ b/services/chat/tests/Chat.FunctionalTests/Infrastructure/HubConnectionHelper.cs
@@ -5,10 +5,10 @@ namespace Chat.FunctionalTests.Infrastructure;
 
 internal static class HubConnectionHelper
 {
-	public static HubConnection Build(ChatApiFactory factory, string? token)
+	public static HubConnection Build(ChatApiFactory factory, string? token, string path = "/v1/hubs/chat")
 	{
 		var server = factory.Server;
-		var hubUri = new UriBuilder(server.BaseAddress) { Path = "/v1/hubs/chat" }.Uri;
+		var hubUri = new UriBuilder(server.BaseAddress) { Path = path }.Uri;
 
 		return new HubConnectionBuilder()
 			.WithUrl(hubUri, options =>

--- a/services/chat/tests/Chat.UnitTests/Presentation/CallRegistryTests.cs
+++ b/services/chat/tests/Chat.UnitTests/Presentation/CallRegistryTests.cs
@@ -1,6 +1,7 @@
 using Chat.Presentation.Hubs;
 using Chat.Presentation.Hubs.Signaling;
 using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using Xunit;
 
@@ -20,7 +21,7 @@ public sealed class CallRegistryTests
 	{
 		var hub = new RecordingSignalingHub();
 		var opts = Options.Create(new SignalingOptions { AnswerTimeoutSeconds = timeoutSeconds });
-		return (new CallRegistry(hub, opts), hub);
+		return (new CallRegistry(hub, opts, NullLogger<CallRegistry>.Instance), hub);
 	}
 
 	[Fact]
@@ -105,7 +106,7 @@ public sealed class CallRegistryTests
 	}
 
 	[Fact]
-	public async Task Timeout_Fires_CallFailed_ToCaller_WhenUnanswered()
+	public async Task Timeout_Fires_CallFailed_ToBothParties_WhenUnanswered()
 	{
 		var (registry, hub) = NewRegistry(timeoutSeconds: 1);
 		registry.TryOffer(Offer());
@@ -113,9 +114,11 @@ public sealed class CallRegistryTests
 		var failed = await hub.WaitForCallFailedAsync(TimeSpan.FromSeconds(4));
 
 		Assert.NotNull(failed);
-		Assert.Equal(Caller.ToString(), failed!.Value.UserId);
+		Assert.Equal("timeout", failed!.Value.Evt.Reason);
 		Assert.Equal(CallId.ToString(), failed.Value.Evt.CallId);
-		Assert.Equal("timeout", failed.Value.Evt.Reason);
+		var sent = hub.Snapshot();
+		Assert.Contains(sent, s => s.UserId == Caller.ToString() && s.Evt.Reason == "timeout");
+		Assert.Contains(sent, s => s.UserId == Callee.ToString() && s.Evt.Reason == "timeout");
 		// state cleared: the caller can offer again
 		Assert.True(registry.TryOffer(new CallInfo(905, Caller, Third, "audio", "x")));
 	}
@@ -153,6 +156,12 @@ public sealed class CallRegistryTests
 			return null;
 		}
 
+		public IReadOnlyList<(string UserId, CallFailedEvent Evt)> Snapshot()
+		{
+			lock (_lock)
+				return [.. _sent];
+		}
+
 		private void Record(string userId, CallFailedEvent evt)
 		{
 			lock (_lock)
@@ -169,7 +178,22 @@ public sealed class CallRegistryTests
 			public ISignalingClient Group(string g) => throw new NotSupportedException();
 			public ISignalingClient GroupExcept(string g, IReadOnlyList<string> e) => throw new NotSupportedException();
 			public ISignalingClient Groups(IReadOnlyList<string> g) => throw new NotSupportedException();
-			public ISignalingClient Users(IReadOnlyList<string> u) => throw new NotSupportedException();
+			public ISignalingClient Users(IReadOnlyList<string> u) => new MultiClient(owner, u);
+		}
+
+		private sealed class MultiClient(RecordingSignalingHub owner, IReadOnlyList<string> userIds) : ISignalingClient
+		{
+			public Task CallFailed(CallFailedEvent evt)
+			{
+				foreach (var id in userIds)
+					owner.Record(id, evt);
+				return Task.CompletedTask;
+			}
+			public Task IncomingCall(IncomingCallEvent evt) => Task.CompletedTask;
+			public Task CallAnswered(CallAnsweredEvent evt) => Task.CompletedTask;
+			public Task CallRejected(CallIdEvent evt) => Task.CompletedTask;
+			public Task CallHungUp(CallIdEvent evt) => Task.CompletedTask;
+			public Task IceCandidate(IceCandidateEvent evt) => Task.CompletedTask;
 		}
 
 		private sealed class Client(RecordingSignalingHub owner, string userId) : ISignalingClient

--- a/services/chat/tests/Chat.UnitTests/Presentation/CallRegistryTests.cs
+++ b/services/chat/tests/Chat.UnitTests/Presentation/CallRegistryTests.cs
@@ -1,0 +1,185 @@
+using Chat.Presentation.Hubs;
+using Chat.Presentation.Hubs.Signaling;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Chat.UnitTests.Presentation;
+
+public sealed class CallRegistryTests
+{
+	private const long Caller = 1;
+	private const long Callee = 2;
+	private const long Third = 3;
+	private const long CallId = 900;
+
+	private static CallInfo Offer(long callId = CallId, long caller = Caller, long callee = Callee) =>
+		new(callId, caller, callee, "video", "sdp-offer");
+
+	private static (CallRegistry Registry, RecordingSignalingHub Hub) NewRegistry(int timeoutSeconds = 3600)
+	{
+		var hub = new RecordingSignalingHub();
+		var opts = Options.Create(new SignalingOptions { AnswerTimeoutSeconds = timeoutSeconds });
+		return (new CallRegistry(hub, opts), hub);
+	}
+
+	[Fact]
+	public void TryOffer_Succeeds_ThenSecondOfferToBusyParticipant_Fails()
+	{
+		var (registry, _) = NewRegistry();
+		Assert.True(registry.TryOffer(Offer()));
+
+		// another call where the callee is already busy
+		Assert.False(registry.TryOffer(new CallInfo(901, Third, Callee, "audio", "x")));
+		// caller already busy
+		Assert.False(registry.TryOffer(new CallInfo(902, Caller, Third, "audio", "x")));
+	}
+
+	[Fact]
+	public void Answer_ByCallee_ReturnsCall_NonCalleeOrUnknown_ReturnsNull()
+	{
+		var (registry, _) = NewRegistry();
+		registry.TryOffer(Offer());
+
+		Assert.Null(registry.Answer(CallId, Third));       // not the callee
+		Assert.Null(registry.Answer(999, Callee));          // unknown call
+		var answered = registry.Answer(CallId, Callee);
+		Assert.NotNull(answered);
+		Assert.Equal(Caller, answered!.CallerId);
+		Assert.Null(registry.Answer(CallId, Callee));       // already answered
+	}
+
+	[Fact]
+	public void End_ByParticipant_ClearsState_AndFreesBothUsers()
+	{
+		var (registry, _) = NewRegistry();
+		registry.TryOffer(Offer());
+
+		Assert.Null(registry.End(CallId, Third));           // not a participant
+		var ended = registry.End(CallId, Callee);           // callee rejects
+		Assert.NotNull(ended);
+
+		// both users are free to start new calls again
+		Assert.True(registry.TryOffer(new CallInfo(903, Caller, Third, "audio", "x")));
+		Assert.True(registry.TryOffer(new CallInfo(904, Callee, 4, "audio", "x")));
+	}
+
+	[Fact]
+	public void ForParticipant_ReturnsCall_OnlyForParticipants()
+	{
+		var (registry, _) = NewRegistry();
+		registry.TryOffer(Offer());
+
+		Assert.NotNull(registry.ForParticipant(CallId, Caller));
+		Assert.NotNull(registry.ForParticipant(CallId, Callee));
+		Assert.Null(registry.ForParticipant(CallId, Third));
+	}
+
+	[Fact]
+	public void Presence_IsRefCounted()
+	{
+		var (registry, _) = NewRegistry();
+		Assert.False(registry.IsConnected(Callee));
+
+		registry.Connect(Callee);
+		registry.Connect(Callee);
+		Assert.True(registry.IsConnected(Callee));
+
+		registry.Disconnect(Callee);
+		Assert.True(registry.IsConnected(Callee));   // still one connection open
+		registry.Disconnect(Callee);
+		Assert.False(registry.IsConnected(Callee));
+	}
+
+	[Fact]
+	public void PendingFor_ReturnsRingingCalls_ForCallee_UntilResolved()
+	{
+		var (registry, _) = NewRegistry();
+		registry.TryOffer(Offer());
+
+		Assert.Equal(CallId, Assert.Single(registry.PendingFor(Callee)).CallId);
+		Assert.Empty(registry.PendingFor(Caller));   // caller is not a callee
+
+		registry.Answer(CallId, Callee);
+		Assert.Empty(registry.PendingFor(Callee));   // answered calls are no longer pending
+	}
+
+	[Fact]
+	public async Task Timeout_Fires_CallFailed_ToCaller_WhenUnanswered()
+	{
+		var (registry, hub) = NewRegistry(timeoutSeconds: 1);
+		registry.TryOffer(Offer());
+
+		var failed = await hub.WaitForCallFailedAsync(TimeSpan.FromSeconds(4));
+
+		Assert.NotNull(failed);
+		Assert.Equal(Caller.ToString(), failed!.Value.UserId);
+		Assert.Equal(CallId.ToString(), failed.Value.Evt.CallId);
+		Assert.Equal("timeout", failed.Value.Evt.Reason);
+		// state cleared: the caller can offer again
+		Assert.True(registry.TryOffer(new CallInfo(905, Caller, Third, "audio", "x")));
+	}
+
+	[Fact]
+	public async Task Timeout_DoesNotFire_AfterAnswer()
+	{
+		var (registry, hub) = NewRegistry(timeoutSeconds: 1);
+		registry.TryOffer(Offer());
+		registry.Answer(CallId, Callee);
+
+		var failed = await hub.WaitForCallFailedAsync(TimeSpan.FromSeconds(2));
+		Assert.Null(failed);
+	}
+
+	// records CallFailed sends; every other member is unused by the registry.
+	private sealed class RecordingSignalingHub : IHubContext<SignalingHub, ISignalingClient>
+	{
+		private readonly List<(string UserId, CallFailedEvent Evt)> _sent = [];
+		private readonly Lock _lock = new();
+
+		public IHubClients<ISignalingClient> Clients => new Hubs(this);
+		public IGroupManager Groups => throw new NotSupportedException();
+
+		public async Task<(string UserId, CallFailedEvent Evt)?> WaitForCallFailedAsync(TimeSpan within)
+		{
+			var deadline = DateTime.UtcNow + within;
+			while (DateTime.UtcNow < deadline)
+			{
+				lock (_lock)
+					if (_sent.Count > 0)
+						return _sent[0];
+				await Task.Delay(25);
+			}
+			return null;
+		}
+
+		private void Record(string userId, CallFailedEvent evt)
+		{
+			lock (_lock)
+				_sent.Add((userId, evt));
+		}
+
+		private sealed class Hubs(RecordingSignalingHub owner) : IHubClients<ISignalingClient>
+		{
+			public ISignalingClient User(string userId) => new Client(owner, userId);
+			public ISignalingClient All => throw new NotSupportedException();
+			public ISignalingClient AllExcept(IReadOnlyList<string> e) => throw new NotSupportedException();
+			public ISignalingClient Client(string connectionId) => throw new NotSupportedException();
+			public ISignalingClient Clients(IReadOnlyList<string> c) => throw new NotSupportedException();
+			public ISignalingClient Group(string g) => throw new NotSupportedException();
+			public ISignalingClient GroupExcept(string g, IReadOnlyList<string> e) => throw new NotSupportedException();
+			public ISignalingClient Groups(IReadOnlyList<string> g) => throw new NotSupportedException();
+			public ISignalingClient Users(IReadOnlyList<string> u) => throw new NotSupportedException();
+		}
+
+		private sealed class Client(RecordingSignalingHub owner, string userId) : ISignalingClient
+		{
+			public Task CallFailed(CallFailedEvent evt) { owner.Record(userId, evt); return Task.CompletedTask; }
+			public Task IncomingCall(IncomingCallEvent evt) => Task.CompletedTask;
+			public Task CallAnswered(CallAnsweredEvent evt) => Task.CompletedTask;
+			public Task CallRejected(CallIdEvent evt) => Task.CompletedTask;
+			public Task CallHungUp(CallIdEvent evt) => Task.CompletedTask;
+			public Task IceCandidate(IceCandidateEvent evt) => Task.CompletedTask;
+		}
+	}
+}

--- a/services/chat/tests/Chat.UnitTests/Presentation/CallRegistryTests.cs
+++ b/services/chat/tests/Chat.UnitTests/Presentation/CallRegistryTests.cs
@@ -37,6 +37,20 @@ public sealed class CallRegistryTests
 	}
 
 	[Fact]
+	public void TryOffer_RejectsDuplicateCallId()
+	{
+		var (registry, _) = NewRegistry();
+		Assert.True(registry.TryOffer(Offer())); // call 900: Caller -> Callee
+
+		// a free pair reusing the same (client-supplied) call_id must be rejected,
+		// not overwrite the live call and strand its participants
+		Assert.False(registry.TryOffer(new CallInfo(CallId, Third, 4, "audio", "x")));
+
+		// the original call is intact: its real caller can still end it
+		Assert.NotNull(registry.End(CallId, Caller));
+	}
+
+	[Fact]
 	public void Answer_ByCallee_ReturnsCall_NonCalleeOrUnknown_ReturnsNull()
 	{
 		var (registry, _) = NewRegistry();
@@ -106,7 +120,7 @@ public sealed class CallRegistryTests
 	}
 
 	[Fact]
-	public async Task Timeout_Fires_CallFailed_ToBothParties_WhenUnanswered()
+	public async Task Timeout_Fires_CallFailed_ToCaller_WhenUnanswered()
 	{
 		var (registry, hub) = NewRegistry(timeoutSeconds: 1);
 		registry.TryOffer(Offer());
@@ -114,11 +128,9 @@ public sealed class CallRegistryTests
 		var failed = await hub.WaitForCallFailedAsync(TimeSpan.FromSeconds(4));
 
 		Assert.NotNull(failed);
-		Assert.Equal("timeout", failed!.Value.Evt.Reason);
+		Assert.Equal(Caller.ToString(), failed!.Value.UserId); // caller only, per contract
 		Assert.Equal(CallId.ToString(), failed.Value.Evt.CallId);
-		var sent = hub.Snapshot();
-		Assert.Contains(sent, s => s.UserId == Caller.ToString() && s.Evt.Reason == "timeout");
-		Assert.Contains(sent, s => s.UserId == Callee.ToString() && s.Evt.Reason == "timeout");
+		Assert.Equal("timeout", failed.Value.Evt.Reason);
 		// state cleared: the caller can offer again
 		Assert.True(registry.TryOffer(new CallInfo(905, Caller, Third, "audio", "x")));
 	}
@@ -156,12 +168,6 @@ public sealed class CallRegistryTests
 			return null;
 		}
 
-		public IReadOnlyList<(string UserId, CallFailedEvent Evt)> Snapshot()
-		{
-			lock (_lock)
-				return [.. _sent];
-		}
-
 		private void Record(string userId, CallFailedEvent evt)
 		{
 			lock (_lock)
@@ -178,22 +184,7 @@ public sealed class CallRegistryTests
 			public ISignalingClient Group(string g) => throw new NotSupportedException();
 			public ISignalingClient GroupExcept(string g, IReadOnlyList<string> e) => throw new NotSupportedException();
 			public ISignalingClient Groups(IReadOnlyList<string> g) => throw new NotSupportedException();
-			public ISignalingClient Users(IReadOnlyList<string> u) => new MultiClient(owner, u);
-		}
-
-		private sealed class MultiClient(RecordingSignalingHub owner, IReadOnlyList<string> userIds) : ISignalingClient
-		{
-			public Task CallFailed(CallFailedEvent evt)
-			{
-				foreach (var id in userIds)
-					owner.Record(id, evt);
-				return Task.CompletedTask;
-			}
-			public Task IncomingCall(IncomingCallEvent evt) => Task.CompletedTask;
-			public Task CallAnswered(CallAnsweredEvent evt) => Task.CompletedTask;
-			public Task CallRejected(CallIdEvent evt) => Task.CompletedTask;
-			public Task CallHungUp(CallIdEvent evt) => Task.CompletedTask;
-			public Task IceCandidate(IceCandidateEvent evt) => Task.CompletedTask;
+			public ISignalingClient Users(IReadOnlyList<string> u) => throw new NotSupportedException();
 		}
 
 		private sealed class Client(RecordingSignalingHub owner, string userId) : ISignalingClient


### PR DESCRIPTION
Resolves #39 

## Summary

Implements the signaling half of 1-on-1 WebRTC voice/video: a dedicated SignalR hub that relays SDP offers/answers and ICE candidates between two peers, tracks call state, and hands off to the Notification path when the callee is offline. The Chat hub is the signaling server only; media stays peer-to-peer (STUN/TURN via coturn is peer-side, not touched here).

## What's included

- **`SignalingHub`** (`[Authorize]`, at `/v1/hubs/signaling`) with five client-invokable methods: `CallOffer`, `CallAnswer`, `CallReject`, `CallHangup`, `IceCandidate`. Peer-directed messages route via `Clients.User(...)`, keyed off the JWT `sub`.
- **Strongly-typed client contract** (`ISignalingClient`): `IncomingCall`, `CallAnswered`, `CallRejected`, `CallHungUp`, `CallFailed`, `IceCandidate`. All DTOs serialize snowflake ids as quoted strings and use snake_case on the wire.
- **`CallRegistry`** (singleton, in-memory, single-node): signaling-hub presence tracking, the one-active-call-per-user invariant (`user_busy` on violation), and the unanswered-call timeout.
- **Offline callee path:** if the callee is not connected to the signaling hub, the offer is published as `call.incoming` to RabbitMQ (for the Notification service) instead of relayed. On (re)connect, any still-ringing calls are delivered as `IncomingCall`.
- **Unanswered timeout:** configurable via `Signaling:AnswerTimeoutSeconds` (default 120s). On expiry, both caller and callee receive `CallFailed:timeout` so neither UI hangs.
- **Structured logging** at the hub and registry for each call-lifecycle step (offer relayed / published / busy, answered, rejected, hung up, timed out).

## Behavior notes

- **Single-node only.** Call and presence state is in-memory; this matches the P2P, single-instance scope. Horizontal scale would need a backplane, out of scope here.
- ICE candidates are relayed but not logged (high volume).

## Dependencies

- Pins `Microsoft.OpenApi` to `2.7.5` in the Chat presentation project to close advisory GHSA-v5pm-xwqc-g5wc (the 3.x line breaks the XML-comment source generator, so 2.7.5 is the compatible patched release). This mirrors the auth+guild fix already on main, scoped to chat.

## Testing

- **Unit** (`CallRegistryTests`, 8): busy rejection, answer validity, end/free, participant scoping, presence ref-counting, pending delivery, timeout fires and notifies both parties, timeout cancelled after answer.
- **Functional** (`SignalingHubTests`, 7): real `HubConnection`s exercising offer to incoming, answer, reject, hangup, ICE relay, `user_busy`, and offline to `call.incoming` published + delivered on connect.
- Full chat suite green: 79 unit + 17 architecture + 107 functional.

## How to test manually (browser harness)

There is a self-contained WebRTC test harness on the **`tmp/webrtc-test-harness`** branch (kept off this PR: it is test tooling, not product code). It registers throwaway users, connects to the signaling hub, and places a real 1-on-1 call between two browsers.

```
git switch tmp/webrtc-test-harness
make #or make dev, nginx serves the page from a read-only mount
```

Then, on two devices on the same network:

1. Open `https://<host>:1443/webrtc-test.html` (accept the self-signed cert once per device).
2. On each: **Register new user**, then **Connect**.
3. Copy one side's `me:` id into the other's `call` box and press **Call**; accept camera/mic.
4. Expect `pc state: connected` and remote video on both ends. Reject / hang up / unanswered-timeout paths are all exercisable from the same page.

Notes:
- Same-machine and same-LAN calls usually connect on STUN alone. For cross-NAT relay, append `?turnUser=<user>&turnPass=<pass>` (TURN creds are runtime-only, never committed).
- The harness lives at `services/chat/tools/webrtc-test/` with its own README on that branch.
