### PR TITLE
Feat(chat): support attachments for DM

### DIFF
--- a/services/chat/src/Chat.Application/Abstractions/Persistence/IAttachmentRepository.cs
+++ b/services/chat/src/Chat.Application/Abstractions/Persistence/IAttachmentRepository.cs
@@ -24,6 +24,17 @@ public interface IAttachmentRepository
 	/// </summary>
 	Task<ILookup<long, AttachmentMetadata>> GetChannelMessagesAttachmentsAsync(
 		long channelId, IReadOnlyList<long> messageIds, CancellationToken ct);
+
+	Task<AttachmentMetadata?> GetDmAttachmentAsync(long conversationId, long messageId, long id, CancellationToken ct);
+
+	Task<IReadOnlyList<AttachmentMetadata>> GetDmMessageAttachmentsAsync(long conversationId, long messageId, CancellationToken ct);
+
+	/// <summary>
+	/// hydrates attachments for a whole page of DM messages in one query, keyed by
+	/// message id (messages with no attachments are simply absent from the lookup)
+	/// </summary>
+	Task<ILookup<long, AttachmentMetadata>> GetDmMessagesAttachmentsAsync(
+		long conversationId, IReadOnlyList<long> messageIds, CancellationToken ct);
 }
 
 /// <summary>

--- a/services/chat/src/Chat.Application/Abstractions/Persistence/IDirectMessageRepository.cs
+++ b/services/chat/src/Chat.Application/Abstractions/Persistence/IDirectMessageRepository.cs
@@ -1,3 +1,4 @@
+using Chat.Domain.Attachments;
 using Chat.Domain.Messages;
 
 namespace Chat.Application.Abstractions.Persistence;
@@ -19,7 +20,7 @@ public interface IDirectMessageRepository
 	/// <summary>excludes soft-deleted messages: a reply may not target a deleted message</summary>
 	Task<long?> FindReplyExistsAsync(long conversationId, long replyToId, CancellationToken ct);
 
-	Task AddAsync(DirectMessage message, string? nonce, CancellationToken ct);
+	Task AddAsync(DirectMessage message, string? nonce, IReadOnlyList<AttachmentMetadata> attachments, CancellationToken ct);
 
 	Task<long?> FindNonceAsync(long senderId, long recipientId, string nonce, CancellationToken ct);
 

--- a/services/chat/src/Chat.Application/Features/Attachments/DownloadAttachment/DownloadAttachmentHandler.cs
+++ b/services/chat/src/Chat.Application/Features/Attachments/DownloadAttachment/DownloadAttachmentHandler.cs
@@ -12,6 +12,7 @@ namespace Chat.Application.Features.Attachments.DownloadAttachment;
 internal sealed class DownloadAttachmentHandler(
 	ICurrentUser currentUser,
 	IAttachmentRepository repository,
+	IDirectMessageRepository directMessageRepository,
 	IGuildClient guildClient,
 	IObjectStore objectStore)
 	: IQueryHandler<DownloadAttachmentQuery, Result<AttachmentDownload>>
@@ -31,9 +32,7 @@ internal sealed class DownloadAttachmentHandler(
 			return await DownloadDraftAsync(query, cancellationToken);
 
 		if (location.IsDm)
-			// DM attachments arrive with the DM feature; nothing on the channel path
-			// can produce one, so deny rather than leak an unauthorized stream
-			return AttachmentFailures.NotAuthorized;
+			return await DownloadDmAttachmentAsync(query, location, cancellationToken);
 
 		return await DownloadChannelAttachmentAsync(query, location, cancellationToken);
 	}
