### PR TITLE
feat(chat): add direct messages (send + history)

### DIFF
--- a/services/chat/src/Chat.Application/Abstractions/IConversationUnicast.cs
+++ b/services/chat/src/Chat.Application/Abstractions/IConversationUnicast.cs
@@ -1,0 +1,8 @@
+using Chat.Application.Features.DirectMessages.Common;
+
+namespace Chat.Application.Abstractions;
+
+public interface IConversationUnicast
+{
+	Task UnicastMessageAsync(long recipientId, DirectMessageResponse message, CancellationToken ct);
+}

--- a/services/chat/src/Chat.Application/Abstractions/Persistence/IDirectMessageRepository.cs
+++ b/services/chat/src/Chat.Application/Abstractions/Persistence/IDirectMessageRepository.cs
@@ -24,5 +24,6 @@ public interface IDirectMessageRepository
 	Task<long?> FindNonceAsync(long senderId, long recipientId, string nonce, CancellationToken ct);
 
 	Task<DirectMessage?> GetByIdAsync(long messageId, CancellationToken ct);
-	Task<IReadOnlyList<DirectMessage>> ListAsync(long conversationId, int limit, CancellationToken ct);
+
+	Task<IReadOnlyList<DirectMessage>> ListAsync(long conversationId, DateTimeOffset beforeTime, int limit, CancellationToken ct);
 }

--- a/services/chat/src/Chat.Application/Abstractions/Persistence/IDirectMessageRepository.cs
+++ b/services/chat/src/Chat.Application/Abstractions/Persistence/IDirectMessageRepository.cs
@@ -9,4 +9,5 @@ public interface IDirectMessageRepository
 	Task AddAsync(DirectMessage message, string? nonce, CancellationToken ct);
 	Task<long?> FindNonceAsync(long senderId, long recipientId, string nonce, CancellationToken ct);
 	Task<DirectMessage?> GetByIdAsync(long messageId, CancellationToken ct);
+	Task<IReadOnlyList<DirectMessage>> ListAsync(long conversationId, int limit, CancellationToken ct);
 }

--- a/services/chat/src/Chat.Application/Abstractions/Persistence/IDirectMessageRepository.cs
+++ b/services/chat/src/Chat.Application/Abstractions/Persistence/IDirectMessageRepository.cs
@@ -1,0 +1,12 @@
+using Chat.Domain.Messages;
+
+namespace Chat.Application.Abstractions.Persistence;
+
+public interface IDirectMessageRepository
+{
+	Task<long?> FindConversationAsync(long senderId, long recipientId, CancellationToken ct);
+	Task<long?> FindReplyExistsAsync(long conversationId, long replyToId, CancellationToken ct);
+	Task AddAsync(DirectMessage message, string? nonce, CancellationToken ct);
+	Task<long?> FindNonceAsync(long senderId, long recipientId, string nonce, CancellationToken ct);
+	Task<DirectMessage?> GetByIdAsync(long messageId, CancellationToken ct);
+}

--- a/services/chat/src/Chat.Application/Abstractions/Persistence/IDirectMessageRepository.cs
+++ b/services/chat/src/Chat.Application/Abstractions/Persistence/IDirectMessageRepository.cs
@@ -16,6 +16,7 @@ public interface IDirectMessageRepository
 	/// </summary>
 	Task<long> GetOrCreateConversationAsync(long senderId, long recipientId, long candidateId, CancellationToken ct);
 
+	/// <summary>excludes soft-deleted messages: a reply may not target a deleted message</summary>
 	Task<long?> FindReplyExistsAsync(long conversationId, long replyToId, CancellationToken ct);
 
 	Task AddAsync(DirectMessage message, string? nonce, CancellationToken ct);

--- a/services/chat/src/Chat.Application/Abstractions/Persistence/IDirectMessageRepository.cs
+++ b/services/chat/src/Chat.Application/Abstractions/Persistence/IDirectMessageRepository.cs
@@ -4,10 +4,24 @@ namespace Chat.Application.Abstractions.Persistence;
 
 public interface IDirectMessageRepository
 {
-	Task<long?> FindConversationAsync(long senderId, long recipientId, CancellationToken ct);
+	/// <summary>read-only lookup; does not create the conversation if it is missing</summary>
+	Task<long?> FindConversationAsync(long userId, long partnerId, CancellationToken ct);
+
+	/// <summary>
+	/// resolves the conversation id for a (senderId, recipientId) pair, creating it
+	/// atomically via a Cassandra lightweight transaction if this is the first
+	/// message between the two users. <paramref name="candidateId"/> is used as the
+	/// conversation id only if this call wins the race; otherwise the id agreed by
+	/// the winner is returned.
+	/// </summary>
+	Task<long> GetOrCreateConversationAsync(long senderId, long recipientId, long candidateId, CancellationToken ct);
+
 	Task<long?> FindReplyExistsAsync(long conversationId, long replyToId, CancellationToken ct);
+
 	Task AddAsync(DirectMessage message, string? nonce, CancellationToken ct);
+
 	Task<long?> FindNonceAsync(long senderId, long recipientId, string nonce, CancellationToken ct);
+
 	Task<DirectMessage?> GetByIdAsync(long messageId, CancellationToken ct);
 	Task<IReadOnlyList<DirectMessage>> ListAsync(long conversationId, int limit, CancellationToken ct);
 }

--- a/services/chat/src/Chat.Application/Contracts/Events.cs
+++ b/services/chat/src/Chat.Application/Contracts/Events.cs
@@ -3,6 +3,7 @@ namespace Chat.Application.Contracts;
 // own-source events published by Chat. consumers in other services bind to
 // these URNs via [MessageUrn("Chat.Application.Contracts:...")] on their side
 public sealed record ChatMessageSent(long ChannelId, long GuildId, long AuthorId, long MessageId, string Content, long[] Mentions);
+public sealed record ChatDmSent(long ConversationId, long MessageId, long SenderId, long RecipientId, string Content);
 public sealed record CallIncoming(long CallId, long CallerId, long CalleeId, string CallType);
 public sealed record UserOnline(long UserId);
 public sealed record UserOffline(long UserId);

--- a/services/chat/src/Chat.Application/Features/DirectMessages/Common/DirectMessageResponse.cs
+++ b/services/chat/src/Chat.Application/Features/DirectMessages/Common/DirectMessageResponse.cs
@@ -1,0 +1,35 @@
+using Chat.Domain.Messages;
+
+namespace Chat.Application.Features.DirectMessages.Common;
+
+/// <summary>
+/// wire shape that mirrors the contract's <c>ReceiveMessage</c> event. snowflake
+/// IDs are quoted strings so JS clients can hold them without precision loss.
+/// attachments and reactions are empty arrays on freshly-created messages
+/// </summary>
+public sealed record DirectMessageResponse(
+	string Id,
+	string ConversationId,
+	string SenderId,
+    string RecipientId,
+	string? Content,
+	string? ReplyToId,
+	DateTimeOffset? EditedAt,
+	DateTimeOffset CreatedAt,
+	object[] Attachments,
+	object[] Reactions,
+	string? Nonce)
+{
+	public static DirectMessageResponse From(DirectMessage m, string? nonce) => new(
+		Id: m.Id.ToString(),
+		ConversationId: m.ConversationId.ToString(),
+		SenderId: m.SenderId.ToString(),
+        RecipientId: m.RecipientId.ToString(),
+		Content: m.Content,
+		ReplyToId: m.ReplyToId?.ToString(),
+		EditedAt: m.EditedAt,
+		CreatedAt: m.CreatedAt,
+		Attachments: [],
+		Reactions: [],
+		Nonce: nonce);
+}

