### PR TITLE
Feat(chat): internal GDPR data-export endpoint

### DIFF
--- a/docs/contracts/chat.md
+++ b/docs/contracts/chat.md
@@ -507,6 +507,37 @@ Remove the caller's own reaction. Removing a reaction the caller did not place i
 
 ---
 
+## Internal Endpoints
+
+### GET /internal/users/{user_id}/data-export
+
+The user's Chat-owned data for a GDPR self-serve export: the messages they authored, in channels and DMs. Called by the User Service's public data-export aggregator, which fans out to every service and stitches the results.
+
+**Auth required:** None. Not reachable through the API Gateway: the gateway only forwards `/api/{service}/vN/...`, and `/internal/...` has no version segment. Callers reach this directly over the docker network (e.g. `http://chat:8080/internal/users/{user_id}/data-export`).
+
+**Response `200`:**
+```json
+{
+  "user_id": "123",
+  "channel_messages": [
+    { "channel_id": "77", "message_id": "9001", "content": "gg", "created_at": "2026-06-01T12:00:00Z", "edited_at": null }
+  ],
+  "direct_messages": [
+    { "conversation_id": "88", "partner_id": "456", "message_id": "9002", "content": "hey", "created_at": "2026-06-02T09:30:00Z", "edited_at": null }
+  ]
+}
+```
+
+**How it's queried.** Scylla partitions `messages` by `channel_id` and `direct_messages` by `conversation_id`, so "all messages by author" is not a direct query. Instead the export uses the per-user index tables to find the partitions the user touched, then filters each to the user's own rows:
+- `channel_read_states` (`PK ((user_id), channel_id)`) → for each channel, read `messages[channel_id]` where `author_id = user`.
+- `user_conversations` (`PK ((user_id), partner_id)`) → for each conversation, read `direct_messages[conversation_id]` where `sender_id = user`.
+
+These are bounded, partition-keyed reads (no cluster-wide scan). Soft-deleted messages (`is_deleted = true`) are excluded.
+
+**Scope.** Only the user's **own messages** - the crown-jewel GDPR data (Discord's export is likewise mostly your messages). Ids stay raw: Chat doesn't own channel or user names (Guild and User do), so the aggregator resolves them when stitching. Coverage of channel messages depends on the user having a `channel_read_states` cursor for the channel (created on activity); a user with no messages returns `200` with empty arrays.
+
+---
+
 ## SignalR Hub - `/hubs/chat`
 
 Connect with the access token:

--- a/services/chat/src/Chat.Application/Abstractions/Persistence/IDataExportRepository.cs
+++ b/services/chat/src/Chat.Application/Abstractions/Persistence/IDataExportRepository.cs
@@ -1,0 +1,31 @@
+namespace Chat.Application.Abstractions.Persistence;
+
+/// <summary>
+/// read-only access for the GDPR data export: the user's own messages. Scylla is
+/// partitioned by channel/conversation, not author, so we find the partitions the
+/// user touched via the per-user index tables (channel_read_states,
+/// user_conversations) and filter each to the user's own rows.
+/// </summary>
+public interface IDataExportRepository
+{
+	Task<ChatUserDataExport> GetUserDataExportAsync(long userId, CancellationToken ct);
+}
+
+public sealed record ChatUserDataExport(
+	IReadOnlyList<ExportedChannelMessage> ChannelMessages,
+	IReadOnlyList<ExportedDirectMessage> DirectMessages);
+
+public sealed record ExportedChannelMessage(
+	long ChannelId,
+	long MessageId,
+	string Content,
+	DateTimeOffset CreatedAt,
+	DateTimeOffset? EditedAt);
+
+public sealed record ExportedDirectMessage(
+	long ConversationId,
+	long PartnerId,
+	long MessageId,
+	string Content,
+	DateTimeOffset CreatedAt,
+	DateTimeOffset? EditedAt);