@@ -54,6 +53,28 @@ internal sealed class DownloadAttachmentHandler(
 
 		var metadata = await repository.GetChannelAttachmentAsync(
 			channelId, location.MessageId, query.Id, ct);
+		if (metadata is null)
+			return AttachmentFailures.NotFound;
+
+		return await OpenAsync(metadata, query.Filename, ct);
+	}
+
+	private async Task<Result<AttachmentDownload>> DownloadDmAttachmentAsync(
+		DownloadAttachmentQuery query,
+		AttachmentLocation location,
+		CancellationToken ct)
+	{
+		var conversationId = location.ConversationId!.Value;
+
+		var message = await directMessageRepository.GetByIdAsync(location.MessageId, ct);
+		if (message is null)
+			return AttachmentFailures.NotAuthorized;
+
+		var userId = currentUser.UserId;
+		if (message.SenderId != userId && message.RecipientId != userId)
+			return AttachmentFailures.NotAuthorized;
+
+		var metadata = await repository.GetDmAttachmentAsync(conversationId, location.MessageId, query.Id, ct);
 		if (metadata is null)
 			return AttachmentFailures.NotFound;
 

--- a/services/chat/src/Chat.Application/Features/DirectMessages/Common/DirectMessageResponse.cs
+++ b/services/chat/src/Chat.Application/Features/DirectMessages/Common/DirectMessageResponse.cs
@@ -1,3 +1,5 @@
+using Chat.Application.Features.Attachments.Common;
+using Chat.Domain.Attachments;
 using Chat.Domain.Messages;
 
 namespace Chat.Application.Features.DirectMessages.Common;
@@ -5,7 +7,7 @@ namespace Chat.Application.Features.DirectMessages.Common;
 /// <summary>
 /// wire shape that mirrors the contract's <c>ReceiveMessage</c> event. snowflake
 /// IDs are quoted strings so JS clients can hold them without precision loss.
-/// attachments and reactions are empty arrays on freshly-created messages
+/// reactions are an empty array on freshly-created messages
 /// </summary>
 public sealed record DirectMessageResponse(
 	string Id,
@@ -16,11 +18,14 @@ public sealed record DirectMessageResponse(
 	string? ReplyToId,
 	DateTimeOffset? EditedAt,
 	DateTimeOffset CreatedAt,
-	object[] Attachments,
+	IReadOnlyList<AttachmentResponse> Attachments,
 	object[] Reactions,
 	string? Nonce)
 {
-	public static DirectMessageResponse From(DirectMessage m, string? nonce) => new(
+	public static DirectMessageResponse From(
+		DirectMessage m,
+		string? nonce,
+		IReadOnlyList<AttachmentMetadata>? attachments = null) => new(
 		Id: m.Id.ToString(),
 		ConversationId: m.ConversationId.ToString(),
 		SenderId: m.SenderId.ToString(),
@@ -29,7 +34,9 @@ public sealed record DirectMessageResponse(
 		ReplyToId: m.ReplyToId?.ToString(),
 		EditedAt: m.EditedAt,
 		CreatedAt: m.CreatedAt,
-		Attachments: [],
+		Attachments: attachments is null or { Count: 0 }
+			? []
+			: attachments.Select(AttachmentResponse.From).ToArray(),
 		Reactions: [],
 		Nonce: nonce);
 }

--- a/services/chat/src/Chat.Application/Features/DirectMessages/ListMessages/ListDirectMessagesHandler.cs
+++ b/services/chat/src/Chat.Application/Features/DirectMessages/ListMessages/ListDirectMessagesHandler.cs
@@ -10,6 +10,7 @@ namespace Chat.Application.Features.DirectMessages.ListMessages;
 internal sealed class ListDirectMessagesHandler(
 	ICurrentUser currentUser,
 	IDirectMessageRepository repository,
+	IAttachmentRepository attachmentRepository,
 	IClock clock)
 	: IQueryHandler<ListDirectMessagesQuery, Result<IReadOnlyList<DirectMessageResponse>>>
 {
@@ -41,8 +42,15 @@ internal sealed class ListDirectMessagesHandler(
 			limit,
 			cancellationToken);
 
+		// hydrate the whole page's attachments in a single multi-message read rather
+		// than one point read per message; the lookup yields an empty sequence for
+		// any message that has none
+		var messageIds = messages.Select(m => m.Id).ToList();
+		var attachmentsByMessage = await attachmentRepository
+			.GetDmMessagesAttachmentsAsync(conversationId.Value, messageIds, cancellationToken);
+
 		return messages
-			.Select(msg => DirectMessageResponse.From(msg, null))
+			.Select(msg => DirectMessageResponse.From(msg, null, [.. attachmentsByMessage[msg.Id]]))
 			.ToList();
 	}
 }

--- a/services/chat/src/Chat.Application/Features/DirectMessages/SendMessage/SendDirectMessageCommand.cs
+++ b/services/chat/src/Chat.Application/Features/DirectMessages/SendMessage/SendDirectMessageCommand.cs
@@ -4,5 +4,10 @@ using Chat.Domain.Results;
 
 namespace Chat.Application.Features.DirectMessages.SendMessage;
 
-public sealed record SendDirectMessageCommand(long RecipientId, string? Content, long? ReplyToId, string? Nonce)
+public sealed record SendDirectMessageCommand(
+	long RecipientId,
+	string? Content,
+	long? ReplyToId,
+	IReadOnlyList<long> AttachmentIds,
+	string? Nonce)
 	: ICommand<Result<DirectMessageResponse>>;

--- a/services/chat/src/Chat.Application/Features/DirectMessages/SendMessage/SendMessageHandler.cs
+++ b/services/chat/src/Chat.Application/Features/DirectMessages/SendMessage/SendMessageHandler.cs
@@ -4,6 +4,7 @@ using Chat.Application.Abstractions.Messaging;
 using Chat.Application.Abstractions.Persistence;
 using Chat.Application.Contracts;
 using Chat.Application.Features.DirectMessages.Common;
+using Chat.Domain.Attachments;
 using Chat.Domain.Messages;
 using Chat.Domain.Results;
 
@@ -12,6 +13,7 @@ namespace Chat.Application.Features.DirectMessages.SendMessage;
 internal sealed class SendDirectMessageHandler(
 	ICurrentUser currentUser,
 	IDirectMessageRepository repository,
+	IAttachmentRepository attachmentRepository,
 	ISnowflakeIdGenerator ids,
 	IUserClient userClient,
 	IClock clock,
@@ -20,6 +22,7 @@ internal sealed class SendDirectMessageHandler(
 	: ICommandHandler<SendDirectMessageCommand, Result<DirectMessageResponse>>
 {
 	private const int MaxNonceLen = 64;
+	private const int MaxAttachments = 10;
 
 	public async Task<Result<DirectMessageResponse>> HandleAsync(
 		SendDirectMessageCommand command,
@@ -43,9 +46,18 @@ internal sealed class SendDirectMessageHandler(
 			{
 				var existing = await repository.GetByIdAsync(existingId.Value, cancellationToken);
 				if (existing is not null)
-					return DirectMessageResponse.From(existing, command.Nonce);
+				{
+					var existingAttachments = await attachmentRepository
+						.GetDmMessageAttachmentsAsync(existing.ConversationId, existing.Id, cancellationToken);
+					return DirectMessageResponse.From(existing, command.Nonce, existingAttachments);
+				}
 			}
 		}
+
+		var attachmentsResult = await ResolveAttachmentsAsync(command.AttachmentIds, userId, cancellationToken);
+		if (attachmentsResult.IsFailure)
+			return attachmentsResult.Error;
+		var attachments = attachmentsResult.Value;
 
 		var messageId = ids.NextId();
 		var conversationId =
@@ -64,16 +76,15 @@ internal sealed class SendDirectMessageHandler(
 			recipientId: command.RecipientId,
 			content: command.Content,
 			replyToId: command.ReplyToId,
-			now: clock.UtcNow);
+			now: clock.UtcNow,
+			hasAttachments: attachments.Count > 0);
 		if (messageResult.IsFailure)
 			return messageResult.Error;
 
 		var message = messageResult.Value;
-		
-		// TODO: wire up attachment resolution; empty until then
-		await repository.AddAsync(message, command.Nonce, [], cancellationToken);
+		await repository.AddAsync(message, command.Nonce, attachments, cancellationToken);
 
-		var response = DirectMessageResponse.From(message, command.Nonce);
+		var response = DirectMessageResponse.From(message, command.Nonce, attachments);
 
 		await eventBus.PublishAsync(
 			new ChatDmSent(
@@ -87,5 +98,34 @@ internal sealed class SendDirectMessageHandler(
 		await unicaster.UnicastMessageAsync(command.RecipientId, response, cancellationToken);
 
 		return response;
+	}
+
+	private async Task<Result<IReadOnlyList<AttachmentMetadata>>> ResolveAttachmentsAsync(
+		IReadOnlyList<long> attachmentIds,
+		long userId,
+		CancellationToken ct)
+	{
+		if (attachmentIds.Count == 0)
+			return Array.Empty<AttachmentMetadata>();
+
+		if (attachmentIds.Count > MaxAttachments)
+			return AttachmentFailures.TooMany;
+
+		var resolved = new List<AttachmentMetadata>(attachmentIds.Count);
+		foreach (var attachmentId in attachmentIds.Distinct())
+		{
+			// each referenced draft must exist, be owned by the caller, and not yet
+			// belong to another message; an expired draft is simply gone (table TTL)
+			var draft = await attachmentRepository.GetDraftAsync(attachmentId, ct);
+			if (draft is null || draft.UploaderId != userId)
+				return AttachmentFailures.InvalidReference;
+
+			if (await attachmentRepository.IsAttachedAsync(attachmentId, ct))
+				return AttachmentFailures.InvalidReference;
+
+			resolved.Add(draft.ToMetadata());
+		}
+
+		return resolved;
 	}
 }

--- a/services/chat/src/Chat.Application/Features/DirectMessages/SendMessage/SendMessageHandler.cs
+++ b/services/chat/src/Chat.Application/Features/DirectMessages/SendMessage/SendMessageHandler.cs
@@ -69,7 +69,9 @@ internal sealed class SendDirectMessageHandler(
 			return messageResult.Error;
 
 		var message = messageResult.Value;
-		await repository.AddAsync(message, command.Nonce, cancellationToken);
+		
+		// TODO: wire up attachment resolution; empty until then
+		await repository.AddAsync(message, command.Nonce, [], cancellationToken);
 
 		var response = DirectMessageResponse.From(message, command.Nonce);
 

--- a/services/chat/src/Chat.Domain/Messages/DirectMessage.cs
+++ b/services/chat/src/Chat.Domain/Messages/DirectMessage.cs
@@ -59,7 +59,8 @@ public sealed class DirectMessage
 		long recipientId,
 		long? replyToId,
 		string? content,
-		DateTimeOffset now)
+		DateTimeOffset now,
+		bool hasAttachments = false)
 	{
 		if (id <= 0)
 			return DirectMessageFailures.InvalidId;
@@ -76,11 +77,16 @@ public sealed class DirectMessage
 		if (senderId == recipientId)
 			return DirectMessageFailures.CannotMessageSelf;
 
+		// content is optional only when the message carries at least one attachment
 		if (string.IsNullOrWhiteSpace(content))
-			return DirectMessageFailures.ContentRequired;
-
-		if (content.Length > MaxContentLen)
+		{
+			if (!hasAttachments)
+				return DirectMessageFailures.ContentRequired;
+		}
+		else if (content.Length > MaxContentLen)
+		{
 			return DirectMessageFailures.ContentTooLong;
+		}
 
 		return new DirectMessage(
 			id: id,

--- a/services/chat/src/Chat.Persistence/Repositories/AttachmentRepository.cs
+++ b/services/chat/src/Chat.Persistence/Repositories/AttachmentRepository.cs
@@ -83,6 +83,32 @@ internal sealed class AttachmentRepository(ISession session, AttachmentStatement
 		return rows.ToLookup(row => row.GetValue<long>("message_id"), MapMetadata);
 	}
 
+	public async Task<AttachmentMetadata?> GetDmAttachmentAsync(long conversationId, long messageId, long id, CancellationToken ct)
+	{
+		var stmt = await statements.SelectDmAttachment.Value;
+		var row = (await session.ExecuteAsync(stmt.Bind(conversationId, messageId, id))).FirstOrDefault();
+		return row is null ? null : MapMetadata(row);
+	}
+
+	public async Task<IReadOnlyList<AttachmentMetadata>> GetDmMessageAttachmentsAsync(long conversationId, long messageId, CancellationToken ct)
+	{
+		var stmt = await statements.SelectDmMessageAttachments.Value;
+		var rows = await session.ExecuteAsync(stmt.Bind(conversationId, messageId));
+		return rows.Select(MapMetadata).ToList();
+	}
+
+	public async Task<ILookup<long, AttachmentMetadata>> GetDmMessagesAttachmentsAsync(
+		long conversationId, IReadOnlyList<long> messageIds, CancellationToken ct)
+	{
+		if (messageIds.Count == 0)
+			return Enumerable.Empty<AttachmentMetadata>().ToLookup(_ => 0L);
+
+		var stmt = await statements.SelectDmMessagesAttachments.Value;
+		var rows = await session.ExecuteAsync(stmt.Bind(conversationId, messageIds.ToArray()));
+
+		return rows.ToLookup(row => row.GetValue<long>("message_id"), MapMetadata);
+	}
+
 	private static AttachmentMetadata MapMetadata(Row row) => new(
 		Id: row.GetValue<long>("id"),
 		Url: row.GetValue<string>("url"),

--- a/services/chat/src/Chat.Persistence/Repositories/AttachmentStatements.cs
+++ b/services/chat/src/Chat.Persistence/Repositories/AttachmentStatements.cs
@@ -33,4 +33,18 @@ internal sealed class AttachmentStatements(ISession session)
 	public Lazy<Task<PreparedStatement>> SelectChannelMessagesAttachments { get; } = new(() => session.PrepareAsync(
 		"SELECT message_id, id, url, filename, size_bytes, mime_type " +
 		"FROM message_attachments WHERE channel_id = ? AND message_id IN ?"));
+
+	public Lazy<Task<PreparedStatement>> SelectDmAttachment { get; } = new(() => session.PrepareAsync(
+		"SELECT id, url, filename, size_bytes, mime_type " +
+		"FROM dm_attachments WHERE conversation_id = ? AND message_id = ? AND id = ?"));
+
+	public Lazy<Task<PreparedStatement>> SelectDmMessageAttachments { get; } = new(() => session.PrepareAsync(
+		"SELECT id, url, filename, size_bytes, mime_type " +
+		"FROM dm_attachments WHERE conversation_id = ? AND message_id = ?"));
+
+	// same IN-on-trailing-partition-key trick as SelectChannelMessagesAttachments,
+	// keyed by conversation_id instead of channel_id
+	public Lazy<Task<PreparedStatement>> SelectDmMessagesAttachments { get; } = new(() => session.PrepareAsync(
+		"SELECT message_id, id, url, filename, size_bytes, mime_type " +
+		"FROM dm_attachments WHERE conversation_id = ? AND message_id IN ?"));
 }

--- a/services/chat/src/Chat.Persistence/Repositories/DirectMessageRepository.cs
+++ b/services/chat/src/Chat.Persistence/Repositories/DirectMessageRepository.cs
@@ -1,5 +1,6 @@
 using Cassandra;
 using Chat.Application.Abstractions.Persistence;
+using Chat.Domain.Attachments;
 using Chat.Domain.Messages;
 
 namespace Chat.Persistence.Repositories;
@@ -47,7 +48,7 @@ internal sealed class DirectMessageRepository(
 		return row.GetValue<long>("conversation_id");
 	}
 
-	public async Task AddAsync(DirectMessage message, string? nonce, CancellationToken ct)
+	public async Task AddAsync(DirectMessage message, string? nonce, IReadOnlyList<AttachmentMetadata> attachments, CancellationToken ct)
 	{
 		var insertDirectMessage = await statements.InsertDirectMessage.Value;
 		var insertLookup = await statements.InsertLookup.Value;
@@ -96,6 +97,33 @@ internal sealed class DirectMessageRepository(
 				message.RecipientId,
 				nonce,
 				message.Id));
+		}
+
+		// binding drafts to the message: write the permanent metadata + download
+		// lookup row and tombstone the draft, all atomic with the message itself
+		if (attachments.Count > 0)
+		{
+			var insertAttachment = await statements.InsertDmAttachment.Value;
+			var insertAttachmentLookup = await statements.InsertDmAttachmentLookup.Value;
+			var deleteDraft = await statements.DeleteDraftAttachment.Value;
+
+			foreach (var attachment in attachments)
+			{
+				batch.Add(insertAttachment.Bind(
+					message.ConversationId,
+					message.Id,
+					attachment.Id,
+					attachment.Url,
+					attachment.Filename,
+					attachment.SizeBytes,
+					attachment.MimeType));
+				batch.Add(insertAttachmentLookup.Bind(
+					attachment.Id,
+					(long?)null,
+					message.ConversationId,
+					message.Id));
+				batch.Add(deleteDraft.Bind(attachment.Id));
+			}
 		}
 
 		await session.ExecuteAsync(batch);

--- a/services/chat/src/Chat.Persistence/Repositories/DirectMessageStatements.cs
+++ b/services/chat/src/Chat.Persistence/Repositories/DirectMessageStatements.cs
@@ -57,4 +57,17 @@ internal sealed class DirectMessageStatements(ISession session)
 		"FROM direct_messages " +
 		"WHERE conversation_id = ? AND created_at < ? " +
 		"LIMIT ?"));
+
+	public Lazy<Task<PreparedStatement>> InsertDmAttachment { get; } = new(() => session.PrepareAsync(
+		"INSERT INTO dm_attachments " +
+		"(conversation_id, message_id, id, url, filename, size_bytes, mime_type) " +
+		"VALUES (?, ?, ?, ?, ?, ?, ?)"));
+
+	public Lazy<Task<PreparedStatement>> InsertDmAttachmentLookup { get; } = new(() => session.PrepareAsync(
+		"INSERT INTO attachment_lookup " +
+		"(attachment_id, is_dm, channel_id, conversation_id, message_id) " +
+		"VALUES (?, true, ?, ?, ?)"));
+
+	public Lazy<Task<PreparedStatement>> DeleteDraftAttachment { get; } = new(() => session.PrepareAsync(
+		"DELETE FROM draft_attachments WHERE id = ?"));
 }

--- a/services/chat/src/Chat.Presentation/Endpoints/DirectMessagesEndpoint.cs
+++ b/services/chat/src/Chat.Presentation/Endpoints/DirectMessagesEndpoint.cs
@@ -33,8 +33,7 @@ public sealed class DirectMessagesEndpoint : ICarterModule
 				RecipientId: userId,
 				Content: request.Content,
 				ReplyToId: request.ReplyToId,
-				// TODO: wire up request field; empty until
-				AttachmentIds: [],
+				AttachmentIds: request.AttachmentIds ?? [],
 				Nonce: request.Nonce),
 			cancellationToken);
 
@@ -83,7 +82,8 @@ public sealed class DirectMessagesEndpoint : ICarterModule
 		return failure.Code switch
 		{
 			"DirectMessage.RecipientNotFound" or
-			"DirectMessage.ConversationNotFound" => TypedResults.NotFound(body),
+			"DirectMessage.ConversationNotFound" or
+			"Attachment.InvalidReference" => TypedResults.NotFound(body),
 
 			"DirectMessage.RecipientBlocked" => TypedResults.Json(
 				body,
@@ -98,6 +98,7 @@ public sealed class DirectMessagesEndpoint : ICarterModule
 			// "DirectMessage.InvalidReplyTarget"
 			// "DirectMessage.CannotMessageSelf"
 			// "DirectMessage.NonceTooLong"
+			// "Attachment.TooMany"
 			_ => TypedResults.BadRequest(body)
 		};
 	}
@@ -105,6 +106,7 @@ public sealed class DirectMessagesEndpoint : ICarterModule
 	private sealed record SendDirectMessageRequest(
 		string? Content,
 		long? ReplyToId,
+		IReadOnlyList<long>? AttachmentIds,
 		string? Nonce);
 
 	private sealed record ErrorBody(string Error);

--- a/services/chat/src/Chat.Presentation/Endpoints/DirectMessagesEndpoint.cs
+++ b/services/chat/src/Chat.Presentation/Endpoints/DirectMessagesEndpoint.cs
@@ -33,6 +33,8 @@ public sealed class DirectMessagesEndpoint : ICarterModule
 				RecipientId: userId,
 				Content: request.Content,
 				ReplyToId: request.ReplyToId,
+				// TODO: wire up request field; empty until
+				AttachmentIds: [],
 				Nonce: request.Nonce),
 			cancellationToken);
 