--- a/services/chat/src/Chat.Application/Features/DirectMessages/ListMessages/ListDirectMessagesHandler.cs
+++ b/services/chat/src/Chat.Application/Features/DirectMessages/ListMessages/ListDirectMessagesHandler.cs
@@ -9,7 +9,8 @@ namespace Chat.Application.Features.DirectMessages.ListMessages;
 
 internal sealed class ListDirectMessagesHandler(
 	ICurrentUser currentUser,
-	IDirectMessageRepository repository)
+	IDirectMessageRepository repository,
+	IClock clock)
 	: IQueryHandler<ListDirectMessagesQuery, Result<IReadOnlyList<DirectMessageResponse>>>
 {
 	public async Task<Result<IReadOnlyList<DirectMessageResponse>>> HandleAsync(
@@ -36,6 +37,7 @@ internal sealed class ListDirectMessagesHandler(
 
 		var messages = await repository.ListAsync(
 			conversationId.Value,
+			query.BeforeTime ?? clock.UtcNow,
 			limit,
 			cancellationToken);
 

--- a/services/chat/src/Chat.Application/Features/DirectMessages/ListMessages/ListDirectMessagesHandler.cs
+++ b/services/chat/src/Chat.Application/Features/DirectMessages/ListMessages/ListDirectMessagesHandler.cs
@@ -40,18 +40,7 @@ internal sealed class ListDirectMessagesHandler(
 			cancellationToken);
 
 		return messages
-			.Select(message => new DirectMessageResponse(
-				Id: message.Id.ToString(),
-				ConversationId: message.ConversationId.ToString(),
-				SenderId: message.SenderId.ToString(),
-				RecipientId: message.RecipientId.ToString(),
-				Content: message.Content,
-				ReplyToId: message.ReplyToId?.ToString(),
-				EditedAt: message.EditedAt,
-				CreatedAt: message.CreatedAt,
-				Attachments: [],
-				Reactions: [],
-				Nonce: null))
+			.Select(msg => DirectMessageResponse.From(msg, null))
 			.ToList();
 	}
 }

--- a/services/chat/src/Chat.Application/Features/DirectMessages/ListMessages/ListDirectMessagesHandler.cs
+++ b/services/chat/src/Chat.Application/Features/DirectMessages/ListMessages/ListDirectMessagesHandler.cs
@@ -1,0 +1,57 @@
+using Chat.Application.Abstractions;
+using Chat.Application.Abstractions.Authentication;
+using Chat.Application.Abstractions.Messaging;
+using Chat.Application.Abstractions.Persistence;
+using Chat.Application.Features.DirectMessages.Common;
+using Chat.Domain.Results;
+
+namespace Chat.Application.Features.DirectMessages.ListMessages;
+
+internal sealed class ListDirectMessagesHandler(
+	ICurrentUser currentUser,
+	IDirectMessageRepository repository)
+	: IQueryHandler<ListDirectMessagesQuery, Result<IReadOnlyList<DirectMessageResponse>>>
+{
+	public async Task<Result<IReadOnlyList<DirectMessageResponse>>> HandleAsync(
+		ListDirectMessagesQuery query,
+		CancellationToken cancellationToken = default)
+	{
+		var userId = currentUser.UserId;
+
+		if (query.RecipientId <= 0)
+			return DirectMessageFailures.InvalidRecipientId;
+
+		if (query.RecipientId == userId)
+			return DirectMessageFailures.CannotMessageSelf;
+
+		var limit = Math.Clamp(query.Limit, 1, 100);
+
+		var conversationId = await repository.FindConversationAsync(
+			userId,
+			query.RecipientId,
+			cancellationToken);
+
+		if (conversationId is null)
+			return Array.Empty<DirectMessageResponse>();
+
+		var messages = await repository.ListAsync(
+			conversationId.Value,
+			limit,
+			cancellationToken);
+
+		return messages
+			.Select(message => new DirectMessageResponse(
+				Id: message.Id.ToString(),
+				ConversationId: message.ConversationId.ToString(),
+				SenderId: message.SenderId.ToString(),
+				RecipientId: message.RecipientId.ToString(),
+				Content: message.Content,
+				ReplyToId: message.ReplyToId?.ToString(),
+				EditedAt: message.EditedAt,
+				CreatedAt: message.CreatedAt,
+				Attachments: [],
+				Reactions: [],
+				Nonce: null))
+			.ToList();
+	}
+}

--- a/services/chat/src/Chat.Application/Features/DirectMessages/ListMessages/ListDirectMessagesQuery.cs
+++ b/services/chat/src/Chat.Application/Features/DirectMessages/ListMessages/ListDirectMessagesQuery.cs
@@ -6,5 +6,6 @@ namespace Chat.Application.Features.DirectMessages.ListMessages;
 
 public sealed record ListDirectMessagesQuery(
 	long RecipientId,
+	DateTimeOffset? BeforeTime,
 	int Limit)
 	: IQuery<Result<IReadOnlyList<DirectMessageResponse>>>;

--- a/services/chat/src/Chat.Application/Features/DirectMessages/ListMessages/ListDirectMessagesQuery.cs
+++ b/services/chat/src/Chat.Application/Features/DirectMessages/ListMessages/ListDirectMessagesQuery.cs
@@ -1,0 +1,10 @@
+using Chat.Application.Abstractions.Messaging;
+using Chat.Application.Features.DirectMessages.Common;
+using Chat.Domain.Results;
+
+namespace Chat.Application.Features.DirectMessages.ListMessages;
+
+public sealed record ListDirectMessagesQuery(
+	long RecipientId,
+	int Limit)
+	: IQuery<Result<IReadOnlyList<DirectMessageResponse>>>;

--- a/services/chat/src/Chat.Application/Features/DirectMessages/SendMessage/SendDirectMessageCommand.cs
+++ b/services/chat/src/Chat.Application/Features/DirectMessages/SendMessage/SendDirectMessageCommand.cs
@@ -1,0 +1,8 @@
+using Chat.Application.Abstractions.Messaging;
+using Chat.Application.Features.DirectMessages.Common;
+using Chat.Domain.Results;
+
+namespace Chat.Application.Features.DirectMessages.SendMessage;
+
+public sealed record SendDirectMessageCommand(long RecipientId, string? Content, long? ReplyToId, string? Nonce)
+	: ICommand<Result<DirectMessageResponse>>;

--- a/services/chat/src/Chat.Application/Features/DirectMessages/SendMessage/SendMessageHandler.cs
+++ b/services/chat/src/Chat.Application/Features/DirectMessages/SendMessage/SendMessageHandler.cs
@@ -48,12 +48,8 @@ internal sealed class SendDirectMessageHandler(
 		}
 
 		var messageId = ids.NextId();
-
-		// Generate a snowflake ids for a first time conversation
-		// There might be a data race if both person send a first time message each other, as this will create two conversation,
-		// one way to solve this is to have a conditional writing in ScyllaDb, so this line will probably dissapear
-		// TODO: conditional writing
-		var conversationId = await repository.FindConversationAsync(userId, command.RecipientId, cancellationToken) ?? ids.NextId();
+		var conversationId =
+			await repository.GetOrCreateConversationAsync(userId, command.RecipientId, ids.NextId(), cancellationToken);
 
 		if (command.ReplyToId is not null)
 		{

--- a/services/chat/src/Chat.Application/Features/DirectMessages/SendMessage/SendMessageHandler.cs
+++ b/services/chat/src/Chat.Application/Features/DirectMessages/SendMessage/SendMessageHandler.cs
@@ -1,0 +1,84 @@
+using Chat.Application.Abstractions;
+using Chat.Application.Abstractions.Authentication;
+using Chat.Application.Abstractions.Messaging;
+using Chat.Application.Abstractions.Persistence;
+using Chat.Application.Contracts;
+using Chat.Application.Features.DirectMessages.Common;
+using Chat.Domain.Messages;
+using Chat.Domain.Results;
+
+namespace Chat.Application.Features.DirectMessages.SendMessage;
+
+internal sealed class SendDirectMessageHandler(
+	ICurrentUser currentUser,
+	IDirectMessageRepository repository,
+	ISnowflakeIdGenerator ids,
+	IClock clock,
+	IEventBus eventBus,
+	IConversationUnicast unicaster)
+	: ICommandHandler<SendDirectMessageCommand, Result<DirectMessageResponse>>
+{
+	private const int MaxNonceLen = 64;
+
+	public async Task<Result<DirectMessageResponse>> HandleAsync(
+		SendDirectMessageCommand command,
+		CancellationToken cancellationToken = default)
+	{
+		// If we have a frend list requirement or server, please readd a user/guild injection in the DependencyInjection,
+		// TODO: check if the the recipient is friend with the sender and/or if they have a relation is a mutual server
+		// TODO: if a message is a reply, you need to check if the message exist in the actual conversation before pointing toward the correct message
+
+		if (command.Nonce is { Length: > MaxNonceLen })
+			return DirectMessageFailures.NonceTooLong;
+
+		var userId = currentUser.UserId;
+
+		if (command.Nonce is not null)
+		{
+			var existingId = await repository.FindNonceAsync(userId, command.RecipientId, command.Nonce, cancellationToken);
+			if (existingId is not null)
+			{
+				var existing = await repository.GetByIdAsync(existingId.Value, cancellationToken);
+				if (existing is not null)
+					return DirectMessageResponse.From(existing, command.Nonce);
+			}
+		}
+
+		var messageId = ids.NextId();
+
+		// Generate a snowflake ids for a first time conversation
+		// There might be a data race if both person send a first time message each other, as this will create two conversation,
+		// one way to solve this is to have a conditional writing in ScyllaDb, so this line will probably dissapear
+		// TODO: conditional writing
+		var conversationId = await repository.FindConversationAsync(userId, command.RecipientId, cancellationToken) ?? ids.NextId();
+
+		var messageResult = DirectMessage.Create(
+			id: messageId,
+			conversationId: conversationId,
+			senderId: userId,
+			recipientId: command.RecipientId,
+			content: command.Content,
+			replyToId: command.ReplyToId,
+			now: clock.UtcNow);
+		if (messageResult.IsFailure)
+			return messageResult.Error;
+
+		var message = messageResult.Value;
+		await repository.AddAsync(message, command.Nonce, cancellationToken);
+
+		var response = DirectMessageResponse.From(message, command.Nonce);
+
+		await eventBus.PublishAsync(
+			new ChatDmSent(
+				ConversationId: conversationId,
+				MessageId: messageId,
+				SenderId: userId,
+				RecipientId: command.RecipientId,
+				Content: message.Content!),
+			cancellationToken);
+
+		await unicaster.UnicastMessageAsync(command.RecipientId, response, cancellationToken);
+
+		return response;
+	}
+}

--- a/services/chat/src/Chat.Application/Features/DirectMessages/SendMessage/SendMessageHandler.cs
+++ b/services/chat/src/Chat.Application/Features/DirectMessages/SendMessage/SendMessageHandler.cs
@@ -54,12 +54,7 @@ internal sealed class SendDirectMessageHandler(
 
 		if (command.ReplyToId is not null)
 		{
-			var replyExists = await repository.FindReplyExistsAsync(
-				conversationId,
-				command.ReplyToId.Value,
-				cancellationToken);
-
-			if (replyExists is null)
+			if (await repository.FindReplyExistsAsync(conversationId, command.ReplyToId.Value, cancellationToken) is null)
 				return DirectMessageFailures.InvalidReplyTarget;
 		}
 

--- a/services/chat/src/Chat.Application/Features/DirectMessages/SendMessage/SendMessageHandler.cs
+++ b/services/chat/src/Chat.Application/Features/DirectMessages/SendMessage/SendMessageHandler.cs
@@ -52,6 +52,17 @@ internal sealed class SendDirectMessageHandler(
 		// TODO: conditional writing
 		var conversationId = await repository.FindConversationAsync(userId, command.RecipientId, cancellationToken) ?? ids.NextId();
 
+		if (command.ReplyToId is not null)
+		{
+			var replyExists = await repository.FindReplyExistsAsync(
+				conversationId,
+				command.ReplyToId.Value,
+				cancellationToken);
+
+			if (replyExists is null)
+				return DirectMessageFailures.InvalidReplyTarget;
+		}
+
 		var messageResult = DirectMessage.Create(
 			id: messageId,
 			conversationId: conversationId,

--- a/services/chat/src/Chat.Application/Features/DirectMessages/SendMessage/SendMessageHandler.cs
+++ b/services/chat/src/Chat.Application/Features/DirectMessages/SendMessage/SendMessageHandler.cs
@@ -13,6 +13,7 @@ internal sealed class SendDirectMessageHandler(
 	ICurrentUser currentUser,
 	IDirectMessageRepository repository,
 	ISnowflakeIdGenerator ids,
+	IUserClient userClient,
 	IClock clock,
 	IEventBus eventBus,
 	IConversationUnicast unicaster)
@@ -24,14 +25,16 @@ internal sealed class SendDirectMessageHandler(
 		SendDirectMessageCommand command,
 		CancellationToken cancellationToken = default)
 	{
-		// If we have a frend list requirement or server, please readd a user/guild injection in the DependencyInjection,
-		// TODO: check if the the recipient is friend with the sender and/or if they have a relation is a mutual server
-		// TODO: if a message is a reply, you need to check if the message exist in the actual conversation before pointing toward the correct message
-
 		if (command.Nonce is { Length: > MaxNonceLen })
 			return DirectMessageFailures.NonceTooLong;
 
 		var userId = currentUser.UserId;
+		var relationship = await userClient.GetUsersRelationship(userId, command.RecipientId, cancellationToken);
+		if (relationship is null)
+			return DirectMessageFailures.RecipientNotFound;
+
+		if (relationship.Status is "blocked_by_them" or "blocked_by_me")
+			return DirectMessageFailures.RecipientBlocked;
 
 		if (command.Nonce is not null)
 		{

--- a/services/chat/src/Chat.Domain/Messages/DirectMessage.cs
+++ b/services/chat/src/Chat.Domain/Messages/DirectMessage.cs
@@ -73,6 +73,9 @@ public sealed class DirectMessage
 		if (recipientId <= 0)
 			return DirectMessageFailures.InvalidRecipientId;
 
+		if (senderId == recipientId)
+			return DirectMessageFailures.CannotMessageSelf;
+
 		if (string.IsNullOrWhiteSpace(content))
 			return DirectMessageFailures.ContentRequired;
 

--- a/services/chat/src/Chat.Domain/Messages/DirectMessage.cs
+++ b/services/chat/src/Chat.Domain/Messages/DirectMessage.cs
@@ -1,0 +1,93 @@
+using Chat.Domain.Results;
+
+namespace Chat.Domain.Messages;
+
+public sealed class DirectMessage
+{
+	public const int MaxContentLen = 4000;
+
+	private DirectMessage() { }
+
+	private DirectMessage(
+		long id,
+		long conversationId,
+		long senderId,
+		long recipientId,
+		long? replyToId,
+		string? content,
+		bool isDeleted,
+		DateTimeOffset? editedAt,
+		DateTimeOffset createdAt)
+	{
+		Id = id;
+		ConversationId = conversationId;
+		SenderId = senderId;
+		RecipientId = recipientId;
+		ReplyToId = replyToId;
+		Content = content;
+		IsDeleted = isDeleted;
+		EditedAt = editedAt;
+		CreatedAt = createdAt;
+	}
+
+	public long Id { get; private set; }
+	public long ConversationId { get; private set; }
+	public long SenderId { get; private set; }
+    public long RecipientId { get; private set; }
+	public long? ReplyToId { get; private set; }
+	public string? Content { get; private set; }
+	public bool IsDeleted { get; private set; }
+	public DateTimeOffset? EditedAt { get; private set; }
+	public DateTimeOffset CreatedAt { get; private set; }
+
+	public static DirectMessage Reconstitute(
+		long id,
+		long conversationId,
+		long senderId,
+		long recipientId,
+		long? replyToId,
+		string? content,
+		bool isDeleted,
+		DateTimeOffset? editedAt,
+		DateTimeOffset createdAt)
+		=> new(id, conversationId, senderId, recipientId, replyToId, content, isDeleted, editedAt, createdAt);
+
+	public static Result<DirectMessage> Create(
+		long id,
+		long conversationId,
+		long senderId,
+		long recipientId,
+		long? replyToId,
+		string? content,
+		DateTimeOffset now)
+	{
+		if (id <= 0)
+			return DirectMessageFailures.InvalidId;
+
+		if (conversationId <= 0)
+			return DirectMessageFailures.InvalidConversationId;
+
+		if (senderId <= 0)
+			return DirectMessageFailures.InvalidSenderId;
+
+		if (recipientId <= 0)
+			return DirectMessageFailures.InvalidRecipientId;
+
+		if (string.IsNullOrWhiteSpace(content))
+			return DirectMessageFailures.ContentRequired;
+
+		if (content.Length > MaxContentLen)
+			return DirectMessageFailures.ContentTooLong;
+
+		return new DirectMessage(
+			id: id,
+			conversationId: conversationId,
+			senderId: senderId,
+			recipientId: recipientId,
+			replyToId: replyToId,
+			content: content,
+			isDeleted: false,
+			editedAt: null,
+			createdAt: now);
+	}
+}

--- a/services/chat/src/Chat.Domain/Results/DirectMessageFailures.cs
+++ b/services/chat/src/Chat.Domain/Results/DirectMessageFailures.cs
@@ -32,8 +32,11 @@ public static class DirectMessageFailures
 	public static readonly Failure CannotMessageSelf =
 		new("DirectMessage.CannotMessageSelf", "Sender and Recipient can't be the same id.");
 
-	public static readonly Failure NotAFriend =
-		new("DirectMessage.NotAFriend", "Sender is not a friend of the Recipient.");
+	public static readonly Failure RecipientNotFound =
+		new("DirectMessage.RecipientNotFound", "Recipient not found.");
+
+	public static readonly Failure RecipientBlocked =
+		new("DirectMessage.RecipientBlocked", "Message cannot be sent because one of the users has blocked the other.");
 
 	public static readonly Failure NonceTooLong =
 		new("DirectMessage.NonceTooLong", "Nonce must be 64 characters or fewer.");

--- a/services/chat/src/Chat.Domain/Results/DirectMessageFailures.cs
+++ b/services/chat/src/Chat.Domain/Results/DirectMessageFailures.cs
@@ -20,6 +20,9 @@ public static class DirectMessageFailures
 	public static readonly Failure ConversationNotFound =
 		new("DirectMessage.ConversationNotFound", "Conversation not found.");
 
+	public static readonly Failure InvalidReplyTarget =
+		new("DirectMessage.InvalidReplyTarget", "Reply target was not found in this conversation.");
+
 	public static readonly Failure InvalidSenderId =
 		new("DirectMessage.InvalidSenderId", "Sender id must be a positive snowflake.");
 

--- a/services/chat/src/Chat.Domain/Results/DirectMessageFailures.cs
+++ b/services/chat/src/Chat.Domain/Results/DirectMessageFailures.cs
@@ -26,6 +26,9 @@ public static class DirectMessageFailures
 	public static readonly Failure InvalidRecipientId =
 		new("DirectMessage.InvalidRecipientId", "Recipient id must be a positive snowflake.");
 
+	public static readonly Failure CannotMessageSelf =
+		new("DirectMessage.CannotMessageSelf", "Sender and Recipient can't be the same id.");
+
 	public static readonly Failure NotAFriend =
 		new("DirectMessage.NotAFriend", "Sender is not a friend of the Recipient.");
 

--- a/services/chat/src/Chat.Domain/Results/DirectMessageFailures.cs
+++ b/services/chat/src/Chat.Domain/Results/DirectMessageFailures.cs
@@ -1,0 +1,34 @@
+using Chat.Domain.Messages;
+
+namespace Chat.Domain.Results;
+
+public static class DirectMessageFailures
+{
+	public static readonly Failure ContentRequired =
+		new("DirectMessage.ContentRequired", "Direct message content is required.");
+
+	public static readonly Failure ContentTooLong =
+		new("DirectMessage.ContentTooLong",
+			$"Direct message content must be {DirectMessage.MaxContentLen} characters or fewer.");
+
+	public static readonly Failure InvalidId =
+		new("DirectMessage.InvalidId", "Direct message id must be a positive snowflake.");
+
+	public static readonly Failure InvalidConversationId =
+		new("DirectMessage.InvalidConversationId", "Conversation id must be a positive snowflake.");
+
+	public static readonly Failure ConversationNotFound =
+		new("DirectMessage.ConversationNotFound", "Conversation not found.");
+
+	public static readonly Failure InvalidSenderId =
+		new("DirectMessage.InvalidSenderId", "Sender id must be a positive snowflake.");
+
+	public static readonly Failure InvalidRecipientId =
+		new("DirectMessage.InvalidRecipientId", "Recipient id must be a positive snowflake.");
+
+	public static readonly Failure NotAFriend =
+		new("DirectMessage.NotAFriend", "Sender is not a friend of the Recipient.");
+
+	public static readonly Failure NonceTooLong =
+		new("DirectMessage.NonceTooLong", "Nonce must be 64 characters or fewer.");
+}

--- a/services/chat/src/Chat.Persistence/DependencyInjection.cs
+++ b/services/chat/src/Chat.Persistence/DependencyInjection.cs
@@ -32,6 +32,8 @@ public static class DependencyInjection
 
 		services.AddSingleton<MessageStatements>();
 		services.AddScoped<IMessageRepository, MessageRepository>();
+		services.AddSingleton<DirectMessageStatements>();
+		services.AddScoped<IDirectMessageRepository, DirectMessageRepository>();
 		services.AddSingleton<AttachmentStatements>();
 		services.AddScoped<IAttachmentRepository, AttachmentRepository>();
 		return services;

--- a/services/chat/src/Chat.Persistence/Repositories/DirectMessageRepository.cs
+++ b/services/chat/src/Chat.Persistence/Repositories/DirectMessageRepository.cs
@@ -26,6 +26,27 @@ internal sealed class DirectMessageRepository(
 		return replyToId;
 	}
 
+	public async Task<long> GetOrCreateConversationAsync(long senderId, long recipientId, long candidateId, CancellationToken ct)
+	{
+		// Canonicalize on (min, max) so that A->B and B->A races contend on the
+		// same user_conversations partition/clustering key
+		var userId = Math.Min(senderId, recipientId);
+		var partnerId = Math.Max(senderId, recipientId);
+
+		var stmt = await statements.InsertConversationIfNotExists.Value;
+		var row = (await session.ExecuteAsync(stmt.Bind(
+														userId,
+														partnerId,
+														candidateId
+													))).FirstOrDefault();
+
+		// A CAS response row only carries "[applied]" on success
+		if (row is null || row.GetValue<bool>("[applied]"))
+			return candidateId;
+
+		return row.GetValue<long>("conversation_id");
+	}
+
 	public async Task AddAsync(DirectMessage message, string? nonce, CancellationToken ct)
 	{
 		var insertDirectMessage = await statements.InsertDirectMessage.Value;

--- a/services/chat/src/Chat.Persistence/Repositories/DirectMessageRepository.cs
+++ b/services/chat/src/Chat.Persistence/Repositories/DirectMessageRepository.cs
@@ -1,0 +1,149 @@
+using Cassandra;
+using Chat.Application.Abstractions.Persistence;
+using Chat.Domain.Messages;
+
+namespace Chat.Persistence.Repositories;
+
+internal sealed class DirectMessageRepository(
+	ISession session,
+	DirectMessageStatements statements)
+	: IDirectMessageRepository
+{
+	public async Task<long?> FindConversationAsync(long senderId, long recipientId, CancellationToken ct)
+	{
+		var stmt = await statements.FindConversation.Value;
+		var row = (await session.ExecuteAsync(stmt.Bind(senderId, recipientId))).FirstOrDefault();
+
+		return row?.GetValue<long>("conversation_id");
+	}
+
+	public async Task<long?> FindReplyExistsAsync(long conversationId, long replyToId, CancellationToken ct)
+	{
+		var lookup = await GetLookupAsync(replyToId);
+		if (lookup is null || lookup.Value.ConversationId != conversationId)
+			return null;
+
+		return replyToId;
+	}
+
+	public async Task AddAsync(DirectMessage message, string? nonce, CancellationToken ct)
+	{
+		var insertDirectMessage = await statements.InsertDirectMessage.Value;
+		var insertLookup = await statements.InsertLookup.Value;
+		var upsertConversation = await statements.UpsertConversation.Value;
+
+		var createdAt = message.CreatedAt.UtcDateTime;
+		var editedAt = message.EditedAt?.UtcDateTime;
+		var preview = BuildPreview(message.Content);
+
+		var batch = new BatchStatement()
+			.SetBatchType(BatchType.Logged)
+			.Add(insertDirectMessage.Bind(
+				message.ConversationId,
+				createdAt,
+				message.Id,
+				message.SenderId,
+				message.RecipientId,
+				message.Content,
+				editedAt,
+				message.IsDeleted,
+				message.ReplyToId))
+			.Add(insertLookup.Bind(
+				message.Id,
+				(long?)null,
+				message.ConversationId,
+				createdAt,
+				message.SenderId))
+			.Add(upsertConversation.Bind(
+				message.SenderId,
+				message.RecipientId,
+				message.ConversationId,
+				createdAt,
+				preview))
+			.Add(upsertConversation.Bind(
+				message.RecipientId,
+				message.SenderId,
+				message.ConversationId,
+				createdAt,
+				preview));
+
+		if (nonce is not null)
+		{
+			var insertNonce = await statements.InsertNonce.Value;
+			batch.Add(insertNonce.Bind(
+				message.SenderId,
+				message.RecipientId,
+				nonce,
+				message.Id));
+		}
+
+		await session.ExecuteAsync(batch);
+	}
+
+	public async Task<long?> FindNonceAsync(long senderId, long recipientId, string nonce, CancellationToken ct)
+	{
+		var stmt = await statements.FindNonce.Value;
+		var row = (await session.ExecuteAsync(stmt.Bind(senderId, recipientId, nonce))).FirstOrDefault();
+
+		return row?.GetValue<long>("message_id");
+	}
+
+	public async Task<DirectMessage?> GetByIdAsync(long messageId, CancellationToken ct)
+	{
+		var lookup = await GetLookupAsync(messageId);
+		if (lookup is null)
+			return null;
+
+		var selectMessage = await statements.SelectDirectMessage.Value;
+		var row = (await session.ExecuteAsync(selectMessage.Bind(
+			lookup.Value.ConversationId,
+			lookup.Value.CreatedAt,
+			messageId))).FirstOrDefault();
+
+		if (row is null)
+			return null;
+
+		return DirectMessage.Reconstitute(
+			id: row.GetValue<long>("id"),
+			conversationId: row.GetValue<long>("conversation_id"),
+			senderId: row.GetValue<long>("sender_id"),
+			recipientId: row.GetValue<long>("recipient_id"),
+			replyToId: row.GetValue<long?>("reply_to_id"),
+			content: row.GetValue<string?>("content"),
+			isDeleted: row.GetValue<bool>("is_deleted"),
+			editedAt: row.GetValue<DateTime?>("edited_at"),
+			createdAt: new DateTimeOffset(row.GetValue<DateTime>("created_at"), TimeSpan.Zero));
+	}
+
+	private async Task<MessageLookup?> GetLookupAsync(long messageId)
+	{
+		var selectLookup = await statements.SelectLookup.Value;
+		var row = (await session.ExecuteAsync(selectLookup.Bind(messageId))).FirstOrDefault();
+
+		if (row is null)
+			return null;
+
+		var isDm = row.GetValue<bool>("is_dm");
+		if (!isDm)
+			return null;
+
+		var conversationId = row.GetValue<long?>("conversation_id");
+		var createdAt = row.GetValue<DateTime?>("created_at");
+
+		if (conversationId is null || createdAt is null)
+			return null;
+
+		return new MessageLookup(conversationId.Value, createdAt.Value);
+	}
+
+	private static string? BuildPreview(string? content)
+	{
+		if (string.IsNullOrWhiteSpace(content))
+			return null;
+
+		var trimmed = content.Trim();
+		return trimmed.Length <= 100 ? trimmed : trimmed[..100];
+	}
+
+	private readonly record struct MessageLookup(long ConversationId, DateTime CreatedAt);
+}

--- a/services/chat/src/Chat.Persistence/Repositories/DirectMessageRepository.cs
+++ b/services/chat/src/Chat.Persistence/Repositories/DirectMessageRepository.cs
@@ -19,8 +19,8 @@ internal sealed class DirectMessageRepository(
 
 	public async Task<long?> FindReplyExistsAsync(long conversationId, long replyToId, CancellationToken ct)
 	{
-		var lookup = await GetLookupAsync(replyToId);
-		if (lookup is null || lookup.Value.ConversationId != conversationId)
+		var message = await GetByIdAsync(replyToId, ct);
+		if (message is null || message.ConversationId != conversationId || message.IsDeleted)
 			return null;
 
 		return replyToId;

--- a/services/chat/src/Chat.Persistence/Repositories/DirectMessageRepository.cs
+++ b/services/chat/src/Chat.Persistence/Repositories/DirectMessageRepository.cs
@@ -168,11 +168,12 @@ internal sealed class DirectMessageRepository(
 
 	public async Task<IReadOnlyList<DirectMessage>> ListAsync(
 			long conversationId,
+			DateTimeOffset beforeTime,
 			int limit,
 			CancellationToken ct)
 	{
 		var stmt = await statements.SelectDirectMessagesByConversation.Value;
-		var rows = await session.ExecuteAsync(stmt.Bind(conversationId, limit));
+		var rows = await session.ExecuteAsync(stmt.Bind(conversationId, beforeTime, limit));
 
 		return rows
 			.Select(row => DirectMessage.Reconstitute(

--- a/services/chat/src/Chat.Persistence/Repositories/DirectMessageRepository.cs
+++ b/services/chat/src/Chat.Persistence/Repositories/DirectMessageRepository.cs
@@ -145,5 +145,27 @@ internal sealed class DirectMessageRepository(
 		return trimmed.Length <= 100 ? trimmed : trimmed[..100];
 	}
 
+	public async Task<IReadOnlyList<DirectMessage>> ListAsync(
+			long conversationId,
+			int limit,
+			CancellationToken ct)
+	{
+		var stmt = await statements.SelectDirectMessagesByConversation.Value;
+		var rows = await session.ExecuteAsync(stmt.Bind(conversationId, limit));
+
+		return rows
+			.Select(row => DirectMessage.Reconstitute(
+						id: row.GetValue<long>("id"),
+						conversationId: row.GetValue<long>("conversation_id"),
+						senderId: row.GetValue<long>("sender_id"),
+						recipientId: row.GetValue<long>("recipient_id"),
+						replyToId: row.GetValue<long?>("reply_to_id"),
+						content: row.GetValue<string?>("content"),
+						isDeleted: row.GetValue<bool>("is_deleted"),
+						editedAt: row.GetValue<DateTime?>("edited_at"),
+						createdAt: new DateTimeOffset(row.GetValue<DateTime>("created_at"), TimeSpan.Zero)))
+			.ToList();
+	}
+
 	private readonly record struct MessageLookup(long ConversationId, DateTime CreatedAt);
 }

--- a/services/chat/src/Chat.Persistence/Repositories/DirectMessageStatements.cs
+++ b/services/chat/src/Chat.Persistence/Repositories/DirectMessageStatements.cs
@@ -1,0 +1,43 @@
+using Cassandra;
+
+namespace Chat.Persistence.Repositories;
+
+internal sealed class DirectMessageStatements(ISession session)
+{
+	public Lazy<Task<PreparedStatement>> InsertDirectMessage { get; } = new(() => session.PrepareAsync(
+		"INSERT INTO direct_messages " +
+		"(conversation_id, created_at, id, sender_id, recipient_id, content, edited_at, is_deleted, reply_to_id) " +
+		"VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)"));
+
+	public Lazy<Task<PreparedStatement>> InsertLookup { get; } = new(() => session.PrepareAsync(
+		"INSERT INTO message_lookup " +
+		"(message_id, is_dm, channel_id, conversation_id, created_at, author_id) " +
+		"VALUES (?, true, ?, ?, ?, ?)"));
+
+	public Lazy<Task<PreparedStatement>> UpsertConversation { get; } = new(() => session.PrepareAsync(
+		"INSERT INTO user_conversations " +
+		"(user_id, partner_id, conversation_id, last_message_at, last_preview, is_archived) " +
+		"VALUES (?, ?, ?, ?, ?, false)"));
+
+	public Lazy<Task<PreparedStatement>> InsertNonce { get; } = new(() => session.PrepareAsync(
+		"INSERT INTO dm_nonce_dedup " +
+		"(sender_id, recipient_id, nonce, message_id) " +
+		"VALUES (?, ?, ?, ?)"));
+
+	public Lazy<Task<PreparedStatement>> FindNonce { get; } = new(() => session.PrepareAsync(
+		"SELECT message_id FROM dm_nonce_dedup " +
+		"WHERE sender_id = ? AND recipient_id = ? AND nonce = ?"));
+
+	public Lazy<Task<PreparedStatement>> FindConversation { get; } = new(() => session.PrepareAsync(
+		"SELECT conversation_id FROM user_conversations " +
+		"WHERE user_id = ? AND partner_id = ?"));
+
+	public Lazy<Task<PreparedStatement>> SelectLookup { get; } = new(() => session.PrepareAsync(
+		"SELECT is_dm, conversation_id, created_at FROM message_lookup " +
+		"WHERE message_id = ?"));
+
+	public Lazy<Task<PreparedStatement>> SelectDirectMessage { get; } = new(() => session.PrepareAsync(
+		"SELECT conversation_id, created_at, id, sender_id, recipient_id, content, edited_at, is_deleted, reply_to_id " +
+		"FROM direct_messages " +
+		"WHERE conversation_id = ? AND created_at = ? AND id = ?"));
+}

--- a/services/chat/src/Chat.Persistence/Repositories/DirectMessageStatements.cs
+++ b/services/chat/src/Chat.Persistence/Repositories/DirectMessageStatements.cs
@@ -55,6 +55,6 @@ internal sealed class DirectMessageStatements(ISession session)
 	public Lazy<Task<PreparedStatement>> SelectDirectMessagesByConversation { get; } = new(() => session.PrepareAsync(
 		"SELECT conversation_id, created_at, id, sender_id, recipient_id, content, edited_at, is_deleted, reply_to_id " +
 		"FROM direct_messages " +
-		"WHERE conversation_id = ? " +
+		"WHERE conversation_id = ? AND created_at < ? " +
 		"LIMIT ?"));
 }

--- a/services/chat/src/Chat.Persistence/Repositories/DirectMessageStatements.cs
+++ b/services/chat/src/Chat.Persistence/Repositories/DirectMessageStatements.cs
@@ -19,6 +19,17 @@ internal sealed class DirectMessageStatements(ISession session)
 		"(user_id, partner_id, conversation_id, last_message_at, last_preview, is_archived) " +
 		"VALUES (?, ?, ?, ?, ?, false)"));
 
+	// Conditional insert used by GetOrCreateConversationAsync to atomically decide
+	// the conversation_id on the very first message between two users. The caller
+	// binds (min(userA, userB), max(userA, userB)) so both send directions land on
+	// the same partition/clustering key and the LWT actually serializes the race.
+	// On a failed condition, Cassandra returns the current row's values (including
+	// conversation_id) in the same RowSet, so no follow-up read is needed.
+	public Lazy<Task<PreparedStatement>> InsertConversationIfNotExists { get; } = new(() => session.PrepareAsync(
+		"INSERT INTO user_conversations " +
+		"(user_id, partner_id, conversation_id, last_message_at, last_preview, is_archived) " +
+		"VALUES (?, ?, ?, null, null, false) IF NOT EXISTS"));
+
 	public Lazy<Task<PreparedStatement>> InsertNonce { get; } = new(() => session.PrepareAsync(
 		"INSERT INTO dm_nonce_dedup " +
 		"(sender_id, recipient_id, nonce, message_id) " +

--- a/services/chat/src/Chat.Persistence/Repositories/DirectMessageStatements.cs
+++ b/services/chat/src/Chat.Persistence/Repositories/DirectMessageStatements.cs
@@ -40,4 +40,10 @@ internal sealed class DirectMessageStatements(ISession session)
 		"SELECT conversation_id, created_at, id, sender_id, recipient_id, content, edited_at, is_deleted, reply_to_id " +
 		"FROM direct_messages " +
 		"WHERE conversation_id = ? AND created_at = ? AND id = ?"));
+
+	public Lazy<Task<PreparedStatement>> SelectDirectMessagesByConversation { get; } = new(() => session.PrepareAsync(
+		"SELECT conversation_id, created_at, id, sender_id, recipient_id, content, edited_at, is_deleted, reply_to_id " +
+		"FROM direct_messages " +
+		"WHERE conversation_id = ? " +
+		"LIMIT ?"));
 }

--- a/services/chat/src/Chat.Presentation/Endpoints/DirectMessagesEndpoint.cs
+++ b/services/chat/src/Chat.Presentation/Endpoints/DirectMessagesEndpoint.cs
@@ -11,7 +11,7 @@ public sealed class DirectMessagesEndpoint : ICarterModule
 {
 	public void AddRoutes(IEndpointRouteBuilder app)
 	{
-		var group = app.MapGroup("/channels/{channelId:long}/messages").WithTags("Direct Messages");
+		var group = app.MapGroup("/dms/{userId:long}/messages").WithTags("Direct Messages");
 		group.MapPost("/", SendAsync);
 	}
 
@@ -67,6 +67,7 @@ public sealed class DirectMessagesEndpoint : ICarterModule
 			"DirectMessage.InvalidConversationId" => TypedResults.BadRequest(body),
 			"DirectMessage.InvalidSenderId" => TypedResults.BadRequest(body),
 			"DirectMessage.InvalidRecipientId" => TypedResults.BadRequest(body),
+			"DirectMessage.InvalidReplyTarget" => TypedResults.BadRequest(body),
 			"DirectMessage.CannotMessageSelf" => TypedResults.BadRequest(body),
 			"DirectMessage.NonceTooLong" => TypedResults.BadRequest(body),
 

--- a/services/chat/src/Chat.Presentation/Endpoints/DirectMessagesEndpoint.cs
+++ b/services/chat/src/Chat.Presentation/Endpoints/DirectMessagesEndpoint.cs
@@ -2,6 +2,7 @@ using Carter;
 using Chat.Application.Abstractions.Messaging;
 using Chat.Application.Features.DirectMessages.Common;
 using Chat.Application.Features.DirectMessages.SendMessage;
+using Chat.Application.Features.DirectMessages.ListMessages;
 using Chat.Domain.Results;
 using Microsoft.AspNetCore.Http.HttpResults;
 
@@ -13,6 +14,7 @@ public sealed class DirectMessagesEndpoint : ICarterModule
 	{
 		var group = app.MapGroup("/dms/{userId:long}/messages").WithTags("Direct Messages");
 		group.MapPost("/", SendAsync);
+		group.MapGet("/", ListAsync);
 	}
 
 	private static async Task<Results<
@@ -43,6 +45,27 @@ public sealed class DirectMessagesEndpoint : ICarterModule
 
 		return MapError(result.Error);
 	}
+
+	private static async Task<Results<
+		Ok<IReadOnlyList<DirectMessageResponse>>,
+	BadRequest<ErrorBody>>>
+		ListAsync(
+				long userId,
+				int? limit,
+				IQueryHandler<ListDirectMessagesQuery, Result<IReadOnlyList<DirectMessageResponse>>> handler,
+				CancellationToken cancellationToken)
+		{
+			var result = await handler.HandleAsync(
+					new ListDirectMessagesQuery(
+						RecipientId: userId,
+						Limit: limit ?? 50),
+					cancellationToken);
+
+			if (result.Succeeded)
+				return TypedResults.Ok(result.Value);
+
+			return TypedResults.BadRequest(new ErrorBody(result.Error.Message));
+		}
 
 	private static Results<
 		Created<DirectMessageResponse>,

--- a/services/chat/src/Chat.Presentation/Endpoints/DirectMessagesEndpoint.cs
+++ b/services/chat/src/Chat.Presentation/Endpoints/DirectMessagesEndpoint.cs
@@ -51,6 +51,7 @@ public sealed class DirectMessagesEndpoint : ICarterModule
 	BadRequest<ErrorBody>>>
 		ListAsync(
 				long userId,
+				DateTimeOffset? before_time,
 				int? limit,
 				IQueryHandler<ListDirectMessagesQuery, Result<IReadOnlyList<DirectMessageResponse>>> handler,
 				CancellationToken cancellationToken)
@@ -58,7 +59,8 @@ public sealed class DirectMessagesEndpoint : ICarterModule
 			var result = await handler.HandleAsync(
 					new ListDirectMessagesQuery(
 						RecipientId: userId,
-						Limit: limit ?? 50),
+						Limit: limit ?? 50,
+						BeforeTime: before_time),
 					cancellationToken);
 
 			if (result.Succeeded)

--- a/services/chat/src/Chat.Presentation/Endpoints/DirectMessagesEndpoint.cs
+++ b/services/chat/src/Chat.Presentation/Endpoints/DirectMessagesEndpoint.cs
@@ -84,16 +84,15 @@ public sealed class DirectMessagesEndpoint : ICarterModule
 				body,
 				statusCode: StatusCodes.Status403Forbidden),
 
-			"DirectMessage.ContentRequired" => TypedResults.BadRequest(body),
-			"DirectMessage.ContentTooLong" => TypedResults.BadRequest(body),
-			"DirectMessage.InvalidId" => TypedResults.BadRequest(body),
-			"DirectMessage.InvalidConversationId" => TypedResults.BadRequest(body),
-			"DirectMessage.InvalidSenderId" => TypedResults.BadRequest(body),
-			"DirectMessage.InvalidRecipientId" => TypedResults.BadRequest(body),
-			"DirectMessage.InvalidReplyTarget" => TypedResults.BadRequest(body),
-			"DirectMessage.CannotMessageSelf" => TypedResults.BadRequest(body),
-			"DirectMessage.NonceTooLong" => TypedResults.BadRequest(body),
-
+			// "DirectMessage.ContentRequired"
+			// "DirectMessage.ContentTooLong"
+			// "DirectMessage.InvalidId"
+			// "DirectMessage.InvalidConversationId"
+			// "DirectMessage.InvalidSenderId"
+			// "DirectMessage.InvalidRecipientId"
+			// "DirectMessage.InvalidReplyTarget"
+			// "DirectMessage.CannotMessageSelf"
+			// "DirectMessage.NonceTooLong"
 			_ => TypedResults.BadRequest(body)
 		};
 	}

--- a/services/chat/src/Chat.Presentation/Endpoints/DirectMessagesEndpoint.cs
+++ b/services/chat/src/Chat.Presentation/Endpoints/DirectMessagesEndpoint.cs
@@ -80,9 +80,10 @@ public sealed class DirectMessagesEndpoint : ICarterModule
 
 		return failure.Code switch
 		{
+			"DirectMessage.RecipientNotFound" or
 			"DirectMessage.ConversationNotFound" => TypedResults.NotFound(body),
 
-			"DirectMessage.NotAFriend" => TypedResults.Json(
+			"DirectMessage.RecipientBlocked" => TypedResults.Json(
 				body,
 				statusCode: StatusCodes.Status403Forbidden),
 

--- a/services/chat/src/Chat.Presentation/Endpoints/DirectMessagesEndpoint.cs
+++ b/services/chat/src/Chat.Presentation/Endpoints/DirectMessagesEndpoint.cs
@@ -1,0 +1,83 @@
+using Carter;
+using Chat.Application.Abstractions.Messaging;
+using Chat.Application.Features.DirectMessages.Common;
+using Chat.Application.Features.DirectMessages.SendMessage;
+using Chat.Domain.Results;
+using Microsoft.AspNetCore.Http.HttpResults;
+
+namespace Chat.Presentation.Endpoints;
+
+public sealed class DirectMessagesEndpoint : ICarterModule
+{
+	public void AddRoutes(IEndpointRouteBuilder app)
+	{
+		var group = app.MapGroup("/channels/{channelId:long}/messages").WithTags("Direct Messages");
+		group.MapPost("/", SendAsync);
+	}
+
+	private static async Task<Results<
+		Created<DirectMessageResponse>,
+		BadRequest<ErrorBody>,
+		JsonHttpResult<ErrorBody>,
+		NotFound<ErrorBody>>>
+	SendAsync(
+		long userId,
+		SendDirectMessageRequest request,
+		ICommandHandler<SendDirectMessageCommand, Result<DirectMessageResponse>> handler,
+		CancellationToken cancellationToken)
+	{
+		var result = await handler.HandleAsync(
+			new SendDirectMessageCommand(
+				RecipientId: userId,
+				Content: request.Content,
+				ReplyToId: request.ReplyToId,
+				Nonce: request.Nonce),
+			cancellationToken);
+
+		if (result.Succeeded)
+		{
+			return TypedResults.Created(
+				$"/dms/{userId}/messages/{result.Value.Id}",
+				result.Value);
+		}
+
+		return MapError(result.Error);
+	}
+
+	private static Results<
+		Created<DirectMessageResponse>,
+		BadRequest<ErrorBody>,
+		JsonHttpResult<ErrorBody>,
+		NotFound<ErrorBody>>
+	MapError(Failure failure)
+	{
+		var body = new ErrorBody(failure.Message);
+
+		return failure.Code switch
+		{
+			"DirectMessage.ConversationNotFound" => TypedResults.NotFound(body),
+
+			"DirectMessage.NotAFriend" => TypedResults.Json(
+				body,
+				statusCode: StatusCodes.Status403Forbidden),
+
+			"DirectMessage.ContentRequired" => TypedResults.BadRequest(body),
+			"DirectMessage.ContentTooLong" => TypedResults.BadRequest(body),
+			"DirectMessage.InvalidId" => TypedResults.BadRequest(body),
+			"DirectMessage.InvalidConversationId" => TypedResults.BadRequest(body),
+			"DirectMessage.InvalidSenderId" => TypedResults.BadRequest(body),
+			"DirectMessage.InvalidRecipientId" => TypedResults.BadRequest(body),
+			"DirectMessage.CannotMessageSelf" => TypedResults.BadRequest(body),
+			"DirectMessage.NonceTooLong" => TypedResults.BadRequest(body),
+
+			_ => TypedResults.BadRequest(body)
+		};
+	}
+
+	private sealed record SendDirectMessageRequest(
+		string? Content,
+		long? ReplyToId,
+		string? Nonce);
+
+	private sealed record ErrorBody(string Error);
+}

--- a/services/chat/src/Chat.Presentation/Hubs/IChatClient.cs
+++ b/services/chat/src/Chat.Presentation/Hubs/IChatClient.cs
@@ -1,10 +1,13 @@
 using Chat.Application.Features.Messages.Common;
+using Chat.Application.Features.DirectMessages.Common;
 
 namespace Chat.Presentation.Hubs;
 
 public interface IChatClient
 {
 	Task ReceiveMessage(MessageResponse message);
+	Task ReceiveDirectMessage(DirectMessageResponse message);
+
 	Task MessageEdited(MessageEditedEvent evt);
 	Task MessageDeleted(MessageDeletedEvent evt);
 

--- a/services/chat/src/Chat.Presentation/Hubs/SignalRConversationUnicast.cs
+++ b/services/chat/src/Chat.Presentation/Hubs/SignalRConversationUnicast.cs
@@ -1,0 +1,19 @@
+using Chat.Application.Abstractions;
+using Chat.Application.Features.DirectMessages.Common;
+using Microsoft.AspNetCore.SignalR;
+
+namespace Chat.Presentation.Hubs;
+
+internal sealed class SignalRConversationUnicast(IHubContext<ChatHub, IChatClient> hub)
+	: IConversationUnicast
+{
+	public Task UnicastMessageAsync(
+		long recipientId,
+		DirectMessageResponse message,
+		CancellationToken ct)
+	{
+		return hub.Clients
+			.User(recipientId.ToString())
+			.ReceiveDirectMessage(message);
+	}
+}

--- a/services/chat/src/Chat.Presentation/Program.cs
+++ b/services/chat/src/Chat.Presentation/Program.cs
@@ -32,6 +32,7 @@ builder.Services.AddSingleton<CallRegistry>();
 builder.Services.Configure<SignalingOptions>(builder.Configuration.GetSection(SignalingOptions.SectionName));
 builder.Services.AddScoped<IChannelBroadcaster, SignalRChannelBroadcaster>();
 builder.Services.AddScoped<IUserBroadcaster, SignalRUserBroadcaster>();
+builder.Services.AddScoped<IConversationUnicast, SignalRConversationUnicast>();
 builder.Services.AddCarter();
 
 var jwtSecret = builder.Configuration["Jwt:SecretKey"]

--- a/services/chat/tests/Chat.FunctionalTests/Endpoints/SendDirectMessageEndpointTests.cs
+++ b/services/chat/tests/Chat.FunctionalTests/Endpoints/SendDirectMessageEndpointTests.cs
@@ -146,14 +146,71 @@ public sealed class SendDirectMessageEndpointTests(ChatApiFactory factory)
 		Assert.Single(factory.SavedDirectMessages);
 	}
 
+	[Fact]
+	public async Task Get_History_ReturnsLatestMessagesFirst()
+	{
+		var client = BuildClient(userId: 42);
+
+		var first = await client.PostAsJsonAsync("/v1/dms/100/messages",
+				new { content = "history functional test 1", nonce = "history-functional-1" });
+
+		var second = await client.PostAsJsonAsync("/v1/dms/100/messages",
+				new { content = "history functional test 2", nonce = "history-functional-2" });
+
+		Assert.Equal(HttpStatusCode.Created, first.StatusCode);
+		Assert.Equal(HttpStatusCode.Created, second.StatusCode);
+
+		var response = await client.GetAsync("/v1/dms/100/messages?limit=50");
+
+		Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+		var messages = await response.Content.ReadFromJsonAsync<List<DirectMessageBody>>(JsonOptions);
+
+		Assert.NotNull(messages);
+		Assert.Equal(2, messages!.Count);
+
+		Assert.Equal("history functional test 2", messages[0].Content);
+		Assert.Equal("history functional test 1", messages[1].Content);
+
+		Assert.Equal(messages[0].ConversationId, messages[1].ConversationId);
+		Assert.Equal("42", messages[0].SenderId);
+		Assert.Equal("100", messages[0].RecipientId);
+		Assert.Null(messages[0].Nonce);
+	}
+
+	[Fact]
+	public async Task Get_HistoryWithoutConversation_ReturnsEmptyList()
+	{
+		var client = BuildClient(userId: 42);
+
+		var response = await client.GetAsync("/v1/dms/999/messages?limit=50");
+
+		Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+		var messages = await response.Content.ReadFromJsonAsync<List<DirectMessageBody>>(JsonOptions);
+
+		Assert.NotNull(messages);
+		Assert.Empty(messages!);
+	}
+
+	[Fact]
+	public async Task Get_HistoryWithSelf_Returns400()
+	{
+		var client = BuildClient(userId: 42);
+
+		var response = await client.GetAsync("/v1/dms/42/messages?limit=50");
+
+		Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+	}
+
 	private sealed record DirectMessageBody(
-		string Id,
-		string ConversationId,
-		string SenderId,
-		string RecipientId,
-		string? Content,
-		string? ReplyToId,
-		DateTimeOffset? EditedAt,
-		DateTimeOffset CreatedAt,
-		string? Nonce);
+			string Id,
+			string ConversationId,
+			string SenderId,
+			string RecipientId,
+			string? Content,
+			string? ReplyToId,
+			DateTimeOffset? EditedAt,
+			DateTimeOffset CreatedAt,
+			string? Nonce);
 }

--- a/services/chat/tests/Chat.FunctionalTests/Endpoints/SendDirectMessageEndpointTests.cs
+++ b/services/chat/tests/Chat.FunctionalTests/Endpoints/SendDirectMessageEndpointTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text.Json;
+using Chat.Application.Abstractions;
 using Chat.Application.Contracts;
 using Chat.FunctionalTests.Infrastructure;
 using Xunit;
@@ -22,6 +23,11 @@ public sealed class SendDirectMessageEndpointTests(ChatApiFactory factory)
 		factory.DirectMessageRepository.Reset();
 		factory.EventBus.Reset();
 		factory.ConversationUnicast.Reset();
+		factory.UserClient.Reset();
+		// every test in this file sends as user 42; seed the relationship pairs
+		// it exercises so the handler's blocked-check passes by default
+		factory.UserClient.Setup(42, 100, new UsersRelationship("accepted", null));
+		factory.UserClient.Setup(42, 42, new UsersRelationship("accepted", null));
 		return Task.CompletedTask;
 	}
 
@@ -154,11 +160,18 @@ public sealed class SendDirectMessageEndpointTests(ChatApiFactory factory)
 		var first = await client.PostAsJsonAsync("/v1/dms/100/messages",
 				new { content = "history functional test 1", nonce = "history-functional-1" });
 
+		// the fake clock doesn't auto-advance like a real one would between
+		// requests; advance it explicitly so each message gets a distinct
+		// created_at and none of them collide with the list's default "now" cursor
+		factory.Clock.Advance(TimeSpan.FromMilliseconds(1));
+
 		var second = await client.PostAsJsonAsync("/v1/dms/100/messages",
 				new { content = "history functional test 2", nonce = "history-functional-2" });
 
 		Assert.Equal(HttpStatusCode.Created, first.StatusCode);
 		Assert.Equal(HttpStatusCode.Created, second.StatusCode);
+
+		factory.Clock.Advance(TimeSpan.FromMilliseconds(1));
 
 		var response = await client.GetAsync("/v1/dms/100/messages?limit=50");
 

--- a/services/chat/tests/Chat.FunctionalTests/Endpoints/SendDirectMessageEndpointTests.cs
+++ b/services/chat/tests/Chat.FunctionalTests/Endpoints/SendDirectMessageEndpointTests.cs
@@ -1,0 +1,159 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Chat.Application.Contracts;
+using Chat.FunctionalTests.Infrastructure;
+using Xunit;
+
+namespace Chat.FunctionalTests.Endpoints;
+
+public sealed class SendDirectMessageEndpointTests(ChatApiFactory factory)
+	: IClassFixture<ChatApiFactory>, IAsyncLifetime
+{
+	private static readonly JsonSerializerOptions JsonOptions = new()
+	{
+		PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+		PropertyNameCaseInsensitive = true,
+	};
+
+	public Task InitializeAsync()
+	{
+		factory.DirectMessageRepository.Reset();
+		factory.EventBus.Reset();
+		factory.ConversationUnicast.Reset();
+		return Task.CompletedTask;
+	}
+
+	public Task DisposeAsync() => Task.CompletedTask;
+
+	private HttpClient BuildClient(long userId)
+	{
+		var client = factory.CreateClient();
+		var token = TestTokens.Issue(ChatApiFactory.JwtSecret, userId: userId);
+		client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+		return client;
+	}
+
+	[Fact]
+	public async Task Post_WithoutToken_Returns401()
+	{
+		var client = factory.CreateClient();
+
+		var response = await client.PostAsJsonAsync("/v1/dms/100/messages",
+			new { content = "hi" });
+
+		Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+	}
+
+	[Fact]
+	public async Task Post_HappyPath_Returns201_PersistsPublishesAndUnicasts()
+	{
+		var client = BuildClient(userId: 42);
+
+		var response = await client.PostAsJsonAsync("/v1/dms/100/messages",
+			new { content = "hello dm", nonce = "dm-nonce-1" });
+
+		Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+
+		var body = await response.Content.ReadFromJsonAsync<DirectMessageBody>(JsonOptions);
+		Assert.NotNull(body);
+		Assert.Equal("42", body.SenderId);
+		Assert.Equal("100", body.RecipientId);
+		Assert.Equal("hello dm", body.Content);
+		Assert.Null(body.ReplyToId);
+		Assert.Equal("dm-nonce-1", body.Nonce);
+		Assert.True(long.TryParse(body.Id, out var messageId));
+		Assert.True(long.TryParse(body.ConversationId, out var conversationId));
+
+		var saved = Assert.Single(factory.SavedDirectMessages);
+		Assert.Equal(messageId, saved.Id);
+		Assert.Equal(conversationId, saved.ConversationId);
+		Assert.Equal(42L, saved.SenderId);
+		Assert.Equal(100L, saved.RecipientId);
+
+		var evt = Assert.Single(factory.EventBus.PublishedOf<ChatDmSent>());
+		Assert.Equal(messageId, evt.MessageId);
+		Assert.Equal(conversationId, evt.ConversationId);
+		Assert.Equal(42L, evt.SenderId);
+		Assert.Equal(100L, evt.RecipientId);
+
+		var (recipientId, unicastMessage) = Assert.Single(factory.ConversationUnicast.Unicasts);
+		Assert.Equal(100L, recipientId);
+		Assert.Equal(body.Id, unicastMessage.Id);
+		Assert.Equal("dm-nonce-1", unicastMessage.Nonce);
+	}
+
+	[Fact]
+	public async Task Post_BlankContent_Returns400_NoSideEffects()
+	{
+		var client = BuildClient(userId: 42);
+
+		var response = await client.PostAsJsonAsync("/v1/dms/100/messages",
+			new { content = "   " });
+
+		Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+		Assert.Empty(factory.SavedDirectMessages);
+		Assert.Empty(factory.EventBus.Published);
+		Assert.Empty(factory.ConversationUnicast.Unicasts);
+	}
+
+	[Fact]
+	public async Task Post_ToSelf_Returns400_NoSideEffects()
+	{
+		var client = BuildClient(userId: 42);
+
+		var response = await client.PostAsJsonAsync("/v1/dms/42/messages",
+			new { content = "nope" });
+
+		Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+		Assert.Empty(factory.SavedDirectMessages);
+		Assert.Empty(factory.EventBus.Published);
+		Assert.Empty(factory.ConversationUnicast.Unicasts);
+	}
+
+	[Fact]
+	public async Task Post_InvalidReplyTarget_Returns400_NoSideEffects()
+	{
+		var client = BuildClient(userId: 42);
+
+		var response = await client.PostAsJsonAsync("/v1/dms/100/messages",
+			new { content = "reply", reply_to_id = 999 });
+
+		Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+		Assert.Empty(factory.SavedDirectMessages);
+		Assert.Empty(factory.EventBus.Published);
+		Assert.Empty(factory.ConversationUnicast.Unicasts);
+	}
+
+	[Fact]
+	public async Task Post_SameNonce_Returns201WithOriginalMessage()
+	{
+		var client = BuildClient(userId: 42);
+
+		var first = await client.PostAsJsonAsync("/v1/dms/100/messages",
+			new { content = "hello", nonce = "dedup-dm-nonce" });
+		var firstBody = await first.Content.ReadFromJsonAsync<DirectMessageBody>(JsonOptions);
+
+		var second = await client.PostAsJsonAsync("/v1/dms/100/messages",
+			new { content = "hello", nonce = "dedup-dm-nonce" });
+		var secondBody = await second.Content.ReadFromJsonAsync<DirectMessageBody>(JsonOptions);
+
+		Assert.Equal(HttpStatusCode.Created, second.StatusCode);
+		Assert.Equal(firstBody!.Id, secondBody!.Id);
+		Assert.Equal(firstBody.CreatedAt, secondBody.CreatedAt);
+		Assert.Equal("dedup-dm-nonce", secondBody.Nonce);
+		Assert.Single(factory.SavedDirectMessages);
+	}
+
+	private sealed record DirectMessageBody(
+		string Id,
+		string ConversationId,
+		string SenderId,
+		string RecipientId,
+		string? Content,
+		string? ReplyToId,
+		DateTimeOffset? EditedAt,
+		DateTimeOffset CreatedAt,
+		string? Nonce);
+}

--- a/services/chat/tests/Chat.FunctionalTests/Infrastructure/ChatApiFactory.cs
+++ b/services/chat/tests/Chat.FunctionalTests/Infrastructure/ChatApiFactory.cs
@@ -44,8 +44,11 @@ public sealed class ChatApiFactory : WebApplicationFactory<Program>
 	public FakeChannelBroadcaster Broadcaster { get; } = new();
 	public FakeClock Clock { get; } = new();
 	public FakeIdGenerator IdGenerator { get; } = new();
+	public FakeDirectMessageRepository DirectMessageRepository { get; } = new();
+	public FakeConversationUnicast ConversationUnicast { get; } = new();
 
 	public IReadOnlyList<Message> SavedMessages => MessageRepository.Saved;
+	public IReadOnlyList<DirectMessage> SavedDirectMessages => DirectMessageRepository.Saved;
 
 	public void WithMembership(long channelId, long userId, long guildId, long permissions)
 	{
@@ -197,9 +200,14 @@ public sealed class ChatApiFactory : WebApplicationFactory<Program>
 			// from memory instead so the upload/download endpoints stay hermetic
 			services.RemoveAll<IObjectStore>();
 			services.AddSingleton<IObjectStore>(ObjectStore);
+			services.RemoveAll<IDirectMessageRepository>();
+			services.AddSingleton<IDirectMessageRepository>(DirectMessageRepository);
 
 			services.RemoveAll<IChannelBroadcaster>();
 			services.AddSingleton<IChannelBroadcaster>(Broadcaster);
+
+			services.RemoveAll<IConversationUnicast>();
+			services.AddSingleton<IConversationUnicast>(ConversationUnicast);
 
 			services.RemoveAll<IClock>();
 			services.AddSingleton<IClock>(Clock);

--- a/services/chat/tests/Chat.UnitTests/Application/SendDirectMessageHandlerTests.cs
+++ b/services/chat/tests/Chat.UnitTests/Application/SendDirectMessageHandlerTests.cs
@@ -1,3 +1,4 @@
+using Chat.Application.Abstractions;
 using Chat.Application.Abstractions.Messaging;
 using Chat.Application.Contracts;
 using Chat.Application.Features.DirectMessages.Common;
@@ -14,25 +15,28 @@ public sealed class SendDirectMessageHandlerTests
 		FakeCurrentUser CurrentUser,
 		FakeDirectMessageRepository Repository,
 		FakeIdGenerator IdGenerator,
+		FakeUserClient UserClient,
 		FakeClock Clock,
 		FakeEventBus EventBus,
 		FakeConversationUnicast Unicaster);
 
 	private static (Harness Harness,
 		ICommandHandler<SendDirectMessageCommand, Result<DirectMessageResponse>> Handler)
-		BuildHandler(long userId = 42)
+		BuildHandler(long userId = 42, long recipientId = 100)
 	{
 		var currentUser = new FakeCurrentUser { UserId = userId };
 		var repository = new FakeDirectMessageRepository();
 		var ids = new FakeIdGenerator();
+		var userClient = new FakeUserClient();
+		userClient.Setup(userId, recipientId, new UsersRelationship("none", null));
 		var clock = new FakeClock();
 		var eventBus = new FakeEventBus();
 		var unicaster = new FakeConversationUnicast();
 
 		var handler = HandlerFactory.CreateCommand<SendDirectMessageCommand, Result<DirectMessageResponse>>(
-			currentUser, repository, ids, clock, eventBus, unicaster);
+			currentUser, repository, ids, userClient, clock, eventBus, unicaster);
 
-		return (new Harness(currentUser, repository, ids, clock, eventBus, unicaster), handler);
+		return (new Harness(currentUser, repository, ids, userClient, clock, eventBus, unicaster), handler);
 	}
 
 	[Fact]

--- a/services/chat/tests/Chat.UnitTests/Application/SendDirectMessageHandlerTests.cs
+++ b/services/chat/tests/Chat.UnitTests/Application/SendDirectMessageHandlerTests.cs
@@ -1,0 +1,171 @@
+using Chat.Application.Abstractions.Messaging;
+using Chat.Application.Contracts;
+using Chat.Application.Features.DirectMessages.Common;
+using Chat.Application.Features.DirectMessages.SendMessage;
+using Chat.Domain.Results;
+using Chat.UnitTests.Fakes;
+using Xunit;
+
+namespace Chat.UnitTests.Application;
+
+public sealed class SendDirectMessageHandlerTests
+{
+	private sealed record Harness(
+		FakeCurrentUser CurrentUser,
+		FakeDirectMessageRepository Repository,
+		FakeIdGenerator IdGenerator,
+		FakeClock Clock,
+		FakeEventBus EventBus,
+		FakeConversationUnicast Unicaster);
+
+	private static (Harness Harness,
+		ICommandHandler<SendDirectMessageCommand, Result<DirectMessageResponse>> Handler)
+		BuildHandler(long userId = 42)
+	{
+		var currentUser = new FakeCurrentUser { UserId = userId };
+		var repository = new FakeDirectMessageRepository();
+		var ids = new FakeIdGenerator();
+		var clock = new FakeClock();
+		var eventBus = new FakeEventBus();
+		var unicaster = new FakeConversationUnicast();
+
+		var handler = HandlerFactory.CreateCommand<SendDirectMessageCommand, Result<DirectMessageResponse>>(
+			currentUser, repository, ids, clock, eventBus, unicaster);
+
+		return (new Harness(currentUser, repository, ids, clock, eventBus, unicaster), handler);
+	}
+
+	[Fact]
+	public async Task HappyPath_NewConversation_Persists_Publishes_Unicasts()
+	{
+		var (h, handler) = BuildHandler(userId: 42);
+
+		var result = await handler.HandleAsync(
+			new SendDirectMessageCommand(RecipientId: 100, Content: "hello", ReplyToId: null, Nonce: null));
+
+		Assert.True(result.Succeeded);
+		var response = result.Value;
+
+		// message persisté
+		var saved = Assert.Single(h.Repository.Saved);
+		Assert.Equal(42L, saved.SenderId);
+		Assert.Equal(100L, saved.RecipientId);
+		Assert.Equal("hello", saved.Content);
+		Assert.True(saved.ConversationId > 0);            // conversation neuve → id généré
+
+		// la réponse enveloppe bien le message sauvegardé
+		Assert.True(long.TryParse(response.Id, out var responseId));
+		Assert.Equal(responseId, saved.Id);
+
+		// event publié
+		var evt = Assert.Single(h.EventBus.PublishedOf<ChatDmSent>());
+		Assert.Equal(42L, evt.SenderId);
+		Assert.Equal(100L, evt.RecipientId);
+		Assert.Equal(saved.Id, evt.MessageId);
+		Assert.Equal(saved.ConversationId, evt.ConversationId);
+		Assert.Equal("hello", evt.Content);
+
+		// livré au destinataire, une fois, avec l'objet réponse
+		var (recipientId, unicastMessage) = Assert.Single(h.Unicaster.Unicasts);
+		Assert.Equal(100L, recipientId);
+		Assert.Same(response, unicastMessage);
+	}
+
+	[Fact]
+	public async Task ExistingConversation_ReusesId_DoesNotGenerateNew()
+	{
+		var (h, handler) = BuildHandler(userId: 42);
+		h.Repository.WithConversation(42, 100, conversationId: 555);   // la paire a déjà une conversation
+
+		var result = await handler.HandleAsync(
+			new SendDirectMessageCommand(RecipientId: 100, Content: "hi", ReplyToId: null, Nonce: null));
+
+		Assert.True(result.Succeeded);
+		var saved = Assert.Single(h.Repository.Saved);
+		Assert.Equal(555L, saved.ConversationId);                     // réutilisé, pas régénéré
+		Assert.Equal(555L, Assert.Single(h.EventBus.PublishedOf<ChatDmSent>()).ConversationId);
+	}
+
+	[Fact]
+	public async Task NonceTooLong_ReturnsFailure_NoSideEffects()
+	{
+		var (h, handler) = BuildHandler();
+
+		var result = await handler.HandleAsync(
+			new SendDirectMessageCommand(RecipientId: 100, Content: "hi", ReplyToId: null, Nonce: new string('x', 65)));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal(DirectMessageFailures.NonceTooLong, result.Error);
+		Assert.Empty(h.Repository.Saved);
+		Assert.Empty(h.EventBus.Published);
+		Assert.Empty(h.Unicaster.Unicasts);
+	}
+
+	[Fact]
+	public async Task Nonce64Chars_MaxAllowed_Succeeds()
+	{
+		var (h, handler) = BuildHandler();
+		var nonce = new string('x', 64);
+
+		var result = await handler.HandleAsync(
+			new SendDirectMessageCommand(RecipientId: 100, Content: "hi", ReplyToId: null, Nonce: nonce));
+
+		Assert.True(result.Succeeded);
+		Assert.Equal(nonce, result.Value.Nonce);   // ⚠️ aligne sur le nom de champ de ton DirectMessageResponse
+	}
+
+	[Fact]
+	public async Task NonceDedupHit_ReturnsSameMessage_NoNewSideEffects()
+	{
+		var (h, handler) = BuildHandler(userId: 42);
+
+		var first = await handler.HandleAsync(
+			new SendDirectMessageCommand(RecipientId: 100, Content: "hello", ReplyToId: null, Nonce: "n1"));
+		Assert.True(first.Succeeded);
+
+		h.EventBus.Reset();
+		h.Unicaster.Reset();
+
+		var second = await handler.HandleAsync(
+			new SendDirectMessageCommand(RecipientId: 100, Content: "hello", ReplyToId: null, Nonce: "n1"));
+
+		Assert.True(second.Succeeded);
+		Assert.Equal(first.Value.Id, second.Value.Id);
+		Assert.Single(h.Repository.Saved);          // pas de nouvelle écriture
+		Assert.Empty(h.EventBus.Published);          // pas de nouvel event
+		Assert.Empty(h.Unicaster.Unicasts);          // pas de nouvelle livraison
+	}
+
+	[Fact]
+	public async Task NonceDedupMiss_DifferentNonces_CreatesTwo()
+	{
+		var (h, handler) = BuildHandler(userId: 42);
+
+		var first = await handler.HandleAsync(
+			new SendDirectMessageCommand(RecipientId: 100, Content: "hello", ReplyToId: null, Nonce: "n-a"));
+		var second = await handler.HandleAsync(
+			new SendDirectMessageCommand(RecipientId: 100, Content: "hello", ReplyToId: null, Nonce: "n-b"));
+
+		Assert.True(first.Succeeded);
+		Assert.True(second.Succeeded);
+		Assert.NotEqual(first.Value.Id, second.Value.Id);
+		Assert.Equal(2, h.Repository.Saved.Count);
+		Assert.Equal(2, h.EventBus.Published.Count);
+		Assert.Equal(2, h.Unicaster.Unicasts.Count);
+	}
+
+	[Fact]
+	public async Task ContentRequired_DomainFailureBubblesUp_NoSideEffects()
+	{
+		var (h, handler) = BuildHandler();
+
+		var result = await handler.HandleAsync(
+			new SendDirectMessageCommand(RecipientId: 100, Content: "   ", ReplyToId: null, Nonce: null));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal(DirectMessageFailures.ContentRequired, result.Error);
+		Assert.Empty(h.Repository.Saved);
+		Assert.Empty(h.EventBus.Published);
+		Assert.Empty(h.Unicaster.Unicasts);
+	}
+}

--- a/services/chat/tests/Chat.UnitTests/Application/SendDirectMessageHandlerTests.cs
+++ b/services/chat/tests/Chat.UnitTests/Application/SendDirectMessageHandlerTests.cs
@@ -46,18 +46,15 @@ public sealed class SendDirectMessageHandlerTests
 		Assert.True(result.Succeeded);
 		var response = result.Value;
 
-		// message persisté
 		var saved = Assert.Single(h.Repository.Saved);
 		Assert.Equal(42L, saved.SenderId);
 		Assert.Equal(100L, saved.RecipientId);
 		Assert.Equal("hello", saved.Content);
-		Assert.True(saved.ConversationId > 0);            // conversation neuve → id généré
+		Assert.True(saved.ConversationId > 0);
 
-		// la réponse enveloppe bien le message sauvegardé
 		Assert.True(long.TryParse(response.Id, out var responseId));
 		Assert.Equal(responseId, saved.Id);
 
-		// event publié
 		var evt = Assert.Single(h.EventBus.PublishedOf<ChatDmSent>());
 		Assert.Equal(42L, evt.SenderId);
 		Assert.Equal(100L, evt.RecipientId);
@@ -65,7 +62,6 @@ public sealed class SendDirectMessageHandlerTests
 		Assert.Equal(saved.ConversationId, evt.ConversationId);
 		Assert.Equal("hello", evt.Content);
 
-		// livré au destinataire, une fois, avec l'objet réponse
 		var (recipientId, unicastMessage) = Assert.Single(h.Unicaster.Unicasts);
 		Assert.Equal(100L, recipientId);
 		Assert.Same(response, unicastMessage);
@@ -131,9 +127,9 @@ public sealed class SendDirectMessageHandlerTests
 
 		Assert.True(second.Succeeded);
 		Assert.Equal(first.Value.Id, second.Value.Id);
-		Assert.Single(h.Repository.Saved);          // pas de nouvelle écriture
-		Assert.Empty(h.EventBus.Published);          // pas de nouvel event
-		Assert.Empty(h.Unicaster.Unicasts);          // pas de nouvelle livraison
+		Assert.Single(h.Repository.Saved);
+		Assert.Empty(h.EventBus.Published);
+		Assert.Empty(h.Unicaster.Unicasts);
 	}
 
 	[Fact]

--- a/services/chat/tests/Chat.UnitTests/Application/SendDirectMessageHandlerTests.cs
+++ b/services/chat/tests/Chat.UnitTests/Application/SendDirectMessageHandlerTests.cs
@@ -164,4 +164,45 @@ public sealed class SendDirectMessageHandlerTests
 		Assert.Empty(h.EventBus.Published);
 		Assert.Empty(h.Unicaster.Unicasts);
 	}
+
+	[Fact]
+	public async Task ReplyToId_NotInConversation_ReturnsInvalidReplyTarget_NoSideEffects()
+	{
+		var (h, handler) = BuildHandler(userId: 42);
+		h.Repository.WithConversation(42, 100, conversationId: 555);
+
+		var result = await handler.HandleAsync(
+				new SendDirectMessageCommand(
+					RecipientId: 100,
+					Content: "reply",
+					ReplyToId: 999,
+					Nonce: null));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal(DirectMessageFailures.InvalidReplyTarget, result.Error);
+		Assert.Empty(h.Repository.Saved);
+		Assert.Empty(h.EventBus.Published);
+		Assert.Empty(h.Unicaster.Unicasts);
+	}
+
+	[Fact]
+	public async Task ReplyToId_InSameConversation_Succeeds_AndPersistsReplyToId()
+	{
+		var (h, handler) = BuildHandler(userId: 42);
+		h.Repository.WithConversation(42, 100, conversationId: 555);
+		h.Repository.WithReply(conversationId: 555, replyToId: 999);
+
+		var result = await handler.HandleAsync(
+				new SendDirectMessageCommand(
+					RecipientId: 100,
+					Content: "reply",
+					ReplyToId: 999,
+					Nonce: null));
+
+		Assert.True(result.Succeeded);
+
+		var saved = Assert.Single(h.Repository.Saved);
+		Assert.Equal(999L, saved.ReplyToId);
+		Assert.Equal(555L, saved.ConversationId);
+	}
 }

