### PR TITLE
Feat/chat/dm conversations

### DIFF
--- a/services/chat/src/Chat.Application/Abstractions/Persistence/IMessageRepository.cs
+++ b/services/chat/src/Chat.Application/Abstractions/Persistence/IMessageRepository.cs
@@ -1,4 +1,5 @@
 using Chat.Domain.Attachments;
+using Chat.Domain.Conversations;
 using Chat.Domain.Messages;
 
 namespace Chat.Application.Abstractions.Persistence;
@@ -39,4 +40,7 @@ public interface IMessageRepository
 	Task<long> GetOrCreateConversationAsync(long senderId, long recipientId, long candidateId, CancellationToken ct);
 
 	Task DeleteConversationAsync(long userId, CancellationToken ct);
+
+	/// <summary>every DM thread for this user, from their own user_conversations partition</summary>
+	Task<IReadOnlyList<DmConversation>> GetConversationsAsync(long userId, CancellationToken ct);
 }

--- a/services/chat/src/Chat.Application/Abstractions/Persistence/IMessageRepository.cs
+++ b/services/chat/src/Chat.Application/Abstractions/Persistence/IMessageRepository.cs
@@ -43,4 +43,7 @@ public interface IMessageRepository
 
 	/// <summary>every DM thread for this user, from their own user_conversations partition</summary>
 	Task<IReadOnlyList<DmConversation>> GetConversationsAsync(long userId, CancellationToken ct);
+
+	/// <summary>flips is_archived = true for the caller's row only; does not touch the partner's row</summary>
+	Task ArchiveConversationAsync(long userId, long partnerId, CancellationToken ct);
 }

--- a/services/chat/src/Chat.Application/Features/DirectMessages/ArchiveConversation/ArchiveConversationCommand.cs
+++ b/services/chat/src/Chat.Application/Features/DirectMessages/ArchiveConversation/ArchiveConversationCommand.cs
@@ -1,0 +1,6 @@
+using Chat.Application.Abstractions.Messaging;
+using Chat.Domain.Results;
+
+namespace Chat.Application.Features.DirectMessages.ArchiveConversation;
+
+public sealed record ArchiveConversationCommand(long PartnerId) : ICommand<Result>;

--- a/services/chat/src/Chat.Application/Features/DirectMessages/ArchiveConversation/ArchiveConversationHandler.cs
+++ b/services/chat/src/Chat.Application/Features/DirectMessages/ArchiveConversation/ArchiveConversationHandler.cs
@@ -1,0 +1,23 @@
+using Chat.Application.Abstractions.Authentication;
+using Chat.Application.Abstractions.Messaging;
+using Chat.Application.Abstractions.Persistence;
+using Chat.Domain.Results;
+
+namespace Chat.Application.Features.DirectMessages.ArchiveConversation;
+
+internal sealed class ArchiveConversationHandler(
+	ICurrentUser currentUser,
+	IMessageRepository repository)
+	: ICommandHandler<ArchiveConversationCommand, Result>
+{
+	public async Task<Result> HandleAsync(ArchiveConversationCommand command, CancellationToken cancellationToken = default)
+	{
+		var conversationId = await repository.FindConversationAsync(currentUser.UserId, command.PartnerId, cancellationToken);
+		if (conversationId is null)
+			return MessageFailures.ConversationNotFound;
+
+		await repository.ArchiveConversationAsync(currentUser.UserId, command.PartnerId, cancellationToken);
+
+		return Result.Ok();
+	}
+}

--- a/services/chat/src/Chat.Application/Features/DirectMessages/Common/DmConversationResponse.cs
+++ b/services/chat/src/Chat.Application/Features/DirectMessages/Common/DmConversationResponse.cs
@@ -1,0 +1,20 @@
+using Chat.Domain.Conversations;
+
+namespace Chat.Application.Features.DirectMessages.Common;
+
+/// <summary>wire shape for a GET /dms sidebar row</summary>
+public sealed record DmConversationResponse(
+	string PartnerId,
+	string? LastPreview,
+	DateTimeOffset LastMessageAt,
+	int UnreadCount,
+	bool IsArchived)
+{
+	// TODO: wire up unread_count when implement read-state
+	public static DmConversationResponse From(DmConversation conversation) => new(
+		PartnerId: conversation.PartnerId.ToString(),
+		LastPreview: conversation.LastPreview,
+		LastMessageAt: conversation.LastMessageAt,
+		UnreadCount: 0,
+		IsArchived: conversation.IsArchived);
+}

