### PR TITLE
Feat(chat): OTEL instrumentation

### DIFF
--- a/services/chat/src/Chat.Presentation/Chat.Presentation.csproj
+++ b/services/chat/src/Chat.Presentation/Chat.Presentation.csproj
@@ -25,6 +25,10 @@
         <PackageReference Include="Microsoft.OpenApi" Version="2.7.5"/>
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3"/>
         <PackageReference Include="Scalar.AspNetCore" Version="2.6.0"/>
+        <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.16.0"/>
+        <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.16.0"/>
+        <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1"/>
+        <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.16.0-beta.1"/>
     </ItemGroup>
 
 </Project>

--- a/services/chat/src/Chat.Presentation/Hubs/CallRegistry.cs
+++ b/services/chat/src/Chat.Presentation/Hubs/CallRegistry.cs
@@ -56,6 +56,21 @@ public sealed class CallRegistry(
 			return _connected.ContainsKey(userId);
 	}
 
+	// point-in-time counts for metrics, taken under a single lock: total calls
+	// tracked, of which ringing (unanswered), and users connected to the
+	// signaling hub.
+	public (int Active, int Ringing, int SignalingUsers) CountsSnapshot()
+	{
+		lock (_gate)
+		{
+			var ringing = 0;
+			foreach (var entry in _byCall.Values)
+				if (entry.Ringing)
+					ringing++;
+			return (_byCall.Count, ringing, _connected.Count);
+		}
+	}
+
 	// ringing calls where the user is the callee, delivered as IncomingCall when
 	// they (re)connect to the signaling hub.
 	public IReadOnlyList<CallInfo> PendingFor(long calleeId)

--- a/services/chat/src/Chat.Presentation/Hubs/UserConnectionTracker.cs
+++ b/services/chat/src/Chat.Presentation/Hubs/UserConnectionTracker.cs
@@ -23,6 +23,12 @@ public sealed class UserConnectionTracker
 
 	private readonly ConcurrentDictionary<long, UserState> _users = new();
 
+	// number of users with at least one open connection (presence gauge). a user
+	// is only kept in _users while it holds a connection, so this is the online
+	// count. ConcurrentDictionary.Count briefly takes the map's internal locks,
+	// which is fine for an infrequent scrape.
+	public int OnlineUserCount => _users.Count;
+
 	// returns true if this is the user's first connection.
 	public bool TrackConnected(long userId, string connectionId)
 	{

--- a/services/chat/src/Chat.Presentation/Observability/ChatMetrics.cs
+++ b/services/chat/src/Chat.Presentation/Observability/ChatMetrics.cs
@@ -1,0 +1,28 @@
+using System.Diagnostics.Metrics;
+using Chat.Presentation.Hubs;
+
+namespace Chat.Presentation.Observability;
+
+/// <summary>
+/// real-time operational gauges for Chat. unlike Guild's DB-backed gauges these
+/// read live in-memory state (SignalR presence, the call registry), so the
+/// observable callbacks are cheap and run directly on the scrape path - no
+/// background collector needed.
+/// </summary>
+public sealed class ChatMetrics : IDisposable
+{
+	public const string MeterName = "Chat.Domain";
+
+	private readonly Meter _meter;
+
+	public ChatMetrics(IMeterFactory factory, UserConnectionTracker connections, CallRegistry calls)
+	{
+		_meter = factory.Create(MeterName);
+		_meter.CreateObservableGauge("chat.hub.connected_users", () => connections.OnlineUserCount, description: "Users with an open chat-hub connection");
+		_meter.CreateObservableGauge("chat.signaling.connected_users", () => calls.CountsSnapshot().SignalingUsers, description: "Users connected to the signaling hub");
+		_meter.CreateObservableGauge("chat.calls.active", () => calls.CountsSnapshot().Active, description: "Calls currently tracked (ringing or in progress)");
+		_meter.CreateObservableGauge("chat.calls.ringing", () => calls.CountsSnapshot().Ringing, description: "Calls ringing (unanswered)");
+	}
+
+	public void Dispose() => _meter.Dispose();
+}

--- a/services/chat/src/Chat.Presentation/Program.cs
+++ b/services/chat/src/Chat.Presentation/Program.cs
@@ -7,10 +7,13 @@ using Chat.Infrastructure;
 using Chat.Persistence;
 using Chat.Presentation.Hubs;
 using Chat.Presentation.Hubs.Signaling;
+using Chat.Presentation.Observability;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.IdentityModel.Tokens;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
 using Scalar.AspNetCore;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -30,6 +33,19 @@ builder.Services.AddApplication()
 builder.Services.AddSingleton<UserConnectionTracker>();
 builder.Services.AddSingleton<CallRegistry>();
 builder.Services.Configure<SignalingOptions>(builder.Configuration.GetSection(SignalingOptions.SectionName));
+
+// metrics for Prometheus to scrape at /metrics. AspNetCore emits the semconv
+// http.server.* RED metrics shared across the fleet; Runtime adds GC/threadpool
+// gauges; the Chat.Domain meter adds real-time gauges (hub presence, live calls)
+// read straight off in-memory state. see docs/monitoring-metrics.md.
+builder.Services.AddSingleton<ChatMetrics>();
+builder.Services.AddOpenTelemetry()
+	.ConfigureResource(r => r.AddService("chat"))
+	.WithMetrics(m => m
+		.AddAspNetCoreInstrumentation()
+		.AddRuntimeInstrumentation()
+		.AddMeter(ChatMetrics.MeterName)
+		.AddPrometheusExporter());
 builder.Services.AddScoped<IChannelBroadcaster, SignalRChannelBroadcaster>();
 builder.Services.AddScoped<IUserBroadcaster, SignalRUserBroadcaster>();
 builder.Services.AddCarter();
@@ -68,6 +84,10 @@ builder.Services.AddAuthorization();
 
 var app = builder.Build();
 
+// force ChatMetrics construction so its observable gauges register; nothing else
+// resolves it (Guild pulls its metrics in via a hosted collector, Chat has none).
+_ = app.Services.GetRequiredService<ChatMetrics>();
+
 if (app.Environment.IsDevelopment())
 {
 	app.MapOpenApi();
@@ -94,6 +114,9 @@ app.MapHealthChecks("/healthz", new HealthCheckOptions
 		}));
 	},
 });
