### PR TITLE
Feat(auth): OTEL instrumentation

### DIFF
--- a/services/auth/src/Auth.Presentation/Auth.Presentation.csproj
+++ b/services/auth/src/Auth.Presentation/Auth.Presentation.csproj
@@ -15,6 +15,10 @@
              2.x API AspNetCore.OpenApi 10.x needs (3.x breaks its source generator). -->
         <PackageReference Include="Microsoft.OpenApi" Version="2.7.5" />
         <PackageReference Include="Scalar.AspNetCore" Version="2.16.7" />
+        <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.16.0" />
+        <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.16.0" />
+        <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.15.1" />
+        <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.16.0-beta.1" />
         <!-- Needed by dotnet-ef for migrations generation -->
         <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.9">
             <PrivateAssets>all</PrivateAssets>

--- a/services/auth/src/Auth.Presentation/Observability/AuthMetrics.cs
+++ b/services/auth/src/Auth.Presentation/Observability/AuthMetrics.cs
@@ -1,0 +1,34 @@
+using System.Diagnostics.Metrics;
+
+namespace Auth.Presentation.Observability;
+
+/// <summary>
+/// domain gauges for Auth (account and active-session totals). the values are
+/// refreshed off the scrape path by <see cref="AuthMetricsCollector"/>; the
+/// observable gauges just read the last cached snapshot, so a Prometheus scrape
+/// never triggers a database query.
+/// </summary>
+public sealed class AuthMetrics : IDisposable
+{
+	public const string MeterName = "Auth.Domain";
+
+	private readonly Meter _meter;
+	private long _accounts, _oauthAccounts, _activeSessions;
+
+	public AuthMetrics(IMeterFactory factory)
+	{
+		_meter = factory.Create(MeterName);
+		_meter.CreateObservableGauge("auth.accounts", () => Volatile.Read(ref _accounts), description: "Live accounts (not deleted)");
+		_meter.CreateObservableGauge("auth.accounts.oauth", () => Volatile.Read(ref _oauthAccounts), description: "Live accounts backed by an OAuth identity");
+		_meter.CreateObservableGauge("auth.sessions.active", () => Volatile.Read(ref _activeSessions), description: "Accounts with a valid, non-revoked refresh token");
+	}
+
+	public void Update(long accounts, long oauthAccounts, long activeSessions)
+	{
+		Volatile.Write(ref _accounts, accounts);
+		Volatile.Write(ref _oauthAccounts, oauthAccounts);
+		Volatile.Write(ref _activeSessions, activeSessions);
+	}
+
+	public void Dispose() => _meter.Dispose();
+}

--- a/services/auth/src/Auth.Presentation/Observability/AuthMetricsCollector.cs
+++ b/services/auth/src/Auth.Presentation/Observability/AuthMetricsCollector.cs
@@ -1,0 +1,53 @@
+using Auth.Persistence.Db;
+using Microsoft.EntityFrameworkCore;
+
+namespace Auth.Presentation.Observability;
+
+/// <summary>
+/// periodically counts the auth accounts and pushes the snapshot into
+/// <see cref="AuthMetrics"/>. runs off the request/scrape path so the count
+/// queries never block a Prometheus scrape; gauges lag reality by at most one
+/// interval, which is fine for business trends.
+/// </summary>
+public sealed class AuthMetricsCollector(
+	IServiceScopeFactory scopeFactory,
+	AuthMetrics metrics,
+	ILogger<AuthMetricsCollector> logger) : BackgroundService
+{
+	private static readonly TimeSpan Interval = TimeSpan.FromSeconds(20);
+
+	protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+	{
+		using var timer = new PeriodicTimer(Interval);
+		do
+		{
+			try
+			{
+				await CollectAsync(stoppingToken);
+			}
+			catch (Exception ex) when (!stoppingToken.IsCancellationRequested)
+			{
+				logger.LogWarning(ex, "auth metrics collection failed; keeping the previous snapshot");
+			}
+		}
+		while (await timer.WaitForNextTickAsync(stoppingToken));
+	}
+
+	private async Task CollectAsync(CancellationToken ct)
+	{
+		using var scope = scopeFactory.CreateScope();
+		var db = scope.ServiceProvider.GetRequiredService<AuthDbContext>();
+		var now = DateTimeOffset.UtcNow;
+
+		var accounts = await db.AuthUsers.CountAsync(u => u.DeletedAt == null, ct);
+		var oauthAccounts = await db.AuthUsers.CountAsync(
+			u => u.DeletedAt == null && u.OAuthIdentity != null, ct);
+		var activeSessions = await db.AuthUsers.CountAsync(
+			u => u.DeletedAt == null
+				&& u.RefreshToken != null
+				&& !u.RefreshToken.Revoked
+				&& u.RefreshToken.ExpiresAt > now, ct);
+
+		metrics.Update(accounts, oauthAccounts, activeSessions);
+	}
+}

--- a/services/auth/src/Auth.Presentation/Program.cs
+++ b/services/auth/src/Auth.Presentation/Program.cs
@@ -4,7 +4,10 @@ using Auth.Infrastructure;
 using Auth.Persistence;
 using Auth.Presentation.Middleware;
 using Auth.Presentation;
+using Auth.Presentation.Observability;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
 using Scalar.AspNetCore;
 using System.Text.Json;
 
@@ -23,6 +26,20 @@ builder.Services.AddApplication()
                 .AddInfrastructure()
                 .AddPersistence()
                 .AddJwtAuthentication();
