### PR TITLE
Feat(frontend): auth wiring

### DIFF
--- a/docs/frontend-backend-backlog.md
+++ b/docs/frontend-backend-backlog.md
@@ -11,15 +11,16 @@ This backlog is ordered by dependency, not by visual priority.
 
 Goal: make the frontend speak the same protocol as the backend services before wiring feature UI.
 
-- [ ] Replace fake auth/session flow with real token handling
-  - [ ] `login` and `register` must call `/auth/login` and `/auth/register` with `email + password`
-  - [ ] persist `access_token` from auth responses
-  - [ ] replace `createFakeSession` with real session bootstrap and logout cleanup
-  - [ ] add refresh-token recovery path on 401 for authenticated requests
-- [ ] Normalize environment and gateway base URLs
-  - [ ] verify the `NEXT_PUBLIC_API_*_URL` values for auth, user, guild, chat, notification
+- [x] Replace fake auth/session flow with real token handling
+  - [x] `login` and `register` must call `/auth/login` and `/auth/register` with `email + password`
+  - [x] persist `access_token` from auth responses
+  - [x] replace `createFakeSession` with real session bootstrap and logout cleanup
+  - [x] add refresh-token recovery path on 401 for authenticated requests
+- [-] Normalize environment and gateway base URLs
+  - [x] verify the `NEXT_PUBLIC_API_*_URL` values for auth, user, guild, chat, notification
+        (collapsed to a single `NEXT_PUBLIC_API_URL`; the gateway routes by `/{service}/v1` under it)
   - [ ] add a shared runtime health check page or dev banner when a service URL is missing
-  - [ ] document the expected gateway paths for each service
+  - [x] document the expected gateway paths for each service (see `.env.example` and `src/shared/api/client.ts`)
 - [ ] Define the canonical frontend DTO layer
   - [ ] map backend snake_case payloads to UI-friendly view models
   - [ ] create one transformation layer per service
@@ -29,22 +30,22 @@ Goal: make the frontend speak the same protocol as the backend services before w
 
 Goal: complete sign-in, sign-up, and account management flows.
 
-- [ ] Login form
-  - [ ] switch the form fields from `username` to `email`
-  - [ ] surface auth errors with backend status mapping
-  - [ ] redirect authenticated users away from `/auth/login` and `/auth/register`
-- [ ] Registration form
-  - [ ] align request body with backend contract
-  - [ ] remove fake account creation logic
-  - [ ] handle email duplication and weak password errors
-- [ ] Account actions
-  - [ ] add `GET /auth/me` consumption for the account menu
-  - [ ] add logout via `POST /auth/logout`
-  - [ ] add delete-account flow with the `409` guild ownership guard
-  - [ ] add `PATCH /auth/me` for email/password changes
-- [ ] OAuth entry points
-  - [ ] add login buttons for `42`, `Google`, and `GitHub`
-  - [ ] handle callback redirects and token handoff
+- [x] Login form
+  - [x] switch the form fields from `username` to `email`
+  - [x] surface auth errors with backend status mapping
+  - [x] redirect authenticated users away from `/auth/login` and `/auth/register` (middleware `proxy.ts`)
+- [x] Registration form
+  - [x] align request body with backend contract
+  - [x] remove fake account creation logic
+  - [x] handle email duplication and weak password errors
+- [x] Account actions
+  - [x] add `GET /auth/me` consumption for the account menu (settings modal)
+  - [x] add logout via `POST /auth/logout`
+  - [x] add delete-account flow with the `409` guild ownership guard
+  - [x] add `PATCH /auth/me` for email/password changes
+- [x] OAuth entry points
+  - [x] add login buttons for `42`, `Google`, and `GitHub` (slugs `fortytwo`, `google`, `github`)
+  - [x] handle callback redirects and token handoff (`/?access_token=...` -> `OAuthHandoff`)
 
 ## Epic 2 - User profile, friends, and social graph
 

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,11 +1,9 @@
 #    ╭─────────────────────────────────────────────────────────────────────╮
-#    │          Public API base URLs (exposed to the browser).             │
-#    │    ── These point to backend services through the gateway ──        │
-#    │         ───── Example: https://localhost:1443/api/auth ─────        │
+#    │              Single API base, exposed to the browser.               │
+#    │   ── Served same-origin behind nginx, which proxies /api to the ──   │
+#    │   gateway. The gateway routes by /{service}/v1/... underneath.       │
+#    │   Leave relative (/api) for local dev; override for a remote gateway │
+#    │   (e.g. https://localhost:1443/api).                                 │
 #    ╰─────────────────────────────────────────────────────────────────────╯
 
-NEXT_PUBLIC_API_AUTH_URL=
-NEXT_PUBLIC_API_GUILD_URL=
-NEXT_PUBLIC_API_USER_URL=
-NEXT_PUBLIC_API_NOTIFICATION_URL=
-NEXT_PUBLIC_API_CHAT_URL=
+NEXT_PUBLIC_API_URL=/api

--- a/frontend/app/auth/login/page.tsx
+++ b/frontend/app/auth/login/page.tsx
@@ -5,7 +5,8 @@ import { useRouter } from 'next/navigation';
 import { LogIn } from 'lucide-react';
 import { AuthCard } from '../../../src/components/auth-card';
 import { login } from '../../../src/shared/api/auth';