--- a/services/chat/tests/Chat.UnitTests/Domain/DirectMessageTests.cs
+++ b/services/chat/tests/Chat.UnitTests/Domain/DirectMessageTests.cs
@@ -1,0 +1,140 @@
+using Chat.Domain.Messages;
+using Chat.Domain.Results;
+using Xunit;
+
+namespace Chat.UnitTests.Domain;
+
+public sealed class DirectMessageTests
+{
+	private static readonly DateTimeOffset Now =
+		new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+	[Fact]
+	public void Create_HappyPath_PopulatesProperties()
+	{
+		var result = DirectMessage.Create(
+			id: 1001,
+			conversationId: 42,
+			senderId: 7,
+			recipientId: 8,
+			content: "hello world",
+			replyToId: null,
+			now: Now);
+
+		Assert.True(result.Succeeded);
+		var message = result.Value;
+
+		Assert.Equal(1001L, message.Id);
+		Assert.Equal(42L, message.ConversationId);
+		Assert.Equal(7L, message.SenderId);
+		Assert.Equal(8L, message.RecipientId);
+		Assert.Equal("hello world", message.Content);
+		Assert.Null(message.ReplyToId);
+		Assert.Null(message.EditedAt);
+		Assert.False(message.IsDeleted);
+		Assert.Equal(Now, message.CreatedAt);
+	}
+
+	[Fact]
+	public void Create_WithReplyToId_PersistsReplyToId()
+	{
+		var result = DirectMessage.Create(
+			id: 1001, conversationId: 42, senderId: 7, recipientId: 8,
+			content: "reply", replyToId: 999, now: Now);
+
+		Assert.True(result.Succeeded);
+		Assert.Equal(999L, result.Value.ReplyToId);
+	}
+
+	[Theory]
+	[InlineData(null)]
+	[InlineData("")]
+	[InlineData("   ")]
+	[InlineData("\t\n")]
+	public void Create_BlankContent_ReturnsContentRequired(string? content)
+	{
+		var result = DirectMessage.Create(
+			id: 1, conversationId: 1, senderId: 1, recipientId: 1,
+			content: content, replyToId: null, now: Now);
+
+		Assert.True(result.IsFailure);
+		Assert.Equal(DirectMessageFailures.ContentRequired, result.Error);
+	}
+
+	[Fact]
+	public void Create_ContentTooLong_ReturnsContentTooLong()
+	{
+		var content = new string('x', Message.MaxContentLen + 1);
+
+		var result = DirectMessage.Create(
+			id: 1, conversationId: 1, senderId: 1, recipientId: 1,
+			content: content, replyToId: null, now: Now);
+
+		Assert.True(result.IsFailure);
+		Assert.Equal(DirectMessageFailures.ContentTooLong, result.Error);
+	}
+
+	[Fact]
+	public void Create_ContentExactlyAtMax_Succeeds()
+	{
+		var content = new string('x', DirectMessage.MaxContentLen);
+
+		var result = DirectMessage.Create(
+			id: 1, conversationId: 1, senderId: 1, recipientId: 1,
+			content: content, replyToId: null, now: Now);
+
+		Assert.True(result.Succeeded);
+	}
+
+	[Theory]
+	[InlineData(0)]
+	[InlineData(-1)]
+	public void Create_NonPositiveId_ReturnsInvalidId(long id)
+	{
+		var result = DirectMessage.Create(
+			id: id, conversationId: 1, senderId: 1, recipientId: 1,
+			content: "hi", replyToId: null, now: Now);
+
+		Assert.True(result.IsFailure);
+		Assert.Equal(DirectMessageFailures.InvalidId, result.Error);
+	}
+
+	[Theory]
+	[InlineData(0)]
+	[InlineData(-1)]
+	public void Create_NonPositiveChannelId_ReturnsInvalidConversationId(long conversationId)
+	{
+		var result = DirectMessage.Create(
+			id: 1, conversationId: conversationId, senderId: 1, recipientId: 1,
+			content: "hi", replyToId: null, now: Now);
+
+		Assert.True(result.IsFailure);
+		Assert.Equal(DirectMessageFailures.InvalidConversationId, result.Error);
+	}
+
+	[Theory]
+	[InlineData(0)]
+	[InlineData(-1)]
+	public void Create_NonPositiveAuthorId_ReturnsInvalidSenderId(long senderId)
+	{
+		var result = DirectMessage.Create(
+			id: 1, conversationId: 1, senderId: senderId, recipientId: 1,
+			content: "hi", replyToId: null, now: Now);
+
+		Assert.True(result.IsFailure);
+		Assert.Equal(DirectMessageFailures.InvalidSenderId, result.Error);
+	}
+
+	[Theory]
+	[InlineData(0)]
+	[InlineData(-1)]
+	public void Create_NonPositiveAuthorId_ReturnsInvalidRecipientId(long recipientId)
+	{
+		var result = DirectMessage.Create(
+			id: 1, conversationId: 1, senderId: 1, recipientId: recipientId,
+			content: "hi", replyToId: null, now: Now);
+
+		Assert.True(result.IsFailure);
+		Assert.Equal(DirectMessageFailures.InvalidSenderId, result.Error);
+	}
+}