--- a/services/chat/src/Chat.Application/Features/DirectMessages/Common/DmConversationResponse.cs
+++ b/services/chat/src/Chat.Application/Features/DirectMessages/Common/DmConversationResponse.cs
@@ -10,7 +10,7 @@ public sealed record DmConversationResponse(
 	int UnreadCount,
 	bool IsArchived)
 {
-	// TODO: wire up unread_count when implement read-state
+	// TODO: wire up unread_count once read-state (#154) lands
 	public static DmConversationResponse From(DmConversation conversation) => new(
 		PartnerId: conversation.PartnerId.ToString(),
 		LastPreview: conversation.LastPreview,

--- a/services/chat/src/Chat.Application/Features/DirectMessages/ListConversations/ListDmConversationsHandler.cs
+++ b/services/chat/src/Chat.Application/Features/DirectMessages/ListConversations/ListDmConversationsHandler.cs
@@ -1,0 +1,26 @@
+using Chat.Application.Abstractions.Authentication;
+using Chat.Application.Abstractions.Messaging;
+using Chat.Application.Abstractions.Persistence;
+using Chat.Application.Features.DirectMessages.Common;
+using Chat.Domain.Results;
+
+namespace Chat.Application.Features.DirectMessages.ListConversations;
+
+internal sealed class ListDmConversationsHandler(
+	ICurrentUser currentUser,
+	IMessageRepository repository)
+	: IQueryHandler<ListDmConversationsQuery, Result<IReadOnlyList<DmConversationResponse>>>
+{
+	public async Task<Result<IReadOnlyList<DmConversationResponse>>> HandleAsync(
+		ListDmConversationsQuery query,
+		CancellationToken cancellationToken = default)
+	{
+		var conversations = await repository.GetConversationsAsync(currentUser.UserId, cancellationToken);
+		var filtered = query.IncludeArchived ? conversations : conversations.Where(c => !c.IsArchived);
+
+		return filtered
+			.OrderByDescending(c => c.LastMessageAt)
+			.Select(DmConversationResponse.From)
+			.ToList();
+	}
+}

--- a/services/chat/src/Chat.Application/Features/DirectMessages/ListConversations/ListDmConversationsQuery.cs
+++ b/services/chat/src/Chat.Application/Features/DirectMessages/ListConversations/ListDmConversationsQuery.cs
@@ -1,0 +1,8 @@
+using Chat.Application.Abstractions.Messaging;
+using Chat.Application.Features.DirectMessages.Common;
+using Chat.Domain.Results;
+
+namespace Chat.Application.Features.DirectMessages.ListConversations;
+
+public sealed record ListDmConversationsQuery(bool IncludeArchived)
+	: IQuery<Result<IReadOnlyList<DmConversationResponse>>>;

--- a/services/chat/src/Chat.Domain/Conversations/DmConversation.cs
+++ b/services/chat/src/Chat.Domain/Conversations/DmConversation.cs
@@ -1,0 +1,11 @@
+namespace Chat.Domain.Conversations;
+
+/// <summary>
+/// storage projection of a row in user_conversations: one DM thread as seen
+/// by a single participant (the partner's own row is independent)
+/// </summary>
+public sealed record DmConversation(
+	long PartnerId,
+	DateTimeOffset LastMessageAt,
+	string? LastPreview,
+	bool IsArchived);

--- a/services/chat/src/Chat.Persistence/Repositories/MessageRepository.cs
+++ b/services/chat/src/Chat.Persistence/Repositories/MessageRepository.cs
@@ -270,6 +270,12 @@ internal sealed class MessageRepository(ISession session, MessageStatements stat
 			.ToList();
 	}
 
+	public async Task ArchiveConversationAsync(long userId, long partnerId, CancellationToken ct)
+	{
+		var stmt = await statements.ArchiveConversation.Value;
+		await session.ExecuteAsync(stmt.Bind(userId, partnerId));
+	}
+
 	private static string? BuildPreview(string? content)
 	{
 		if (string.IsNullOrWhiteSpace(content))

--- a/services/chat/src/Chat.Persistence/Repositories/MessageRepository.cs
+++ b/services/chat/src/Chat.Persistence/Repositories/MessageRepository.cs
@@ -1,6 +1,7 @@
 using Cassandra;
 using Chat.Application.Abstractions.Persistence;
 using Chat.Domain.Attachments;
+using Chat.Domain.Conversations;
 using Chat.Domain.Messages;
 
 namespace Chat.Persistence.Repositories;
@@ -249,6 +250,24 @@ internal sealed class MessageRepository(ISession session, MessageStatements stat
 	{
 		var stmt = await statements.DeleteConversation.Value;
 		await session.ExecuteAsync(stmt.Bind(userId));
+	}
+
+	public async Task<IReadOnlyList<DmConversation>> GetConversationsAsync(long userId, CancellationToken ct)
+	{
+		var stmt = await statements.SelectConversationsByUser.Value;
+		var rows = await session.ExecuteAsync(stmt.Bind(userId));
+
+		// last_message_at can be null between GetOrCreateConversationAsync
+		// creating the row and the first message's AddAsync populating it; such
+		// a conversation has no message to preview yet, so it is not listed
+		return rows
+			.Where(row => row.GetValue<DateTime?>("last_message_at") is not null)
+			.Select(row => new DmConversation(
+				PartnerId: row.GetValue<long>("partner_id"),
+				LastMessageAt: new DateTimeOffset(row.GetValue<DateTime>("last_message_at"), TimeSpan.Zero),
+				LastPreview: row.GetValue<string?>("last_preview"),
+				IsArchived: row.GetValue<bool>("is_archived")))
+			.ToList();
 	}
 
 	private static string? BuildPreview(string? content)

--- a/services/chat/src/Chat.Persistence/Repositories/MessageStatements.cs
+++ b/services/chat/src/Chat.Persistence/Repositories/MessageStatements.cs
@@ -104,6 +104,9 @@ internal sealed class MessageStatements(ISession session)
 	public Lazy<Task<PreparedStatement>> SelectConversationsByUser { get; } = new(() => session.PrepareAsync(
 		"SELECT partner_id, last_message_at, last_preview, is_archived FROM user_conversations WHERE user_id = ?"));
 
+	public Lazy<Task<PreparedStatement>> ArchiveConversation { get; } = new(() => session.PrepareAsync(
+		"UPDATE user_conversations SET is_archived = true WHERE user_id = ? AND partner_id = ?"));
+
 
 	/* ### Attachements ### */
 

--- a/services/chat/src/Chat.Persistence/Repositories/MessageStatements.cs
+++ b/services/chat/src/Chat.Persistence/Repositories/MessageStatements.cs
@@ -101,6 +101,9 @@ internal sealed class MessageStatements(ISession session)
 		"(user_id, partner_id, conversation_id, last_message_at, last_preview, is_archived) " +
 		"VALUES (?, ?, ?, null, null, false) IF NOT EXISTS"));
 
+	public Lazy<Task<PreparedStatement>> SelectConversationsByUser { get; } = new(() => session.PrepareAsync(
+		"SELECT partner_id, last_message_at, last_preview, is_archived FROM user_conversations WHERE user_id = ?"));
+
 
 	/* ### Attachements ### */
 

--- a/services/chat/src/Chat.Presentation/Endpoints/DirectMessagesEndpoint.cs
+++ b/services/chat/src/Chat.Presentation/Endpoints/DirectMessagesEndpoint.cs
@@ -3,6 +3,7 @@ using Chat.Application.Abstractions.Messaging;
 using Chat.Application.Features.DirectMessages.Common;
 using Chat.Application.Features.DirectMessages.SendMessage;
 using Chat.Application.Features.DirectMessages.ListMessages;
+using Chat.Application.Features.DirectMessages.ListConversations;
 using Chat.Domain.Results;
 using Microsoft.AspNetCore.Http.HttpResults;
 
@@ -12,9 +13,12 @@ public sealed class DirectMessagesEndpoint : ICarterModule
 {
 	public void AddRoutes(IEndpointRouteBuilder app)
 	{
-		var group = app.MapGroup("/dms/{userId:long}/messages").WithTags("Direct Messages");
-		group.MapPost("/", SendAsync);
-		group.MapGet("/", ListAsync);
+		var messagesGroup = app.MapGroup("/dms/{userId:long}/messages").WithTags("Direct Messages");
+		messagesGroup.MapPost("/", SendAsync);
+		messagesGroup.MapGet("/", ListAsync);
+
+		var conversationsGroup = app.MapGroup("/dms").WithTags("Direct Messages");
+		conversationsGroup.MapGet("/", ListConversationsAsync);
 	}
 
 	private static async Task<Results<
@@ -69,6 +73,18 @@ public sealed class DirectMessagesEndpoint : ICarterModule
 		return result.Succeeded
 			? TypedResults.Ok(result.Value)
 			: MapListError(result.Error);
+	}
+
+	private static async Task<Ok<IReadOnlyList<DmConversationResponse>>> ListConversationsAsync(
+		bool? include_archived,
+		IQueryHandler<ListDmConversationsQuery, Result<IReadOnlyList<DmConversationResponse>>> handler,
+		CancellationToken cancellationToken)
+	{
+		var result = await handler.HandleAsync(
+			new ListDmConversationsQuery(include_archived ?? false),
+			cancellationToken);
+
+		return TypedResults.Ok(result.Value);
 	}
 
 	private static Results<

--- a/services/chat/src/Chat.Presentation/Endpoints/DirectMessagesEndpoint.cs
+++ b/services/chat/src/Chat.Presentation/Endpoints/DirectMessagesEndpoint.cs
@@ -77,7 +77,8 @@ public sealed class DirectMessagesEndpoint : ICarterModule
 			: MapListError(result.Error);
 	}
 
-	private static async Task<Ok<IReadOnlyList<DmConversationResponse>>> ListConversationsAsync(
+	private static async Task<Results<Ok<IReadOnlyList<DmConversationResponse>>, JsonHttpResult<ErrorBody>>>
+	ListConversationsAsync(
 		bool? include_archived,
 		IQueryHandler<ListDmConversationsQuery, Result<IReadOnlyList<DmConversationResponse>>> handler,
 		CancellationToken cancellationToken)
@@ -86,7 +87,9 @@ public sealed class DirectMessagesEndpoint : ICarterModule
 			new ListDmConversationsQuery(include_archived ?? false),
 			cancellationToken);
 
-		return TypedResults.Ok(result.Value);
+		return result.Succeeded
+			? TypedResults.Ok(result.Value)
+			: TypedResults.Json(new ErrorBody(result.Error.Message), statusCode: StatusCodes.Status500InternalServerError);
 	}
 
 	private static async Task<Results<NoContent, NotFound<ErrorBody>>> ArchiveAsync(

--- a/services/chat/src/Chat.Presentation/Endpoints/DirectMessagesEndpoint.cs
+++ b/services/chat/src/Chat.Presentation/Endpoints/DirectMessagesEndpoint.cs
@@ -1,5 +1,6 @@
 using Carter;
 using Chat.Application.Abstractions.Messaging;
+using Chat.Application.Features.DirectMessages.ArchiveConversation;
 using Chat.Application.Features.DirectMessages.Common;
 using Chat.Application.Features.DirectMessages.SendMessage;
 using Chat.Application.Features.DirectMessages.ListMessages;
@@ -19,6 +20,7 @@ public sealed class DirectMessagesEndpoint : ICarterModule
 
 		var conversationsGroup = app.MapGroup("/dms").WithTags("Direct Messages");
 		conversationsGroup.MapGet("/", ListConversationsAsync);
+		conversationsGroup.MapDelete("/{userId:long}", ArchiveAsync);
 	}
 
 	private static async Task<Results<
