### PR TITLE
Build(infra): add mailhog container

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -67,6 +67,19 @@ local_resource(
 )
 
 local_resource(
+    'mailhog',
+    serve_cmd=container_serve(DOCKER, FLAGS, 'mailhog',
+        '--network ft_transcendence ' +
+        '-p 127.0.0.1:1025:1025 -p 127.0.0.1:8025:8025 ' +
+        '-e MH_UI_WEB_PATH=mailhog ' +
+        'docker.io/mailhog/mailhog:v1.0.1'
+    ),
+    resource_deps=['dev-network'],
+    labels=['infra'],
+    links=[BASE_URL + '/mailhog'],
+)
+
+local_resource(
     'coturn',
     # STUN/TURN for WebRTC. Host networking (like nginx) so the relay UDP range
     # and 3478/5349 bind directly. Realm + long-term user come from the root .env;

--- a/compose.yaml
+++ b/compose.yaml
@@ -109,6 +109,19 @@ services:
       retries: 5
       start_period: 30s
 
+  mailhog:
+    container_name: mailhog
+    image: docker.io/mailhog/mailhog:v1.0.1
+    environment:
+      MH_UI_WEB_PATH: mailhog
+    ports:
+      - "127.0.0.1:8025:8025"
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O", "/dev/null", "http://localhost:8025/mailhog/"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
 volumes:
   rabbitmq_data:
   minio_data:

--- a/infra/nginx/nginx.conf
+++ b/infra/nginx/nginx.conf
@@ -106,6 +106,21 @@ http {
             proxy_set_header X-Forwarded-Proto $scheme;
         }
 
+        location = /mailhog {
+            return 301 https://$host:1443/mailhog/;
+        }
+
+        location /mailhog/ {
+            proxy_pass http://127.0.0.1:8025;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
         location / {
             proxy_pass http://unix:/run/frontend/frontend.sock;
             proxy_http_version 1.1;

--- a/services/notification/.env.example
+++ b/services/notification/.env.example
@@ -27,3 +27,15 @@ DATABASE_URL=
 GOOSE_DRIVER=
 GOOSE_DBSTRING=
 GOOSE_MIGRATION_DIR=
+
+#    ╭─────────────────────────────────────────────────────────────────────╮
+#    │                  SMTP server (confirmation emails).                 │
+#    │                                                                     │
+#    │     ── Example: mailhog / 1025 / noreply@transcendencers.com ──     │
+#    │   ── user / pass stay empty for MailHog (real provider in prod) ──  │
+#    ╰─────────────────────────────────────────────────────────────────────╯
+SMTP_HOST=
+SMTP_PORT=
+SMTP_FROM=
+SMTP_USER=
+SMTP_PASS=


### PR DESCRIPTION
Resolves #243 
Part of #242 

- `compose.yaml`: `mailhog` service (SMTP internal at `mailhog:1025`, UI published on loopback only, wget healthcheck)
- `infra/nginx/nginx.conf`: UI proxied over TLS at `/mailhog` (prefix owned by MailHog via `MH_UI_WEB_PATH`, websocket upgrade headers for live inbox updates)
- `Tiltfile`: matching infra resource for dev parity
- `services/notification/.env.example`: SMTP vars for the upcoming email-sending side (empty user/pass for MailHog, real provider in prod but that's never gonna happen soooo)

Verified: `podman compose config` and `nginx -t` pass; live smoke test on the image confirmed healthcheck, SMTP delivery, and the UI under the `/mailhog/` prefix.