### PR TITLE
fix(auth): carry email on user.deleted event

### DIFF
--- a/services/auth/src/Auth.Application/Contracts/Events.cs
+++ b/services/auth/src/Auth.Application/Contracts/Events.cs
@@ -16,7 +16,7 @@ public sealed record UserLoggedOut(long UserId) : IEvent
     public string EventType => "user.logged_out";
 }
 
-public sealed record UserDeleted(long UserId) : IEvent
+public sealed record UserDeleted(long UserId, string? Email) : IEvent
 {
     public string EventType => "user.deleted";
 }

--- a/services/auth/src/Auth.Application/Features/DeleteMe/DeleteMeHandler.cs
+++ b/services/auth/src/Auth.Application/Features/DeleteMe/DeleteMeHandler.cs
@@ -31,7 +31,7 @@ internal sealed class DeleteMeHandler(
         user.RevokeRefreshToken(clock.UtcNow);
 
         await userRepository.SaveChangesAsync(cancellationToken);
-        await eventBus.PublishAsync(new UserDeleted(command.UserId), cancellationToken);
+        await eventBus.PublishAsync(new UserDeleted(command.UserId, user.Email?.Value), cancellationToken);
 
         return Result.Ok();
     }

--- a/services/auth/tests/Auth.UnitTests/Application/DeleteMeHandlerTests.cs
+++ b/services/auth/tests/Auth.UnitTests/Application/DeleteMeHandlerTests.cs
@@ -33,6 +33,17 @@ public sealed class DeleteMeHandlerTests
         return user;
     }
 
+    private async Task<AuthUser> SeedOAuthUser()
+    {
+        var user = AuthUser.CreateOAuthUser(
+            id: _idGenerator.NextId(),
+            oauthProvider: OAuthProvider.FortyTwo,
+            oauthId: "42-123",
+            now: _clock.UtcNow).Value;
+        await _repo.AddAsync(user);
+        return user;
+    }
+
     private async Task<AuthUser> SeedEmailUserWithRefreshToken()
     {
         var now  = _clock.UtcNow;
@@ -110,12 +121,24 @@ public sealed class DeleteMeHandlerTests
     }
 
     [Fact]
-    public async Task ValidUser_PublishesUserDeleted()
+    public async Task ValidUser_PublishesUserDeleted_WithEmail()
     {
         var user = await SeedEmailUser();
         await Handle(user.Id);
 
         var evt = Assert.Single(_eventBus.Published.OfType<UserDeleted>());
         Assert.Equal(user.Id, evt.UserId);
+        Assert.Equal("user@example.com", evt.Email);
+    }
+
+    [Fact]
+    public async Task OAuthOnlyUser_PublishesUserDeleted_WithNullEmail()
+    {
+        var user = await SeedOAuthUser();
+        await Handle(user.Id);
+
+        var evt = Assert.Single(_eventBus.Published.OfType<UserDeleted>());
+        Assert.Equal(user.Id, evt.UserId);
+        Assert.Null(evt.Email);
     }
 }


### PR DESCRIPTION
Add email to the `user.deleted` event, per the contract Vanta specified in #292.

Close #292