@@ -48,7 +50,7 @@ public sealed class DirectMessagesEndpoint : ICarterModule
 				result.Value);
 		}
 
-		return MapError(result.Error);
+		return MapSendError(result.Error);
 	}
 
 	private static async Task<Results<
@@ -57,11 +59,11 @@ public sealed class DirectMessagesEndpoint : ICarterModule
 		JsonHttpResult<ErrorBody>,
 		NotFound<ErrorBody>>>
 	ListAsync(
-			long userId,
-			DateTimeOffset? before_time,
-			int? limit,
-			IQueryHandler<ListDirectMessagesQuery, Result<IReadOnlyList<DirectMessageResponse>>> handler,
-			CancellationToken cancellationToken)
+		long userId,
+		DateTimeOffset? before_time,
+		int? limit,
+		IQueryHandler<ListDirectMessagesQuery, Result<IReadOnlyList<DirectMessageResponse>>> handler,
+		CancellationToken cancellationToken)
 	{
 		var result = await handler.HandleAsync(
 				new ListDirectMessagesQuery(
@@ -85,6 +87,18 @@ public sealed class DirectMessagesEndpoint : ICarterModule
 			cancellationToken);
 
 		return TypedResults.Ok(result.Value);
+	}
+
+	private static async Task<Results<NoContent, NotFound<ErrorBody>>> ArchiveAsync(
+		long userId,
+		ICommandHandler<ArchiveConversationCommand, Result> handler,
+		CancellationToken cancellationToken)
+	{
+		var result = await handler.HandleAsync(new ArchiveConversationCommand(userId), cancellationToken);
+
+		return result.Succeeded
+			? TypedResults.NoContent()
+			: TypedResults.NotFound(new ErrorBody(result.Error.Message));
 	}
 
 	private static Results<
@@ -115,7 +129,7 @@ public sealed class DirectMessagesEndpoint : ICarterModule
 		BadRequest<ErrorBody>,
 		JsonHttpResult<ErrorBody>,
 		NotFound<ErrorBody>>
-	MapError(Failure failure)
+	MapSendError(Failure failure)
 	{
 		var body = new ErrorBody(failure.Message);
 

--- a/services/chat/tests/Chat.FunctionalTests/Endpoints/ArchiveConversationEndpointTests.cs
+++ b/services/chat/tests/Chat.FunctionalTests/Endpoints/ArchiveConversationEndpointTests.cs
@@ -110,11 +110,4 @@ public sealed class ArchiveConversationEndpointTests(ChatApiFactory factory)
 		var conversation = Assert.Single(listWithArchivedBody!);
 		Assert.True(conversation.IsArchived);
 	}
-
-	private sealed record DmConversationBody(
-		string PartnerId,
-		string? LastPreview,
-		DateTimeOffset LastMessageAt,
-		int UnreadCount,
-		bool IsArchived);
 }