--- a/services/chat/src/Chat.Application/Features/Users/ExportUserData/ExportUserDataHandler.cs
+++ b/services/chat/src/Chat.Application/Features/Users/ExportUserData/ExportUserDataHandler.cs
@@ -1,0 +1,21 @@
+using Chat.Application.Abstractions.Messaging;
+using Chat.Application.Abstractions.Persistence;
+using Chat.Domain.Results;
+
+namespace Chat.Application.Features.Users.ExportUserData;
+
+internal sealed class ExportUserDataHandler(IDataExportRepository repository)
+	: IQueryHandler<ExportUserDataQuery, Result<UserDataExportResponse>>
+{
+	public async Task<Result<UserDataExportResponse>> HandleAsync(
+		ExportUserDataQuery query,
+		CancellationToken cancellationToken = default)
+	{
+		var data = await repository.GetUserDataExportAsync(query.UserId, cancellationToken);
+
+		return new UserDataExportResponse(
+			query.UserId.ToString(),
+			data.ChannelMessages.Select(ChannelMessageDto.From).ToList(),
+			data.DirectMessages.Select(DirectMessageDto.From).ToList());
+	}
+}

--- a/services/chat/src/Chat.Application/Features/Users/ExportUserData/ExportUserDataQuery.cs
+++ b/services/chat/src/Chat.Application/Features/Users/ExportUserData/ExportUserDataQuery.cs
@@ -1,0 +1,40 @@
+using Chat.Application.Abstractions.Messaging;
+using Chat.Application.Abstractions.Persistence;
+using Chat.Domain.Results;
+
+namespace Chat.Application.Features.Users.ExportUserData;
+
+public sealed record ExportUserDataQuery(long UserId) : IQuery<Result<UserDataExportResponse>>;
+
+/// <summary>
+/// the user's Chat-owned data for a GDPR export: the messages they authored, in
+/// channels and DMs. ids are raw - Chat doesn't own channel/user names (Guild and
+/// User do), so the User aggregator resolves them when stitching the bundle.
+/// </summary>
+public sealed record UserDataExportResponse(
+	string UserId,
+	IReadOnlyList<ChannelMessageDto> ChannelMessages,
+	IReadOnlyList<DirectMessageDto> DirectMessages);
+
+public sealed record ChannelMessageDto(
+	string ChannelId,
+	string MessageId,
+	string Content,
+	DateTimeOffset CreatedAt,
+	DateTimeOffset? EditedAt)
+{
+	public static ChannelMessageDto From(ExportedChannelMessage m) =>
+		new(m.ChannelId.ToString(), m.MessageId.ToString(), m.Content, m.CreatedAt, m.EditedAt);
+}
+
+public sealed record DirectMessageDto(
+	string ConversationId,
+	string PartnerId,
+	string MessageId,
+	string Content,
+	DateTimeOffset CreatedAt,
+	DateTimeOffset? EditedAt)
+{
+	public static DirectMessageDto From(ExportedDirectMessage m) =>
+		new(m.ConversationId.ToString(), m.PartnerId.ToString(), m.MessageId.ToString(), m.Content, m.CreatedAt, m.EditedAt);
+}

--- a/services/chat/src/Chat.Persistence/DependencyInjection.cs
+++ b/services/chat/src/Chat.Persistence/DependencyInjection.cs
@@ -34,6 +34,8 @@ public static class DependencyInjection
 		services.AddScoped<IMessageRepository, MessageRepository>();
 		services.AddSingleton<AttachmentStatements>();
 		services.AddScoped<IAttachmentRepository, AttachmentRepository>();
+		services.AddSingleton<DataExportStatements>();
+		services.AddScoped<IDataExportRepository, DataExportRepository>();
 		return services;
 	}
 