+// Prometheus scrape endpoint (GET /metrics), anonymous + internal-only like /healthz.
+app.MapPrometheusScrapingEndpoint();
+
 var v1 = app.MapGroup("/v1").RequireAuthorization();
 v1.MapCarter();
 app.MapHub<ChatHub>("/v1/hubs/chat");

--- a/services/chat/tests/Chat.FunctionalTests/Features/MetricsEndpointTests.cs
+++ b/services/chat/tests/Chat.FunctionalTests/Features/MetricsEndpointTests.cs
@@ -1,0 +1,59 @@
+using System.Net;
+using Chat.FunctionalTests.Infrastructure;
+using Xunit;
+
+namespace Chat.FunctionalTests.Features;
+
+public sealed class MetricsEndpointTests(ChatApiFactory factory) : IClassFixture<ChatApiFactory>
+{
+	// /metrics is scraped by Prometheus over the docker network and must not sit
+	// behind the JWT wall, mirroring /healthz.
+	[Fact]
+	public async Task Metrics_Is_Anonymous_And_PrometheusText()
+	{
+		var client = factory.CreateClient();
+
+		var resp = await client.GetAsync("/metrics");
+
+		Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+		Assert.Equal("text/plain", resp.Content.Headers.ContentType?.MediaType);
+	}
+
+	[Fact]
+	public async Task Metrics_Expose_HttpServer_RedMetric_AfterTraffic()
+	{
+		var client = factory.CreateClient();
+		// any completed request populates the http.server histogram; a 404 avoids
+		// /healthz (which probes Scylla and throws in the test host)
+		await client.GetAsync("/does-not-exist");
+
+		string body = "";
+		var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(3);
+		do
+		{
+			body = await (await client.GetAsync("/metrics")).Content.ReadAsStringAsync();
+			if (body.Contains("http_server_request_duration_seconds", StringComparison.Ordinal))
+				break;
+			await Task.Delay(50);
+		}
+		while (DateTime.UtcNow < deadline);
+
+		Assert.Contains("# TYPE", body);
+		Assert.Contains("http_server_request_duration_seconds", body);
+	}
+
+	// gauge existence is robust to the parallel multi-host OTel bleed; the count
+	// logic behind them is unit-tested deterministically in CallRegistryTests.
+	[Fact]
+	public async Task Metrics_Expose_Chat_Domain_Gauges()
+	{
+		var client = factory.CreateClient();
+
+		var body = await (await client.GetAsync("/metrics")).Content.ReadAsStringAsync();
+
+		Assert.Contains("chat_hub_connected_users", body);
+		Assert.Contains("chat_signaling_connected_users", body);
+		Assert.Contains("chat_calls_active", body);
+		Assert.Contains("chat_calls_ringing", body);
+	}
+}