--- a/services/chat/tests/Chat.FunctionalTests/Endpoints/ArchiveConversationEndpointTests.cs
+++ b/services/chat/tests/Chat.FunctionalTests/Endpoints/ArchiveConversationEndpointTests.cs
@@ -1,0 +1,120 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Chat.FunctionalTests.Infrastructure;
+using Chat.Domain.Conversations;
+using Xunit;
+
+namespace Chat.FunctionalTests.Endpoints;
+
+public sealed class ArchiveConversationEndpointTests(ChatApiFactory factory)
+	: IClassFixture<ChatApiFactory>, IAsyncLifetime
+{
+	private static readonly JsonSerializerOptions JsonOptions = new()
+	{
+		PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+		PropertyNameCaseInsensitive = true,
+	};
+
+	public Task InitializeAsync()
+	{
+		factory.MessageRepository.Reset();
+		return Task.CompletedTask;
+	}
+
+	public Task DisposeAsync() => Task.CompletedTask;
+
+	private HttpClient BuildClient(long userId)
+	{
+		var client = factory.CreateClient();
+		var token = TestTokens.Issue(ChatApiFactory.JwtSecret, userId: userId);
+		client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+		return client;
+	}
+
+	[Fact]
+	public async Task Delete_WithoutToken_Returns401()
+	{
+		var client = factory.CreateClient();
+
+		var response = await client.DeleteAsync("/v1/dms/100");
+
+		Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+	}
+
+	[Fact]
+	public async Task Delete_NoConversation_Returns404()
+	{
+		var client = BuildClient(userId: 42);
+
+		var response = await client.DeleteAsync("/v1/dms/999");
+
+		Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+	}
+
+	[Fact]
+	public async Task Delete_HappyPath_Returns204_ArchivesCallerSideOnly()
+	{
+		factory.MessageRepository.WithConversation(42, 100, conversationId: 555);
+		factory.MessageRepository.WithConversationSummary(42, new DmConversation(
+			PartnerId: 100, LastMessageAt: DateTimeOffset.UtcNow, LastPreview: "hey", IsArchived: false));
+		factory.MessageRepository.WithConversationSummary(100, new DmConversation(
+			PartnerId: 42, LastMessageAt: DateTimeOffset.UtcNow, LastPreview: "hey", IsArchived: false));
+
+		var client = BuildClient(userId: 42);
+		var response = await client.DeleteAsync("/v1/dms/100");
+
+		Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+
+		var callerSide = Assert.Single(await factory.MessageRepository.GetConversationsAsync(42, default));
+		Assert.True(callerSide.IsArchived);
+
+		var partnerSide = Assert.Single(await factory.MessageRepository.GetConversationsAsync(100, default));
+		Assert.False(partnerSide.IsArchived);
+	}
+
+	[Fact]
+	public async Task Delete_AlreadyArchived_IsIdempotent_Returns204()
+	{
+		factory.MessageRepository.WithConversation(42, 100, conversationId: 555);
+		factory.MessageRepository.WithConversationSummary(42, new DmConversation(
+			PartnerId: 100, LastMessageAt: DateTimeOffset.UtcNow, LastPreview: "hey", IsArchived: true));
+
+		var client = BuildClient(userId: 42);
+		var response = await client.DeleteAsync("/v1/dms/100");
+
+		Assert.Equal(HttpStatusCode.NoContent, response.StatusCode);
+	}
+
+	[Fact]
+	public async Task Delete_ThenGetDms_HidesArchivedConversation_UntilIncludeArchivedRequested()
+	{
+		factory.MessageRepository.WithConversation(42, 100, conversationId: 555);
+		factory.MessageRepository.WithConversationSummary(42, new DmConversation(
+			PartnerId: 100, LastMessageAt: DateTimeOffset.UtcNow, LastPreview: "hey", IsArchived: false));
+
+		var client = BuildClient(userId: 42);
+
+		var archiveResponse = await client.DeleteAsync("/v1/dms/100");
+		Assert.Equal(HttpStatusCode.NoContent, archiveResponse.StatusCode);
+
+		var listResponse = await client.GetAsync("/v1/dms");
+		var listBody = await listResponse.Content.ReadFromJsonAsync<List<DmConversationBody>>(JsonOptions);
+		Assert.NotNull(listBody);
+		Assert.Empty(listBody!);
+
+		var listWithArchivedResponse = await client.GetAsync("/v1/dms?include_archived=true");
+		var listWithArchivedBody = await listWithArchivedResponse.Content.ReadFromJsonAsync<List<DmConversationBody>>(JsonOptions);
+		Assert.NotNull(listWithArchivedBody);
+		var conversation = Assert.Single(listWithArchivedBody!);
+		Assert.True(conversation.IsArchived);
+	}
+
+	private sealed record DmConversationBody(
+		string PartnerId,
+		string? LastPreview,
+		DateTimeOffset LastMessageAt,
+		int UnreadCount,
+		bool IsArchived);
+}

