### PR TITLE
Feat(guild): OTEL instrumentation

### DIFF
--- a/docs/monitoring-metrics.md
+++ b/docs/monitoring-metrics.md
@@ -1,0 +1,103 @@
+# Monitoring: per-service metrics contract
+
+Contract for the per-service OpenTelemetry EPIC (#227). Six services, three
+languages, one Prometheus + Grafana stack (coming with #264). The shared dashboards
+query metrics **by name**, so consistency across languages is the whole point. This
+doc is the source of truth each service issue (#228-#233) implements against.
+Guild (#230) is the reference implementation; see
+`services/guild/src/Guild.Presentation/Program.cs`.
+
+## The invariant
+
+Every service MUST expose a Prometheus scrape endpoint:
+
+- **Path:** `GET /metrics`
+- **Port:** `8080` (the service's existing HTTP port)
+- **Format:** Prometheus text (`text/plain; version=0.0.4`)
+- **Auth:** none. `/metrics` is unauthenticated and internal-only: the API
+  Gateway forwards only `/api/{service}/vN/...`, so `/metrics` is reachable
+  solely over the internal network, exactly like `/healthz`.
+
+## Required metrics (the fleet RED baseline)
+
+The shared dashboards depend on one metric family, present in every service:
+
+| Concern | Metric (Prometheus name) | Notes |
+|---------|--------------------------|-------|
+| Latency + rate + errors | `http_server_request_duration_seconds` (histogram: `_bucket` / `_sum` / `_count`) | Rate = `rate(..._count[5m])`; errors filter on the status label; latency from the buckets |
+
+Required labels on that metric:
+
+- `http_request_method`
+- `http_route` (the route template, not the raw path, to keep cardinality bounded)
+- `http_response_status_code`
+
+Plus a `service` label identifying the source (see Prometheus config below).
+
+This name is not arbitrary: it is the OpenTelemetry HTTP semantic-convention
+metric `http.server.request.duration` (unit seconds), and every OTel Prometheus
+exporter applies the same OTel-to-Prometheus naming rules (dots to underscores,
+unit suffix, `_total`/`_bucket`). So .NET, Go, and Rust exporters all land on the
+identical Prometheus name without coordination. That determinism is why we route
+through OTel rather than six hand-rolled Prometheus clients.
+
+## Recommended (per-service, not cross-language)
+
+Language-specific runtime metrics are encouraged for per-service panels but are
+NOT part of the cross-language contract (their names differ by runtime):
+
+- .NET: `AddRuntimeInstrumentation()` (GC, threadpool, exceptions)
+- Go: the Go collector (goroutines, GC, heap (vive la stack))
+- Rust: process/runtime metrics as available
+
+## Per-language implementation
+
+| Service(s) | Language | Libraries |
+|------------|----------|-----------|
+| Auth, Guild, Chat | .NET | `OpenTelemetry.Extensions.Hosting`, `OpenTelemetry.Instrumentation.AspNetCore`, `OpenTelemetry.Instrumentation.Runtime`, `OpenTelemetry.Exporter.Prometheus.AspNetCore` |
+| Gateway, Notification | Go | `go.opentelemetry.io/otel` SDK, `otelhttp` middleware, `go.opentelemetry.io/otel/exporters/prometheus` |
+| User | Rust | `opentelemetry` + `opentelemetry-prometheus`. Rust OTel metrics is the least mature link; if it misbehaves, a native Prometheus client (e.g. `metrics-exporter-prometheus`) is acceptable **provided it emits the same metric name and labels above**. The contract is the names, not the tool. |
+
+### .NET reference (Guild)
+
+```csharp
+builder.Services.AddOpenTelemetry()
+    .ConfigureResource(r => r.AddService("guild"))
+    .WithMetrics(m => m
+        .AddAspNetCoreInstrumentation()
+        .AddRuntimeInstrumentation()
+        .AddPrometheusExporter());
+
+// ... after Build():
+app.MapPrometheusScrapingEndpoint(); // GET /metrics, anonymous
+```
+
+`ConfigureResource(... AddService("<name>"))` sets `service.name`, which the
+exporter surfaces as a `target_info` metric. Prefer the `service` scrape label
+below for dashboard queries; keep the resource name for provenance.
+
+## Prometheus scrape config (#264)
+
+`infra/prometheus/prometheus.yml` already carries the target job, commented out
+until instrumentation lands, with a per-service `service` label to match the
+`healthz` job convention:
+
+```yaml
+  - job_name: services
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["guild:8080"]
+        labels: { service: guild }
+      # ... one entry per service as each lands
+```
+
+As each service ships its `/metrics`, uncomment its target (and add the
+`service` label). Leaving a target enabled before its endpoint exists makes it
+sit permanently `DOWN`.
+
+## Checklist per service
+
+- [ ] `/metrics` on `:8080`, Prometheus text, unauthenticated
+- [ ] emits `http_server_request_duration_seconds` with method / route / status labels
+- [ ] functional test: `/metrics` is 200 without a token and exposes the RED metric
+- [ ] add the `service`-labelled target to `prometheus.yml` (coordinate with #264)

--- a/docs/monitoring-metrics.md
+++ b/docs/monitoring-metrics.md
@@ -50,6 +50,18 @@ NOT part of the cross-language contract (their names differ by runtime):
 - Go: the Go collector (goroutines, GC, heap (vive la stack))
 - Rust: process/runtime metrics as available
 
+Services may also expose **domain (business) gauges** via a custom `Meter`, again
+per-service and not part of the cross-language contract. Guild does this with a
+`Guild.Domain` meter and a background collector: `guild_guilds`, `guild_members`,
+`guild_channels`, `guild_roles`, `guild_invites_active`, `guild_bans`. The counts
+are polled off the scrape path (an `IHostedService` every ~20s writes a snapshot;
+the observable gauges just read it), so a scrape never triggers a DB query. Keep
+these low-cardinality: totals only, never a per-entity id label.
+
+Note: the `MassTransit` meter does **not** work on MassTransit 8.x (its metrics
+are the legacy prometheus-net package, not the `Meter` API); event-side counters,
+if wanted, need a custom meter.
+
 ## Per-language implementation
 
 | Service(s) | Language | Libraries |

--- a/services/guild/src/Guild.Presentation/Guild.Presentation.csproj
+++ b/services/guild/src/Guild.Presentation/Guild.Presentation.csproj
@@ -16,6 +16,10 @@
              must stay on 2.x: AspNetCore.OpenApi 10.x targets Microsoft.OpenApi 2.x, and 3.x
              makes IOpenApiMediaType.Example read-only, breaking its source generator. -->
         <PackageReference Include="Microsoft.OpenApi" Version="2.7.5" />
+        <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.16.0-beta.1" />
+        <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.16.0" />
+        <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.16.0" />
+        <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
         <PackageReference Include="Scalar.AspNetCore" Version="2.16.7" />
         <!-- Needed by dotnet-ef for migrations generation -->
         <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.9">

--- a/services/guild/src/Guild.Presentation/Observability/GuildMetrics.cs
+++ b/services/guild/src/Guild.Presentation/Observability/GuildMetrics.cs
@@ -1,0 +1,40 @@
+using System.Diagnostics.Metrics;
+
+namespace Guild.Presentation.Observability;
+
+/// <summary>
+/// domain gauges for Guild (guild/member/channel/role/invite/ban totals). the
+/// values are refreshed off the scrape path by <see cref="GuildMetricsCollector"/>;
+/// the observable gauges just read the last cached snapshot, so a Prometheus
+/// scrape never triggers a database query.
+/// </summary>
+public sealed class GuildMetrics : IDisposable
+{
+	public const string MeterName = "Guild.Domain";
+
+	private readonly Meter _meter;
+	private long _guilds, _members, _channels, _roles, _activeInvites, _bans;
+
+	public GuildMetrics(IMeterFactory factory)
+	{
+		_meter = factory.Create(MeterName);
+		_meter.CreateObservableGauge("guild.guilds", () => Volatile.Read(ref _guilds), description: "Guilds");
+		_meter.CreateObservableGauge("guild.members", () => Volatile.Read(ref _members), description: "Guild memberships");
+		_meter.CreateObservableGauge("guild.channels", () => Volatile.Read(ref _channels), description: "Channels");
+		_meter.CreateObservableGauge("guild.roles", () => Volatile.Read(ref _roles), description: "Roles");
+		_meter.CreateObservableGauge("guild.invites.active", () => Volatile.Read(ref _activeInvites), description: "Invites that are not revoked, expired, or used up");
+		_meter.CreateObservableGauge("guild.bans", () => Volatile.Read(ref _bans), description: "Active bans");
+	}
+
+	public void Update(long guilds, long members, long channels, long roles, long activeInvites, long bans)
+	{
+		Volatile.Write(ref _guilds, guilds);
+		Volatile.Write(ref _members, members);
+		Volatile.Write(ref _channels, channels);
+		Volatile.Write(ref _roles, roles);
+		Volatile.Write(ref _activeInvites, activeInvites);
+		Volatile.Write(ref _bans, bans);
+	}
+
+	public void Dispose() => _meter.Dispose();
+}

--- a/services/guild/src/Guild.Presentation/Observability/GuildMetricsCollector.cs
+++ b/services/guild/src/Guild.Presentation/Observability/GuildMetricsCollector.cs
@@ -1,0 +1,54 @@
+using Guild.Persistence.Db;
+using Microsoft.EntityFrameworkCore;
+
+namespace Guild.Presentation.Observability;
+
+/// <summary>
+/// periodically counts the domain tables and pushes the snapshot into
+/// <see cref="GuildMetrics"/>. runs off the request/scrape path so the count
+/// queries never block a Prometheus scrape; gauges lag reality by at most one
+/// interval, which is fine for business trends.
+/// </summary>
+public sealed class GuildMetricsCollector(
+	IServiceScopeFactory scopeFactory,
+	GuildMetrics metrics,
+	ILogger<GuildMetricsCollector> logger) : BackgroundService
+{
+	private static readonly TimeSpan Interval = TimeSpan.FromSeconds(20);
+
+	protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+	{
+		using var timer = new PeriodicTimer(Interval);
+		do
+		{
+			try
+			{
+				await CollectAsync(stoppingToken);
+			}
+			catch (Exception ex) when (!stoppingToken.IsCancellationRequested)
+			{
+				logger.LogWarning(ex, "guild metrics collection failed; keeping the previous snapshot");
+			}
+		}
+		while (await timer.WaitForNextTickAsync(stoppingToken));
+	}
+
+	private async Task CollectAsync(CancellationToken ct)
+	{
+		using var scope = scopeFactory.CreateScope();
+		var db = scope.ServiceProvider.GetRequiredService<GuildDbContext>();
+		var now = DateTimeOffset.UtcNow;
+
+		var guilds = await db.Guilds.CountAsync(ct);
+		var members = await db.Members.CountAsync(ct);
+		var channels = await db.Channels.CountAsync(ct);
+		var roles = await db.Roles.CountAsync(ct);
+		var bans = await db.GuildBans.CountAsync(ct);
+		var activeInvites = await db.GuildInvites.CountAsync(
+			i => !i.IsRevoked
+				&& (i.ExpiresAt == null || i.ExpiresAt > now)
+				&& (i.MaxUses == null || i.Uses < i.MaxUses), ct);
+
+		metrics.Update(guilds, members, channels, roles, activeInvites, bans);
+	}
+}

--- a/services/guild/src/Guild.Presentation/Program.cs
+++ b/services/guild/src/Guild.Presentation/Program.cs
@@ -9,6 +9,8 @@ using Guild.Presentation.Endpoints;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.IdentityModel.Tokens;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
 using Scalar.AspNetCore;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -21,6 +23,16 @@ builder.Services.ConfigureHttpJsonOptions(o =>
 builder.Services.AddOpenApi();
 builder.Services.AddHealthChecks()
 	.AddPersistenceHealthChecks();
+
+// metrics for Prometheus to scrape at /metrics. AspNetCore instrumentation emits
+// the semconv http.server.* RED metrics shared across the fleet; Runtime adds
+// GC/threadpool gauges. see docs/monitoring-metrics.md for the cross-service contract.
+builder.Services.AddOpenTelemetry()
+	.ConfigureResource(r => r.AddService("guild"))
+	.WithMetrics(m => m
+		.AddAspNetCoreInstrumentation()
+		.AddRuntimeInstrumentation()
+		.AddPrometheusExporter());
 
 builder.Services.AddApplication()
 	.AddInfrastructure<GuildDbContext>()
@@ -131,6 +143,11 @@ app.MapHealthChecks("/healthz", new HealthCheckOptions
 		}));
 	},
 });
+
+// Prometheus scrape endpoint (GET /metrics). anonymous + internal-only: the
+// gateway only forwards /api/{service}/vN/..., so /metrics is reachable solely
+// over the docker network, like /healthz.
+app.MapPrometheusScrapingEndpoint();
 
 var v1 = app.MapGroup("/v1").RequireAuthorization();
 v1.MapCarter();

--- a/services/guild/src/Guild.Presentation/Program.cs
+++ b/services/guild/src/Guild.Presentation/Program.cs
@@ -9,6 +9,7 @@ using Guild.Presentation.Endpoints;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.IdentityModel.Tokens;
+using Guild.Presentation.Observability;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
 using Scalar.AspNetCore;
@@ -26,12 +27,16 @@ builder.Services.AddHealthChecks()
 
 // metrics for Prometheus to scrape at /metrics. AspNetCore instrumentation emits
 // the semconv http.server.* RED metrics shared across the fleet; Runtime adds
-// GC/threadpool gauges. see docs/monitoring-metrics.md for the cross-service contract.
+// GC/threadpool gauges; the Guild.Domain meter adds business gauges (guild/member/
+// channel/role/invite/ban totals). see docs/monitoring-metrics.md for the contract.
+builder.Services.AddSingleton<GuildMetrics>();
+builder.Services.AddHostedService<GuildMetricsCollector>();
 builder.Services.AddOpenTelemetry()
 	.ConfigureResource(r => r.AddService("guild"))
 	.WithMetrics(m => m
 		.AddAspNetCoreInstrumentation()
 		.AddRuntimeInstrumentation()
+		.AddMeter(GuildMetrics.MeterName)
 		.AddPrometheusExporter());
 
 builder.Services.AddApplication()

--- a/services/guild/tests/Guild.FunctionalTests/Endpoints/MetricsEndpointTests.cs
+++ b/services/guild/tests/Guild.FunctionalTests/Endpoints/MetricsEndpointTests.cs
@@ -1,0 +1,34 @@
+using System.Net;
+using Guild.FunctionalTests.Infrastructure;
+using Xunit;
+
+namespace Guild.FunctionalTests.Endpoints;
+
+public sealed class MetricsEndpointTests(GuildApiFactory factory) : IClassFixture<GuildApiFactory>
+{
+	// /metrics is scraped by Prometheus over the docker network and must not sit
+	// behind the JWT wall, mirroring /healthz.
+	[Fact]
+	public async Task Metrics_Is_Anonymous_And_PrometheusText()
+	{
+		var client = factory.CreateClient();
+
+		var resp = await client.GetAsync("/metrics");
+
+		Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+		Assert.Equal("text/plain", resp.Content.Headers.ContentType?.MediaType);
+	}
+
+	[Fact]
+	public async Task Metrics_Expose_HttpServer_RedMetric_AfterTraffic()
+	{
+		var client = factory.CreateClient();
+		// one completed request so the http.server request-duration histogram exists
+		await client.GetAsync("/healthz");
+
+		var body = await (await client.GetAsync("/metrics")).Content.ReadAsStringAsync();
+
+		Assert.Contains("# TYPE", body);
+		Assert.Contains("http_server_request_duration_seconds", body);
+	}
+}

--- a/services/guild/tests/Guild.FunctionalTests/Endpoints/MetricsEndpointTests.cs
+++ b/services/guild/tests/Guild.FunctionalTests/Endpoints/MetricsEndpointTests.cs
@@ -31,4 +31,17 @@ public sealed class MetricsEndpointTests(GuildApiFactory factory) : IClassFixtur
 		Assert.Contains("# TYPE", body);
 		Assert.Contains("http_server_request_duration_seconds", body);
 	}
+
+	[Fact]
+	public async Task Metrics_Expose_Domain_Business_Gauges()
+	{
+		var client = factory.CreateClient();
+
+		var body = await (await client.GetAsync("/metrics")).Content.ReadAsStringAsync();
+
+		// observable gauges fire on scrape, so they surface regardless of collector timing
+		Assert.Contains("guild_guilds", body);
+		Assert.Contains("guild_members", body);
+		Assert.Contains("guild_invites_active", body);
+	}
 }