--- a/services/chat/tests/Chat.UnitTests/Domain/DirectMessageTests.cs
+++ b/services/chat/tests/Chat.UnitTests/Domain/DirectMessageTests.cs
@@ -6,135 +6,133 @@ namespace Chat.UnitTests.Domain;
 
 public sealed class DirectMessageTests
 {
-	private static readonly DateTimeOffset Now =
-		new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+    private static readonly DateTimeOffset Now =
+        new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
 
-	[Fact]
-	public void Create_HappyPath_PopulatesProperties()
-	{
-		var result = DirectMessage.Create(
-			id: 1001,
-			conversationId: 42,
-			senderId: 7,
-			recipientId: 8,
-			content: "hello world",
-			replyToId: null,
-			now: Now);
+    [Fact]
+    public void Create_HappyPath_PopulatesProperties()
+    {
+        var result = DirectMessage.Create(
+            id: 1001,
+            conversationId: 42,
+            senderId: 7,
+            recipientId: 8,
+            content: "hello world",
+            replyToId: null,
+            now: Now);
+        Assert.True(result.Succeeded);
+        var message = result.Value;
+        Assert.Equal(1001L, message.Id);
+        Assert.Equal(42L, message.ConversationId);
+        Assert.Equal(7L, message.SenderId);
+        Assert.Equal(8L, message.RecipientId);
+        Assert.Equal("hello world", message.Content);
+        Assert.Null(message.ReplyToId);
+        Assert.Null(message.EditedAt);
+        Assert.False(message.IsDeleted);
+        Assert.Equal(Now, message.CreatedAt);
+    }
 
-		Assert.True(result.Succeeded);
-		var message = result.Value;
+    [Fact]
+    public void Create_WithReplyToId_PersistsReplyToId()
+    {
+        var result = DirectMessage.Create(
+            id: 1001, conversationId: 42, senderId: 7, recipientId: 8,
+            content: "reply", replyToId: 999, now: Now);
+        Assert.True(result.Succeeded);
+        Assert.Equal(999L, result.Value.ReplyToId);
+    }
 
-		Assert.Equal(1001L, message.Id);
-		Assert.Equal(42L, message.ConversationId);
-		Assert.Equal(7L, message.SenderId);
-		Assert.Equal(8L, message.RecipientId);
-		Assert.Equal("hello world", message.Content);
-		Assert.Null(message.ReplyToId);
-		Assert.Null(message.EditedAt);
-		Assert.False(message.IsDeleted);
-		Assert.Equal(Now, message.CreatedAt);
-	}
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("\t\n")]
+    public void Create_BlankContent_ReturnsContentRequired(string? content)
+    {
+        var result = DirectMessage.Create(
+            id: 1, conversationId: 1, senderId: 1, recipientId: 2,
+            content: content, replyToId: null, now: Now);
+        Assert.True(result.IsFailure);
+        Assert.Equal(DirectMessageFailures.ContentRequired, result.Error);
+    }
 