--- a/services/chat/tests/Chat.FunctionalTests/Endpoints/ListDmConversationsEndpointTests.cs
+++ b/services/chat/tests/Chat.FunctionalTests/Endpoints/ListDmConversationsEndpointTests.cs
@@ -138,11 +138,11 @@ public sealed class ListDmConversationsEndpointTests(ChatApiFactory factory)
 		var conversation = Assert.Single(body!);
 		Assert.Equal("mine", conversation.LastPreview);
 	}
-
-	private sealed record DmConversationBody(
-		string PartnerId,
-		string? LastPreview,
-		DateTimeOffset LastMessageAt,
-		int UnreadCount,
-		bool IsArchived);
 }
+
+internal sealed record DmConversationBody(
+	string PartnerId,
+	string? LastPreview,
+	DateTimeOffset LastMessageAt,
+	int UnreadCount,
+	bool IsArchived);

--- a/services/chat/tests/Chat.FunctionalTests/Endpoints/ListDmConversationsEndpointTests.cs
+++ b/services/chat/tests/Chat.FunctionalTests/Endpoints/ListDmConversationsEndpointTests.cs
@@ -1,0 +1,148 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Chat.FunctionalTests.Infrastructure;
+using Chat.Domain.Conversations;
+using Xunit;
+
+namespace Chat.FunctionalTests.Endpoints;
+
+public sealed class ListDmConversationsEndpointTests(ChatApiFactory factory)
+	: IClassFixture<ChatApiFactory>, IAsyncLifetime
+{
+	private static readonly JsonSerializerOptions JsonOptions = new()
+	{
+		PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+		PropertyNameCaseInsensitive = true,
+	};
+
+	public Task InitializeAsync()
+	{
+		factory.MessageRepository.Reset();
+		return Task.CompletedTask;
+	}
+
+	public Task DisposeAsync() => Task.CompletedTask;
+
+	private HttpClient BuildClient(long userId)
+	{
+		var client = factory.CreateClient();
+		var token = TestTokens.Issue(ChatApiFactory.JwtSecret, userId: userId);
+		client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+		return client;
+	}
+
+	[Fact]
+	public async Task Get_WithoutToken_Returns401()
+	{
+		var client = factory.CreateClient();
+
+		var response = await client.GetAsync("/v1/dms");
+
+		Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+	}
+
+	[Fact]
+	public async Task Get_NoConversations_Returns200WithEmptyArray()
+	{
+		var client = BuildClient(userId: 42);
+
+		var response = await client.GetAsync("/v1/dms");
+
+		Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+		var body = await response.Content.ReadFromJsonAsync<List<DmConversationBody>>(JsonOptions);
+		Assert.NotNull(body);
+		Assert.Empty(body!);
+	}
+
+	[Fact]
+	public async Task Get_HappyPath_ReturnsConversations_NewestFirst()
+	{
+		var anchor = new DateTimeOffset(2026, 1, 1, 12, 0, 0, TimeSpan.Zero);
+
+		factory.MessageRepository.WithConversationSummary(42, new DmConversation(
+			PartnerId: 100, LastMessageAt: anchor.AddMinutes(-10), LastPreview: "older chat", IsArchived: false));
+		factory.MessageRepository.WithConversationSummary(42, new DmConversation(
+			PartnerId: 200, LastMessageAt: anchor, LastPreview: "newest chat", IsArchived: false));
+
+		var client = BuildClient(userId: 42);
+		var response = await client.GetAsync("/v1/dms");
+
+		Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+		var body = await response.Content.ReadFromJsonAsync<List<DmConversationBody>>(JsonOptions);
+		Assert.NotNull(body);
+		Assert.Equal(2, body!.Count);
+
+		Assert.Equal("200", body[0].PartnerId);
+		Assert.Equal("newest chat", body[0].LastPreview);
+		Assert.Equal(0, body[0].UnreadCount);
+		Assert.False(body[0].IsArchived);
+
+		Assert.Equal("100", body[1].PartnerId);
+	}
+
+	[Fact]
+	public async Task Get_ExcludesArchived_ByDefault()
+	{
+		var anchor = DateTimeOffset.UtcNow;
+
+		factory.MessageRepository.WithConversationSummary(42, new DmConversation(
+			PartnerId: 100, LastMessageAt: anchor, LastPreview: "open", IsArchived: false));
+		factory.MessageRepository.WithConversationSummary(42, new DmConversation(
+			PartnerId: 200, LastMessageAt: anchor, LastPreview: "closed", IsArchived: true));
+
+		var client = BuildClient(userId: 42);
+		var response = await client.GetAsync("/v1/dms");
+
+		var body = await response.Content.ReadFromJsonAsync<List<DmConversationBody>>(JsonOptions);
+		Assert.NotNull(body);
+		var conversation = Assert.Single(body!);
+		Assert.Equal("100", conversation.PartnerId);
+	}
+
+	[Fact]
+	public async Task Get_IncludeArchivedTrue_ReturnsBoth()
+	{
+		var anchor = DateTimeOffset.UtcNow;
+
+		factory.MessageRepository.WithConversationSummary(42, new DmConversation(
+			PartnerId: 100, LastMessageAt: anchor, LastPreview: "open", IsArchived: false));
+		factory.MessageRepository.WithConversationSummary(42, new DmConversation(
+			PartnerId: 200, LastMessageAt: anchor, LastPreview: "closed", IsArchived: true));
+
+		var client = BuildClient(userId: 42);
+		var response = await client.GetAsync("/v1/dms?include_archived=true");
+
+		var body = await response.Content.ReadFromJsonAsync<List<DmConversationBody>>(JsonOptions);
+		Assert.NotNull(body);
+		Assert.Equal(2, body!.Count);
+		Assert.Contains(body, c => c.PartnerId == "200" && c.IsArchived);
+	}
+
+	[Fact]
+	public async Task Get_OnlyReturnsCallersOwnConversations()
+	{
+		factory.MessageRepository.WithConversationSummary(42, new DmConversation(
+			PartnerId: 100, LastMessageAt: DateTimeOffset.UtcNow, LastPreview: "mine", IsArchived: false));
+		factory.MessageRepository.WithConversationSummary(999, new DmConversation(
+			PartnerId: 100, LastMessageAt: DateTimeOffset.UtcNow, LastPreview: "not mine", IsArchived: false));
+
+		var client = BuildClient(userId: 42);
+		var response = await client.GetAsync("/v1/dms");
+
+		var body = await response.Content.ReadFromJsonAsync<List<DmConversationBody>>(JsonOptions);
+		Assert.NotNull(body);
+		var conversation = Assert.Single(body!);
+		Assert.Equal("mine", conversation.LastPreview);
+	}
+
+	private sealed record DmConversationBody(
+		string PartnerId,
+		string? LastPreview,
+		DateTimeOffset LastMessageAt,
+		int UnreadCount,
+		bool IsArchived);
+}