--- a/services/chat/src/Chat.Persistence/Repositories/DataExportRepository.cs
+++ b/services/chat/src/Chat.Persistence/Repositories/DataExportRepository.cs
@@ -1,0 +1,75 @@
+using Cassandra;
+using Chat.Application.Abstractions.Persistence;
+
+namespace Chat.Persistence.Repositories;
+
+internal sealed class DataExportRepository(ISession session, DataExportStatements statements) : IDataExportRepository
+{
+	public async Task<ChatUserDataExport> GetUserDataExportAsync(long userId, CancellationToken ct)
+	{
+		var channelMessages = await CollectChannelMessagesAsync(userId);
+		var directMessages = await CollectDirectMessagesAsync(userId);
+		return new ChatUserDataExport(channelMessages, directMessages);
+	}
+
+	private async Task<List<ExportedChannelMessage>> CollectChannelMessagesAsync(long userId)
+	{
+		var channelsStmt = await statements.SelectUserChannels.Value;
+		var channelRows = await session.ExecuteAsync(channelsStmt.Bind(userId));
+		var channelIds = channelRows.Select(r => r.GetValue<long>("channel_id")).ToList();
+
+		var messages = new List<ExportedChannelMessage>();
+		if (channelIds.Count == 0)
+			return messages;
+
+		var msgStmt = await statements.SelectAuthoredChannelMessages.Value;
+		foreach (var channelId in channelIds)
+		{
+			var rows = await session.ExecuteAsync(msgStmt.Bind(channelId, userId));
+			foreach (var r in rows)
+			{
+				if (r.GetValue<bool>("is_deleted"))
+					continue;
+				messages.Add(new ExportedChannelMessage(
+					channelId,
+					r.GetValue<long>("id"),
+					r.GetValue<string>("content"),
+					r.GetValue<DateTimeOffset>("created_at"),
+					r.GetValue<DateTimeOffset?>("edited_at")));
+			}
+		}
+		return messages;
+	}
+
+	private async Task<List<ExportedDirectMessage>> CollectDirectMessagesAsync(long userId)
+	{
+		var convStmt = await statements.SelectUserConversations.Value;
+		var convRows = await session.ExecuteAsync(convStmt.Bind(userId));
+		var conversations = convRows
+			.Select(r => (PartnerId: r.GetValue<long>("partner_id"), ConversationId: r.GetValue<long>("conversation_id")))
+			.ToList();
+
+		var messages = new List<ExportedDirectMessage>();
+		if (conversations.Count == 0)
+			return messages;
+
+		var msgStmt = await statements.SelectAuthoredDmMessages.Value;
+		foreach (var (partnerId, conversationId) in conversations)
+		{
+			var rows = await session.ExecuteAsync(msgStmt.Bind(conversationId, userId));
+			foreach (var r in rows)
+			{
+				if (r.GetValue<bool>("is_deleted"))
+					continue;
+				messages.Add(new ExportedDirectMessage(
+					conversationId,
+					partnerId,
+					r.GetValue<long>("id"),
+					r.GetValue<string>("content"),
+					r.GetValue<DateTimeOffset>("created_at"),
+					r.GetValue<DateTimeOffset?>("edited_at")));
+			}
+		}
+		return messages;
+	}
+}