-	[Fact]
-	public void Create_WithReplyToId_PersistsReplyToId()
-	{
-		var result = DirectMessage.Create(
-			id: 1001, conversationId: 42, senderId: 7, recipientId: 8,
-			content: "reply", replyToId: 999, now: Now);
+    [Fact]
+    public void Create_ContentTooLong_ReturnsContentTooLong()
+    {
+        var content = new string('x', DirectMessage.MaxContentLen + 1);
+        var result = DirectMessage.Create(
+            id: 1, conversationId: 1, senderId: 1, recipientId: 2,
+            content: content, replyToId: null, now: Now);
+        Assert.True(result.IsFailure);
+        Assert.Equal(DirectMessageFailures.ContentTooLong, result.Error);
+    }
 
-		Assert.True(result.Succeeded);
-		Assert.Equal(999L, result.Value.ReplyToId);
-	}
+    [Fact]
+    public void Create_ContentExactlyAtMax_Succeeds()
+    {
+        var content = new string('x', DirectMessage.MaxContentLen);
+        var result = DirectMessage.Create(
+            id: 1, conversationId: 1, senderId: 1, recipientId: 2,
+            content: content, replyToId: null, now: Now);
+        Assert.True(result.Succeeded);
+    }
 
-	[Theory]
-	[InlineData(null)]
-	[InlineData("")]
-	[InlineData("   ")]
-	[InlineData("\t\n")]
-	public void Create_BlankContent_ReturnsContentRequired(string? content)
-	{
-		var result = DirectMessage.Create(
-			id: 1, conversationId: 1, senderId: 1, recipientId: 1,
-			content: content, replyToId: null, now: Now);
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void Create_NonPositiveId_ReturnsInvalidId(long id)
+    {
+        var result = DirectMessage.Create(
+            id: id, conversationId: 1, senderId: 1, recipientId: 2,
+            content: "hi", replyToId: null, now: Now);
+        Assert.True(result.IsFailure);
+        Assert.Equal(DirectMessageFailures.InvalidId, result.Error);
+    }
 
-		Assert.True(result.IsFailure);
-		Assert.Equal(DirectMessageFailures.ContentRequired, result.Error);
-	}
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void Create_NonPositiveConversationId_ReturnsInvalidConversationId(long conversationId)
+    {
+        var result = DirectMessage.Create(
+            id: 1, conversationId: conversationId, senderId: 1, recipientId: 2,
+            content: "hi", replyToId: null, now: Now);
+        Assert.True(result.IsFailure);
+        Assert.Equal(DirectMessageFailures.InvalidConversationId, result.Error);
+    }
 