--- a/services/chat/tests/Chat.UnitTests/Application/ArchiveConversationHandlerTests.cs
+++ b/services/chat/tests/Chat.UnitTests/Application/ArchiveConversationHandlerTests.cs
@@ -1,0 +1,72 @@
+using Chat.Application.Abstractions.Messaging;
+using Chat.Application.Features.DirectMessages.ArchiveConversation;
+using Chat.Domain.Conversations;
+using Chat.Domain.Results;
+using Chat.UnitTests.Fakes;
+using Xunit;
+
+namespace Chat.UnitTests.Application;
+
+public sealed class ArchiveConversationHandlerTests
+{
+	private sealed record Harness(FakeCurrentUser CurrentUser, FakeMessageRepository Repository);
+
+	private static (Harness Harness, ICommandHandler<ArchiveConversationCommand, Result> Handler)
+		BuildHandler(long userId = 42)
+	{
+		var currentUser = new FakeCurrentUser { UserId = userId };
+		var repository = new FakeMessageRepository();
+
+		var handler = HandlerFactory.CreateCommand<ArchiveConversationCommand, Result>(currentUser, repository);
+
+		return (new Harness(currentUser, repository), handler);
+	}
+
+	[Fact]
+	public async Task NoConversation_ReturnsConversationNotFound()
+	{
+		var (_, handler) = BuildHandler();
+
+		var result = await handler.HandleAsync(new ArchiveConversationCommand(PartnerId: 100));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal(MessageFailures.ConversationNotFound, result.Error);
+	}
+
+	[Fact]
+	public async Task ExistingConversation_FlipsIsArchived_ForCallerOnly()
+	{
+		var (h, handler) = BuildHandler();
+
+		h.Repository.WithConversation(42, 100, conversationId: 999);
+		h.Repository.WithConversationSummary(42, new DmConversation(
+			PartnerId: 100, LastMessageAt: DateTimeOffset.UtcNow, LastPreview: "hey", IsArchived: false));
+		h.Repository.WithConversationSummary(100, new DmConversation(
+			PartnerId: 42, LastMessageAt: DateTimeOffset.UtcNow, LastPreview: "hey", IsArchived: false));
+
+		var result = await handler.HandleAsync(new ArchiveConversationCommand(PartnerId: 100));
+
+		Assert.True(result.Succeeded);
+
+		var callerSide = Assert.Single(await h.Repository.GetConversationsAsync(42, default));
+		Assert.True(callerSide.IsArchived);
+
+		var partnerSide = Assert.Single(await h.Repository.GetConversationsAsync(100, default));
+		Assert.False(partnerSide.IsArchived);
+	}
+
+	[Fact]
+	public async Task AlreadyArchived_IsIdempotent()
+	{
+		var (h, handler) = BuildHandler();
+
+		h.Repository.WithConversation(42, 100, conversationId: 999);
+		h.Repository.WithConversationSummary(42, new DmConversation(
+			PartnerId: 100, LastMessageAt: DateTimeOffset.UtcNow, LastPreview: "hey", IsArchived: true));
+
+		var result = await handler.HandleAsync(new ArchiveConversationCommand(PartnerId: 100));
+
+		Assert.True(result.Succeeded);
+		Assert.True(Assert.Single(await h.Repository.GetConversationsAsync(42, default)).IsArchived);
+	}
+}