--- a/services/chat/src/Chat.Persistence/Repositories/DataExportStatements.cs
+++ b/services/chat/src/Chat.Persistence/Repositories/DataExportStatements.cs
@@ -1,0 +1,24 @@
+using Cassandra;
+
+namespace Chat.Persistence.Repositories;
+
+internal sealed class DataExportStatements(ISession session)
+{
+	// channels the user has a read cursor in - their per-user channel index
+	public Lazy<Task<PreparedStatement>> SelectUserChannels { get; } = new(() => session.PrepareAsync(
+		"SELECT channel_id FROM channel_read_states WHERE user_id = ?"));
+
+	// the user's own messages inside one channel partition (single-partition filter)
+	public Lazy<Task<PreparedStatement>> SelectAuthoredChannelMessages { get; } = new(() => session.PrepareAsync(
+		"SELECT id, content, created_at, edited_at, is_deleted " +
+		"FROM messages WHERE channel_id = ? AND author_id = ? ALLOW FILTERING"));
+
+	// DM conversations the user is part of - their per-user conversation index
+	public Lazy<Task<PreparedStatement>> SelectUserConversations { get; } = new(() => session.PrepareAsync(
+		"SELECT partner_id, conversation_id FROM user_conversations WHERE user_id = ?"));
+
+	// the user's own messages inside one conversation partition (single-partition filter)
+	public Lazy<Task<PreparedStatement>> SelectAuthoredDmMessages { get; } = new(() => session.PrepareAsync(
+		"SELECT id, content, created_at, edited_at, is_deleted " +
+		"FROM direct_messages WHERE conversation_id = ? AND sender_id = ? ALLOW FILTERING"));
+}

--- a/services/chat/src/Chat.Presentation/Endpoints/UserDataExportEndpoint.cs
+++ b/services/chat/src/Chat.Presentation/Endpoints/UserDataExportEndpoint.cs
@@ -1,0 +1,37 @@
+using Chat.Application.Abstractions.Messaging;
+using Chat.Application.Features.Users.ExportUserData;
+using Chat.Domain.Results;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+
+namespace Chat.Presentation.Endpoints;
+
+/// <summary>
+/// internal GDPR data-export lookup: returns the user's Chat-owned messages as
+/// JSON, consumed by the User Service's data-export aggregator. mounted under
+/// <c>/internal</c> by <c>Program.cs</c>, so unreachable from outside the docker
+/// network (the API Gateway only forwards <c>/api/{service}/vN/...</c>).
+/// </summary>
+public static class UserDataExportEndpoint
+{
+	public static void MapInternalRoutes(IEndpointRouteBuilder endpoints)
+	{
+		endpoints.MapGet("/users/{userId:long}/data-export", GetAsync);
+	}
+
+	private static async Task<Results<
+		Ok<UserDataExportResponse>,
+		BadRequest<ErrorBody>>>
+	GetAsync(
+		long userId,
+		IQueryHandler<ExportUserDataQuery, Result<UserDataExportResponse>> handler,
+		CancellationToken cancellationToken)
+	{
+		if (userId <= 0)
+			return TypedResults.BadRequest(new ErrorBody("user_id must be a positive snowflake."));
+
+		// a well-formed request always succeeds; a user with no messages exports empty
+		var result = await handler.HandleAsync(new ExportUserDataQuery(userId), cancellationToken);
+		return TypedResults.Ok(result.Value);
+	}
+}

--- a/services/chat/src/Chat.Presentation/Program.cs
+++ b/services/chat/src/Chat.Presentation/Program.cs
@@ -5,6 +5,7 @@ using Chat.Application;
 using Chat.Application.Abstractions;
 using Chat.Infrastructure;
 using Chat.Persistence;
+using Chat.Presentation.Endpoints;
 using Chat.Presentation.Hubs;
 using Chat.Presentation.Hubs.Signaling;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
@@ -98,6 +99,11 @@ var v1 = app.MapGroup("/v1").RequireAuthorization();
 v1.MapCarter();
 app.MapHub<ChatHub>("/v1/hubs/chat");
 app.MapHub<SignalingHub>("/v1/hubs/signaling");
+
+// internal endpoints: the API Gateway only forwards /api/{service}/vN/..., so
+// /internal/... is reachable only over the docker network (no auth header).
+var internalRoutes = app.MapGroup("/internal");
+UserDataExportEndpoint.MapInternalRoutes(internalRoutes);
 
 app.Run();
 