-	[Fact]
-	public void Create_ContentTooLong_ReturnsContentTooLong()
-	{
-		var content = new string('x', Message.MaxContentLen + 1);
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void Create_NonPositiveSenderId_ReturnsInvalidSenderId(long senderId)
+    {
+        var result = DirectMessage.Create(
+            id: 1, conversationId: 1, senderId: senderId, recipientId: 2,
+            content: "hi", replyToId: null, now: Now);
+        Assert.True(result.IsFailure);
+        Assert.Equal(DirectMessageFailures.InvalidSenderId, result.Error);
+    }
 
-		var result = DirectMessage.Create(
-			id: 1, conversationId: 1, senderId: 1, recipientId: 1,
-			content: content, replyToId: null, now: Now);
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void Create_NonPositiveRecipientId_ReturnsInvalidRecipientId(long recipientId)
+    {
+        var result = DirectMessage.Create(
+            id: 1, conversationId: 1, senderId: 1, recipientId: recipientId,
+            content: "hi", replyToId: null, now: Now);
+        Assert.True(result.IsFailure);
+        Assert.Equal(DirectMessageFailures.InvalidRecipientId, result.Error);
+    }
 
-		Assert.True(result.IsFailure);
-		Assert.Equal(DirectMessageFailures.ContentTooLong, result.Error);
-	}
-
-	[Fact]
-	public void Create_ContentExactlyAtMax_Succeeds()
-	{
-		var content = new string('x', DirectMessage.MaxContentLen);
-
-		var result = DirectMessage.Create(
-			id: 1, conversationId: 1, senderId: 1, recipientId: 1,
-			content: content, replyToId: null, now: Now);
-
-		Assert.True(result.Succeeded);
-	}
-
-	[Theory]
-	[InlineData(0)]
-	[InlineData(-1)]
-	public void Create_NonPositiveId_ReturnsInvalidId(long id)
-	{
-		var result = DirectMessage.Create(
-			id: id, conversationId: 1, senderId: 1, recipientId: 1,
-			content: "hi", replyToId: null, now: Now);
-
-		Assert.True(result.IsFailure);
-		Assert.Equal(DirectMessageFailures.InvalidId, result.Error);
-	}
-
-	[Theory]
-	[InlineData(0)]
-	[InlineData(-1)]
-	public void Create_NonPositiveChannelId_ReturnsInvalidConversationId(long conversationId)
-	{
-		var result = DirectMessage.Create(
-			id: 1, conversationId: conversationId, senderId: 1, recipientId: 1,
-			content: "hi", replyToId: null, now: Now);
-
-		Assert.True(result.IsFailure);
-		Assert.Equal(DirectMessageFailures.InvalidConversationId, result.Error);
-	}
-
-	[Theory]
-	[InlineData(0)]
-	[InlineData(-1)]
-	public void Create_NonPositiveAuthorId_ReturnsInvalidSenderId(long senderId)
-	{
-		var result = DirectMessage.Create(
-			id: 1, conversationId: 1, senderId: senderId, recipientId: 1,
-			content: "hi", replyToId: null, now: Now);
-
-		Assert.True(result.IsFailure);
-		Assert.Equal(DirectMessageFailures.InvalidSenderId, result.Error);
-	}
-
-	[Theory]
-	[InlineData(0)]
-	[InlineData(-1)]
-	public void Create_NonPositiveAuthorId_ReturnsInvalidRecipientId(long recipientId)
-	{
-		var result = DirectMessage.Create(
-			id: 1, conversationId: 1, senderId: 1, recipientId: recipientId,
-			content: "hi", replyToId: null, now: Now);
-
-		Assert.True(result.IsFailure);
-		Assert.Equal(DirectMessageFailures.InvalidSenderId, result.Error);
-	}
+    [Fact]
+    public void Create_SenderEqualsRecipient_ReturnsCannotMessageSelf()
+    {
+        var result = DirectMessage.Create(
+            id: 1, conversationId: 1, senderId: 5, recipientId: 5,
+            content: "hi", replyToId: null, now: Now);
+        Assert.True(result.IsFailure);
+        Assert.Equal(DirectMessageFailures.CannotMessageSelf, result.Error);
+    }
 }

