### PR TITLE
feat(auth): add internal GDPR data-export endpoint

### DIFF
--- a/services/auth/src/Auth.Application/Features/ExportUserData/ExportUserDataHandler.cs
+++ b/services/auth/src/Auth.Application/Features/ExportUserData/ExportUserDataHandler.cs
@@ -1,0 +1,28 @@
+using Auth.Application.Abstractions.Messaging;
+using Auth.Application.Abstractions.Persistence;
+using Auth.Domain.AuthUser;
+using Auth.Domain.Results;
+
+namespace Auth.Application.Features.ExportUserData;
+
+internal sealed class ExportUserDataHandler(IAuthUserRepository users)
+	: IQueryHandler<ExportUserDataQuery, Result<UserDataExportResponse>>
+{
+	public async Task<Result<UserDataExportResponse>> HandleAsync(
+		ExportUserDataQuery query,
+		CancellationToken cancellationToken = default)
+	{
+		var user = await users.GetByIdAsync(query.UserId, cancellationToken);
+
+		if (user is null || user.IsDeleted)
+			return new UserDataExportResponse(query.UserId.ToString(), null, null, null, null, null);
+
+		return new UserDataExportResponse(
+			UserId: user.Id.ToString(),
+			Email: user.Email?.Value,
+			EmailVerified: user.Email?.IsVerified,
+			OAuthProvider: user.OAuthIdentity?.Provider.ToSlug(),
+			OAuthId: user.OAuthIdentity?.Id,
+			CreatedAt: user.CreatedAt);
+	}
+}

--- a/services/auth/src/Auth.Application/Features/ExportUserData/ExportUserDataQuery.cs
+++ b/services/auth/src/Auth.Application/Features/ExportUserData/ExportUserDataQuery.cs
@@ -1,0 +1,15 @@
+using System.Text.Json.Serialization;
+using Auth.Application.Abstractions.Messaging;
+using Auth.Domain.Results;
+
+namespace Auth.Application.Features.ExportUserData;
+
+public sealed record ExportUserDataQuery(long UserId) : IQuery<Result<UserDataExportResponse>>;
+
+public sealed record UserDataExportResponse(
+	string UserId,
+	string? Email,
+	bool? EmailVerified,
+	[property: JsonPropertyName("oauth_provider")] string? OAuthProvider,
+	[property: JsonPropertyName("oauth_id")] string? OAuthId,
+	DateTimeOffset? CreatedAt);

--- a/services/auth/src/Auth.Presentation/Endpoints/UserDataExportEndpoint.cs
+++ b/services/auth/src/Auth.Presentation/Endpoints/UserDataExportEndpoint.cs
@@ -1,0 +1,38 @@
+using Auth.Application.Abstractions.Messaging;
+using Auth.Application.Features.ExportUserData;
+using Auth.Domain.Results;
+using Auth.Presentation.Contracts;
+using Microsoft.AspNetCore.Http.HttpResults;
+
+namespace Auth.Presentation.Endpoints;
+
+/// <summary>
+/// internal GDPR data-export lookup: returns the user's Auth-owned data as JSON,
+/// mounted under <c>/internal</c> by <c>Program.cs</c>, so unreachable from outside
+/// the docker network.
+/// </summary>
+public static class UserDataExportEndpoint
+{
+	public static void MapInternalRoutes(IEndpointRouteBuilder endpoints)
+	{
+		endpoints.MapGet("/users/{userId:long}/data-export", GetAsync);
+	}
+
+	private static async Task<Results<
+		Ok<UserDataExportResponse>,
+		BadRequest<ErrorResponse>,
+		JsonHttpResult<ErrorResponse>>>
+	GetAsync(
+		long userId,
+		IQueryHandler<ExportUserDataQuery, Result<UserDataExportResponse>> handler,
+		CancellationToken cancellationToken)
+	{
+		if (userId <= 0)
+			return TypedResults.BadRequest(new ErrorResponse("user_id must be a positive snowflake."));
+
+		var result = await handler.HandleAsync(new ExportUserDataQuery(userId), cancellationToken);
+		return result.Succeeded
+			? TypedResults.Ok(result.Value)
+			: TypedResults.Json(new ErrorResponse(result.Error.Message), statusCode: StatusCodes.Status500InternalServerError);
+	}
+}

--- a/services/auth/src/Auth.Presentation/Program.cs
+++ b/services/auth/src/Auth.Presentation/Program.cs
@@ -2,6 +2,7 @@ using Carter;
 using Auth.Application;
 using Auth.Infrastructure;
 using Auth.Persistence;
+using Auth.Presentation.Endpoints;
 using Auth.Presentation.Middleware;
 using Auth.Presentation;
 using Auth.Presentation.Observability;