--- a/services/chat/tests/Chat.FunctionalTests/Features/UserDataExportTests.cs
+++ b/services/chat/tests/Chat.FunctionalTests/Features/UserDataExportTests.cs
@@ -1,0 +1,45 @@
+using System.Net;
+using System.Text.Json;
+using Chat.Application.Abstractions.Persistence;
+using Chat.FunctionalTests.Infrastructure;
+using Xunit;
+
+namespace Chat.FunctionalTests.Features;
+
+public sealed class UserDataExportTests(ChatApiFactory factory) : IClassFixture<ChatApiFactory>
+{
+	[Fact]
+	public async Task Internal_Anonymous_NotUnderV1_RejectsNonPositive()
+	{
+		var anon = factory.CreateClient();
+		// internal group: reachable without a token, but not under /v1 (gateway-facing)
+		Assert.Equal(HttpStatusCode.OK, (await anon.GetAsync("/internal/users/1/data-export")).StatusCode);
+		Assert.Equal(HttpStatusCode.NotFound, (await anon.GetAsync("/v1/users/1/data-export")).StatusCode);
+		Assert.Equal(HttpStatusCode.BadRequest, (await anon.GetAsync("/internal/users/0/data-export")).StatusCode);
+	}
+
+	[Fact]
+	public async Task Exports_Seeded_Channel_And_Direct_Messages()
+	{
+		factory.DataExportRepository.ChannelMessages.Add(
+			new ExportedChannelMessage(10, 100, "hello channel", DateTimeOffset.UtcNow, null));
+		factory.DataExportRepository.DirectMessages.Add(
+			new ExportedDirectMessage(20, 30, 200, "hi dm", DateTimeOffset.UtcNow, null));
+
+		var resp = await factory.CreateClient().GetAsync("/internal/users/42/data-export");
+		Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+
+		var root = JsonDocument.Parse(await resp.Content.ReadAsStringAsync()).RootElement;
+		Assert.Equal("42", root.GetProperty("user_id").GetString());
+
+		var ch = Assert.Single(root.GetProperty("channel_messages").EnumerateArray());
+		Assert.Equal("10", ch.GetProperty("channel_id").GetString());
+		Assert.Equal("100", ch.GetProperty("message_id").GetString());
+		Assert.Equal("hello channel", ch.GetProperty("content").GetString());
+
+		var dm = Assert.Single(root.GetProperty("direct_messages").EnumerateArray());
+		Assert.Equal("30", dm.GetProperty("partner_id").GetString());
+		Assert.Equal("200", dm.GetProperty("message_id").GetString());
+		Assert.Equal("hi dm", dm.GetProperty("content").GetString());
+	}
+}

--- a/services/chat/tests/Chat.FunctionalTests/Infrastructure/ChatApiFactory.cs
+++ b/services/chat/tests/Chat.FunctionalTests/Infrastructure/ChatApiFactory.cs
@@ -39,6 +39,7 @@ public sealed class ChatApiFactory : WebApplicationFactory<Program>
 	public FakeUserClient UserClient { get; } = new();
 	public FakeMessageRepository MessageRepository { get; } = new();
 	public FakeAttachmentRepository AttachmentRepository { get; } = new();
+	public FakeDataExportRepository DataExportRepository { get; } = new();
 	public FakeObjectStore ObjectStore { get; } = new();
 	public FakeEventBus EventBus { get; } = new();
 	public FakeChannelBroadcaster Broadcaster { get; } = new();
@@ -192,6 +193,10 @@ public sealed class ChatApiFactory : WebApplicationFactory<Program>
 			// swap in the in-memory fake for the message handlers that depend on it
 			services.RemoveAll<IAttachmentRepository>();
 			services.AddSingleton<IAttachmentRepository>(AttachmentRepository);
+
+			// the real DataExportRepository needs ISession (stripped above)
+			services.RemoveAll<IDataExportRepository>();
+			services.AddSingleton<IDataExportRepository>(DataExportRepository);
 
 			// the real MinioObjectStore would dial MinIO; serve attachment blobs
 			// from memory instead so the upload/download endpoints stay hermetic