--- a/services/chat/tests/Chat.UnitTests/Fakes/FakeConversationUnicast.cs
+++ b/services/chat/tests/Chat.UnitTests/Fakes/FakeConversationUnicast.cs
@@ -1,0 +1,18 @@
+using Chat.Application.Abstractions;
+using Chat.Application.Features.DirectMessages.Common;
+
+namespace Chat.UnitTests.Fakes;
+
+public sealed class FakeConversationUnicast : IConversationUnicast
+{
+	private readonly List<(long RecipientId, DirectMessageResponse Message)> _unicasts = [];
+
+	public IReadOnlyList<(long RecipientId, DirectMessageResponse Message)> Unicasts => _unicasts;
+
+	public void Reset() => _unicasts.Clear();
+	public Task UnicastMessageAsync(long recipientId, DirectMessageResponse message, CancellationToken ct)
+	{
+		_unicasts.Add((recipientId, message));
+		return Task.CompletedTask;
+	}
+}

--- a/services/chat/tests/Chat.UnitTests/Fakes/FakeDirectMessageRepository.cs
+++ b/services/chat/tests/Chat.UnitTests/Fakes/FakeDirectMessageRepository.cs
@@ -53,5 +53,21 @@ public sealed class FakeDirectMessageRepository : IDirectMessageRepository
 		return Task.FromResult(message);
 	}
 