--- a/services/chat/src/Chat.Presentation/Endpoints/MessagesEndpoint.cs
+++ b/services/chat/src/Chat.Presentation/Endpoints/MessagesEndpoint.cs
@@ -110,7 +110,8 @@ public sealed class MessagesEndpoint : ICarterModule
 	private static Results<Created<MessageResponse>, BadRequest<ErrorBody>, JsonHttpResult<ErrorBody>, NotFound<ErrorBody>>
 		MapSendError(Failure failure) => failure.Code switch
 		{
-			"Message.ChannelNotFound" => TypedResults.NotFound(new ErrorBody(failure.Message)),
+			"Message.ChannelNotFound" or
+			"Attachment.InvalidReference" => TypedResults.NotFound(new ErrorBody(failure.Message)),
 			"Message.NotAMember" => TypedResults.Json(new ErrorBody(failure.Message), statusCode: StatusCodes.Status403Forbidden),
 			"Message.MissingSendPermission" => TypedResults.Json(new ErrorBody(failure.Message), statusCode: StatusCodes.Status403Forbidden),
 			_ => TypedResults.BadRequest(new ErrorBody(failure.Message)),

--- a/services/chat/tests/Chat.FunctionalTests/Endpoints/AttachmentsEndpointTests.cs
+++ b/services/chat/tests/Chat.FunctionalTests/Endpoints/AttachmentsEndpointTests.cs
@@ -4,6 +4,7 @@ using System.Net.Http.Json;
 using System.Text;
 using System.Text.Json;
 using Chat.Domain.Attachments;
+using Chat.Domain.Messages;
 using Chat.FunctionalTests.Infrastructure;
 using Xunit;
 
@@ -28,6 +29,7 @@ public sealed class AttachmentsEndpointTests(ChatApiFactory factory)
 		factory.GuildClient.Result = null;
 		factory.AttachmentRepository.Reset();
 		factory.ObjectStore.Reset();
+		factory.DirectMessageRepository.Reset();
 		return Task.CompletedTask;
 	}
 