--- a/services/chat/tests/Chat.UnitTests/Fakes/FakeDataExportRepository.cs
+++ b/services/chat/tests/Chat.UnitTests/Fakes/FakeDataExportRepository.cs
@@ -1,0 +1,17 @@
+using Chat.Application.Abstractions.Persistence;
+
+namespace Chat.UnitTests.Fakes;
+
+/// <summary>
+/// in-memory stand-in for the Scylla-backed export repo. tests seed the two lists
+/// and the endpoint/handler/serialization are exercised against them; the real
+/// Cassandra query path is verified at runtime against a live Scylla.
+/// </summary>
+public sealed class FakeDataExportRepository : IDataExportRepository
+{
+	public List<ExportedChannelMessage> ChannelMessages { get; } = [];
+	public List<ExportedDirectMessage> DirectMessages { get; } = [];
+
+	public Task<ChatUserDataExport> GetUserDataExportAsync(long userId, CancellationToken ct) =>
+		Task.FromResult(new ChatUserDataExport(ChannelMessages, DirectMessages));
+}


### PR DESCRIPTION
Resolves #238

## Summary

Adds Chat's internal GDPR data-export endpoint, `GET /internal/users/{user_id}/data-export` (internal-only, no auth), returning the user's authored messages (channel + DM). Consumed by the User Service's data-export aggregator. Follows the convention Guild set in #237.

## Response
```json
{
  "user_id": "123",
  "channel_messages": [
    { "channel_id": "77", "message_id": "9001", "content": "gg", "created_at": "...", "edited_at": null }
  ],
  "direct_messages": [
    { "conversation_id": "88", "partner_id": "456", "message_id": "9002", "content": "hey", "created_at": "...", "edited_at": null }
  ]
}
```

Only the user's **own messages** - the crown-jewel GDPR data (Discord's export is likewise mostly your messages). Soft-deleted messages excluded. Ids stay raw: Chat doesn't own channel/user names (Guild/User do), so the aggregator resolves them.

## The Scylla design (the interesting bit)

`messages` is partitioned by `channel_id` and `direct_messages` by `conversation_id`, so "all messages by author" is **not** a direct query - it'd be a cluster-wide `ALLOW FILTERING` scan (anti-pattern).

Instead the export uses Chat's **per-user index tables** to find the partitions the user touched, then does bounded, partition-keyed reads filtered to their own rows:
- `channel_read_states` (`PK ((user_id), channel_id)`) → per channel, read `messages[channel_id]` where `author_id = user`.
- `user_conversations` (`PK ((user_id), partner_id)`) → per conversation, read `direct_messages[conversation_id]` where `sender_id = user`.

## Lands ahead of its data sources (intentional)

Those index tables exist (created in `V0001`) but aren't **written** yet - read-state (#154) and DMs (#199-202) are still in progress. So today the export returns empty, and it **lights up automatically** the moment those features start writing. It also gives their authors a live consumer validating the `channel_read_states` / `user_conversations` / `direct_messages` schema. Coverage of channel messages depends on the user having a read-state cursor for a channel (created on activity) - noted in the contract.

## Testing

Chat's tests use in-memory fakes and strip Scylla, so this is verified two ways:
- **Functional** (fake repo): endpoint is anonymous + on the internal group (not under `/v1`), rejects non-positive ids, and returns seeded channel/DM messages with correct snake_case + string-id serialization. Suite green: unit 80, architecture 17, functional 109.
- **Runtime (real Scylla)**: seeded `channel_read_states` / `messages` / `user_conversations` / `direct_messages` directly and hit the live endpoint. The real Cassandra queries returned exactly the user's own, non-deleted messages - correctly excluding another author's message and a soft-deleted one. So the actual query path is validated, not just the plumbing.

Contract documented in `docs/contracts/chat.md`, including the partition-strategy rationale.