@@ -81,5 +82,10 @@ app.MapPrometheusScrapingEndpoint();
 
 var v1 = app.MapGroup("/v1");
 v1.MapCarter();
+
+// internal endpoints. the API Gateway only forwards /api/{service}/vN/...
+// so /internal/... is unreachable from outside the docker network.
+var internalRoutes = app.MapGroup("/internal").ExcludeFromDescription();
+UserDataExportEndpoint.MapInternalRoutes(internalRoutes);
 
 app.Run();

--- a/services/auth/tests/Auth.FunctionalTests/Endpoints/UserDataExportEndpointTests.cs
+++ b/services/auth/tests/Auth.FunctionalTests/Endpoints/UserDataExportEndpointTests.cs
@@ -1,0 +1,74 @@
+using System.Net;
+using Auth.Application.Abstractions.Persistence;
+using Auth.Domain.AuthUser;
+using Auth.FunctionalTests.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Auth.FunctionalTests.Endpoints;
+
+public sealed class UserDataExportEndpointTests(AuthApiFactory factory) : IClassFixture<AuthApiFactory>
+{
+	[Fact]
+	public async Task Anonymous_OnInternalGroup_NotUnderV1_RejectsNonPositive()
+	{
+		var anon = factory.CreateClient();
+		// internal group: reachable without a token, but not under /v1 (gateway-facing)
+		Assert.Equal(HttpStatusCode.OK, (await anon.GetAsync("/internal/users/1/data-export")).StatusCode);
+		Assert.Equal(HttpStatusCode.NotFound, (await anon.GetAsync("/v1/users/1/data-export")).StatusCode);
+		Assert.Equal(HttpStatusCode.BadRequest, (await anon.GetAsync("/internal/users/0/data-export")).StatusCode);
+	}
+
+	[Fact]
+	public async Task UnknownUser_Returns_AllNullExport()
+	{
+		var anon = factory.CreateClient();
+		var body = await (await anon.GetAsync("/internal/users/888888/data-export")).ReadJsonAsync();
+
+		Assert.Equal("888888", body["user_id"]?.GetValue<string>());
+		Assert.Null(body["email"]);
+		Assert.Null(body["email_verified"]);
+		Assert.Null(body["oauth_provider"]);
+		Assert.Null(body["oauth_id"]);
+		Assert.Null(body["created_at"]);
+	}
+
+	[Fact]
+	public async Task EmailPasswordUser_Returns200_WithNullOAuthFields()
+	{
+		await factory.SeedEmailUserAsync("export_pw@example.com", "password123");
+		var anon = factory.CreateClient();
+
+		using var scope = factory.Services.CreateScope();
+		var users = scope.ServiceProvider.GetRequiredService<IAuthUserRepository>();
+		var user = await users.GetByEmailAsync("export_pw@example.com");
+
+		var body = await (await anon.GetAsync($"/internal/users/{user!.Id}/data-export")).ReadJsonAsync();
+
+		Assert.Equal(user.Id.ToString(), body["user_id"]?.GetValue<string>());
+		Assert.Equal("export_pw@example.com", body["email"]?.GetValue<string>());
+		Assert.False(body["email_verified"]?.GetValue<bool>());
+		Assert.Null(body["oauth_provider"]);
+		Assert.Null(body["oauth_id"]);
+		Assert.NotNull(body["created_at"]?.GetValue<DateTimeOffset>());
+	}
+
+	[Fact]
+	public async Task OAuthUser_Returns200_WithProviderAndNullEmail()
+	{
+		_ = await factory.SeedOAuthUserWithAccessTokenAsync(OAuthProvider.FortyTwo, "42-export-123");
+		var anon = factory.CreateClient();
+
+		using var scope = factory.Services.CreateScope();
+		var users = scope.ServiceProvider.GetRequiredService<IAuthUserRepository>();
+		var user = await users.GetByOAuthAsync(OAuthProvider.FortyTwo, "42-export-123");
+
+		var body = await (await anon.GetAsync($"/internal/users/{user!.Id}/data-export")).ReadJsonAsync();
+
+		Assert.Null(body["email"]);
+		Assert.Null(body["email_verified"]);
+		Assert.Equal("fortytwo", body["oauth_provider"]?.GetValue<string>());
+		Assert.Equal("42-export-123", body["oauth_id"]?.GetValue<string>());
+		Assert.NotNull(body["created_at"]?.GetValue<DateTimeOffset>());
+	}
+}


### PR DESCRIPTION
Implement the internal `GET /internal/users/{user_id}/data-export` endpoint, following the convention Guild set in #237.

Exports Auth-owned identity/sign-in data for the User Service's data-export aggregator. No secrets (password_hash, refresh_token_hash). Unknown user → 200 with null fields, not a 404.

Close #235