+	public Task<IReadOnlyList<DirectMessage>> ListAsync(
+			long conversationId,
+			int limit,
+			CancellationToken ct)
+	{
+		var messages = _saved
+			.Where(m => m.ConversationId == conversationId)
+			.OrderByDescending(m => m.CreatedAt)
+			.ThenByDescending(m => m.Id)
+			.Take(limit)
+			.ToList();
+
+		return Task.FromResult<IReadOnlyList<DirectMessage>>(messages);
+	}
+
 	public void WithReply(long conversationId, long replyToId) =>
-		_replies[(conversationId, replyToId)] = replyToId;}
+		_replies[(conversationId, replyToId)] = replyToId;
+}

--- a/services/chat/tests/Chat.UnitTests/Fakes/FakeDirectMessageRepository.cs
+++ b/services/chat/tests/Chat.UnitTests/Fakes/FakeDirectMessageRepository.cs
@@ -1,0 +1,52 @@
+using Chat.Application.Abstractions.Persistence;
+using Chat.Domain.Messages;
+
+namespace Chat.UnitTests.Fakes;
+
+public sealed class FakeDirectMessageRepository : IDirectMessageRepository
+{
+	private readonly List<DirectMessage> _saved = [];
+	private readonly Dictionary<(long SenderId, long RecipientId, string Nonce), long> _nonces = [];
+	private readonly Dictionary<(long, long), long> _conversations = [];
+
+	public IReadOnlyList<DirectMessage> Saved => _saved;
+
+	private static (long, long) Pair(long a, long b) => a < b ? (a, b) : (b, a);
+
+	public void WithConversation(long userA, long userB, long conversationId) =>
+		_conversations[Pair(userA, userB)] = conversationId;
+
+	public void Reset()
+	{
+		_saved.Clear();
+		_nonces.Clear();
+		_conversations.Clear();
+	}
+
+	public Task<long?> FindConversationAsync(long senderId, long recipientId, CancellationToken ct) =>
+		Task.FromResult(_conversations.TryGetValue(Pair(senderId, recipientId), out var id) ? id : (long?)null);
+
+	public Task<long?> FindReplyExistsAsync(long conversationId, long replyToId, CancellationToken ct) =>
+		Task.FromResult<long?>(null);
+
+	public Task AddAsync(DirectMessage message, string? nonce, CancellationToken ct)
+	{
+		_saved.Add(message);
+		_conversations[Pair(message.SenderId, message.RecipientId)] = message.ConversationId;
+		if (nonce is not null)
+			_nonces[(message.SenderId, message.RecipientId, nonce)] = message.Id;
+		return Task.CompletedTask;
+	}
+
+	public Task<long?> FindNonceAsync(long senderId, long recipientId, string nonce, CancellationToken ct)
+	{
+		_nonces.TryGetValue((senderId, recipientId, nonce), out var messageId);
+		return Task.FromResult(messageId == 0 ? null : (long?)messageId);
+	}
+
+	public Task<DirectMessage?> GetByIdAsync(long messageId, CancellationToken ct)
+	{
+		var message = _saved.FirstOrDefault(m => m.Id == messageId);
+		return Task.FromResult(message);
+	}
+}

--- a/services/chat/tests/Chat.UnitTests/Fakes/FakeDirectMessageRepository.cs
+++ b/services/chat/tests/Chat.UnitTests/Fakes/FakeDirectMessageRepository.cs
@@ -8,6 +8,8 @@ public sealed class FakeDirectMessageRepository : IDirectMessageRepository
 	private readonly List<DirectMessage> _saved = [];
 	private readonly Dictionary<(long SenderId, long RecipientId, string Nonce), long> _nonces = [];
 	private readonly Dictionary<(long, long), long> _conversations = [];
+	private readonly Dictionary<(long ConversationId, long ReplyToId), long> _replies = [];
+
 
 	public IReadOnlyList<DirectMessage> Saved => _saved;
 
@@ -21,13 +23,14 @@ public sealed class FakeDirectMessageRepository : IDirectMessageRepository
 		_saved.Clear();
 		_nonces.Clear();
 		_conversations.Clear();
+		_replies.Clear();
 	}
 
 	public Task<long?> FindConversationAsync(long senderId, long recipientId, CancellationToken ct) =>
 		Task.FromResult(_conversations.TryGetValue(Pair(senderId, recipientId), out var id) ? id : (long?)null);
 
 	public Task<long?> FindReplyExistsAsync(long conversationId, long replyToId, CancellationToken ct) =>
-		Task.FromResult<long?>(null);
+		Task.FromResult(_replies.TryGetValue((conversationId, replyToId), out var id) ? id : (long?)null);
 
 	public Task AddAsync(DirectMessage message, string? nonce, CancellationToken ct)
 	{
@@ -49,4 +52,6 @@ public sealed class FakeDirectMessageRepository : IDirectMessageRepository
 		var message = _saved.FirstOrDefault(m => m.Id == messageId);
 		return Task.FromResult(message);
 	}
-}
+
+	public void WithReply(long conversationId, long replyToId) =>
+		_replies[(conversationId, replyToId)] = replyToId;}

--- a/services/chat/tests/Chat.UnitTests/Fakes/FakeDirectMessageRepository.cs
+++ b/services/chat/tests/Chat.UnitTests/Fakes/FakeDirectMessageRepository.cs
@@ -29,6 +29,15 @@ public sealed class FakeDirectMessageRepository : IDirectMessageRepository
 	public Task<long?> FindConversationAsync(long senderId, long recipientId, CancellationToken ct) =>
 		Task.FromResult(_conversations.TryGetValue(Pair(senderId, recipientId), out var id) ? id : (long?)null);
 
+	public Task<long> GetOrCreateConversationAsync(long senderId, long recipientId, long candidateId, CancellationToken ct)
+	{
+		var pair = Pair(senderId, recipientId);
+		if (!_conversations.TryGetValue(pair, out var id))
+			_conversations[pair] = id = candidateId;
+
+		return Task.FromResult(id);
+	}
+
 	public Task<long?> FindReplyExistsAsync(long conversationId, long replyToId, CancellationToken ct) =>
 		Task.FromResult(_replies.TryGetValue((conversationId, replyToId), out var id) ? id : (long?)null);
 
@@ -55,11 +64,12 @@ public sealed class FakeDirectMessageRepository : IDirectMessageRepository
 
 	public Task<IReadOnlyList<DirectMessage>> ListAsync(
 			long conversationId,
+			DateTimeOffset beforeTime,
 			int limit,
 			CancellationToken ct)
 	{
 		var messages = _saved
-			.Where(m => m.ConversationId == conversationId)
+			.Where(m => m.ConversationId == conversationId && m.CreatedAt < beforeTime)
 			.OrderByDescending(m => m.CreatedAt)
 			.ThenByDescending(m => m.Id)
 			.Take(limit)


### PR DESCRIPTION
## About

Adds the first DM slice: send a direct message and list conversation history, mirroring the existing channel message flow.

## Changes
  - `SendDirectMessageHandler` / `ListDirectMessagesHandler`
  - `DirectMessage` domain entity + `DirectMessageRepository`/`DirectMessageStatements` (Cassandra)
  - `POST/GET /dms/{userId}/messages`
  - Nonce dedup, reply-target validation, race-safe conversation creation a Cassandra LWT

### Changes on @Cartoone9 commit's

I'm based my changes on your `TODO: ` comments, and some minor style issues. 
**In `SendMessageHandler`**:
- check the friendship (blocked by one of the users cancel the message)
- fix race condition on conversation creation (first message sent) by a conditionnal write in DB out of the final batch
- `FindReplyExistsAsync` now check `is_deleted`

**In `ListMessagesHandler`**:
- handle `before_time` params

## Notes
> No attachment support yet — that's the next PR (#286).

Close #199 
Close #156 
Close #201