+
+// metrics for Prometheus to scrape at /metrics. AspNetCore instrumentation emits
+// the semconv http.server.* RED metrics shared across the fleet; Runtime adds
+// GC/threadpool gauges; the Auth.Domain meter adds business gauges (accounts,
+// OAuth adoption, active sessions). see docs/monitoring-metrics.md.
+builder.Services.AddSingleton<AuthMetrics>();
+builder.Services.AddHostedService<AuthMetricsCollector>();
+builder.Services.AddOpenTelemetry()
+                .ConfigureResource(r => r.AddService("auth"))
+                .WithMetrics(m => m
+                    .AddAspNetCoreInstrumentation()
+                    .AddRuntimeInstrumentation()
+                    .AddMeter(AuthMetrics.MeterName)
+                    .AddPrometheusExporter());
 
 builder.Services.AddCarter();
 
@@ -59,6 +76,9 @@ app.MapHealthChecks("/healthz", new HealthCheckOptions
         }));
     },
 });
+// Prometheus scrape endpoint (GET /metrics), anonymous + internal-only like /healthz.
+app.MapPrometheusScrapingEndpoint();
+
 var v1 = app.MapGroup("/v1");
 v1.MapCarter();
 

--- a/services/auth/tests/Auth.FunctionalTests/Endpoints/MetricsEndpointTests.cs
+++ b/services/auth/tests/Auth.FunctionalTests/Endpoints/MetricsEndpointTests.cs
@@ -1,0 +1,56 @@
+using System.Net;
+using Auth.FunctionalTests.Infrastructure;
+using Xunit;
+
+namespace Auth.FunctionalTests.Endpoints;
+
+public sealed class MetricsEndpointTests(AuthApiFactory factory) : IClassFixture<AuthApiFactory>
+{
+    // /metrics is scraped by Prometheus over the docker network and must not sit
+    // behind auth, mirroring /healthz.
+    [Fact]
+    public async Task Metrics_Is_Anonymous_And_PrometheusText()
+    {
+        var client = factory.CreateClient();
+
+        var resp = await client.GetAsync("/metrics");
+
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        Assert.Equal("text/plain", resp.Content.Headers.ContentType?.MediaType);
+    }
+
+    [Fact]
+    public async Task Metrics_Expose_HttpServer_RedMetric_AfterTraffic()
+    {
+        var client = factory.CreateClient();
+        await client.GetAsync("/does-not-exist"); // any completed request populates the histogram
+
+        string body = "";
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(3);
+        do
+        {
+            body = await (await client.GetAsync("/metrics")).Content.ReadAsStringAsync();
+            if (body.Contains("http_server_request_duration_seconds", StringComparison.Ordinal))
+                break;
+            await Task.Delay(50);
+        }
+        while (DateTime.UtcNow < deadline);
+
+        Assert.Contains("# TYPE", body);
+        Assert.Contains("http_server_request_duration_seconds", body);
+    }
+
+    // existence only: exact gauge values bleed across the parallel multi-host OTel
+    // listener, so value assertions would flake. the counts are verified at runtime.
+    [Fact]
+    public async Task Metrics_Expose_Auth_Domain_Gauges()
+    {
+        var client = factory.CreateClient();
+
+        var body = await (await client.GetAsync("/metrics")).Content.ReadAsStringAsync();
+
+        Assert.Contains("auth_accounts", body);
+        Assert.Contains("auth_accounts_oauth", body);
+        Assert.Contains("auth_sessions_active", body);
+    }
+}


### PR DESCRIPTION
Resolves #228

## Summary

Instruments the Auth Service with OpenTelemetry metrics, exposed as a Prometheus scrape endpoint at `GET /metrics` (`:8080`, unauthenticated, internal-only, mirroring `/healthz`). Follows the cross-service metrics contract from #230 (`docs/monitoring-metrics.md`); scrape model, not OTLP push, to match `prometheus.yml`.

## What's included

- **RED baseline** (the cross-service contract): `http_server_request_duration_seconds` with `http_request_method` / `http_route` / `http_response_status_code` labels, via `AddAspNetCoreInstrumentation()`.
- **Runtime metrics**: `AddRuntimeInstrumentation()` (`dotnet_gc_*`, exceptions, threadpool).
- **Domain business gauges** (`Auth.Domain` meter, DB-backed collector - same pattern as Guild #230 since Auth is Postgres):
  - `auth_accounts` - live accounts (`deleted_at IS NULL`)
  - `auth_accounts_oauth` - accounts backed by an OAuth identity (OAuth-module adoption signal)
  - `auth_sessions_active` - accounts with a valid, non-revoked, non-expired refresh token = currently logged-in users

The gauges are fed by a background `IHostedService` that polls counts every ~20s and writes a snapshot; the observable gauges read the cached snapshot, so a scrape never triggers a DB query. Low cardinality by design (totals only, no per-account labels).

## Testing

- Unit 74, architecture 12, functional 49 - all green (functional includes `/metrics` is anonymous + Prometheus text, exposes the RED metric after traffic, and exposes the domain gauges).
- Functional tests assert gauge **existence** only; exact values bleed across the parallel multi-host OTel listener, so value assertions are avoided (same rationale as #231).
- Verified at runtime against the live container: `/metrics` 200, RED + runtime + all three gauges present with sensible values (24 accounts / 1 OAuth / 24 active sessions).