@@ -181,6 +183,61 @@ public sealed class AttachmentsEndpointTests(ChatApiFactory factory)
 		var response = await client.GetAsync($"/v1/attachments/{attachmentId}/pic.png");
 
 		Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+	}
+
+	// ---- download: DM path (participant-gated) ----
+
+	[Fact]
+	public async Task Get_DmAttachmentAsSender_Returns200()
+	{
+		const long attachmentId = 8001, conversationId = 900, messageId = 6001;
+		SeedDmAttachment(attachmentId, conversationId, messageId, senderId: 42, recipientId: 100, "pic.png", "image/png");
+
+		var client = BuildClient(userId: 42);
+		var response = await client.GetAsync($"/v1/attachments/{attachmentId}/pic.png");
+
+		Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+		Assert.Equal(PngBytes, await response.Content.ReadAsByteArrayAsync());
+	}
+
+	[Fact]
+	public async Task Get_DmAttachmentAsRecipient_Returns200()
+	{
+		const long attachmentId = 8002, conversationId = 901, messageId = 6002;
+		SeedDmAttachment(attachmentId, conversationId, messageId, senderId: 42, recipientId: 100, "pic.png", "image/png");
+
+		var client = BuildClient(userId: 100);
+		var response = await client.GetAsync($"/v1/attachments/{attachmentId}/pic.png");
+
+		Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+		Assert.Equal(PngBytes, await response.Content.ReadAsByteArrayAsync());
+	}
+
+	[Fact]
+	public async Task Get_DmAttachmentAsUnrelatedUser_Returns403()
+	{
+		const long attachmentId = 8003, conversationId = 902, messageId = 6003;
+		SeedDmAttachment(attachmentId, conversationId, messageId, senderId: 42, recipientId: 100, "pic.png", "image/png");
+
+		var client = BuildClient(userId: 99);
+		var response = await client.GetAsync($"/v1/attachments/{attachmentId}/pic.png");
+
+		Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+	}
+
+	private void SeedDmAttachment(
+		long attachmentId, long conversationId, long messageId, long senderId, long recipientId, string filename, string mimeType)
+	{
+		var url = $"http://localhost/api/chat/v1/attachments/{attachmentId}/{filename}";
+		factory.AttachmentRepository.SeedDmAttachment(conversationId, messageId,
+			new AttachmentMetadata(attachmentId, url, filename, PngBytes.Length, mimeType));
+		factory.ObjectStore.Seed(attachmentId.ToString(), PngBytes);
+
+		var message = DirectMessage.Reconstitute(
+			id: messageId, conversationId: conversationId, senderId: senderId, recipientId: recipientId,
+			replyToId: null, content: "has an attachment", isDeleted: false, editedAt: null,
+			createdAt: DateTimeOffset.UtcNow);
+		factory.DirectMessageRepository.Seed(message);
 	}
 
 	private async Task<long> UploadAsync(HttpClient client, string filename, string contentType)