--- a/services/chat/tests/Chat.UnitTests/Application/ListDmConversationsHandlerTests.cs
+++ b/services/chat/tests/Chat.UnitTests/Application/ListDmConversationsHandlerTests.cs
@@ -1,0 +1,101 @@
+using Chat.Application.Abstractions.Messaging;
+using Chat.Application.Features.DirectMessages.Common;
+using Chat.Application.Features.DirectMessages.ListConversations;
+using Chat.Domain.Conversations;
+using Chat.Domain.Results;
+using Chat.UnitTests.Fakes;
+using Xunit;
+
+namespace Chat.UnitTests.Application;
+
+public sealed class ListDmConversationsHandlerTests
+{
+	private sealed record Harness(FakeCurrentUser CurrentUser, FakeMessageRepository Repository);
+
+	private static (Harness Harness, IQueryHandler<ListDmConversationsQuery, Result<IReadOnlyList<DmConversationResponse>>> Handler)
+		BuildHandler(long userId = 42)
+	{
+		var currentUser = new FakeCurrentUser { UserId = userId };
+		var repository = new FakeMessageRepository();
+
+		var handler = HandlerFactory.CreateQuery<ListDmConversationsQuery, Result<IReadOnlyList<DmConversationResponse>>>(
+			currentUser, repository);
+
+		return (new Harness(currentUser, repository), handler);
+	}
+
+	[Fact]
+	public async Task ExcludesArchived_ByDefault()
+	{
+		var (h, handler) = BuildHandler();
+
+		h.Repository.WithConversationSummary(42, new DmConversation(
+			PartnerId: 100, LastMessageAt: DateTimeOffset.UtcNow, LastPreview: "hey", IsArchived: false));
+		h.Repository.WithConversationSummary(42, new DmConversation(
+			PartnerId: 200, LastMessageAt: DateTimeOffset.UtcNow, LastPreview: "closed", IsArchived: true));
+
+		var result = await handler.HandleAsync(new ListDmConversationsQuery(IncludeArchived: false));
+
+		Assert.True(result.Succeeded);
+		var conversation = Assert.Single(result.Value);
+		Assert.Equal("100", conversation.PartnerId);
+	}
+
+	[Fact]
+	public async Task IncludesArchived_WhenRequested()
+	{
+		var (h, handler) = BuildHandler();
+
+		h.Repository.WithConversationSummary(42, new DmConversation(
+			PartnerId: 100, LastMessageAt: DateTimeOffset.UtcNow, LastPreview: "hey", IsArchived: false));
+		h.Repository.WithConversationSummary(42, new DmConversation(
+			PartnerId: 200, LastMessageAt: DateTimeOffset.UtcNow, LastPreview: "closed", IsArchived: true));
+
+		var result = await handler.HandleAsync(new ListDmConversationsQuery(IncludeArchived: true));
+
+		Assert.True(result.Succeeded);
+		Assert.Equal(2, result.Value.Count);
+		Assert.Contains(result.Value, c => c.PartnerId == "200" && c.IsArchived);
+	}
+
+	[Fact]
+	public async Task Sorts_ByLastMessageAt_Descending()
+	{
+		var (h, handler) = BuildHandler();
+
+		var anchor = new DateTimeOffset(2026, 1, 1, 12, 0, 0, TimeSpan.Zero);
+		h.Repository.WithConversationSummary(42, new DmConversation(
+			PartnerId: 100, LastMessageAt: anchor.AddMinutes(-10), LastPreview: "older", IsArchived: false));
+		h.Repository.WithConversationSummary(42, new DmConversation(
+			PartnerId: 200, LastMessageAt: anchor, LastPreview: "newer", IsArchived: false));
+
+		var result = await handler.HandleAsync(new ListDmConversationsQuery(IncludeArchived: false));
+
+		Assert.True(result.Succeeded);
+		Assert.Equal(["200", "100"], result.Value.Select(c => c.PartnerId));
+	}
+
+	[Fact]
+	public async Task NoConversations_ReturnsEmptyList()
+	{
+		var (_, handler) = BuildHandler();
+
+		var result = await handler.HandleAsync(new ListDmConversationsQuery(IncludeArchived: false));
+
+		Assert.True(result.Succeeded);
+		Assert.Empty(result.Value);
+	}
+
+	[Fact]
+	public async Task UnreadCount_IsAlwaysZero()
+	{
+		var (h, handler) = BuildHandler();
+
+		h.Repository.WithConversationSummary(42, new DmConversation(
+			PartnerId: 100, LastMessageAt: DateTimeOffset.UtcNow, LastPreview: "hey", IsArchived: false));
+
+		var result = await handler.HandleAsync(new ListDmConversationsQuery(IncludeArchived: false));
+
+		Assert.Equal(0, Assert.Single(result.Value).UnreadCount);
+	}
+}