-import { createFakeSession } from '../../../src/shared/lib/session';
+import { establishSession } from '../../../src/shared/lib/session';
+import { describeLoginError } from '../../../src/shared/lib/auth-errors';
 import { validateLoginForm, type LoginFormErrors } from '../../../src/shared/lib/validators/auth';
 
 export default function LoginPage() {
@@ -15,10 +16,10 @@ export default function LoginPage() {
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   async function handleSubmit(formData: FormData) {
-    const username = String(formData.get('username') ?? '');
+    const email = String(formData.get('email') ?? '');
     const password = String(formData.get('password') ?? '');
 
-    const nextErrors = validateLoginForm({ username, password });
+    const nextErrors = validateLoginForm({ email, password });
     setErrors(nextErrors);
     setServerError('');
 
@@ -28,11 +29,11 @@ export default function LoginPage() {
 
     try {
       setIsSubmitting(true);
-      await login({ username: username.trim(), password });
-      createFakeSession(username.trim());
+      const { access_token, user_id } = await login({ email: email.trim(), password });
+      establishSession(access_token, user_id);
       router.push('/chat');
     } catch (error) {
-      setServerError(error instanceof Error ? error.message : 'Login failed.');
+      setServerError(describeLoginError(error));
     } finally {
       setIsSubmitting(false);
     }
@@ -47,16 +48,18 @@ export default function LoginPage() {
     >
       <form action={handleSubmit} className="grid gap-4">
         <div className="grid gap-2">
-          <label htmlFor="username" className="text-sm font-semibold text-white/70">
-            Username
+          <label htmlFor="email" className="text-sm font-semibold text-white/70">
+            Email
           </label>
           <input
-            id="username"
-            name="username"
-            placeholder="username"
+            id="email"
+            name="email"
+            type="email"
+            autoComplete="email"
+            placeholder="all@42.fr"
             className="h-11 w-full rounded-md border border-transparent bg-input-bg px-4 text-base text-white outline-none transition placeholder:text-input-placeholder focus:border-aqua/35"
           />
-          {errors.username ? <p className="text-sm text-pink">{errors.username}</p> : null}
+          {errors.email ? <p className="text-sm text-pink">{errors.email}</p> : null}
         </div>
         <div className="grid gap-2">
           <label htmlFor="password" className="text-sm font-semibold text-white/70">
@@ -66,6 +69,7 @@ export default function LoginPage() {
             id="password"
             name="password"
             type="password"
+            autoComplete="current-password"
             placeholder="password"
             className="h-11 w-full rounded-md border border-transparent bg-input-bg px-4 text-base text-white outline-none transition placeholder:text-input-placeholder focus:border-aqua/35"
           />

--- a/frontend/app/auth/register/page.tsx
+++ b/frontend/app/auth/register/page.tsx
@@ -5,7 +5,8 @@ import { useRouter } from 'next/navigation';
 import { UserPlus } from 'lucide-react';
 import { AuthCard } from '../../../src/components/auth-card';
 import { register } from '../../../src/shared/api/auth';
-import { createFakeSession } from '../../../src/shared/lib/session';
+import { establishSession } from '../../../src/shared/lib/session';
+import { describeRegisterError } from '../../../src/shared/lib/auth-errors';
 import {
   validateRegisterForm,
   type RegisterFormErrors
@@ -18,14 +19,10 @@ export default function RegisterPage() {
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   async function handleSubmit(formData: FormData) {
-    const username = String(formData.get('username') ?? '');
+    const email = String(formData.get('email') ?? '');
     const password = String(formData.get('password') ?? '');
     const confirm = String(formData.get('confirm') ?? '');
-    const nextErrors = validateRegisterForm({
-      username,
-      password,
-      confirm
-    });
+    const nextErrors = validateRegisterForm({ email, password, confirm });
 
     setErrors(nextErrors);
     setServerError('');
@@ -36,15 +33,11 @@ export default function RegisterPage() {
 
     try {
       setIsSubmitting(true);
-      await register({
-        username: username.trim(),
-        password,
-        confirm
-      });
-      createFakeSession(username.trim());
+      const { access_token, user_id } = await register({ email: email.trim(), password });
+      establishSession(access_token, user_id);
       router.push('/chat');
     } catch (error) {
-      setServerError(error instanceof Error ? error.message : 'Registration failed.');
+      setServerError(describeRegisterError(error));
     } finally {
       setIsSubmitting(false);
     }
@@ -53,22 +46,24 @@ export default function RegisterPage() {
   return (
     <AuthCard
       title="Register"
-      subtitle="Cree ton profil local pour tester le chat et les guildes."
+      subtitle="Cree ton profil pour tester le chat et les guildes."
       alternateHref="/auth/login"
       alternateLabel="Login"
     >
       <form action={handleSubmit} className="grid gap-4">
         <div className="grid gap-2">
-          <label htmlFor="username" className="text-sm font-semibold text-white/70">
-            Username
+          <label htmlFor="email" className="text-sm font-semibold text-white/70">
+            Email
           </label>
           <input
-            id="username"
-            name="username"
-            placeholder="username"
+            id="email"
+            name="email"
+            type="email"
+            autoComplete="email"
+            placeholder="all@42.fr"
             className="h-11 w-full rounded-md border border-transparent bg-input-bg px-4 text-base text-white outline-none transition placeholder:text-input-placeholder focus:border-aqua/35"
           />
-          {errors.username ? <p className="text-sm text-pink">{errors.username}</p> : null}
+          {errors.email ? <p className="text-sm text-pink">{errors.email}</p> : null}
         </div>
         <div className="grid gap-2">
           <label htmlFor="password" className="text-sm font-semibold text-white/70">
@@ -78,6 +73,7 @@ export default function RegisterPage() {
             id="password"
             name="password"
             type="password"
+            autoComplete="new-password"
             placeholder="password"
             className="h-11 w-full rounded-md border border-transparent bg-input-bg px-4 text-base text-white outline-none transition placeholder:text-input-placeholder focus:border-aqua/35"
           />
@@ -91,6 +87,7 @@ export default function RegisterPage() {
             id="confirm"
             name="confirm"
             type="password"
+            autoComplete="new-password"
             placeholder="confirm"
             className="h-11 w-full rounded-md border border-transparent bg-input-bg px-4 text-base text-white outline-none transition placeholder:text-input-placeholder focus:border-aqua/35"
           />

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,8 +1,10 @@
 import Link from 'next/link';
+import { OAuthHandoff } from '../src/components/oauth-handoff';
 
 export default function HomePage() {
   return (
     <section className="mx-auto flex min-h-screen w-full max-w-6xl items-center px-6 py-12">
+      <OAuthHandoff />
       <div className="w-full rounded-[2rem] border border-white/8 bg-secondary-bg/90 p-8 shadow-2xl shadow-black/40 backdrop-blur md:p-12">
         <p className="mono-detail text-aqua">ft_transcendence</p>
         <h1 className="mt-4 max-w-3xl text-5xl font-extrabold tracking-[-0.07em] text-white md:text-7xl">

--- a/frontend/proxy.ts
+++ b/frontend/proxy.ts
@@ -13,10 +13,14 @@ function isProtectedPath(pathname: string) {
 }
 
 export function proxy(request: NextRequest) {
-  const { pathname } = request.nextUrl;
+  const { pathname, searchParams } = request.nextUrl;
   const session = request.cookies.get(SESSION_COOKIE_KEY)?.value;
 
-  if (!session && isProtectedPath(pathname)) {
+  // oauth token handoff lands on `/?access_token=...` before the presence
+  // cookie exists; let it through so the client can capture the token
+  const isOAuthHandoff = pathname === '/' && searchParams.has('access_token');
+
+  if (!session && isProtectedPath(pathname) && !isOAuthHandoff) {
     const loginUrl = new URL('/auth/login', request.url);
     return NextResponse.redirect(loginUrl);
   }

--- a/frontend/src/components/auth-card.tsx
+++ b/frontend/src/components/auth-card.tsx
@@ -1,4 +1,7 @@
 import Link from 'next/link';
+import type { ComponentType } from 'react';
+import { API_BASE_URL } from '../shared/config/env';
+import { FortyTwoIcon, GitHubIcon, GoogleIcon } from './icons/brand-icons';
 
 type AuthCardProps = {
   title: 'Login' | 'Register';
@@ -7,6 +10,12 @@ type AuthCardProps = {
   alternateLabel: string;
   children: React.ReactNode;
 };
+
+const OAUTH_PROVIDERS: { slug: string; label: string; Icon: ComponentType<{ className?: string }> }[] = [
+  { slug: 'fortytwo', label: '42', Icon: FortyTwoIcon },
+  { slug: 'google', label: 'Google', Icon: GoogleIcon },
+  { slug: 'github', label: 'GitHub', Icon: GitHubIcon }
+];
 
 export function AuthCard({ title, subtitle, alternateHref, alternateLabel, children }: AuthCardProps) {
   return (
@@ -29,12 +38,19 @@ export function AuthCard({ title, subtitle, alternateHref, alternateLabel, child
             <p className="mt-2 text-sm leading-6 text-white/45">{subtitle}</p>
           </div>
 
-          <Link
-            href="/auth/oauth/42"
-            className="flex h-11 w-full items-center justify-center rounded-md border border-aqua/30 bg-aqua/10 text-sm font-bold text-aqua transition hover:border-aqua/50 hover:bg-aqua/15 hover:text-white"
-          >
-            Continue with 42 OAuth
-          </Link>
+          <div className="flex justify-center gap-3">
+            {OAUTH_PROVIDERS.map(({ slug, label, Icon }) => (
+              <a
+                key={slug}
+                href={`${API_BASE_URL}/auth/v1/oauth/${slug}`}
+                aria-label={`Continue with ${label}`}
+                title={`Continue with ${label}`}
+                className="flex h-11 w-11 items-center justify-center rounded-md border border-aqua/30 bg-aqua/10 text-aqua transition hover:border-aqua/50 hover:bg-aqua/15 hover:text-white"
+              >
+                <Icon className="h-5 w-5" />
+              </a>
+            ))}
+          </div>
 
           <div className="my-5 flex items-center gap-4 text-white/25">
             <div className="h-px flex-1 bg-white/10" />

--- a/frontend/src/components/chat-workspace.tsx
+++ b/frontend/src/components/chat-workspace.tsx
@@ -30,7 +30,8 @@ import { ProfileCard } from './profile-card';
 import { SettingsModal } from './settings-modal';
 import { directMessages } from './mocks/dm-mocks';
 import { initialMessages } from './mocks/message-mocks';
-import { clearFakeSession, SESSION_USERNAME_KEY } from '../shared/lib/session';
+import { clearSession } from '../shared/lib/session';
+import { logout } from '../shared/api/auth';
 
 const LAST_CHAT_MODE_KEY = 'ft_transcendence_last_chat_mode';
 const LAST_CHAT_CHANNEL_KEY = 'ft_transcendence_last_chat_channel';
@@ -87,7 +88,7 @@ export function ChatWorkspace() {
   const [editingMessageId, setEditingMessageId] = useState<string | null>(null);
   const [editingDraft, setEditingDraft] = useState('');
   const [mobilePane, setMobilePane] = useState<'channels' | 'messages'>('messages');
-  const [username, setUsername] = useState('cartoone');
+  const [username] = useState('cartoone');
   const [isHydrated, setIsHydrated] = useState(false);
   const [dmConversations, setDmConversations] = useState(directMessages);
   const [messagesByConversation, setMessagesByConversation] = useState(initialMessages);
@@ -100,11 +101,7 @@ export function ChatWorkspace() {
   const [isDmProfileOpen, setIsDmProfileOpen] = useState(false);
 
   useEffect(() => {
-    const storedUsername = window.localStorage.getItem(SESSION_USERNAME_KEY);
-    if (storedUsername) {
-      setUsername(storedUsername);
-    }
-
+    // TODO(api:user): hydrate the real profile from GET /users/me (epic 2).
     const storedMode = window.sessionStorage.getItem(LAST_CHAT_MODE_KEY);
     const storedChannel = window.sessionStorage.getItem(LAST_CHAT_CHANNEL_KEY);
     const storedDm = window.sessionStorage.getItem(LAST_CHAT_DM_KEY);
@@ -325,8 +322,13 @@ export function ChatWorkspace() {
     });
   }
 
-  function handleDisconnect() {
-    clearFakeSession();
+  async function handleDisconnect() {
+    try {
+      await logout();
+    } catch {
+      // best-effort revoke; clear the local session regardless
+    }
+    clearSession();
     router.push('/auth/login');
     router.refresh();
   }

--- a/frontend/src/components/icons/brand-icons.tsx
+++ b/frontend/src/components/icons/brand-icons.tsx
@@ -1,0 +1,30 @@
+// monochrome brand marks (simpleicons); fill inherits currentColor so they take
+// the button's text color. lucide ships no brand icons in this version.
+
+type BrandIconProps = {
+  className?: string;
+};
+
+export function GitHubIcon({ className }: BrandIconProps) {
+  return (
+    <svg viewBox="0 0 24 24" className={className} fill="currentColor" aria-hidden="true">
+      <path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12" />
+    </svg>
+  );
+}
+
+export function GoogleIcon({ className }: BrandIconProps) {
+  return (
+    <svg viewBox="0 0 24 24" className={className} fill="currentColor" aria-hidden="true">
+      <path d="M12.48 10.92v3.28h7.84c-.24 1.84-.853 3.187-1.787 4.133-1.147 1.147-2.933 2.4-6.053 2.4-4.827 0-8.6-3.893-8.6-8.72s3.773-8.72 8.6-8.72c2.6 0 4.507 1.027 5.907 2.347l2.307-2.307C18.747 1.44 16.133 0 12.48 0 5.867 0 .307 5.387.307 12s5.56 12 12.173 12c3.573 0 6.267-1.173 8.373-3.36 2.16-2.16 2.84-5.213 2.84-7.667 0-.76-.053-1.467-.173-2.053H12.48z" />
+    </svg>
+  );
+}
+
+export function FortyTwoIcon({ className }: BrandIconProps) {
+  return (
+    <svg viewBox="0 0 24 24" className={className} fill="currentColor" aria-hidden="true">
+      <path d="M19.581 16.851H24v-4.439ZM24 3.574h-4.419v4.42l-4.419 4.418v4.44h4.419v-4.44L24 7.993Zm-4.419 0h-4.419v4.42zm-6.324 8.838H4.419l8.838-8.838H8.838L0 12.412v3.595h8.838v4.419h4.419z" />
+    </svg>
+  );
+}

--- a/frontend/src/components/oauth-handoff.tsx
+++ b/frontend/src/components/oauth-handoff.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { establishSession } from '../shared/lib/session';
+
+export function OAuthHandoff() {
+  const router = useRouter();
+  const [pending, setPending] = useState(false);
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const accessToken = params.get('access_token');
+    if (!accessToken) {
+      return;
+    }
+
+    setPending(true);
+    establishSession(accessToken);
+    window.history.replaceState(null, '', window.location.pathname);
+    router.replace('/chat');
+  }, [router]);
+
+  if (!pending) {
+    return null;
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-primary-bg">
+      <p className="text-sm text-white/60">Signing you in...</p>
+    </div>
+  );
+}

--- a/frontend/src/components/settings-modal.tsx
+++ b/frontend/src/components/settings-modal.tsx
@@ -1,7 +1,20 @@
 'use client';
 
-import { useEffect } from 'react';
-import { LogOut, Settings, X } from 'lucide-react';
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { LogOut, Settings, Trash2, X } from 'lucide-react';
+import {
+  deleteAccount,
+  getIdentity,
+  updateIdentity,
+  type AuthIdentity
+} from '../shared/api/auth';
+import { clearSession } from '../shared/lib/session';
+import {
+  describeAccountUpdateError,
+  describeDeleteAccountError
+} from '../shared/lib/auth-errors';
+import { checkEmail, checkPassword } from '../shared/lib/validators/auth';
 
 type SettingsModalProps = {
   username: string;
@@ -9,7 +22,13 @@ type SettingsModalProps = {
   onDisconnect: () => void;
 };
 
+type Panel = 'menu' | 'credentials' | 'delete';
+
 export function SettingsModal({ username, onClose, onDisconnect }: SettingsModalProps) {
+  const router = useRouter();
+  const [identity, setIdentity] = useState<AuthIdentity | null>(null);
+  const [panel, setPanel] = useState<Panel>('menu');
+
   useEffect(() => {
     function handleEscape(event: KeyboardEvent) {
       if (event.key !== 'Escape' && event.key !== 'Esc' && event.code !== 'Escape') {
@@ -23,6 +42,28 @@ export function SettingsModal({ username, onClose, onDisconnect }: SettingsModal
     return () => window.removeEventListener('keydown', handleEscape);
   }, [onClose]);
 
+  useEffect(() => {
+    let active = true;
+    getIdentity()
+      .then((value) => {
+        if (active) setIdentity(value);
+      })
+      .catch(() => {
+        // identity is best-effort; the rest of the modal still works
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const isOAuthOnly = identity !== null && identity.email === null;
+
+  async function handleAccountDeleted() {
+    clearSession();
+    router.push('/auth/login');
+    router.refresh();
+  }
+
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/55 px-4 py-6">
       <button
@@ -31,7 +72,7 @@ export function SettingsModal({ username, onClose, onDisconnect }: SettingsModal
         onClick={onClose}
         aria-label="Close settings"
       />
-      <section className="relative w-full max-w-[22rem] overflow-hidden rounded-[1rem] bg-secondary-bg shadow-2xl shadow-black/50 ring-1 ring-white/10">
+      <section className="relative w-full max-w-[24rem] overflow-hidden rounded-[1rem] bg-secondary-bg shadow-2xl shadow-black/50 ring-1 ring-white/10">
         <div className="flex h-[4.75rem] items-center justify-between border-b border-white/8 px-5">
           <div className="flex min-w-0 items-center gap-3">
             <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-md bg-aqua/10 text-aqua">
@@ -42,7 +83,7 @@ export function SettingsModal({ username, onClose, onDisconnect }: SettingsModal
                 Settings
               </h2>
               <p className="font-category text-[0.7rem] uppercase tracking-[0.14em] text-white/35">
-                Profile
+                Account
               </p>
             </div>
           </div>
@@ -65,20 +106,227 @@ export function SettingsModal({ username, onClose, onDisconnect }: SettingsModal
               <h3 className="truncate text-[1.35rem] font-bold tracking-[-0.04em] text-white">
                 {username}
               </h3>
-              <p className="mono-detail mt-1 truncate text-sm text-white/40">{username}#4242</p>
+              <p className="mono-detail mt-1 truncate text-sm text-white/40">
+                {identity?.email ?? `${username}#4242`}
+              </p>
             </div>
           </div>
 
-          <button
-            type="button"
-            onClick={onDisconnect}
-            className="mt-6 flex h-11 w-full items-center justify-center gap-2 rounded-md border border-pink/25 bg-pink/10 text-sm font-bold text-pink transition hover:border-pink/45 hover:bg-pink/15"
-          >
-            <LogOut className="h-4 w-4" strokeWidth={1.9} />
-            Disconnect
-          </button>
+          {panel === 'menu' ? (
+            <div className="mt-6 grid gap-2.5">
+              <button
+                type="button"
+                onClick={() => setPanel('credentials')}
+                disabled={isOAuthOnly}
+                className="flex h-11 w-full items-center justify-center rounded-md border border-white/10 bg-frame text-sm font-semibold text-white/80 transition hover:border-aqua/40 hover:text-white disabled:cursor-not-allowed disabled:opacity-40"
+              >
+                Change email or password
+              </button>
+              {isOAuthOnly ? (
+                <p className="text-xs text-white/35">
+                  This account signs in with an OAuth provider, so it has no password to change here.
+                </p>
+              ) : null}
+              <button
+                type="button"
+                onClick={onDisconnect}
+                className="flex h-11 w-full items-center justify-center gap-2 rounded-md border border-pink/25 bg-pink/10 text-sm font-bold text-pink transition hover:border-pink/45 hover:bg-pink/15"
+              >
+                <LogOut className="h-4 w-4" strokeWidth={1.9} />
+                Disconnect
+              </button>
+              <button
+                type="button"
+                onClick={() => setPanel('delete')}
+                className="flex h-9 w-full items-center justify-center gap-2 rounded-md text-sm font-semibold text-white/40 transition hover:text-pink"
+              >
+                <Trash2 className="h-4 w-4" strokeWidth={1.9} />
+                Delete account
+              </button>
+            </div>
+          ) : null}
+
+          {panel === 'credentials' ? (
+            <CredentialsForm onBack={() => setPanel('menu')} currentEmail={identity?.email ?? ''} />
+          ) : null}
+
+          {panel === 'delete' ? (
+            <DeleteAccountPanel onBack={() => setPanel('menu')} onDeleted={handleAccountDeleted} />
+          ) : null}
         </div>
       </section>
+    </div>
+  );
+}
+
+type CredentialsFormProps = {
+  currentEmail: string;
+  onBack: () => void;
+};
+
+function CredentialsForm({ currentEmail, onBack }: CredentialsFormProps) {
+  const [error, setError] = useState('');
+  const [success, setSuccess] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  async function handleSubmit(formData: FormData) {
+    const email = String(formData.get('email') ?? '').trim();
+    const newPassword = String(formData.get('new_password') ?? '');
+    const currentPassword = String(formData.get('current_password') ?? '');
+
+    setError('');
+    setSuccess('');
+
+    const emailChanged = email.length > 0 && email !== currentEmail;
+    const passwordChanged = newPassword.length > 0;
+
+    if (!emailChanged && !passwordChanged) {
+      setError('Enter a new email or a new password.');
+      return;
+    }
+    if (!currentPassword) {
+      setError('Enter your current password to confirm the change.');
+      return;
+    }
+    if (emailChanged) {
+      const emailError = checkEmail(email);
+      if (emailError) {
+        setError(emailError);
+        return;
+      }
+    }
+    if (passwordChanged) {
+      const passwordError = checkPassword(newPassword);
+      if (passwordError) {
+        setError(passwordError);
+        return;
+      }
+    }
+
+    try {
+      setIsSubmitting(true);
+      await updateIdentity({
+        email: emailChanged ? email : undefined,
+        new_password: passwordChanged ? newPassword : undefined,
+        current_password: currentPassword
+      });
+      setSuccess('Account updated.');
+    } catch (err) {
+      setError(describeAccountUpdateError(err));
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <form action={handleSubmit} className="mt-6 grid gap-3">
+      <Field name="email" label="New email" type="email" placeholder={currentEmail || 'you@example.com'} autoComplete="email" />
+      <Field name="new_password" label="New password" type="password" placeholder="leave blank to keep" autoComplete="new-password" />
+      <Field name="current_password" label="Current password" type="password" placeholder="required to confirm" autoComplete="current-password" />
+
+      {error ? (
+        <p className="rounded-md border border-pink/25 bg-pink/10 px-3 py-2 text-sm text-pink">{error}</p>
+      ) : null}
+      {success ? (
+        <p className="rounded-md border border-lime/25 bg-lime/10 px-3 py-2 text-sm text-lime">{success}</p>
+      ) : null}
+
+      <div className="mt-1 grid grid-cols-2 gap-2.5">
+        <button
+          type="button"
+          onClick={onBack}
+          className="flex h-11 items-center justify-center rounded-md border border-white/10 bg-frame text-sm font-semibold text-white/70 transition hover:text-white"
+        >
+          Back
+        </button>
+        <button
+          type="submit"
+          disabled={isSubmitting}
+          className="flex h-11 items-center justify-center rounded-md bg-aqua text-sm font-bold text-primary-bg transition hover:bg-white disabled:cursor-not-allowed disabled:bg-frame disabled:text-white/25"
+        >
+          {isSubmitting ? 'Saving...' : 'Save changes'}
+        </button>
+      </div>
+    </form>
+  );
+}
+
+type DeleteAccountPanelProps = {
+  onBack: () => void;
+  onDeleted: () => void;
+};
+
+function DeleteAccountPanel({ onBack, onDeleted }: DeleteAccountPanelProps) {
+  const [error, setError] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  async function handleDelete() {
+    setError('');
+    try {
+      setIsSubmitting(true);
+      await deleteAccount();
+      onDeleted();
+    } catch (err) {
+      setError(describeDeleteAccountError(err));
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="mt-6 grid gap-3">
+      <p className="text-sm leading-6 text-white/60">
+        This permanently deletes your account and frees your email for re-registration. This cannot be undone.
+      </p>
+
+      {error ? (
+        <p className="rounded-md border border-pink/25 bg-pink/10 px-3 py-2 text-sm text-pink">{error}</p>
+      ) : null}
+
+      <div className="grid grid-cols-2 gap-2.5">
+        <button
+          type="button"
+          onClick={onBack}
+          disabled={isSubmitting}
+          className="flex h-11 items-center justify-center rounded-md border border-white/10 bg-frame text-sm font-semibold text-white/70 transition hover:text-white disabled:opacity-50"
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          onClick={handleDelete}
+          disabled={isSubmitting}
+          className="flex h-11 items-center justify-center gap-2 rounded-md bg-pink text-sm font-bold text-primary-bg transition hover:bg-white disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          <Trash2 className="h-4 w-4" strokeWidth={2} />
+          {isSubmitting ? 'Deleting...' : 'Delete'}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+type FieldProps = {
+  name: string;
+  label: string;
+  type: string;
+  placeholder: string;
+  autoComplete: string;
+};
+
+function Field({ name, label, type, placeholder, autoComplete }: FieldProps) {
+  return (
+    <div className="grid gap-1.5">
+      <label htmlFor={name} className="text-xs font-semibold uppercase tracking-[0.1em] text-white/45">
+        {label}
+      </label>
+      <input
+        id={name}
+        name={name}
+        type={type}
+        placeholder={placeholder}
+        autoComplete={autoComplete}
+        className="h-11 w-full rounded-md border border-transparent bg-input-bg px-4 text-base text-white outline-none transition placeholder:text-input-placeholder focus:border-aqua/35"
+      />
     </div>
   );
 }

--- a/frontend/src/shared/api/auth.ts
+++ b/frontend/src/shared/api/auth.ts
@@ -1,29 +1,68 @@
-export type AuthPayload = {
-  username: string;
+import { apiFetch } from "./client";
+
+export type Credentials = {
+  email: string;
   password: string;
 };
 
-export type RegisterPayload = AuthPayload & {
-  confirm: string;
+export type AuthTokenResponse = {
+  access_token: string;
+  user_id: string;
 };
 
-type FakeAuthResponse = {
-  username: string;
+export type AuthIdentity = {
+  id: string;
+  email: string | null;
+  email_verified: boolean;
+  oauth_providers: string[];
+  created_at: string;
+  updated_at: string;
 };
 
-async function simulateAuth<T>(result: T): Promise<T> {
-  await new Promise((resolve) => setTimeout(resolve, 150));
-  return result;
-}
+export type UpdateIdentityPayload = {
+  email?: string;
+  current_password?: string;
+  new_password?: string;
+};
 
-export async function login(payload: AuthPayload) {
-  return simulateAuth<FakeAuthResponse>({
-    username: payload.username.trim()
+export function register(payload: Credentials) {
+  return apiFetch<AuthTokenResponse>("auth", "/register", {
+    method: "POST",
+    body: payload,
+    skipAuthRefresh: true,
   });
 }
 
-export async function register(payload: RegisterPayload) {
-  return simulateAuth<FakeAuthResponse>({
-    username: payload.username.trim()
+export function login(payload: Credentials) {
+  return apiFetch<AuthTokenResponse>("auth", "/login", {
+    method: "POST",
+    body: payload,
+    skipAuthRefresh: true,
   });
+}
+
+export function refresh() {
+  return apiFetch<{ access_token: string }>("auth", "/refresh", {
+    method: "POST",
+    skipAuthRefresh: true,
+  });
+}
+
+export function logout() {
+  return apiFetch<void>("auth", "/logout", { method: "POST" });
+}
+
+export function getIdentity() {
+  return apiFetch<AuthIdentity>("auth", "/me");
+}
+
+export function updateIdentity(payload: UpdateIdentityPayload) {
+  return apiFetch<AuthIdentity>("auth", "/me", {
+    method: "PATCH",
+    body: payload,
+  });
+}
+
+export function deleteAccount() {
+  return apiFetch<void>("auth", "/me", { method: "DELETE" });
 }

--- a/frontend/src/shared/api/client.ts
+++ b/frontend/src/shared/api/client.ts
@@ -1,52 +1,118 @@
-import { getPublicApiBase } from "../config/env";
-import { getAccessToken } from "../lib/session";
+import { API_BASE_URL } from "../config/env";
+import { clearSession, getAccessToken, setAccessToken } from "../lib/session";
 
-type Service = "auth" | "guild" | "user" | "notification" | "chat";
+export type Service = "auth" | "user" | "guild" | "chat" | "notification";
 
-type ApiOptions = Omit<RequestInit, "body"> & {
+export type ApiOptions = Omit<RequestInit, "body"> & {
   body?: unknown;
-  query?: Record<string, string | number | boolean | undefined | null>;
+  query?: Record<string, string | number | boolean | null | undefined>;
+  // 401 on these is a real credential failure, not an expired token; don't retry
+  skipAuthRefresh?: boolean;
 };
 
-function buildUrl(base: string, path: string, query?: ApiOptions["query"]) {
-  const url = new URL(path.replace(/^\//, ""), `${base}/`);
-  if (query) {
-    Object.entries(query).forEach(([key, value]) => {
-      if (value === undefined || value === null) return;
-      url.searchParams.set(key, String(value));
-    });
+export class ApiError extends Error {
+  readonly service: Service;
+  readonly status: number;
+  readonly body: unknown;
+
+  constructor(service: Service, status: number, message: string, body: unknown) {
+    super(message);
+    this.name = "ApiError";
+    this.service = service;
+    this.status = status;
+    this.body = body;
   }
-  return url.toString();
 }
 
-export async function apiFetch<T>(
-  service: Service,
-  path: string,
-  options: ApiOptions = {},
-): Promise<T> {
-  const base = getPublicApiBase(service);
-  const url = buildUrl(base, path, options.query);
+function buildUrl(service: Service, path: string, query?: ApiOptions["query"]): string {
+  const cleanPath = path.startsWith("/") ? path : `/${path}`;
+  let url = `${API_BASE_URL}/${service}/v1${cleanPath}`;
 
-  const headers = new Headers(options.headers);
-  const accessToken = getAccessToken();
-
-  if (accessToken && !headers.has("Authorization")) {
-    headers.set("Authorization", `Bearer ${accessToken}`);
+  if (query) {
+    const params = new URLSearchParams();
+    for (const [key, value] of Object.entries(query)) {
+      if (value === undefined || value === null) continue;
+      params.set(key, String(value));
+    }
+    const qs = params.toString();
+    if (qs) url += `?${qs}`;
   }
 
-  if (options.body !== undefined && !headers.has("Content-Type")) {
+  return url;
+}
+
+function performRequest(
+  service: Service,
+  path: string,
+  options: ApiOptions,
+  overrideToken?: string,
+): Promise<Response> {
+  const { body, query, skipAuthRefresh: _skip, headers: rawHeaders, ...rest } = options;
+  const headers = new Headers(rawHeaders);
+  const token = overrideToken ?? getAccessToken();
+
+  if (token && !headers.has("Authorization")) {
+    headers.set("Authorization", `Bearer ${token}`);
+  }
+  if (body !== undefined && !headers.has("Content-Type")) {
     headers.set("Content-Type", "application/json");
   }
 
-  const res = await fetch(url, {
-    ...options,
+  return fetch(buildUrl(service, path, query), {
+    ...rest,
     headers,
-    body: options.body !== undefined ? JSON.stringify(options.body) : undefined,
+    credentials: "include",
+    body: body !== undefined ? JSON.stringify(body) : undefined,
   });
+}
 
+// single-flight: concurrent 401s share one refresh instead of stampeding
+let refreshInFlight: Promise<string | null> | null = null;
+
+function refreshAccessToken(): Promise<string | null> {
+  if (!refreshInFlight) {
+    refreshInFlight = (async () => {
+      try {
+        const res = await fetch(`${API_BASE_URL}/auth/v1/refresh`, {
+          method: "POST",
+          credentials: "include",
+        });
+        if (!res.ok) return null;
+        const data = (await res.json()) as { access_token: string };
+        setAccessToken(data.access_token);
+        return data.access_token;
+      } catch {
+        return null;
+      } finally {
+        refreshInFlight = null;
+      }
+    })();
+  }
+  return refreshInFlight;
+}
+
+async function parseResponse<T>(service: Service, res: Response): Promise<T> {
   if (!res.ok) {
+    let message = res.statusText;
+    let body: unknown;
     const text = await res.text().catch(() => "");
-    throw new Error(`API ${service} ${res.status}: ${text || res.statusText}`);
+
+    if (text) {
+      try {
+        body = JSON.parse(text);
+        if (body && typeof body === "object" && "error" in body) {
+          message = String((body as { error: unknown }).error);
+        }
+      } catch {
+        message = text;
+      }
+    }
+
+    throw new ApiError(service, res.status, message, body);
+  }
+
+  if (res.status === 204) {
+    return undefined as T;
   }
 
   const contentType = res.headers.get("content-type") ?? "";
@@ -54,5 +120,25 @@ export async function apiFetch<T>(
     return (await res.json()) as T;
   }
 
-  return (await res.text()) as T;
+  const text = await res.text();
+  return (text || undefined) as T;
+}
+
+export async function apiFetch<T>(
+  service: Service,
+  path: string,
+  options: ApiOptions = {},
+): Promise<T> {
+  let res = await performRequest(service, path, options);
+
+  if (res.status === 401 && !options.skipAuthRefresh) {
+    const newToken = await refreshAccessToken();
+    if (newToken) {
+      res = await performRequest(service, path, options, newToken);
+    } else {
+      clearSession();
+    }
+  }
+
+  return parseResponse<T>(service, res);
 }

--- a/frontend/src/shared/api/index.ts
+++ b/frontend/src/shared/api/index.ts
@@ -1,4 +1,6 @@
-export { apiFetch } from "./client";
+export { apiFetch, ApiError } from "./client";
+export type { Service, ApiOptions } from "./client";
+export * from "./auth";
 export * from "./chat";
 export * from "./guild";
 export * from "./notification";

--- a/frontend/src/shared/config/env.ts
+++ b/frontend/src/shared/config/env.ts
@@ -1,18 +1,2 @@
-type Service = "auth" | "guild" | "user" | "notification" | "chat";
-
-const ENV_KEYS: Record<Service, string> = {
-  auth: "NEXT_PUBLIC_API_AUTH_URL",
-  guild: "NEXT_PUBLIC_API_GUILD_URL",
-  user: "NEXT_PUBLIC_API_USER_URL",
-  notification: "NEXT_PUBLIC_API_NOTIFICATION_URL",
-  chat: "NEXT_PUBLIC_API_CHAT_URL",
-};
-
-export function getPublicApiBase(service: Service): string {
-  const key = ENV_KEYS[service];
-  const value = process.env[key];
-  if (!value) {
-    throw new Error(`Missing ${key}. Define it in .env (see .env.example).`);
-  }
-  return value.replace(/\/$/, "");
-}
+// single api entrypoint; relative by default so it stays same-origin behind nginx
+export const API_BASE_URL = (process.env.NEXT_PUBLIC_API_URL ?? "/api").replace(/\/$/, "");

--- a/frontend/src/shared/lib/auth-errors.ts
+++ b/frontend/src/shared/lib/auth-errors.ts
@@ -1,0 +1,41 @@
+import { ApiError } from "../api";
+
+const FALLBACK = "Something went wrong. Please try again.";
+
+export function describeLoginError(error: unknown): string {
+  if (error instanceof ApiError) {
+    if (error.status === 401) return "Invalid email or password.";
+    if (error.status === 400) return error.message || "Enter your email and password.";
+    return error.message || FALLBACK;
+  }
+  return FALLBACK;
+}
+
+export function describeRegisterError(error: unknown): string {
+  if (error instanceof ApiError) {
+    if (error.status === 409) return "That email is already registered.";
+    if (error.status === 400) return error.message || "Invalid email or weak password.";
+    return error.message || FALLBACK;
+  }
+  return FALLBACK;
+}
+
+export function describeAccountUpdateError(error: unknown): string {
+  if (error instanceof ApiError) {
+    if (error.status === 401) return "Your current password is incorrect.";
+    if (error.status === 403) return "This account is managed by an OAuth provider and has no password.";
+    if (error.status === 409) return "That email is already in use.";
+    if (error.status === 400) return error.message || "Check your email and password.";
+    return error.message || FALLBACK;
+  }
+  return FALLBACK;
+}
+
+export function describeDeleteAccountError(error: unknown): string {
+  if (error instanceof ApiError) {
+    if (error.status === 409)
+      return "You still own one or more guilds. Transfer ownership or delete them first.";
+    return error.message || FALLBACK;
+  }
+  return FALLBACK;
+}

--- a/frontend/src/shared/lib/session.ts
+++ b/frontend/src/shared/lib/session.ts
@@ -1,42 +1,65 @@
-export const SESSION_USERNAME_KEY = 'ft_transcendence_username';
-export const SESSION_COOKIE_KEY = 'ft_transcendence_session';
-export const SESSION_ACCESS_TOKEN_KEY = 'ft_transcendence_access_token';
+// access token lives in localStorage (readable by the api client); a non-secret
+// presence cookie lets the server-side middleware gate routes. the refresh token
+// is an HttpOnly cookie owned by the backend and never touched here.
 
-export function getAccessToken() {
-  if (typeof window === 'undefined') {
+export const SESSION_ACCESS_TOKEN_KEY = "ft_transcendence_access_token";
+export const SESSION_USER_ID_KEY = "ft_transcendence_user_id";
+export const SESSION_COOKIE_KEY = "ft_transcendence_session";
+
+const SESSION_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;
+
+let accessTokenCache: string | null = null;
+
+export function getAccessToken(): string | null {
+  if (accessTokenCache !== null) {
+    return accessTokenCache;
+  }
+  if (typeof window === "undefined") {
     return null;
   }
-
-  return window.localStorage.getItem(SESSION_ACCESS_TOKEN_KEY);
+  accessTokenCache = window.localStorage.getItem(SESSION_ACCESS_TOKEN_KEY);
+  return accessTokenCache;
 }
 
-export function setAccessToken(accessToken: string) {
-  if (typeof window !== 'undefined') {
+export function setAccessToken(accessToken: string): void {
+  accessTokenCache = accessToken;
+  if (typeof window !== "undefined") {
     window.localStorage.setItem(SESSION_ACCESS_TOKEN_KEY, accessToken);
   }
 }
 
-export function createFakeSession(username: string, accessToken?: string) {
-  if (typeof window !== 'undefined') {
-    window.localStorage.setItem(SESSION_USERNAME_KEY, username);
+export function getUserId(): string | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+  return window.localStorage.getItem(SESSION_USER_ID_KEY);
+}
 
-    if (accessToken) {
-      window.localStorage.setItem(SESSION_ACCESS_TOKEN_KEY, accessToken);
-    }
+export function hasSession(): boolean {
+  return getAccessToken() !== null;
+}
+
+export function establishSession(accessToken: string, userId?: string): void {
+  setAccessToken(accessToken);
+
+  if (typeof window !== "undefined" && userId) {
+    window.localStorage.setItem(SESSION_USER_ID_KEY, userId);
   }
 
-  if (typeof document !== 'undefined') {
-    document.cookie = `${SESSION_COOKIE_KEY}=${encodeURIComponent(username)}; Path=/; Max-Age=${60 * 60 * 24 * 7}; SameSite=Lax`;
+  if (typeof document !== "undefined") {
+    document.cookie = `${SESSION_COOKIE_KEY}=1; Path=/; Max-Age=${SESSION_COOKIE_MAX_AGE}; SameSite=Lax`;
   }
 }
 
-export function clearFakeSession() {
-  if (typeof window !== 'undefined') {
-    window.localStorage.removeItem(SESSION_USERNAME_KEY);
+export function clearSession(): void {
+  accessTokenCache = null;
+
+  if (typeof window !== "undefined") {
     window.localStorage.removeItem(SESSION_ACCESS_TOKEN_KEY);
+    window.localStorage.removeItem(SESSION_USER_ID_KEY);
   }
 
-  if (typeof document !== 'undefined') {
+  if (typeof document !== "undefined") {
     document.cookie = `${SESSION_COOKIE_KEY}=; Path=/; Max-Age=0; SameSite=Lax`;
   }
 }

--- a/frontend/src/shared/lib/validators/auth.ts
+++ b/frontend/src/shared/lib/validators/auth.ts
@@ -1,53 +1,66 @@
-import * as z from 'zod';
+import * as z from "zod";
 
 export type RegisterFormValues = {
-  username: string;
+  email: string;
   password: string;
   confirm: string;
 };
 
 export type LoginFormValues = {
-  username: string;
+  email: string;
   password: string;
 };
 
 export type RegisterFormErrors = Partial<Record<keyof RegisterFormValues, string>>;
 export type LoginFormErrors = Partial<Record<keyof LoginFormValues, string>>;
 
+export const emailSchema = z
+  .string()
+  .trim()
+  .min(1, "Email is required.")
+  .email("Enter a valid email address.");
+
+export const passwordSchema = z
+  .string()
+  .min(1, "Password is required.")
+  .min(12, "Password must be at least 12 characters long.")
+  .regex(/[a-z]/, "Password must contain at least one lowercase letter.")
+  .regex(/[A-Z]/, "Password must contain at least one uppercase letter.")
+  .regex(/[0-9]/, "Password must contain at least one number.")
+  .regex(/[^A-Za-z0-9]/, "Password must contain at least one special character.")
+  .regex(/^\S+$/, "Password must not contain spaces.");
+
+export function checkPassword(value: string): string | null {
+  const result = passwordSchema.safeParse(value);
+  return result.success ? null : result.error.issues[0].message;
+}
+
+export function checkEmail(value: string): string | null {
+  const result = emailSchema.safeParse(value);
+  return result.success ? null : result.error.issues[0].message;
+}
+
 const loginSchema = z.object({
-  username: z.string().trim().min(1, 'Username is required.'),
-  password: z.string().min(1, 'Password is required.')
+  email: emailSchema,
+  password: z.string().min(1, "Password is required."),
 });
 
 const registerSchema = z
   .object({
-    username: z
-      .string()
-      .trim()
-      .min(1, 'Username is required.')
-      .min(4, 'Username must be at least 4 characters long.')
-      .regex(/^[A-Za-z0-9_]+$/, 'Username must contain only letters, numbers, and underscores.'),
-    password: z
-      .string()
-      .min(1, 'Password is required.')
-      .min(12, 'Password must be at least 12 characters long.')
-      .regex(/[a-z]/, 'Password must contain at least one lowercase letter.')
-      .regex(/[A-Z]/, 'Password must contain at least one uppercase letter.')
-      .regex(/[0-9]/, 'Password must contain at least one number.')
-      .regex(/[^A-Za-z0-9]/, 'Password must contain at least one special character.')
-      .regex(/^\S+$/, 'Password must not contain spaces.'),
-    confirm: z.string().min(1, 'Password confirmation is required.')
+    email: emailSchema,
+    password: passwordSchema,
+    confirm: z.string().min(1, "Password confirmation is required."),
   })
   .refine((values) => values.password === values.confirm, {
-    path: ['confirm'],
-    message: 'Passwords do not match.'
+    path: ["confirm"],
+    message: "Passwords do not match.",
   });
 
 export function validateRegisterForm(values: RegisterFormValues): RegisterFormErrors {
   const result = registerSchema.safeParse({
-    username: values.username.trim(),
+    email: values.email.trim(),
     password: values.password,
-    confirm: values.confirm
+    confirm: values.confirm,
   });
 
   if (result.success) {
@@ -59,7 +72,7 @@ export function validateRegisterForm(values: RegisterFormValues): RegisterFormEr
   for (const issue of result.error.issues) {
     const field = issue.path[0];
 
-    if ((field === 'username' || field === 'password' || field === 'confirm') && !errors[field]) {
+    if ((field === "email" || field === "password" || field === "confirm") && !errors[field]) {
       errors[field] = issue.message;
     }
   }
@@ -69,8 +82,8 @@ export function validateRegisterForm(values: RegisterFormValues): RegisterFormEr
 
 export function validateLoginForm(values: LoginFormValues): LoginFormErrors {
   const result = loginSchema.safeParse({
-    username: values.username.trim(),
-    password: values.password
+    email: values.email.trim(),
+    password: values.password,
   });
 
   if (result.success) {
@@ -82,7 +95,7 @@ export function validateLoginForm(values: LoginFormValues): LoginFormErrors {
   for (const issue of result.error.issues) {
     const field = issue.path[0];
 
-    if ((field === 'username' || field === 'password') && !errors[field]) {
+    if ((field === "email" || field === "password") && !errors[field]) {
       errors[field] = issue.message;
     }
   }

--- a/infra/secretman/secrets/front.env.crypt
+++ b/infra/secretman/secrets/front.env.crypt
@@ -1,9 +1,5 @@
 {
-	"NEXT_PUBLIC_API_AUTH_URL": "ENC[AES256_GCM,data:8ztwR1DH96F/I4o6keJ6ThPCENmx,iv:21Taf7+mYNt9Zqm4oHxNmf5DfRojsUtonvLxgUoIugg=,tag:IpdBdAAyQQUhCFOXbRvl/g==,type:str]",
-	"NEXT_PUBLIC_API_GUILD_URL": "ENC[AES256_GCM,data:m8KTvColCdpg8AjZDY8niWZbWAFh,iv:XTEO5gDeQB03Hyfqo8n0yjqWcOZQv5JvH31Blt4lNjo=,tag:bJsfcGjwNQn0xPuwvV3BWg==,type:str]",
-	"NEXT_PUBLIC_API_USER_URL": "ENC[AES256_GCM,data:nXdO0cug38+pY14/4H9sUF/GM5aJ,iv:BKmBRTqMQnD2oHqBjl9s+RnAutIiff7jkNOSjy643t0=,tag:Wp6VOjKct2SGSVCes2GvZA==,type:str]",
-	"NEXT_PUBLIC_API_NOTIFICATION_URL": "ENC[AES256_GCM,data:xq5u3z0XtnrLMjm+s+XKqSUn5s+q,iv:s9yZCfikDmLCZgSCb6SxMlAD+ifR3zAdZgdK7zanGPI=,tag:XCwVW23hSZwhysgamKO8rQ==,type:str]",
-	"NEXT_PUBLIC_API_CHAT_URL": "ENC[AES256_GCM,data:1zA2jsPS/TkZgjWH+1z4Q9/y4LH3,iv:hGpTccaQQqwZk15hTDQQftNGn6Br9Q5oneydsirRdrI=,tag:FG6ZdRZcT1YLwQ4zgCFAvw==,type:str]",
+	"NEXT_PUBLIC_API_URL": "ENC[AES256_GCM,data:LuCBRQ==,iv:7Y/qzURB5tMSFt59YIV8gXRpLO9azIUevPVc0b+wD3Q=,tag:4mJaIWYKe/OKYX00jTF9GA==,type:str]",
 	"sops": {
 		"age": [
 			{
@@ -27,8 +23,8 @@
 				"recipient": "age1zplf0tl6979dpazzmedpe7zakaeqzkpvgqjuxlfd7uell645nc6qccjzjv"
 			}
 		],
-		"lastmodified": "2026-06-06T12:01:10Z",
-		"mac": "ENC[AES256_GCM,data:UUCqr9Cz/Xs5TZA8bGEzvaFDR8vF5eJH1QNCd+SmY7rM4pMWChVXYbbpnVcwKQ3rM0Twx4TNm2p6FEed5BIqxbKv70Znc70EFEJ9UhaH1dqg3PazWGOn0Y8azAjbBzasRrxNfL4ZUq1xVKJa9FbMmdbI44BCUNEKF17eKhxC4Rw=,iv:Mn/X5nJd3guZqNeecGjeAf3t1l8lUrZiJSHm2bXLSF8=,tag:8VR/J9P60JMjD3ftvbSeoA==,type:str]",
+		"lastmodified": "2026-07-07T20:51:21Z",
+		"mac": "ENC[AES256_GCM,data:L4PBVE8v1pAAEJChaGRd9S07BWkzeMCnNS+iEEOYDTrFm3pq2QlhF0HIfB/OovFlzTkAWmjpDASoylYZEI4Qpw/5GRdJNwiNNFiJ7CtyaeFzTSjCwrBlnPSCirCmwugzz0H2mTE9GQE26MubYITn1AWJNWxOQ5Mz8IJe5bzgffw=,iv:BHqvDcgWHoOtvon0yI0NN21ZZOP4ZmAOWWODSwOwuI0=,tag:CSj7ntWb3OdkKGfkxb17QA==,type:str]",
 		"unencrypted_suffix": "_unencrypted",
 		"version": "3.13.1"
 	}


### PR DESCRIPTION
<img src="https://c.tenor.com/DfXYNBOTEQ8AAAAd/tenor.gif"/>

Wires the frontend auth flow to the real backend through the gateway, replacing the fake session/auth scaffolding. Establishes the API client conventions the rest of the frontend will build on.

## What changed
- **API client core** (`shared/api/client.ts`): single base (`/api`), composes `/{service}/v1{path}`, `credentials: include`, structured `ApiError`, single-flight 401->refresh->retry, 204 handling.
- **Session** (`shared/lib/session.ts`): real access-token persistence + presence cookie for middleware; `establishSession`/`clearSession` replace the fake session.
- **Env**: collapsed the 5 per-service `NEXT_PUBLIC_API_*_URL` vars into one `NEXT_PUBLIC_API_URL` (`.env.example` + encrypted `front.env.crypt`).
- **Auth pages**: login/register on email + password with backend status->message mapping.
- **OAuth**: 42 / Google / GitHub buttons (brand icons) to the gateway start endpoint, plus `/?access_token=...` token handoff (`OAuthHandoff` + middleware allowance).
- **Account actions** (settings modal): `GET /auth/me`, change email/password via `PATCH /auth/me`, delete account via `DELETE /auth/me` with the 409 guild-ownership guard, real logout via `POST /auth/logout`.

## Design decisions
- Frontend knows one origin (`/api`); the gateway routes by service. Same-origin behind nginx, so no CORS and the HttpOnly refresh cookie just works.
- OAuth provider slugs are `fortytwo` / `google` / `github` (the contract's `42` is stale).

## Issues
- Resolves #150 (delete account flow).
- Realizes #29 / #30 / #49 (were closed on scaffold; now backed by real auth).
- Not #95 (profile editing is Epic 2 / User service).

## Testing
- `tsc` clean, eslint clean.
- Verified live against the gateway: register/login/refresh/logout round trip, `GET /auth/me`, and OAuth start 302s for Google, GitHub and our beloved 42 intra <3

## Out of scope / follow-ups
- Guild-list link on the 409 delete case (message only for now).
- Epic 0 DTO/view-model layer and missing-config dev banner.