--- a/services/chat/tests/Chat.FunctionalTests/Endpoints/SendDirectMessageEndpointTests.cs
+++ b/services/chat/tests/Chat.FunctionalTests/Endpoints/SendDirectMessageEndpointTests.cs
@@ -216,6 +216,71 @@ public sealed class SendDirectMessageEndpointTests(ChatApiFactory factory)
 		Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
 	}
 
+	// a 1x1 PNG; the exact bytes don't matter, only that a draft can be resolved
+	private static readonly byte[] PngBytes = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x01];
+
+	private async Task<string> UploadDraftAsync(HttpClient client)
+	{
+		var fileContent = new ByteArrayContent(PngBytes);
+		fileContent.Headers.ContentType = new MediaTypeHeaderValue("image/png");
+		var form = new MultipartFormDataContent { { fileContent, "file", "pic.png" } };
+
+		var response = await client.PostAsync("/v1/attachments", form);
+		response.EnsureSuccessStatusCode();
+		var body = await response.Content.ReadFromJsonAsync<UploadedAttachmentBody>(JsonOptions);
+		return body!.Id;
+	}
+
+	[Fact]
+	public async Task Post_WithAttachment_Returns201WithAttachment()
+	{
+		var client = BuildClient(userId: 42);
+		var attachmentId = await UploadDraftAsync(client);
+
+		var response = await client.PostAsJsonAsync("/v1/dms/100/messages",
+			new { content = "look at this", attachment_ids = new[] { attachmentId } });
+
+		Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+		var body = await response.Content.ReadFromJsonAsync<DirectMessageBody>(JsonOptions);
+		Assert.NotNull(body);
+		var attachment = Assert.Single(body.Attachments);
+		Assert.Equal(attachmentId, attachment.Id);
+		Assert.Equal("pic.png", attachment.Filename);
+	}
+
+	[Fact]
+	public async Task Post_AttachmentOnly_NoContent_Returns201()
+	{
+		var client = BuildClient(userId: 42);
+		var attachmentId = await UploadDraftAsync(client);
+
+		var response = await client.PostAsJsonAsync("/v1/dms/100/messages",
+			new { content = (string?)null, attachment_ids = new[] { attachmentId } });
+
+		Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+		var body = await response.Content.ReadFromJsonAsync<DirectMessageBody>(JsonOptions);
+		Assert.NotNull(body);
+		Assert.Single(body.Attachments);
+	}
+
+	[Fact]
+	public async Task Post_AttachmentOwnedByAnotherUser_Returns404_NoSideEffects()
+	{
+		var uploader = BuildClient(userId: 100);
+		var attachmentId = await UploadDraftAsync(uploader);
+
+		var sender = BuildClient(userId: 42);
+		var response = await sender.PostAsJsonAsync("/v1/dms/100/messages",
+			new { content = "sneaky", attachment_ids = new[] { attachmentId } });
+
+		Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+		Assert.Empty(factory.SavedDirectMessages);
+	}
+
+	private sealed record UploadedAttachmentBody(string Id, string Url, string Filename, long SizeBytes, string MimeType);
+
+	private sealed record AttachmentBody(string Id, string Url, string Filename, long SizeBytes, string MimeType);
+
 	private sealed record DirectMessageBody(
 			string Id,
 			string ConversationId,
@@ -225,5 +290,6 @@ public sealed class SendDirectMessageEndpointTests(ChatApiFactory factory)
 			string? ReplyToId,
 			DateTimeOffset? EditedAt,
 			DateTimeOffset CreatedAt,
+			IReadOnlyList<AttachmentBody> Attachments,
 			string? Nonce);
 }

--- a/services/chat/tests/Chat.UnitTests/Application/SendDirectMessageHandlerTests.cs
+++ b/services/chat/tests/Chat.UnitTests/Application/SendDirectMessageHandlerTests.cs
@@ -14,6 +14,7 @@ public sealed class SendDirectMessageHandlerTests
 	private sealed record Harness(
 		FakeCurrentUser CurrentUser,
 		FakeDirectMessageRepository Repository,
+		FakeAttachmentRepository AttachmentRepository,
 		FakeIdGenerator IdGenerator,
 		FakeUserClient UserClient,
 		FakeClock Clock,
@@ -26,6 +27,7 @@ public sealed class SendDirectMessageHandlerTests
 	{
 		var currentUser = new FakeCurrentUser { UserId = userId };
 		var repository = new FakeDirectMessageRepository();
+		var attachmentRepository = new FakeAttachmentRepository();
 		var ids = new FakeIdGenerator();
 		var userClient = new FakeUserClient();
 		userClient.Setup(userId, recipientId, new UsersRelationship("none", null));
@@ -34,9 +36,9 @@ public sealed class SendDirectMessageHandlerTests
 		var unicaster = new FakeConversationUnicast();
 
 		var handler = HandlerFactory.CreateCommand<SendDirectMessageCommand, Result<DirectMessageResponse>>(
-			currentUser, repository, ids, userClient, clock, eventBus, unicaster);
+			currentUser, repository, attachmentRepository, ids, userClient, clock, eventBus, unicaster);
 
-		return (new Harness(currentUser, repository, ids, userClient, clock, eventBus, unicaster), handler);
+		return (new Harness(currentUser, repository, attachmentRepository, ids, userClient, clock, eventBus, unicaster), handler);
 	}
 
 	[Fact]