--- a/services/chat/tests/Chat.UnitTests/Fakes/FakeMessageRepository.cs
+++ b/services/chat/tests/Chat.UnitTests/Fakes/FakeMessageRepository.cs
@@ -1,5 +1,6 @@
 using Chat.Application.Abstractions.Persistence;
 using Chat.Domain.Attachments;
+using Chat.Domain.Conversations;
 using Chat.Domain.Messages;
 
 namespace Chat.UnitTests.Fakes;
@@ -12,6 +13,7 @@ public sealed class FakeMessageRepository : IMessageRepository
 	private readonly Dictionary<(long, long), long> _conversations = [];
 	private readonly Dictionary<long, IReadOnlyList<AttachmentMetadata>> _attachments = [];
 	private readonly List<long> _deletedConversationsFor = [];
+	private readonly Dictionary<(long UserId, long PartnerId), DmConversation> _conversationSummaries = [];
 
 	public IReadOnlyList<Message> Saved => _saved;
 	public IReadOnlyList<long> DeletedConversationsFor => _deletedConversationsFor;
@@ -24,6 +26,10 @@ public sealed class FakeMessageRepository : IMessageRepository
 	public void WithConversation(long userA, long userB, long conversationId) =>
 		_conversations[Pair(userA, userB)] = conversationId;
 
+	/// <summary>seeds userId's own row for the userId/partnerId DM thread (asymmetric, mirrors user_conversations)</summary>
+	public void WithConversationSummary(long userId, DmConversation conversation) =>
+		_conversationSummaries[(userId, conversation.PartnerId)] = conversation;
+
 	public void Reset()
 	{
 		_saved.Clear();
@@ -32,6 +38,7 @@ public sealed class FakeMessageRepository : IMessageRepository
 		_conversations.Clear();
 		_attachments.Clear();
 		_deletedConversationsFor.Clear();
+		_conversationSummaries.Clear();
 		Updated.Clear();
 		SoftDeleted.Clear();
 	}
@@ -120,6 +127,16 @@ public sealed class FakeMessageRepository : IMessageRepository
 	{
 		_deletedConversationsFor.Add(userId);
 		return Task.CompletedTask;
+	}
+
+	public Task<IReadOnlyList<DmConversation>> GetConversationsAsync(long userId, CancellationToken ct)
+	{
+		var result = _conversationSummaries
+			.Where(kv => kv.Key.UserId == userId)
+			.Select(kv => kv.Value)
+			.ToList();
+
+		return Task.FromResult<IReadOnlyList<DmConversation>>(result);
 	}
 
 	public void Seed(Message message) => _saved.Add(message);

--- a/services/chat/tests/Chat.UnitTests/Fakes/FakeMessageRepository.cs
+++ b/services/chat/tests/Chat.UnitTests/Fakes/FakeMessageRepository.cs
@@ -139,6 +139,14 @@ public sealed class FakeMessageRepository : IMessageRepository
 		return Task.FromResult<IReadOnlyList<DmConversation>>(result);
 	}
 
+	public Task ArchiveConversationAsync(long userId, long partnerId, CancellationToken ct)
+	{
+		if (_conversationSummaries.TryGetValue((userId, partnerId), out var conversation))
+			_conversationSummaries[(userId, partnerId)] = conversation with { IsArchived = true };
+
+		return Task.CompletedTask;
+	}
+
 	public void Seed(Message message) => _saved.Add(message);
 
 	public List<Message> Updated { get; } = [];


### PR DESCRIPTION
## About

Adds the DM conversation sidebar surface on top of the unified message handling from #289: listing threads and archiving ("closing") one from the caller's side.

> Blocked by #289

## Changes

- `GET /dms — lists the caller's DM conversations from their user_conversations partition, sorted by `last_message_at` descending. Supports `include_archived` to surface archived conversations. `unread_count` is hardcoded to `0` for now — it's wired up properly once the read-state PR lands.
- `DELETE /dms/{user_id}` — archives the caller's side of a conversation (is_archived = true). Idempotent; 404 if no conversation exists with that user. Partner's row and message history are untouched, matching the contract's per-side semantics.
- `IMessageRepository` gains `GetConversationsAsync` / `ArchiveConversationAsync`; new `DmConversation` domain record projects a user_conversations row.

## Notes
> Auto-unarchive on next send (either direction) already exists from the earlier DM send work  (executed by the `UpsertConversation` statement) — this PR only adds the read/archive side.

## Testing

Unit tests for both handlers (list filtering/sorting, archive idempotency and per-side isolation) plus functional tests covering auth, 404s, ordering, include_archived, caller isolation, and an end-to-end archive → list round trip.

Close #200
Close #187