### PR DESCRIPTION
Resolves #230

## Summary

Instruments the Guild Service with OpenTelemetry metrics, exposed as a Prometheus scrape endpoint at `GET /metrics` (`:8080`, unauthenticated, internal-only, mirroring `/healthz`). This is the reference implementation for the per-service OTel epic (#227), so it also lands the cross-service metrics contract the other five services (#228, #229, #231, #232, #233) implement against.

## Approach: Prometheus scrape, not OTLP push

The issue says "via OTLP", but #264's `prometheus.yml` actually **scrapes** each service at `/metrics`. Scrape is also the one model all three backend languages support natively (.NET / Go / Rust), which matters for a polyglot fleet feeding shared Grafana dashboards (because someone lost their mind designing this :p). So: OTel SDK for instrumentation, Prometheus exporter for transport. Rationale is written up in `docs/monitoring-metrics.md`.

## What's included

- **RED baseline** (the cross-service contract): `http_server_request_duration_seconds` with `http_request_method` / `http_route` / `http_response_status_code` labels, via `AddAspNetCoreInstrumentation()`.
- **Runtime metrics**: `AddRuntimeInstrumentation()` (`dotnet_gc_*`, exceptions, threadpool).
- **Domain business gauges** (`Guild.Domain` meter): `guild_guilds`, `guild_members`, `guild_channels`, `guild_roles`, `guild_invites_active`, `guild_bans`. Fed by a background `IHostedService` that polls counts every ~20s and writes a snapshot; the observable gauges read the cached snapshot, so a Prometheus scrape never triggers a DB query. Low cardinality by design (totals only, no per-entity labels).
- **`docs/monitoring-metrics.md`**: the fleet contract (endpoint, required metric names + labels, per-language implementation table, Prometheus config expectations, per-service checklist).

## Notes

- **MassTransit meter is a dead end on 8.x.** `.AddMeter("MassTransit")` exports nothing (verified after a real `guild.deleted` publish); MT 8's OTel surface is tracing only, its metrics are the legacy prometheus-net package. Event-side counters, if wanted later, need a custom meter. Documented in the contract doc.
- **`prometheus.yml` untouched** - it lives in #264 (not yet on main). Its commented `guild:8080` target (with a `service: guild` label) gets uncommented once both merge; noted in the doc.

## Testing

- Unit 451, architecture 12, functional 266 - all green (functional includes 3 new tests: `/metrics` is anonymous + Prometheus text, exposes the RED metric after traffic, and exposes the domain gauges).
- Verified at runtime against the live container: RED + runtime + gauges all present, and `guild_guilds` tracked a create (6 -> 7) after one poll interval.