@@ -45,7 +47,7 @@ public sealed class SendDirectMessageHandlerTests
 		var (h, handler) = BuildHandler(userId: 42);
 
 		var result = await handler.HandleAsync(
-			new SendDirectMessageCommand(RecipientId: 100, Content: "hello", ReplyToId: null, Nonce: null));
+			new SendDirectMessageCommand(RecipientId: 100, Content: "hello", ReplyToId: null, AttachmentIds: [], Nonce: null));
 
 		Assert.True(result.Succeeded);
 		var response = result.Value;
@@ -78,7 +80,7 @@ public sealed class SendDirectMessageHandlerTests
 		h.Repository.WithConversation(42, 100, conversationId: 555);   // la paire a déjà une conversation
 
 		var result = await handler.HandleAsync(
-			new SendDirectMessageCommand(RecipientId: 100, Content: "hi", ReplyToId: null, Nonce: null));
+			new SendDirectMessageCommand(RecipientId: 100, Content: "hi", ReplyToId: null, AttachmentIds: [], Nonce: null));
 
 		Assert.True(result.Succeeded);
 		var saved = Assert.Single(h.Repository.Saved);
@@ -92,7 +94,7 @@ public sealed class SendDirectMessageHandlerTests
 		var (h, handler) = BuildHandler();
 
 		var result = await handler.HandleAsync(
-			new SendDirectMessageCommand(RecipientId: 100, Content: "hi", ReplyToId: null, Nonce: new string('x', 65)));
+			new SendDirectMessageCommand(RecipientId: 100, Content: "hi", ReplyToId: null, AttachmentIds: [], Nonce: new string('x', 65)));
 
 		Assert.True(result.IsFailure);
 		Assert.Equal(DirectMessageFailures.NonceTooLong, result.Error);
@@ -108,7 +110,7 @@ public sealed class SendDirectMessageHandlerTests
 		var nonce = new string('x', 64);
 
 		var result = await handler.HandleAsync(
-			new SendDirectMessageCommand(RecipientId: 100, Content: "hi", ReplyToId: null, Nonce: nonce));
+			new SendDirectMessageCommand(RecipientId: 100, Content: "hi", ReplyToId: null, AttachmentIds: [], Nonce: nonce));
 
 		Assert.True(result.Succeeded);
 		Assert.Equal(nonce, result.Value.Nonce);   // ⚠️ aligne sur le nom de champ de ton DirectMessageResponse
@@ -120,14 +122,14 @@ public sealed class SendDirectMessageHandlerTests
 		var (h, handler) = BuildHandler(userId: 42);
 
 		var first = await handler.HandleAsync(
-			new SendDirectMessageCommand(RecipientId: 100, Content: "hello", ReplyToId: null, Nonce: "n1"));
+			new SendDirectMessageCommand(RecipientId: 100, Content: "hello", ReplyToId: null, AttachmentIds: [], Nonce: "n1"));
 		Assert.True(first.Succeeded);
 
 		h.EventBus.Reset();
 		h.Unicaster.Reset();
 
 		var second = await handler.HandleAsync(
-			new SendDirectMessageCommand(RecipientId: 100, Content: "hello", ReplyToId: null, Nonce: "n1"));
+			new SendDirectMessageCommand(RecipientId: 100, Content: "hello", ReplyToId: null, AttachmentIds: [], Nonce: "n1"));
 
 		Assert.True(second.Succeeded);
 		Assert.Equal(first.Value.Id, second.Value.Id);
@@ -142,9 +144,9 @@ public sealed class SendDirectMessageHandlerTests
 		var (h, handler) = BuildHandler(userId: 42);
 
 		var first = await handler.HandleAsync(
-			new SendDirectMessageCommand(RecipientId: 100, Content: "hello", ReplyToId: null, Nonce: "n-a"));
+			new SendDirectMessageCommand(RecipientId: 100, Content: "hello", ReplyToId: null, AttachmentIds: [], Nonce: "n-a"));
 		var second = await handler.HandleAsync(
-			new SendDirectMessageCommand(RecipientId: 100, Content: "hello", ReplyToId: null, Nonce: "n-b"));
+			new SendDirectMessageCommand(RecipientId: 100, Content: "hello", ReplyToId: null, AttachmentIds: [], Nonce: "n-b"));
 
 		Assert.True(first.Succeeded);
 		Assert.True(second.Succeeded);
@@ -160,7 +162,7 @@ public sealed class SendDirectMessageHandlerTests
 		var (h, handler) = BuildHandler();
 
 		var result = await handler.HandleAsync(
-			new SendDirectMessageCommand(RecipientId: 100, Content: "   ", ReplyToId: null, Nonce: null));
+			new SendDirectMessageCommand(RecipientId: 100, Content: "   ", ReplyToId: null, AttachmentIds: [], Nonce: null));
 
 		Assert.True(result.IsFailure);
 		Assert.Equal(DirectMessageFailures.ContentRequired, result.Error);
@@ -180,6 +182,7 @@ public sealed class SendDirectMessageHandlerTests
 					RecipientId: 100,
 					Content: "reply",
 					ReplyToId: 999,
+					AttachmentIds: [],
 					Nonce: null));
 
 		Assert.True(result.IsFailure);
@@ -201,6 +204,7 @@ public sealed class SendDirectMessageHandlerTests
 					RecipientId: 100,
 					Content: "reply",
 					ReplyToId: 999,
+					AttachmentIds: [],
 					Nonce: null));
 
 		Assert.True(result.Succeeded);

--- a/services/chat/tests/Chat.UnitTests/Application/SendDirectMessageHandlerTests.cs
+++ b/services/chat/tests/Chat.UnitTests/Application/SendDirectMessageHandlerTests.cs
@@ -3,6 +3,7 @@ using Chat.Application.Abstractions.Messaging;
 using Chat.Application.Contracts;
 using Chat.Application.Features.DirectMessages.Common;
 using Chat.Application.Features.DirectMessages.SendMessage;
+using Chat.Domain.Attachments;
 using Chat.Domain.Results;
 using Chat.UnitTests.Fakes;
 using Xunit;
@@ -212,5 +213,133 @@ public sealed class SendDirectMessageHandlerTests
 		var saved = Assert.Single(h.Repository.Saved);
 		Assert.Equal(999L, saved.ReplyToId);
 		Assert.Equal(555L, saved.ConversationId);