--- a/services/chat/tests/Chat.UnitTests/Presentation/CallRegistryTests.cs
+++ b/services/chat/tests/Chat.UnitTests/Presentation/CallRegistryTests.cs
@@ -80,6 +80,29 @@ public sealed class CallRegistryTests
 	}
 
 	[Fact]
+	public void CountsSnapshot_Reflects_Connections_And_Calls()
+	{
+		var (registry, _) = NewRegistry();
+		Assert.Equal((0, 0, 0), registry.CountsSnapshot());
+
+		registry.Connect(Caller);
+		registry.Connect(Callee);
+		Assert.Equal((0, 0, 2), registry.CountsSnapshot());   // two signaling users, no calls
+
+		registry.TryOffer(Offer());
+		Assert.Equal((1, 1, 2), registry.CountsSnapshot());   // one ringing call
+
+		registry.Answer(CallId, Callee);
+		Assert.Equal((1, 0, 2), registry.CountsSnapshot());   // now in progress, not ringing
+
+		registry.End(CallId, Caller);
+		Assert.Equal((0, 0, 2), registry.CountsSnapshot());   // call cleared
+
+		registry.Disconnect(Caller);
+		Assert.Equal((0, 0, 1), registry.CountsSnapshot());   // one signaling user left
+	}
+
+	[Fact]
 	public void ForParticipant_ReturnsCall_OnlyForParticipants()
 	{
 		var (registry, _) = NewRegistry();


### PR DESCRIPTION
Resolves #231 

## Summary

Instruments the Chat Service with OpenTelemetry metrics, exposed as a Prometheus scrape endpoint at `GET /metrics` (`:8080`, unauthenticated, internal-only, mirroring `/healthz`). Follows the cross-service metrics contract established by #230 (`docs/monitoring-metrics.md`); scrape model, not OTLP push, to match `prometheus.yml` and stay consistent across the polyglot fleet.

## What's included

- **RED baseline** (the cross-service contract): `http_server_request_duration_seconds` with `http_request_method` / `http_route` / `http_response_status_code` labels, via `AddAspNetCoreInstrumentation()`.
- **Runtime metrics**: `AddRuntimeInstrumentation()` (`dotnet_gc_*`, exceptions, threadpool).
- **Real-time domain gauges** (`Chat.Domain` meter): `chat_hub_connected_users`, `chat_signaling_connected_users`, `chat_calls_active`, `chat_calls_ringing`.

## Design notes (how Chat differs from Guild #230)

- **No background collector.** Guild polls Postgres off-thread because ScyllaDB can't do cheap `COUNT(*)`. Chat's business state is in-memory (`UserConnectionTracker`, `CallRegistry`), so the observable gauges read it directly on scrape - always current, nothing to poll.
- **Force-instantiated the metrics singleton.** No hosted service pulls `ChatMetrics` in (Guild's collector did), so `Program.cs` does `_ = app.Services.GetRequiredService<ChatMetrics>()` after `Build()` to register the gauges.
- **MassTransit meter is a dead end on 8.x** (same finding as #230): `.AddMeter("MassTransit")` exports nothing, so it's not used.
- **`docs/monitoring-metrics.md` not duplicated here** - it lives in #230; this PR conforms to it.

## Testing

- Unit 80, architecture 17, functional 110 - all green.
- The count logic behind the gauges is unit-tested deterministically (`CallRegistry.CountsSnapshot`: connect/disconnect and offer/answer/end reflected in the snapshot).
- Functional metrics tests assert endpoint behavior + gauge **existence** only. Value assertions are intentionally avoided: OTel's metrics listener is process-global, so exact gauge values bleed across the multiple `WebApplicationFactory` hosts the suite runs in parallel.
- Verified at runtime against the live container: `/metrics` 200, RED + runtime + all four gauges present.