+	}
+
+	private static DraftAttachment SeedDraft(FakeAttachmentRepository repo, long id, long uploaderId)
+	{
+		var draft = DraftAttachment.Create(
+			id: id, uploaderId: uploaderId,
+			url: $"http://localhost/api/chat/v1/attachments/{id}/pic.png",
+			filename: "pic.png", sizeBytes: 1024, mimeType: "image/png",
+			now: new DateTimeOffset(2026, 1, 1, 12, 0, 0, TimeSpan.Zero)).Value;
+		repo.SeedDraft(draft);
+		return draft;
+	}
+
+	[Fact]
+	public async Task ValidDraft_AttachesToMessage_HydratesResponse_AndPersists()
+	{
+		var (h, handler) = BuildHandler(userId: 42);
+		var draft = SeedDraft(h.AttachmentRepository, id: 555, uploaderId: 42);
+
+		var result = await handler.HandleAsync(new SendDirectMessageCommand(
+			RecipientId: 100, Content: "look", ReplyToId: null, AttachmentIds: [draft.Id], Nonce: null));
+
+		Assert.True(result.Succeeded);
+		var attachment = Assert.Single(result.Value.Attachments);
+		Assert.Equal("555", attachment.Id);
+		Assert.Equal("pic.png", attachment.Filename);
+
+		var saved = Assert.Single(h.Repository.Saved);
+		var persisted = Assert.Single(h.Repository.SavedAttachments[saved.Id]);
+		Assert.Equal(555L, persisted.Id);
+	}
+
+	[Fact]
+	public async Task AttachmentWithoutContent_Succeeds()
+	{
+		var (h, handler) = BuildHandler(userId: 42);
+		var draft = SeedDraft(h.AttachmentRepository, id: 777, uploaderId: 42);
+
+		var result = await handler.HandleAsync(new SendDirectMessageCommand(
+			RecipientId: 100, Content: null, ReplyToId: null, AttachmentIds: [draft.Id], Nonce: null));
+
+		Assert.True(result.Succeeded);
+		Assert.Single(result.Value.Attachments);
+	}
+
+	[Fact]
+	public async Task TooManyAttachments_ReturnsTooMany_NoSideEffects()
+	{
+		var (h, handler) = BuildHandler(userId: 42);
+		long[] ids = [.. Enumerable.Range(1, 11).Select(i => (long)i)];
+
+		var result = await handler.HandleAsync(new SendDirectMessageCommand(
+			RecipientId: 100, Content: "hi", ReplyToId: null, AttachmentIds: ids, Nonce: null));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal(AttachmentFailures.TooMany, result.Error);
+		Assert.Empty(h.Repository.Saved);
+		Assert.Empty(h.EventBus.Published);
+		Assert.Empty(h.Unicaster.Unicasts);
+	}
+
+	[Fact]
+	public async Task UnknownDraft_ReturnsInvalidReference_NoSideEffects()
+	{
+		var (h, handler) = BuildHandler(userId: 42);
+
+		var result = await handler.HandleAsync(new SendDirectMessageCommand(
+			RecipientId: 100, Content: "hi", ReplyToId: null, AttachmentIds: [999], Nonce: null));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal(AttachmentFailures.InvalidReference, result.Error);
+		Assert.Empty(h.Repository.Saved);
+	}
+
+	[Fact]
+	public async Task DraftOwnedByAnotherUser_ReturnsInvalidReference()
+	{
+		var (h, handler) = BuildHandler(userId: 42);
+		var draft = SeedDraft(h.AttachmentRepository, id: 555, uploaderId: 7); // not 42
+
+		var result = await handler.HandleAsync(new SendDirectMessageCommand(
+			RecipientId: 100, Content: "hi", ReplyToId: null, AttachmentIds: [draft.Id], Nonce: null));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal(AttachmentFailures.InvalidReference, result.Error);
+		Assert.Empty(h.Repository.Saved);
+	}
+
+	[Fact]
+	public async Task AlreadyAttachedDraft_ReturnsInvalidReference()
+	{
+		var (h, handler) = BuildHandler(userId: 42);
+		var draft = SeedDraft(h.AttachmentRepository, id: 555, uploaderId: 42);
+		h.AttachmentRepository.MarkAttached(draft.Id);
+
+		var result = await handler.HandleAsync(new SendDirectMessageCommand(
+			RecipientId: 100, Content: "hi", ReplyToId: null, AttachmentIds: [draft.Id], Nonce: null));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal(AttachmentFailures.InvalidReference, result.Error);
+		Assert.Empty(h.Repository.Saved);
+	}
+
+	[Fact]
+	public async Task NonceDedupHit_WithAttachments_RehydratesAttachmentsOnSecondCall()
+	{
+		var (h, handler) = BuildHandler(userId: 42);
+		var draft = SeedDraft(h.AttachmentRepository, id: 555, uploaderId: 42);
+
+		var first = await handler.HandleAsync(new SendDirectMessageCommand(
+			RecipientId: 100, Content: "hello", ReplyToId: null, AttachmentIds: [draft.Id], Nonce: "n1"));
+		Assert.True(first.Succeeded);
+		Assert.Single(first.Value.Attachments);
+
+		// the real repository writes dm_attachments + attachment_lookup atomically
+		// with the message in the same batch; the fakes are decoupled, so mirror
+		// that persisted state by hand before exercising the dedup rehydration path
+		var saved = Assert.Single(h.Repository.Saved);
+		h.AttachmentRepository.SeedDmAttachment(saved.ConversationId, saved.Id, draft.ToMetadata());
+
+		var second = await handler.HandleAsync(new SendDirectMessageCommand(
+			RecipientId: 100, Content: "hello", ReplyToId: null, AttachmentIds: [], Nonce: "n1"));
+
+		Assert.True(second.Succeeded);
+		Assert.Equal(first.Value.Id, second.Value.Id);
+		var attachment = Assert.Single(second.Value.Attachments);
+		Assert.Equal("555", attachment.Id);
+		Assert.Single(h.Repository.Saved);
 	}
 }

--- a/services/chat/tests/Chat.UnitTests/Fakes/FakeAttachmentRepository.cs
+++ b/services/chat/tests/Chat.UnitTests/Fakes/FakeAttachmentRepository.cs
@@ -15,6 +15,7 @@ public sealed class FakeAttachmentRepository : IAttachmentRepository
 	private readonly HashSet<long> _attached = [];
 	private readonly Dictionary<long, AttachmentLocation> _locations = [];
 	private readonly Dictionary<(long ChannelId, long MessageId), List<AttachmentMetadata>> _byMessage = [];
+	private readonly Dictionary<(long ConversationId, long MessageId), List<AttachmentMetadata>> _byDmMessage = [];
 
 	public void Reset()
 	{
@@ -22,6 +23,7 @@ public sealed class FakeAttachmentRepository : IAttachmentRepository
 		_attached.Clear();
 		_locations.Clear();
 		_byMessage.Clear();
+		_byDmMessage.Clear();
 	}
 
 	/// <summary>seed an uploaded-but-unattached draft for the resolve path</summary>
@@ -43,6 +45,22 @@ public sealed class FakeAttachmentRepository : IAttachmentRepository
 
 		if (!_byMessage.TryGetValue((channelId, messageId), out var list))
 			_byMessage[(channelId, messageId)] = list = [];
+		list.Add(metadata);
+	}
+
+	/// <summary>
+	/// seed an attachment already bound to a DM message, so the download path's
+	/// lookup + per-message read both resolve (mirrors the real attachment_lookup +
+	/// dm_attachments rows written when a draft is sent)
+	/// </summary>
+	public void SeedDmAttachment(long conversationId, long messageId, AttachmentMetadata metadata)
+	{
+		_attached.Add(metadata.Id);
+		_locations[metadata.Id] = new AttachmentLocation(
+			IsDm: true, ChannelId: null, ConversationId: conversationId, MessageId: messageId);
+
+		if (!_byDmMessage.TryGetValue((conversationId, messageId), out var list))
+			_byDmMessage[(conversationId, messageId)] = list = [];
 		list.Add(metadata);
 	}
 
@@ -81,6 +99,31 @@ public sealed class FakeAttachmentRepository : IAttachmentRepository
 		var wanted = messageIds.ToHashSet();
 		var lookup = _byMessage
 			.Where(e => e.Key.ChannelId == channelId && wanted.Contains(e.Key.MessageId))
+			.SelectMany(e => e.Value.Select(m => (e.Key.MessageId, Metadata: m)))
+			.ToLookup(x => x.MessageId, x => x.Metadata);
+		return Task.FromResult(lookup);
+	}
+
+	public Task<AttachmentMetadata?> GetDmAttachmentAsync(long conversationId, long messageId, long id, CancellationToken ct)
+	{
+		var match = _byDmMessage.GetValueOrDefault((conversationId, messageId))?
+			.FirstOrDefault(a => a.Id == id);
+		return Task.FromResult(match);
+	}
+
+	public Task<IReadOnlyList<AttachmentMetadata>> GetDmMessageAttachmentsAsync(long conversationId, long messageId, CancellationToken ct)
+	{
+		IReadOnlyList<AttachmentMetadata> result =
+			_byDmMessage.GetValueOrDefault((conversationId, messageId)) ?? [];
+		return Task.FromResult(result);
+	}
+
+	public Task<ILookup<long, AttachmentMetadata>> GetDmMessagesAttachmentsAsync(
+		long conversationId, IReadOnlyList<long> messageIds, CancellationToken ct)
+	{
+		var wanted = messageIds.ToHashSet();
+		var lookup = _byDmMessage
+			.Where(e => e.Key.ConversationId == conversationId && wanted.Contains(e.Key.MessageId))
 			.SelectMany(e => e.Value.Select(m => (e.Key.MessageId, Metadata: m)))
 			.ToLookup(x => x.MessageId, x => x.Metadata);
 		return Task.FromResult(lookup);

--- a/services/chat/tests/Chat.UnitTests/Fakes/FakeDirectMessageRepository.cs
+++ b/services/chat/tests/Chat.UnitTests/Fakes/FakeDirectMessageRepository.cs
@@ -1,4 +1,5 @@
 using Chat.Application.Abstractions.Persistence;
+using Chat.Domain.Attachments;
 using Chat.Domain.Messages;
 
 namespace Chat.UnitTests.Fakes;
@@ -9,9 +10,13 @@ public sealed class FakeDirectMessageRepository : IDirectMessageRepository
 	private readonly Dictionary<(long SenderId, long RecipientId, string Nonce), long> _nonces = [];
 	private readonly Dictionary<(long, long), long> _conversations = [];
 	private readonly Dictionary<(long ConversationId, long ReplyToId), long> _replies = [];
+	private readonly Dictionary<long, IReadOnlyList<AttachmentMetadata>> _attachments = [];
 
 
 	public IReadOnlyList<DirectMessage> Saved => _saved;
+
+	/// <summary>attachments persisted alongside each message, keyed by message id</summary>
+	public IReadOnlyDictionary<long, IReadOnlyList<AttachmentMetadata>> SavedAttachments => _attachments;
 
 	private static (long, long) Pair(long a, long b) => a < b ? (a, b) : (b, a);
 
@@ -24,6 +29,7 @@ public sealed class FakeDirectMessageRepository : IDirectMessageRepository
 		_nonces.Clear();
 		_conversations.Clear();
 		_replies.Clear();
+		_attachments.Clear();
 	}
 
 	public Task<long?> FindConversationAsync(long senderId, long recipientId, CancellationToken ct) =>
@@ -41,10 +47,11 @@ public sealed class FakeDirectMessageRepository : IDirectMessageRepository
 	public Task<long?> FindReplyExistsAsync(long conversationId, long replyToId, CancellationToken ct) =>
 		Task.FromResult(_replies.TryGetValue((conversationId, replyToId), out var id) ? id : (long?)null);
 
-	public Task AddAsync(DirectMessage message, string? nonce, CancellationToken ct)
+	public Task AddAsync(DirectMessage message, string? nonce, IReadOnlyList<AttachmentMetadata> attachments, CancellationToken ct)
 	{
 		_saved.Add(message);
 		_conversations[Pair(message.SenderId, message.RecipientId)] = message.ConversationId;
+		_attachments[message.Id] = attachments;
 		if (nonce is not null)
 			_nonces[(message.SenderId, message.RecipientId, nonce)] = message.Id;
 		return Task.CompletedTask;

--- a/services/chat/tests/Chat.UnitTests/Fakes/FakeDirectMessageRepository.cs
+++ b/services/chat/tests/Chat.UnitTests/Fakes/FakeDirectMessageRepository.cs
@@ -87,4 +87,6 @@ public sealed class FakeDirectMessageRepository : IDirectMessageRepository
 
 	public void WithReply(long conversationId, long replyToId) =>
 		_replies[(conversationId, replyToId)] = replyToId;
+
+	public void Seed(DirectMessage message) => _saved.Add(message);
 }


### PR DESCRIPTION
## About
Extends direct messages with file attachment support, on top of #285.
> Blocked by #285

## Changes
- attachment_ids wired through the DM send endpoint
- `IAttachmentRepository` gains DM read paths; `DirectMessageRepository` persists attachments alongside the message
- `ListDirectMessagesHandler` hydrates attachments per message
- Download authorization: only conversation participants can fetch a DM attachment
- Allow an **attachment only** (attachments but no content) DM

## Notes
> This **duplicates** a fair amount of the channel attachment logic almost verbatim (repository methods, handler wiring). That's **intentional for now** — a follow-up branch unifies channel/DM message and attachment handling, this PR just gets DM attachments working first. For the same reason it was **not** depthly tested.