### PR TITLE
feat(chat): message reactions (add/remove, per-message hydration)

### DIFF
--- a/docs/contracts/chat.md
+++ b/docs/contracts/chat.md
@@ -81,7 +81,7 @@ Send a message to a channel. Returns the canonical persisted message synchronous
 The nonce is a client-supplied string that the server treats as opaque. Its purpose is threefold:
 
 1. **Optimistic UI reconciliation.** The sender places a local message bubble keyed by nonce, then replaces it when either the `201` response or the `ReceiveMessage` broadcast arrives (whichever wins the race).
-2. **Idempotency.** If the same `(author_id, channel_id, nonce)` triple is seen again within **10 minutes**, the server returns the originally persisted message (same `id`, `created_at`) instead of writing a new row. Lets clients safely retry on network failure. Outside that window the nonce is forgotten and a repeat call would create a new message.
+2. **Idempotency.** If the same `(author_id, channel_id, nonce)` triple is seen again within **10 minutes**, the server returns the originally persisted message (same `id`, `created_at`) instead of writing a new row. Lets clients safely retry on network failure. Outside that window the nonce is forgotten and a repeat call would create a new message. For a channel message, this replayed response carries the message's *current* `reactions[]` (it may have accrued some since the original send) rather than the `[]` a truly new message gets.
 3. **Send-status feedback.** The sender can show "failed, retry" if neither the `201` nor a matching `ReceiveMessage` arrives within a UI timeout.
 
 Omitting `nonce` opts out of all three: the response and broadcast carry `"nonce": null`, and retries will create duplicate messages.

--- a/services/chat/src/Chat.Application/Abstractions/IChannelBroadcaster.cs
+++ b/services/chat/src/Chat.Application/Abstractions/IChannelBroadcaster.cs
@@ -7,4 +7,6 @@ public interface IChannelBroadcaster
 	Task BroadcastMessageAsync(long channelId, ChannelMessageResponse message, CancellationToken ct);
 	Task BroadcastMessageEditedAsync(long channelId, ChannelMessageEditedEvent evt, CancellationToken ct);
 	Task BroadcastMessageDeletedAsync(long channelId, long messageId, CancellationToken ct);
+	Task BroadcastReactionAddedAsync(long channelId, ReactionAddedEvent evt, CancellationToken ct);
+	Task BroadcastReactionRemovedAsync(long channelId, ReactionRemovedEvent evt, CancellationToken ct);
 }

--- a/services/chat/src/Chat.Application/Abstractions/Persistence/IReactionRepository.cs
+++ b/services/chat/src/Chat.Application/Abstractions/Persistence/IReactionRepository.cs
@@ -1,0 +1,25 @@
+using Chat.Domain.Reactions;
+
+namespace Chat.Application.Abstractions.Persistence;
+
+/// <summary>
+/// Persistence for channel message reactions. Backed by two ScyllaDB tables:
+/// <c>message_reactions</c> (per-user row, doubles as the idempotency guard)
+/// and <c>message_reaction_counts</c> (COUNTER, updated only when the guard
+/// row's insert/delete actually applied, so repeat calls never drift the count).
+/// </summary>
+public interface IReactionRepository
+{
+	/// <summary>true if this call added the reaction; false if the caller had already reacted (no-op)</summary>
+	Task<bool> AddAsync(long channelId, long messageId, long userId, string emoji, DateTimeOffset now, CancellationToken ct);
+
+	/// <summary>true if this call removed the reaction; false if the caller had not reacted (no-op)</summary>
+	Task<bool> RemoveAsync(long channelId, long messageId, long userId, string emoji, CancellationToken ct);
+
+	Task<long> GetCountAsync(long channelId, long messageId, string emoji, CancellationToken ct);
+
+	Task<IReadOnlyList<ReactionSummary>> GetMessageReactionsAsync(long channelId, long messageId, long currentUserId, CancellationToken ct);
+
+	Task<ILookup<long, ReactionSummary>> GetMessagesReactionsAsync(
+		long channelId, IReadOnlyList<long> messageIds, long currentUserId, CancellationToken ct);
+}

--- a/services/chat/src/Chat.Application/Features/Channels/Common/ChannelMessageResponse.cs
+++ b/services/chat/src/Chat.Application/Features/Channels/Common/ChannelMessageResponse.cs
@@ -1,5 +1,6 @@
 using Chat.Domain.Attachments;
 using Chat.Domain.Messages;
+using Chat.Domain.Reactions;
 using Chat.Application.Features.Attachments.Common;
 using Chat.Application.Features.Messages.SendMessage;
 
@@ -19,13 +20,14 @@ public sealed record ChannelMessageResponse(
 	DateTimeOffset? EditedAt,
 	DateTimeOffset CreatedAt,
 	IReadOnlyList<AttachmentResponse> Attachments,
-	object[] Reactions,
+	IReadOnlyList<ReactionResponse> Reactions,
 	string? Nonce) : IMessageWireResponse<ChannelMessageResponse>
 {
 	public static ChannelMessageResponse From(
 		Message m,
 		string? nonce,
-		IReadOnlyList<AttachmentMetadata>? attachments = null) => new(
+		IReadOnlyList<AttachmentMetadata>? attachments = null,
+		IReadOnlyList<ReactionSummary>? reactions = null) => new(
 		Id: m.Id.ToString(),
 		ChannelId: m.ContainerId.ToString(),
 		AuthorId: m.AuthorId.ToString(),
@@ -36,6 +38,8 @@ public sealed record ChannelMessageResponse(
 		Attachments: attachments is null or { Count: 0 }
 			? []
 			: attachments.Select(AttachmentResponse.From).ToArray(),
-		Reactions: [],
+		Reactions: reactions is null or { Count: 0 }
+			? []
+			: reactions.Select(ReactionResponse.From).ToArray(),
 		Nonce: nonce);
 }

--- a/services/chat/src/Chat.Application/Features/Channels/Common/ReactionAddedEvent.cs
+++ b/services/chat/src/Chat.Application/Features/Channels/Common/ReactionAddedEvent.cs
@@ -1,0 +1,3 @@
+namespace Chat.Application.Features.Channels.Common;
+
+public sealed record ReactionAddedEvent(string MessageId, string ChannelId, string UserId, string Emoji, long Count);

--- a/services/chat/src/Chat.Application/Features/Channels/Common/ReactionRemovedEvent.cs
+++ b/services/chat/src/Chat.Application/Features/Channels/Common/ReactionRemovedEvent.cs
@@ -1,0 +1,3 @@
+namespace Chat.Application.Features.Channels.Common;
+
+public sealed record ReactionRemovedEvent(string MessageId, string ChannelId, string UserId, string Emoji, long Count);

--- a/services/chat/src/Chat.Application/Features/Channels/Common/ReactionResponse.cs
+++ b/services/chat/src/Chat.Application/Features/Channels/Common/ReactionResponse.cs
@@ -1,0 +1,9 @@
+using Chat.Domain.Reactions;
+
+namespace Chat.Application.Features.Channels.Common;
+
+/// <summary>wire shape for one entry in a message's <c>reactions[]</c>, per the contract</summary>
+public sealed record ReactionResponse(string Emoji, long Count, bool MeReacted)
+{
+	public static ReactionResponse From(ReactionSummary s) => new(s.Emoji, s.Count, s.MeReacted);
+}

--- a/services/chat/src/Chat.Application/Features/Channels/GetChannelMessages/GetChannelMessagesHandler.cs
+++ b/services/chat/src/Chat.Application/Features/Channels/GetChannelMessages/GetChannelMessagesHandler.cs
@@ -12,6 +12,7 @@ internal sealed class GetChannelMessagesHandler(
 	IGuildClient guildClient,
 	IMessageRepository repository,
 	IAttachmentRepository attachmentRepository,
+	IReactionRepository reactionRepository,
 	IClock clock)
 	: IQueryHandler<GetChannelMessagesQuery, Result<IReadOnlyList<ChannelMessageResponse>>>
 {
@@ -43,9 +44,11 @@ internal sealed class GetChannelMessagesHandler(
 		var messageIds = messages.Select(m => m.Id).ToList();
 		var attachmentsByMessage = await attachmentRepository
 			.GetMessagesAttachmentsAsync(query.ChannelId, isDm: false, messageIds, cancellationToken);
+		var reactionsByMessage = await reactionRepository
+			.GetMessagesReactionsAsync(query.ChannelId, messageIds, userId, cancellationToken);
 
 		var hydrated = messages
-			.Select(m => ChannelMessageResponse.From(m, null, [.. attachmentsByMessage[m.Id]]))
+			.Select(m => ChannelMessageResponse.From(m, null, [.. attachmentsByMessage[m.Id]], [.. reactionsByMessage[m.Id]]))
 			.ToList();
 
 		return Result.Ok<IReadOnlyList<ChannelMessageResponse>>(hydrated);

--- a/services/chat/src/Chat.Application/Features/Channels/SendMessage/SendChannelMessageHandler.cs
+++ b/services/chat/src/Chat.Application/Features/Channels/SendMessage/SendChannelMessageHandler.cs
@@ -5,6 +5,7 @@ using Chat.Application.Contracts;
 using Chat.Application.Features.Channels.Common;
 using Chat.Application.Features.Messages.SendMessage;
 using Chat.Domain.Messages;
+using Chat.Domain.Reactions;
 using Chat.Domain.Results;
 
 namespace Chat.Application.Features.Channels.SendMessage;
@@ -17,7 +18,8 @@ internal sealed class SendChannelMessageHandler(
 	IClock clock,
 	IGuildClient guildClient,
 	IEventBus eventBus,
-	IChannelBroadcaster broadcaster)
+	IChannelBroadcaster broadcaster,
+	IReactionRepository reactionRepository)
 	: SendMessageHandlerBase<SendChannelMessageCommand, ChannelMessageResponse, long>(currentUser, repository, attachmentRepository, ids, clock)
 {
 	// permission bits mirror the Guild Service domain so this stays a pure
@@ -50,6 +52,11 @@ internal sealed class SendChannelMessageHandler(
 
 	protected override Task<long> ResolveContainerIdAsync(SendChannelMessageCommand command, CancellationToken ct) =>
 		Task.FromResult(command.ChannelId);
+
+	// on a nonce replay, the existing message may have accrued reactions since
+	// the original send, so hydrate them for real instead of always returning []
+	protected override async Task<IReadOnlyList<ReactionSummary>?> ResolveReactionsAsync(Message existing, CancellationToken ct) =>
+		await reactionRepository.GetMessageReactionsAsync(existing.ContainerId, existing.Id, AuthorId, ct);
 
 	protected override Result<Message> CreateMessage(
 		SendChannelMessageCommand command, long containerId, long messageId, bool hasAttachments, DateTimeOffset now) =>

--- a/services/chat/src/Chat.Application/Features/DirectMessages/Common/DirectMessageResponse.cs
+++ b/services/chat/src/Chat.Application/Features/DirectMessages/Common/DirectMessageResponse.cs
@@ -2,13 +2,14 @@ using Chat.Application.Features.Attachments.Common;
 using Chat.Application.Features.Messages.SendMessage;
 using Chat.Domain.Attachments;
 using Chat.Domain.Messages;
+using Chat.Domain.Reactions;
 
 namespace Chat.Application.Features.DirectMessages.Common;
 
 /// <summary>
 /// wire shape that mirrors the contract's <c>ReceiveMessage</c> event. snowflake
 /// IDs are quoted strings so JS clients can hold them without precision loss.
-/// reactions are an empty array on freshly-created messages
+/// no reactions field: the contract excludes DMs from reactions by design
 /// </summary>
 public sealed record DirectMessageResponse(
 	string Id,
@@ -19,13 +20,13 @@ public sealed record DirectMessageResponse(
 	string? ReplyToId,
 	DateTimeOffset CreatedAt,
 	IReadOnlyList<AttachmentResponse> Attachments,
-	object[] Reactions,
 	string? Nonce) : IMessageWireResponse<DirectMessageResponse>
 {
 	public static DirectMessageResponse From(
 		Message m,
 		string? nonce,
-		IReadOnlyList<AttachmentMetadata>? attachments = null) => new(
+		IReadOnlyList<AttachmentMetadata>? attachments = null,
+		IReadOnlyList<ReactionSummary>? _ = null) => new(
 		Id: m.Id.ToString(),
 		ConversationId: m.ContainerId.ToString(),
 		SenderId: m.AuthorId.ToString(),
@@ -36,6 +37,5 @@ public sealed record DirectMessageResponse(
 		Attachments: attachments is null or { Count: 0 }
 			? []
 			: attachments.Select(AttachmentResponse.From).ToArray(),
-		Reactions: [],
 		Nonce: nonce);
 }

--- a/services/chat/src/Chat.Application/Features/DirectMessages/SendMessage/SendDirectMessageHandler.cs
+++ b/services/chat/src/Chat.Application/Features/DirectMessages/SendMessage/SendDirectMessageHandler.cs
@@ -5,6 +5,7 @@ using Chat.Application.Contracts;
 using Chat.Application.Features.DirectMessages.Common;
 using Chat.Application.Features.Messages.SendMessage;
 using Chat.Domain.Messages;
+using Chat.Domain.Reactions;
 using Chat.Domain.Results;
 
 namespace Chat.Application.Features.DirectMessages.SendMessage;
@@ -47,6 +48,10 @@ internal sealed class SendDirectMessageHandler(
 
 	protected override Task<long> ResolveContainerIdAsync(SendDirectMessageCommand command, CancellationToken ct) =>
 		Repository.GetOrCreateConversationAsync(AuthorId, command.RecipientId, Ids.NextId(), ct);
+
+	// DMs never carry reactions per the contract
+	protected override Task<IReadOnlyList<ReactionSummary>?> ResolveReactionsAsync(Message existing, CancellationToken ct) =>
+		Task.FromResult<IReadOnlyList<ReactionSummary>?>(null);
 
 	protected override Result<Message> CreateMessage(
 		SendDirectMessageCommand command, long containerId, long messageId, bool hasAttachments, DateTimeOffset now) =>

--- a/services/chat/src/Chat.Application/Features/Messages/SendMessage/IMessageWireResponse.cs
+++ b/services/chat/src/Chat.Application/Features/Messages/SendMessage/IMessageWireResponse.cs
@@ -1,5 +1,6 @@
 using Chat.Domain.Attachments;
 using Chat.Domain.Messages;
+using Chat.Domain.Reactions;
 
 namespace Chat.Application.Features.Messages.SendMessage;
 
@@ -10,5 +11,9 @@ namespace Chat.Application.Features.Messages.SendMessage;
 /// </summary>
 public interface IMessageWireResponse<out TSelf> where TSelf : IMessageWireResponse<TSelf>
 {
-	static abstract TSelf From(Message m, string? nonce, IReadOnlyList<AttachmentMetadata>? attachments);
+	static abstract TSelf From(
+		Message m,
+		string? nonce,
+		IReadOnlyList<AttachmentMetadata>? attachments,
+		IReadOnlyList<ReactionSummary>? reactions);
 }

--- a/services/chat/src/Chat.Application/Features/Messages/SendMessage/SendMessageHandlerBase.cs
+++ b/services/chat/src/Chat.Application/Features/Messages/SendMessage/SendMessageHandlerBase.cs
@@ -4,6 +4,7 @@ using Chat.Application.Abstractions.Messaging;
 using Chat.Application.Abstractions.Persistence;
 using Chat.Domain.Attachments;
 using Chat.Domain.Messages;
+using Chat.Domain.Reactions;
 using Chat.Domain.Results;
 
 namespace Chat.Application.Features.Messages.SendMessage;
@@ -57,7 +58,8 @@ internal abstract class SendMessageHandlerBase<TCommand, TResponse, TContext>(
 					return TResponse.From(
 						existing, command.Nonce,
 						await attachmentRepository.GetMessageAttachmentsAsync(existing.ContainerId,
-							existing.IsDirectMessage, existing.Id, cancellationToken));
+							existing.IsDirectMessage, existing.Id, cancellationToken),
+						await ResolveReactionsAsync(existing, cancellationToken));
 				}
 				// else: fall through, this nonce is no longer bound to a live message, send for real
 			}
@@ -85,7 +87,7 @@ internal abstract class SendMessageHandlerBase<TCommand, TResponse, TContext>(
 		var message = messageResult.Value;
 		await Repository.AddAsync(message, command.Nonce, attachments, cancellationToken);
 
-		var response = TResponse.From(message, command.Nonce, attachments);
+		var response = TResponse.From(message, command.Nonce, attachments, null);
 
 		await PublishAndNotifyAsync(command, context, message, response, cancellationToken);
 
@@ -105,6 +107,9 @@ internal abstract class SendMessageHandlerBase<TCommand, TResponse, TContext>(
 	protected abstract Task<long?> FindExistingContainerIdAsync(TCommand command, CancellationToken ct);
 
 	protected abstract Task<long> ResolveContainerIdAsync(TCommand command, CancellationToken ct);
+
+	/// <summary>hydrates reactions for the nonce-replay path only, where <paramref name="existing"/> may have accrued some since the original send</summary>
+	protected abstract Task<IReadOnlyList<ReactionSummary>?> ResolveReactionsAsync(Message existing, CancellationToken ct);
 
 	protected abstract Result<Message> CreateMessage(TCommand command, long containerId, long messageId, bool hasAttachments, DateTimeOffset now);
 

--- a/services/chat/src/Chat.Application/Features/Reactions/AddReaction/AddReactionCommand.cs
+++ b/services/chat/src/Chat.Application/Features/Reactions/AddReaction/AddReactionCommand.cs
@@ -1,0 +1,7 @@
+using Chat.Application.Abstractions.Messaging;
+using Chat.Application.Features.Channels.Common;
+using Chat.Domain.Results;
+
+namespace Chat.Application.Features.Reactions.AddReaction;
+
+public sealed record AddReactionCommand(long MessageId, string Emoji) : ICommand<Result<ReactionResponse>>;

--- a/services/chat/src/Chat.Application/Features/Reactions/AddReaction/AddReactionHandler.cs
+++ b/services/chat/src/Chat.Application/Features/Reactions/AddReaction/AddReactionHandler.cs
@@ -1,0 +1,58 @@
+using Chat.Application.Abstractions;
+using Chat.Application.Abstractions.Authentication;
+using Chat.Application.Abstractions.Messaging;
+using Chat.Application.Abstractions.Persistence;
+using Chat.Application.Features.Channels.Common;
+using Chat.Domain.Reactions;
+using Chat.Domain.Results;
+
+namespace Chat.Application.Features.Reactions.AddReaction;
+
+internal sealed class AddReactionHandler(
+	ICurrentUser currentUser,
+	IMessageRepository messageRepository,
+	IReactionRepository reactionRepository,
+	IGuildClient guildClient,
+	IClock clock,
+	IChannelBroadcaster broadcaster)
+	: ICommandHandler<AddReactionCommand, Result<ReactionResponse>>
+{
+	private const long ReadMessages = 1L << 1;
+	private const long Administrator = 1L << 8;
+
+	public async Task<Result<ReactionResponse>> HandleAsync(AddReactionCommand command, CancellationToken cancellationToken = default)
+	{
+		var emojiResult = ReactionEmoji.Validate(command.Emoji);
+		if (emojiResult.IsFailure)
+			return emojiResult.Error;
+		var emoji = emojiResult.Value;
+
+		var message = await messageRepository.GetByIdAsync(command.MessageId, cancellationToken);
+		if (message is null || message.IsDeleted)
+			return MessageFailures.NotFound;
+
+		if (message.IsDirectMessage)
+			return ReactionFailures.IsDirectMessage;
+
+		var userId = currentUser.UserId;
+		var membership = await guildClient.GetMembershipAsync(message.ContainerId, userId, cancellationToken);
+		if (membership is null || !membership.IsMember || (membership.Permissions & (ReadMessages | Administrator)) == 0)
+			return MessageFailures.MissingReadPermission;
+
+		var added = await reactionRepository.AddAsync(message.ContainerId, message.Id, userId, emoji, clock.UtcNow, cancellationToken);
+		var count = await reactionRepository.GetCountAsync(message.ContainerId, message.Id, emoji, cancellationToken);
+
+		if (added)
+			await broadcaster.BroadcastReactionAddedAsync(
+				message.ContainerId,
+				new ReactionAddedEvent(
+					MessageId: message.Id.ToString(),
+					ChannelId: message.ContainerId.ToString(),
+					UserId: userId.ToString(),
+					Emoji: emoji,
+					Count: count),
+				cancellationToken);
+
+		return new ReactionResponse(emoji, count, MeReacted: true);
+	}
+}

--- a/services/chat/src/Chat.Application/Features/Reactions/RemoveReaction/RemoveReactionCommand.cs
+++ b/services/chat/src/Chat.Application/Features/Reactions/RemoveReaction/RemoveReactionCommand.cs
@@ -1,0 +1,7 @@
+using Chat.Application.Abstractions.Messaging;
+using Chat.Application.Features.Channels.Common;
+using Chat.Domain.Results;
+
+namespace Chat.Application.Features.Reactions.RemoveReaction;
+
+public sealed record RemoveReactionCommand(long MessageId, string Emoji) : ICommand<Result<ReactionResponse>>;

--- a/services/chat/src/Chat.Application/Features/Reactions/RemoveReaction/RemoveReactionHandler.cs
+++ b/services/chat/src/Chat.Application/Features/Reactions/RemoveReaction/RemoveReactionHandler.cs
@@ -1,0 +1,57 @@
+using Chat.Application.Abstractions;
+using Chat.Application.Abstractions.Authentication;
+using Chat.Application.Abstractions.Messaging;
+using Chat.Application.Abstractions.Persistence;
+using Chat.Application.Features.Channels.Common;
+using Chat.Domain.Reactions;
+using Chat.Domain.Results;
+
+namespace Chat.Application.Features.Reactions.RemoveReaction;
+
+internal sealed class RemoveReactionHandler(
+	ICurrentUser currentUser,
+	IMessageRepository messageRepository,
+	IReactionRepository reactionRepository,
+	IGuildClient guildClient,
+	IChannelBroadcaster broadcaster)
+	: ICommandHandler<RemoveReactionCommand, Result<ReactionResponse>>
+{
+	private const long ReadMessages = 1L << 1;
+	private const long Administrator = 1L << 8;
+
+	public async Task<Result<ReactionResponse>> HandleAsync(RemoveReactionCommand command, CancellationToken cancellationToken = default)
+	{
+		var emojiResult = ReactionEmoji.Validate(command.Emoji);
+		if (emojiResult.IsFailure)
+			return emojiResult.Error;
+		var emoji = emojiResult.Value;
+
+		var message = await messageRepository.GetByIdAsync(command.MessageId, cancellationToken);
+		if (message is null || message.IsDeleted)
+			return MessageFailures.NotFound;
+
+		if (message.IsDirectMessage)
+			return ReactionFailures.IsDirectMessage;
+
+		var userId = currentUser.UserId;
+		var membership = await guildClient.GetMembershipAsync(message.ContainerId, userId, cancellationToken);
+		if (membership is null || !membership.IsMember || (membership.Permissions & (ReadMessages | Administrator)) == 0)
+			return MessageFailures.MissingReadPermission;
+
+		var removed = await reactionRepository.RemoveAsync(message.ContainerId, message.Id, userId, emoji, cancellationToken);
+		var count = await reactionRepository.GetCountAsync(message.ContainerId, message.Id, emoji, cancellationToken);
+
+		if (removed)
+			await broadcaster.BroadcastReactionRemovedAsync(
+				message.ContainerId,
+				new ReactionRemovedEvent(
+					MessageId: message.Id.ToString(),
+					ChannelId: message.ContainerId.ToString(),
+					UserId: userId.ToString(),
+					Emoji: emoji,
+					Count: count),
+				cancellationToken);
+
+		return new ReactionResponse(emoji, count, MeReacted: false);
+	}
+}

--- a/services/chat/src/Chat.Domain/Reactions/ReactionEmoji.cs
+++ b/services/chat/src/Chat.Domain/Reactions/ReactionEmoji.cs
@@ -1,0 +1,25 @@
+using Chat.Domain.Results;
+
+namespace Chat.Domain.Reactions;
+
+/// <summary>
+/// Reactions have no rich aggregate of their own - a reaction is just a
+/// (message, emoji, user) key plus a counter, both handled at the persistence
+/// layer. This holds the one piece of domain logic that isn't storage: emoji
+/// format validation.
+/// </summary>
+public static class ReactionEmoji
+{
+	public const int MaxEmojiLen = 32;
+
+	public static Result<string> Validate(string? emoji)
+	{
+		if (string.IsNullOrWhiteSpace(emoji))
+			return ReactionFailures.EmojiRequired;
+
+		if (emoji.Length > MaxEmojiLen)
+			return ReactionFailures.EmojiTooLong;
+
+		return emoji;
+	}
+}

--- a/services/chat/src/Chat.Domain/Reactions/ReactionSummary.cs
+++ b/services/chat/src/Chat.Domain/Reactions/ReactionSummary.cs
@@ -1,0 +1,4 @@
+namespace Chat.Domain.Reactions;
+
+/// <summary>wire-and-storage shape of one emoji's reaction summary on a message</summary>
+public sealed record ReactionSummary(string Emoji, long Count, bool MeReacted);

--- a/services/chat/src/Chat.Domain/Results/ReactionFailures.cs
+++ b/services/chat/src/Chat.Domain/Results/ReactionFailures.cs
@@ -1,0 +1,15 @@
+using Chat.Domain.Reactions;
+
+namespace Chat.Domain.Results;
+
+public static class ReactionFailures
+{
+	public static readonly Failure EmojiRequired =
+		new("Reaction.EmojiRequired", "Emoji is required.");
+
+	public static readonly Failure EmojiTooLong =
+		new("Reaction.EmojiTooLong", $"Emoji must be {ReactionEmoji.MaxEmojiLen} characters or fewer.");
+
+	public static readonly Failure IsDirectMessage =
+		new("Reaction.IsDirectMessage", "Reactions are not supported on direct messages.");
+}

--- a/services/chat/src/Chat.Persistence/DependencyInjection.cs
+++ b/services/chat/src/Chat.Persistence/DependencyInjection.cs
@@ -38,6 +38,8 @@ public static class DependencyInjection
 		services.AddScoped<IDataExportRepository, DataExportRepository>();
 		services.AddSingleton<ReadStateStatements>();
 		services.AddScoped<IReadStateRepository, ReadStateRepository>();
+		services.AddSingleton<ReactionStatements>();
+		services.AddScoped<IReactionRepository, ReactionRepository>();
 		return services;
 	}
 

--- a/services/chat/src/Chat.Persistence/Repositories/ReactionRepository.cs
+++ b/services/chat/src/Chat.Persistence/Repositories/ReactionRepository.cs
@@ -1,0 +1,89 @@
+using Cassandra;
+using Chat.Application.Abstractions.Persistence;
+using Chat.Domain.Reactions;
+
+namespace Chat.Persistence.Repositories;
+
+internal sealed class ReactionRepository(ISession session, ReactionStatements statements) : IReactionRepository
+{
+	public async Task<bool> AddAsync(long channelId, long messageId, long userId, string emoji, DateTimeOffset now, CancellationToken ct)
+	{
+		var insert = await statements.InsertReactionIfNotExists.Value;
+		var row = (await session.ExecuteAsync(insert.Bind(channelId, messageId, emoji, userId, now.UtcDateTime))).First();
+
+		var applied = row.GetValue<bool>("[applied]");
+		if (!applied)
+			return false;
+
+		var increment = await statements.IncrementCount.Value;
+		await session.ExecuteAsync(increment.Bind(channelId, messageId, emoji));
+		return true;
+	}
+
+	public async Task<bool> RemoveAsync(long channelId, long messageId, long userId, string emoji, CancellationToken ct)
+	{
+		var delete = await statements.DeleteReactionIfExists.Value;
+		var row = (await session.ExecuteAsync(delete.Bind(channelId, messageId, emoji, userId))).First();
+
+		var applied = row.GetValue<bool>("[applied]");
+		if (!applied)
+			return false;
+
+		var decrement = await statements.DecrementCount.Value;
+		await session.ExecuteAsync(decrement.Bind(channelId, messageId, emoji));
+		return true;
+	}
+
+	public async Task<long> GetCountAsync(long channelId, long messageId, string emoji, CancellationToken ct)
+	{
+		var stmt = await statements.SelectCount.Value;
+		var row = (await session.ExecuteAsync(stmt.Bind(channelId, messageId, emoji))).FirstOrDefault();
+		return row?.GetValue<long>("count") ?? 0;
+	}
+
+	public async Task<IReadOnlyList<ReactionSummary>> GetMessageReactionsAsync(
+		long channelId, long messageId, long currentUserId, CancellationToken ct)
+	{
+		var countsStmt = await statements.SelectCountsForMessage.Value;
+		var countRows = await session.ExecuteAsync(countsStmt.Bind(channelId, messageId));
+
+		var mineStmt = await statements.SelectMineForMessage.Value;
+		var mineRows = await session.ExecuteAsync(mineStmt.Bind(channelId, messageId, currentUserId));
+
+		var mine = mineRows.Select(r => r.GetValue<string>("emoji")).ToHashSet();
+
+		return countRows
+			.Select(r =>
+			{
+				var emoji = r.GetValue<string>("emoji");
+				return new ReactionSummary(emoji, r.GetValue<long>("count"), mine.Contains(emoji));
+			})
+			.ToList();
+	}
+
+	public async Task<ILookup<long, ReactionSummary>> GetMessagesReactionsAsync(
+		long channelId, IReadOnlyList<long> messageIds, long currentUserId, CancellationToken ct)
+	{
+		if (messageIds.Count == 0)
+			return Enumerable.Empty<ReactionSummary>().ToLookup(_ => 0L);
+
+		var countsStmt = await statements.SelectCountsForMessages.Value;
+		var countRows = await session.ExecuteAsync(countsStmt.Bind(channelId, messageIds.ToArray()));
+
+		var mineStmt = await statements.SelectMineForMessages.Value;
+		var mineRows = await session.ExecuteAsync(mineStmt.Bind(channelId, messageIds.ToArray(), currentUserId));
+
+		var mine = mineRows
+			.Select(r => (MessageId: r.GetValue<long>("message_id"), Emoji: r.GetValue<string>("emoji")))
+			.ToHashSet();
+
+		return countRows
+			.Select(r =>
+			{
+				var messageId = r.GetValue<long>("message_id");
+				var emoji = r.GetValue<string>("emoji");
+				return (messageId, Reaction: new ReactionSummary(emoji, r.GetValue<long>("count"), mine.Contains((messageId, emoji))));
+			})
+			.ToLookup(x => x.messageId, x => x.Reaction);
+	}
+}

--- a/services/chat/src/Chat.Persistence/Repositories/ReactionRepository.cs
+++ b/services/chat/src/Chat.Persistence/Repositories/ReactionRepository.cs
@@ -53,6 +53,7 @@ internal sealed class ReactionRepository(ISession session, ReactionStatements st
 		var mine = mineRows.Select(r => r.GetValue<string>("emoji")).ToHashSet();
 
 		return countRows
+			.Where(r => r.GetValue<long>("count") > 0)
 			.Select(r =>
 			{
 				var emoji = r.GetValue<string>("emoji");
@@ -78,6 +79,7 @@ internal sealed class ReactionRepository(ISession session, ReactionStatements st
 			.ToHashSet();
 
 		return countRows
+			.Where(r => r.GetValue<long>("count") > 0)
 			.Select(r =>
 			{
 				var messageId = r.GetValue<long>("message_id");

--- a/services/chat/src/Chat.Persistence/Repositories/ReactionStatements.cs
+++ b/services/chat/src/Chat.Persistence/Repositories/ReactionStatements.cs
@@ -1,0 +1,40 @@
+using Cassandra;
+
+namespace Chat.Persistence.Repositories;
+
+internal sealed class ReactionStatements(ISession session)
+{
+	public Lazy<Task<PreparedStatement>> InsertReactionIfNotExists { get; } = new(() => session.PrepareAsync(
+		"INSERT INTO message_reactions (channel_id, message_id, emoji, user_id, created_at) " +
+		"VALUES (?, ?, ?, ?, ?) IF NOT EXISTS"));
+
+	public Lazy<Task<PreparedStatement>> DeleteReactionIfExists { get; } = new(() => session.PrepareAsync(
+		"DELETE FROM message_reactions WHERE channel_id = ? AND message_id = ? AND emoji = ? AND user_id = ? IF EXISTS"));
+
+	public Lazy<Task<PreparedStatement>> IncrementCount { get; } = new(() => session.PrepareAsync(
+		"UPDATE message_reaction_counts SET count = count + 1 WHERE channel_id = ? AND message_id = ? AND emoji = ?"));
+
+	public Lazy<Task<PreparedStatement>> DecrementCount { get; } = new(() => session.PrepareAsync(
+		"UPDATE message_reaction_counts SET count = count - 1 WHERE channel_id = ? AND message_id = ? AND emoji = ?"));
+
+	public Lazy<Task<PreparedStatement>> SelectCount { get; } = new(() => session.PrepareAsync(
+		"SELECT count FROM message_reaction_counts WHERE channel_id = ? AND message_id = ? AND emoji = ?"));
+
+	public Lazy<Task<PreparedStatement>> SelectCountsForMessage { get; } = new(() => session.PrepareAsync(
+		"SELECT emoji, count FROM message_reaction_counts WHERE channel_id = ? AND message_id = ?"));
+
+	// same ALLOW FILTERING trade-off as SelectMineForMessages, scoped to a single message
+	public Lazy<Task<PreparedStatement>> SelectMineForMessage { get; } = new(() => session.PrepareAsync(
+		"SELECT emoji FROM message_reactions WHERE channel_id = ? AND message_id = ? AND user_id = ? ALLOW FILTERING"));
+
+	// same IN-on-trailing-partition-key trick as message_attachments' page reads
+	public Lazy<Task<PreparedStatement>> SelectCountsForMessages { get; } = new(() => session.PrepareAsync(
+		"SELECT message_id, emoji, count FROM message_reaction_counts WHERE channel_id = ? AND message_id IN ?"));
+
+	// filters on user_id while skipping the leading emoji clustering column, so it
+	// needs ALLOW FILTERING - safe here because the IN-list already bounds the scan
+	// to one page's worth of message partitions under a single channel_id
+	public Lazy<Task<PreparedStatement>> SelectMineForMessages { get; } = new(() => session.PrepareAsync(
+		"SELECT message_id, emoji FROM message_reactions " +
+		"WHERE channel_id = ? AND message_id IN ? AND user_id = ? ALLOW FILTERING"));
+}

--- a/services/chat/src/Chat.Presentation/Endpoints/MessagesEndpoint.cs
+++ b/services/chat/src/Chat.Presentation/Endpoints/MessagesEndpoint.cs
@@ -6,6 +6,8 @@ using Chat.Application.Features.Channels.SendMessage;
 using Chat.Application.Features.Messages.Common;
 using Chat.Application.Features.Messages.DeleteMessage;
 using Chat.Application.Features.Messages.EditMessage;
+using Chat.Application.Features.Reactions.AddReaction;
+using Chat.Application.Features.Reactions.RemoveReaction;
 using Chat.Domain.Results;
 using Microsoft.AspNetCore.Http.HttpResults;
 
@@ -19,9 +21,11 @@ public sealed class MessagesEndpoint : ICarterModule
 		channelGroup.MapGet("/", GetChannelHistoryAsync);
 		channelGroup.MapPost("/", SendAsync);
 
-		var messageGroup = endpoints.MapGroup("/messages").WithTags("Messages");
-		messageGroup.MapPatch("/{messageId:long}", EditAsync);
-		messageGroup.MapDelete("/{messageId:long}", DeleteAsync);
+		var messageGroup = endpoints.MapGroup("/messages/{messageId:long}");
+		messageGroup.MapPatch("/", EditAsync);
+		messageGroup.MapDelete("/", DeleteAsync);
+		messageGroup.MapPut("/reactions/{emoji}", AddReactionAsync);
+		messageGroup.MapDelete("/reactions/{emoji}", RemoveReactionAsync);
 	}
 
 	private static async Task<Results<
@@ -127,6 +131,42 @@ public sealed class MessagesEndpoint : ICarterModule
 			_ => TypedResults.BadRequest(new ErrorBody(failure.Message)),
 		};
 
+	private static async Task<Results<
+		Ok<ReactionResponse>,
+		BadRequest<ErrorBody>,
+		JsonHttpResult<ErrorBody>,
+		NotFound<ErrorBody>>>
+	AddReactionAsync(
+		long messageId,
+		string emoji,
+		ICommandHandler<AddReactionCommand, Result<ReactionResponse>> handler,
+		CancellationToken cancellationToken)
+	{
+		var result = await handler.HandleAsync(new AddReactionCommand(messageId, emoji), cancellationToken);
+
+		return result.Succeeded
+			? TypedResults.Ok(result.Value)
+			: MapReactionError(result.Error);
+	}
+
+	private static async Task<Results<
+		Ok<ReactionResponse>,
+		BadRequest<ErrorBody>,
+		JsonHttpResult<ErrorBody>,
+		NotFound<ErrorBody>>>
+	RemoveReactionAsync(
+		long messageId,
+		string emoji,
+		ICommandHandler<RemoveReactionCommand, Result<ReactionResponse>> handler,
+		CancellationToken cancellationToken)
+	{
+		var result = await handler.HandleAsync(new RemoveReactionCommand(messageId, emoji), cancellationToken);
+
+		return result.Succeeded
+			? TypedResults.Ok(result.Value)
+			: MapReactionError(result.Error);
+	}
+
 	private static Results<Ok<IReadOnlyList<ChannelMessageResponse>>, JsonHttpResult<ErrorBody>, NotFound<ErrorBody>>
 		MapGetChannelHistoryError(Failure failure) => failure.Code switch
 		{
@@ -141,6 +181,17 @@ public sealed class MessagesEndpoint : ICarterModule
 			"Message.MissingManagePermission" or
 			"Message.NotAuthor" => TypedResults.Json(new ErrorBody(failure.Message), statusCode: StatusCodes.Status403Forbidden),
 			_ => TypedResults.NotFound(new ErrorBody(failure.Message)),
+		};
+
+	private static Results<Ok<ReactionResponse>, BadRequest<ErrorBody>, JsonHttpResult<ErrorBody>, NotFound<ErrorBody>>
+		MapReactionError(Failure failure) => failure.Code switch
+		{
+			"Message.NotFound" or
+			"Reaction.IsDirectMessage" => TypedResults.NotFound(new ErrorBody(failure.Message)),
+			"Message.MissingReadPermission" => TypedResults.Json(new ErrorBody(failure.Message), statusCode: StatusCodes.Status403Forbidden),
+			// "Reaction.EmojiRequired"
+			// "Reaction.EmojiTooLong"
+			_ => TypedResults.BadRequest(new ErrorBody(failure.Message)),
 		};
 
 	private sealed record SendChannelMessageRequest(

--- a/services/chat/src/Chat.Presentation/Hubs/IChatClient.cs
+++ b/services/chat/src/Chat.Presentation/Hubs/IChatClient.cs
@@ -11,6 +11,9 @@ public interface IChatClient
 	Task MessageEdited(ChannelMessageEditedEvent evt);
 	Task MessageDeleted(ChannelMessageDeletedEvent evt);
 
+	Task ReactionAdded(ReactionAddedEvent evt);
+	Task ReactionRemoved(ReactionRemovedEvent evt);
+
 	Task DirectMessageEdited(DirectMessageEditedEvent evt);
 	Task DirectMessageDeleted(DirectMessageDeletedEvent evt);
 

--- a/services/chat/src/Chat.Presentation/Hubs/SignalRChannelBroadcaster.cs
+++ b/services/chat/src/Chat.Presentation/Hubs/SignalRChannelBroadcaster.cs
@@ -17,4 +17,10 @@ internal sealed class SignalRChannelBroadcaster(IHubContext<ChatHub, IChatClient
 		hub.Clients.Group($"channel:{channelId}").MessageDeleted(new ChannelMessageDeletedEvent(
 			MessageId: messageId.ToString(),
 			ChannelId: channelId.ToString()));
+
+	public Task BroadcastReactionAddedAsync(long channelId, ReactionAddedEvent evt, CancellationToken ct) =>
+		hub.Clients.Group($"channel:{channelId}").ReactionAdded(evt);
+
+	public Task BroadcastReactionRemovedAsync(long channelId, ReactionRemovedEvent evt, CancellationToken ct) =>
+		hub.Clients.Group($"channel:{channelId}").ReactionRemoved(evt);
 }

--- a/services/chat/tests/Chat.FunctionalTests/Endpoints/ReactionsEndpointTests.cs
+++ b/services/chat/tests/Chat.FunctionalTests/Endpoints/ReactionsEndpointTests.cs
@@ -1,0 +1,222 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Chat.Application.Abstractions;
+using Chat.Domain.Messages;
+using Chat.FunctionalTests.Infrastructure;
+using Xunit;
+
+namespace Chat.FunctionalTests.Endpoints;
+
+public sealed class ReactionsEndpointTests(ChatApiFactory factory)
+	: IClassFixture<ChatApiFactory>, IAsyncLifetime
+{
+	private const long ReadMessagesPermission = 1L << 1;
+
+	private static readonly JsonSerializerOptions JsonOptions = new()
+	{
+		PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+		PropertyNameCaseInsensitive = true,
+	};
+
+	public Task InitializeAsync()
+	{
+		factory.GuildClient.Result = null;
+		factory.MessageRepository.Reset();
+		factory.ReactionRepository.Reset();
+		factory.Broadcaster.Reset();
+		return Task.CompletedTask;
+	}
+
+	public Task DisposeAsync() => Task.CompletedTask;
+
+	private HttpClient BuildClient(long userId)
+	{
+		var client = factory.CreateClient();
+		var token = TestTokens.Issue(ChatApiFactory.JwtSecret, userId: userId);
+		client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+		return client;
+	}
+
+	private static Message SeedChannelMessage(ChatApiFactory f, long id, long channelId, long authorId = 99, bool isDeleted = false)
+	{
+		var message = Message.Reconstitute(
+			id: id, containerId: channelId, authorId: authorId, recipientId: null,
+			content: "hello", replyToId: null, editedAt: null,
+			isDeleted: isDeleted, createdAt: DateTimeOffset.UtcNow);
+		f.MessageRepository.Seed(message);
+		return message;
+	}
+
+	private static Message SeedDirectMessage(ChatApiFactory f, long id, long conversationId, long authorId, long recipientId)
+	{
+		var message = Message.Reconstitute(
+			id: id, containerId: conversationId, authorId: authorId, recipientId: recipientId,
+			content: "hello", replyToId: null, editedAt: null,
+			isDeleted: false, createdAt: DateTimeOffset.UtcNow);
+		f.MessageRepository.Seed(message);
+		return message;
+	}
+
+	private static string ReactionUrl(long messageId, string emoji) =>
+		$"/v1/messages/{messageId}/reactions/{Uri.EscapeDataString(emoji)}";
+
+	[Fact]
+	public async Task Put_WithoutToken_Returns401()
+	{
+		var response = await factory.CreateClient().PutAsync(ReactionUrl(1, "👍"), content: null);
+
+		Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+	}
+
+	[Fact]
+	public async Task Put_HappyPath_Returns200AndBroadcasts()
+	{
+		SeedChannelMessage(factory, id: 1, channelId: 100);
+		factory.GuildClient.Result = new ChannelMembership(IsMember: true, GuildId: 5, Permissions: ReadMessagesPermission);
+		var client = BuildClient(userId: 42);
+
+		var response = await client.PutAsync(ReactionUrl(1, "👍"), content: null);
+
+		Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+		var body = await response.Content.ReadFromJsonAsync<ReactionBody>(JsonOptions);
+		Assert.NotNull(body);
+		Assert.Equal("👍", body.Emoji);
+		Assert.Equal(1, body.Count);
+		Assert.True(body.MeReacted);
+
+		var (channelId, evt) = Assert.Single(factory.Broadcaster.ReactionAddedBroadcasts);
+		Assert.Equal(100L, channelId);
+		Assert.Equal("1", evt.MessageId);
+		Assert.Equal("👍", evt.Emoji);
+		Assert.Equal(1, evt.Count);
+	}
+
+	[Fact]
+	public async Task Put_MessageNotFound_Returns404()
+	{
+		var client = BuildClient(userId: 42);
+
+		var response = await client.PutAsync(ReactionUrl(999, "👍"), content: null);
+
+		Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+	}
+
+	[Fact]
+	public async Task Put_DirectMessage_Returns404()
+	{
+		SeedDirectMessage(factory, id: 1, conversationId: 555, authorId: 42, recipientId: 100);
+		var client = BuildClient(userId: 42);
+
+		var response = await client.PutAsync(ReactionUrl(1, "👍"), content: null);
+
+		Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+		Assert.Empty(factory.Broadcaster.ReactionAddedBroadcasts);
+	}
+
+	[Fact]
+	public async Task Put_NotAMember_Returns403()
+	{
+		SeedChannelMessage(factory, id: 1, channelId: 100);
+		factory.GuildClient.Result = new ChannelMembership(IsMember: false, GuildId: 5, Permissions: 0);
+		var client = BuildClient(userId: 42);
+
+		var response = await client.PutAsync(ReactionUrl(1, "👍"), content: null);
+
+		Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+	}
+
+	[Fact]
+	public async Task Put_MissingReadPermission_Returns403()
+	{
+		SeedChannelMessage(factory, id: 1, channelId: 100);
+		factory.GuildClient.Result = new ChannelMembership(IsMember: true, GuildId: 5, Permissions: 0);
+		var client = BuildClient(userId: 42);
+
+		var response = await client.PutAsync(ReactionUrl(1, "👍"), content: null);
+
+		Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+	}
+
+	[Fact]
+	public async Task Put_Repeated_IsIdempotent_ReturnsSameCount_SingleBroadcast()
+	{
+		SeedChannelMessage(factory, id: 1, channelId: 100);
+		factory.GuildClient.Result = new ChannelMembership(IsMember: true, GuildId: 5, Permissions: ReadMessagesPermission);
+		var client = BuildClient(userId: 42);
+
+		var first = await client.PutAsync(ReactionUrl(1, "👍"), content: null);
+		var second = await client.PutAsync(ReactionUrl(1, "👍"), content: null);
+
+		Assert.Equal(HttpStatusCode.OK, first.StatusCode);
+		Assert.Equal(HttpStatusCode.OK, second.StatusCode);
+
+		var secondBody = await second.Content.ReadFromJsonAsync<ReactionBody>(JsonOptions);
+		Assert.Equal(1, secondBody!.Count);
+		Assert.Single(factory.Broadcaster.ReactionAddedBroadcasts);
+	}
+
+	[Fact]
+	public async Task Delete_HappyPath_Returns200AndBroadcasts()
+	{
+		SeedChannelMessage(factory, id: 1, channelId: 100);
+		factory.GuildClient.Result = new ChannelMembership(IsMember: true, GuildId: 5, Permissions: ReadMessagesPermission);
+		factory.ReactionRepository.Seed(channelId: 100, messageId: 1, emoji: "👍", userId: 42);
+		var client = BuildClient(userId: 42);
+
+		var response = await client.DeleteAsync(ReactionUrl(1, "👍"));
+
+		Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+		var body = await response.Content.ReadFromJsonAsync<ReactionBody>(JsonOptions);
+		Assert.NotNull(body);
+		Assert.Equal("👍", body.Emoji);
+		Assert.Equal(0, body.Count);
+		Assert.False(body.MeReacted);
+
+		var (channelId, evt) = Assert.Single(factory.Broadcaster.ReactionRemovedBroadcasts);
+		Assert.Equal(100L, channelId);
+		Assert.Equal("1", evt.MessageId);
+		Assert.Equal("👍", evt.Emoji);
+		Assert.Equal(0, evt.Count);
+	}
+
+	[Fact]
+	public async Task Delete_NeverReacted_IsIdempotent_ReturnsCurrentCount_NoBroadcast()
+	{
+		SeedChannelMessage(factory, id: 1, channelId: 100);
+		factory.GuildClient.Result = new ChannelMembership(IsMember: true, GuildId: 5, Permissions: ReadMessagesPermission);
+		var client = BuildClient(userId: 42);
+
+		var response = await client.DeleteAsync(ReactionUrl(1, "👍"));
+
+		Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+		var body = await response.Content.ReadFromJsonAsync<ReactionBody>(JsonOptions);
+		Assert.Equal(0, body!.Count);
+		Assert.Empty(factory.Broadcaster.ReactionRemovedBroadcasts);
+	}
+
+	[Fact]
+	public async Task Delete_MessageNotFound_Returns404()
+	{
+		var client = BuildClient(userId: 42);
+
+		var response = await client.DeleteAsync(ReactionUrl(999, "👍"));
+
+		Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+	}
+
+	[Fact]
+	public async Task Delete_DirectMessage_Returns404()
+	{
+		SeedDirectMessage(factory, id: 1, conversationId: 555, authorId: 42, recipientId: 100);
+		var client = BuildClient(userId: 42);
+
+		var response = await client.DeleteAsync(ReactionUrl(1, "👍"));
+
+		Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+		Assert.Empty(factory.Broadcaster.ReactionRemovedBroadcasts);
+	}
+
+	private sealed record ReactionBody(string Emoji, long Count, bool MeReacted);
+}

--- a/services/chat/tests/Chat.FunctionalTests/Features/MessageMutationTests.cs
+++ b/services/chat/tests/Chat.FunctionalTests/Features/MessageMutationTests.cs
@@ -170,3 +170,126 @@ public sealed class DeleteMessageBroadcastTests(ChatApiFactory factory)
 		Assert.False(received);
 	}
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Hub broadcast reception — ReactionAdded / ReactionRemoved
+// ─────────────────────────────────────────────────────────────────────────────
+
+public sealed class ReactionBroadcastTests(ChatApiFactory factory)
+	: IClassFixture<ChatApiFactory>, IAsyncLifetime
+{
+	private const long ReadMessages = 1L << 1;
+	private const long GuildId      = 999;
+	private const long ChannelId    = 300;
+
+	private const long UserSubscriber    = 7_001;
+	private const long UserNonSubscriber = 7_002;
+
+	public Task InitializeAsync()
+	{
+		factory.GuildClient.Result = null;
+		factory.MessageRepository.Reset();
+		factory.Broadcaster.Reset();
+		return Task.CompletedTask;
+	}
+
+	public Task DisposeAsync() => Task.CompletedTask;
+
+	[Fact]
+	public async Task ReactionAdded_SubscriberInGroup_ReceivesEventWithCorrectPayload()
+	{
+		factory.WithMembershipFor(ChannelId, UserSubscriber, GuildId, ReadMessages);
+		var token = TestTokens.Issue(ChatApiFactory.JwtSecret, UserSubscriber);
+		await using var conn = HubConnectionHelper.Build(factory, token);
+
+		var tcs = new TaskCompletionSource<ReactionAddedEvent>();
+		conn.On<ReactionAddedEvent>("ReactionAdded", evt => tcs.TrySetResult(evt));
+
+		await conn.StartAsync();
+		await conn.InvokeAsync("JoinChannel", ChannelId);
+
+		var sentEvt = new ReactionAddedEvent(
+			MessageId: "42",
+			ChannelId: ChannelId.ToString(),
+			UserId: "99",
+			Emoji: "👍",
+			Count: 3);
+
+		await factory.SimulateReactionAddedAsync(ChannelId, sentEvt);
+
+		var received = await tcs.Task.WaitAsync(TimeSpan.FromSeconds(3));
+		Assert.Equal("42", received.MessageId);
+		Assert.Equal(ChannelId.ToString(), received.ChannelId);
+		Assert.Equal("99", received.UserId);
+		Assert.Equal("👍", received.Emoji);
+		Assert.Equal(3, received.Count);
+	}
+
+	[Fact]
+	public async Task ReactionAdded_NonSubscriber_DoesNotReceive()
+	{
+		var token = TestTokens.Issue(ChatApiFactory.JwtSecret, UserNonSubscriber);
+		await using var conn = HubConnectionHelper.Build(factory, token);
+
+		var received = false;
+		conn.On<ReactionAddedEvent>("ReactionAdded", _ => received = true);
+
+		await conn.StartAsync();
+		// intentionally no JoinChannel
+
+		await factory.SimulateReactionAddedAsync(ChannelId,
+			new ReactionAddedEvent("1", ChannelId.ToString(), "99", "👍", 1));
+
+		await Task.Delay(300);
+		Assert.False(received);
+	}
+
+	[Fact]
+	public async Task ReactionRemoved_SubscriberInGroup_ReceivesEventWithCorrectPayload()
+	{
+		factory.WithMembershipFor(ChannelId, UserSubscriber, GuildId, ReadMessages);
+		var token = TestTokens.Issue(ChatApiFactory.JwtSecret, UserSubscriber);
+		await using var conn = HubConnectionHelper.Build(factory, token);
+
+		var tcs = new TaskCompletionSource<ReactionRemovedEvent>();
+		conn.On<ReactionRemovedEvent>("ReactionRemoved", evt => tcs.TrySetResult(evt));
+
+		await conn.StartAsync();
+		await conn.InvokeAsync("JoinChannel", ChannelId);
+
+		var sentEvt = new ReactionRemovedEvent(
+			MessageId: "42",
+			ChannelId: ChannelId.ToString(),
+			UserId: "99",
+			Emoji: "👍",
+			Count: 2);
+
+		await factory.SimulateReactionRemovedAsync(ChannelId, sentEvt);
+
+		var received = await tcs.Task.WaitAsync(TimeSpan.FromSeconds(3));
+		Assert.Equal("42", received.MessageId);
+		Assert.Equal(ChannelId.ToString(), received.ChannelId);
+		Assert.Equal("99", received.UserId);
+		Assert.Equal("👍", received.Emoji);
+		Assert.Equal(2, received.Count);
+	}
+
+	[Fact]
+	public async Task ReactionRemoved_NonSubscriber_DoesNotReceive()
+	{
+		var token = TestTokens.Issue(ChatApiFactory.JwtSecret, UserNonSubscriber);
+		await using var conn = HubConnectionHelper.Build(factory, token);
+
+		var received = false;
+		conn.On<ReactionRemovedEvent>("ReactionRemoved", _ => received = true);
+
+		await conn.StartAsync();
+		// intentionally no JoinChannel
+
+		await factory.SimulateReactionRemovedAsync(ChannelId,
+			new ReactionRemovedEvent("1", ChannelId.ToString(), "99", "👍", 0));
+
+		await Task.Delay(300);
+		Assert.False(received);
+	}
+}

--- a/services/chat/tests/Chat.FunctionalTests/Infrastructure/ChatApiFactory.cs
+++ b/services/chat/tests/Chat.FunctionalTests/Infrastructure/ChatApiFactory.cs
@@ -86,6 +86,18 @@ public sealed class ChatApiFactory : WebApplicationFactory<Program>
 			new ChannelMessageDeletedEvent(messageId.ToString(), channelId.ToString()));
 	}
 
+	public async Task SimulateReactionAddedAsync(long channelId, ReactionAddedEvent evt)
+	{
+		var hub = Server.Services.GetRequiredService<IHubContext<ChatHub, IChatClient>>();
+		await hub.Clients.Group($"channel:{channelId}").ReactionAdded(evt);
+	}
+
+	public async Task SimulateReactionRemovedAsync(long channelId, ReactionRemovedEvent evt)
+	{
+		var hub = Server.Services.GetRequiredService<IHubContext<ChatHub, IChatClient>>();
+		await hub.Clients.Group($"channel:{channelId}").ReactionRemoved(evt);
+	}
+
 	// Directly calls the real SignalRUserBroadcaster (not a fake) so that
 	// connected hub clients receive GuildJoined/GuildLeft invocations.
 	// MassTransit is stripped in tests, so consumers cannot be triggered via

--- a/services/chat/tests/Chat.FunctionalTests/Infrastructure/ChatApiFactory.cs
+++ b/services/chat/tests/Chat.FunctionalTests/Infrastructure/ChatApiFactory.cs
@@ -40,6 +40,7 @@ public sealed class ChatApiFactory : WebApplicationFactory<Program>
 	public FakeMessageRepository MessageRepository { get; } = new();
 	public FakeAttachmentRepository AttachmentRepository { get; } = new();
 	public FakeDataExportRepository DataExportRepository { get; } = new();
+	public FakeReactionRepository ReactionRepository { get; } = new();
 	public FakeObjectStore ObjectStore { get; } = new();
 	public FakeEventBus EventBus { get; } = new();
 	public FakeChannelBroadcaster Broadcaster { get; } = new();
@@ -200,6 +201,10 @@ public sealed class ChatApiFactory : WebApplicationFactory<Program>
 			// the real DataExportRepository needs ISession (stripped above)
 			services.RemoveAll<IDataExportRepository>();
 			services.AddSingleton<IDataExportRepository>(DataExportRepository);
+
+			// same story as IAttachmentRepository: the real ReactionRepository needs ISession
+			services.RemoveAll<IReactionRepository>();
+			services.AddSingleton<IReactionRepository>(ReactionRepository);
 
 			// the real MinioObjectStore would dial MinIO; serve attachment blobs
 			// from memory instead so the upload/download endpoints stay hermetic

--- a/services/chat/tests/Chat.UnitTests/Application/AddReactionHandlerTests.cs
+++ b/services/chat/tests/Chat.UnitTests/Application/AddReactionHandlerTests.cs
@@ -1,0 +1,200 @@
+using Chat.Application.Abstractions;
+using Chat.Application.Abstractions.Messaging;
+using Chat.Application.Features.Channels.Common;
+using Chat.Application.Features.Reactions.AddReaction;
+using Chat.Domain.Messages;
+using Chat.Domain.Results;
+using Chat.UnitTests.Fakes;
+using Xunit;
+
+namespace Chat.UnitTests.Application;
+
+public sealed class AddReactionHandlerTests
+{
+	private const long ReadMessagesPermission = 1L << 1;
+	private const long AdministratorPermission = 1L << 8;
+
+	private sealed record Harness(
+		FakeCurrentUser CurrentUser,
+		FakeMessageRepository Repository,
+		FakeReactionRepository ReactionRepository,
+		FakeGuildClient GuildClient,
+		FakeClock Clock,
+		FakeChannelBroadcaster Broadcaster);
+
+	private static (Harness Harness, ICommandHandler<AddReactionCommand, Result<ReactionResponse>> Handler)
+		BuildHandler(long userId = 42)
+	{
+		var currentUser = new FakeCurrentUser { UserId = userId };
+		var repository = new FakeMessageRepository();
+		var reactionRepository = new FakeReactionRepository();
+		var guildClient = new FakeGuildClient();
+		var clock = new FakeClock();
+		var broadcaster = new FakeChannelBroadcaster();
+
+		var handler = HandlerFactory.CreateCommand<AddReactionCommand, Result<ReactionResponse>>(
+			currentUser, repository, reactionRepository, guildClient, clock, broadcaster);
+
+		return (new Harness(currentUser, repository, reactionRepository, guildClient, clock, broadcaster), handler);
+	}
+
+	private static Message SeedChannelMessage(FakeMessageRepository repo, long id = 1, long channelId = 100, long authorId = 99, bool isDeleted = false)
+	{
+		var message = Message.Reconstitute(
+			id: id, containerId: channelId, authorId: authorId, recipientId: null,
+			content: "hello", replyToId: null, editedAt: null,
+			isDeleted: isDeleted, createdAt: DateTimeOffset.UtcNow);
+		repo.Seed(message);
+		return message;
+	}
+
+	private static Message SeedDirectMessage(FakeMessageRepository repo, long id, long conversationId, long authorId, long recipientId)
+	{
+		var message = Message.Reconstitute(
+			id: id, containerId: conversationId, authorId: authorId, recipientId: recipientId,
+			content: "hello", replyToId: null, editedAt: null,
+			isDeleted: false, createdAt: DateTimeOffset.UtcNow);
+		repo.Seed(message);
+		return message;
+	}
+
+	[Fact]
+	public async Task EmptyEmoji_ReturnsEmojiRequired_NoSideEffects()
+	{
+		var (h, handler) = BuildHandler();
+		SeedChannelMessage(h.Repository);
+
+		var result = await handler.HandleAsync(new AddReactionCommand(MessageId: 1, Emoji: "   "));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal(ReactionFailures.EmojiRequired, result.Error);
+		Assert.Empty(h.Broadcaster.ReactionAddedBroadcasts);
+	}
+
+	[Fact]
+	public async Task EmojiTooLong_ReturnsEmojiTooLong_NoSideEffects()
+	{
+		var (h, handler) = BuildHandler();
+		SeedChannelMessage(h.Repository);
+
+		var result = await handler.HandleAsync(new AddReactionCommand(MessageId: 1, Emoji: new string('x', 33)));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal(ReactionFailures.EmojiTooLong, result.Error);
+		Assert.Empty(h.Broadcaster.ReactionAddedBroadcasts);
+	}
+
+	[Fact]
+	public async Task MessageNotFound_ReturnsNotFound_NoSideEffects()
+	{
+		var (h, handler) = BuildHandler();
+
+		var result = await handler.HandleAsync(new AddReactionCommand(MessageId: 999, Emoji: "👍"));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal(MessageFailures.NotFound, result.Error);
+		Assert.Empty(h.Broadcaster.ReactionAddedBroadcasts);
+	}
+
+	[Fact]
+	public async Task DeletedMessage_ReturnsNotFound_NoSideEffects()
+	{
+		var (h, handler) = BuildHandler();
+		SeedChannelMessage(h.Repository, isDeleted: true);
+
+		var result = await handler.HandleAsync(new AddReactionCommand(MessageId: 1, Emoji: "👍"));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal(MessageFailures.NotFound, result.Error);
+	}
+
+	[Fact]
+	public async Task DirectMessage_ReturnsIsDirectMessage_NoSideEffects()
+	{
+		var (h, handler) = BuildHandler(userId: 42);
+		SeedDirectMessage(h.Repository, id: 1, conversationId: 555, authorId: 42, recipientId: 100);
+
+		var result = await handler.HandleAsync(new AddReactionCommand(MessageId: 1, Emoji: "👍"));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal(ReactionFailures.IsDirectMessage, result.Error);
+		Assert.Empty(h.Broadcaster.ReactionAddedBroadcasts);
+	}
+
+	[Fact]
+	public async Task NotAMember_ReturnsMissingReadPermission_NoSideEffects()
+	{
+		var (h, handler) = BuildHandler();
+		SeedChannelMessage(h.Repository);
+		h.GuildClient.Result = new ChannelMembership(IsMember: false, GuildId: 5, Permissions: ReadMessagesPermission);
+
+		var result = await handler.HandleAsync(new AddReactionCommand(MessageId: 1, Emoji: "👍"));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal(MessageFailures.MissingReadPermission, result.Error);
+	}
+
+	[Fact]
+	public async Task MemberWithoutReadPermission_ReturnsMissingReadPermission_NoSideEffects()
+	{
+		var (h, handler) = BuildHandler();
+		SeedChannelMessage(h.Repository);
+		h.GuildClient.Result = new ChannelMembership(IsMember: true, GuildId: 5, Permissions: 0);
+
+		var result = await handler.HandleAsync(new AddReactionCommand(MessageId: 1, Emoji: "👍"));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal(MessageFailures.MissingReadPermission, result.Error);
+	}
+
+	[Fact]
+	public async Task Administrator_BypassesReadPermissionCheck()
+	{
+		var (h, handler) = BuildHandler(userId: 42);
+		SeedChannelMessage(h.Repository, id: 1, channelId: 100);
+		h.GuildClient.Result = new ChannelMembership(IsMember: true, GuildId: 5, Permissions: AdministratorPermission);
+
+		var result = await handler.HandleAsync(new AddReactionCommand(MessageId: 1, Emoji: "👍"));
+
+		Assert.True(result.Succeeded);
+	}
+
+	[Fact]
+	public async Task HappyPath_AddsReaction_Broadcasts_ReturnsMeReactedTrue()
+	{
+		var (h, handler) = BuildHandler(userId: 42);
+		SeedChannelMessage(h.Repository, id: 1, channelId: 100);
+		h.GuildClient.Result = new ChannelMembership(IsMember: true, GuildId: 5, Permissions: ReadMessagesPermission);
+
+		var result = await handler.HandleAsync(new AddReactionCommand(MessageId: 1, Emoji: "👍"));
+
+		Assert.True(result.Succeeded);
+		Assert.Equal("👍", result.Value.Emoji);
+		Assert.Equal(1, result.Value.Count);
+		Assert.True(result.Value.MeReacted);
+
+		var (channelId, evt) = Assert.Single(h.Broadcaster.ReactionAddedBroadcasts);
+		Assert.Equal(100L, channelId);
+		Assert.Equal("1", evt.MessageId);
+		Assert.Equal("100", evt.ChannelId);
+		Assert.Equal("42", evt.UserId);
+		Assert.Equal("👍", evt.Emoji);
+		Assert.Equal(1, evt.Count);
+	}
+
+	[Fact]
+	public async Task AlreadyReacted_IsIdempotent_NoBroadcast_ReturnsCurrentCount()
+	{
+		var (h, handler) = BuildHandler(userId: 42);
+		SeedChannelMessage(h.Repository, id: 1, channelId: 100);
+		h.GuildClient.Result = new ChannelMembership(IsMember: true, GuildId: 5, Permissions: ReadMessagesPermission);
+		h.ReactionRepository.Seed(channelId: 100, messageId: 1, emoji: "👍", userId: 42);
+
+		var result = await handler.HandleAsync(new AddReactionCommand(MessageId: 1, Emoji: "👍"));
+
+		Assert.True(result.Succeeded);
+		Assert.Equal(1, result.Value.Count);
+		Assert.True(result.Value.MeReacted);
+		Assert.Empty(h.Broadcaster.ReactionAddedBroadcasts);
+	}
+}

--- a/services/chat/tests/Chat.UnitTests/Application/GetChannelMessagesHandlerTests.cs
+++ b/services/chat/tests/Chat.UnitTests/Application/GetChannelMessagesHandlerTests.cs
@@ -20,6 +20,7 @@ public sealed class GetChannelMessagesHandlerTests
 		FakeGuildClient GuildClient,
 		FakeMessageRepository Repository,
 		FakeAttachmentRepository AttachmentRepository,
+		FakeReactionRepository ReactionRepository,
 		FakeClock Clock);
 
 	private static (Harness Harness, IQueryHandler<GetChannelMessagesQuery, Result<IReadOnlyList<ChannelMessageResponse>>> Handler)
@@ -29,12 +30,13 @@ public sealed class GetChannelMessagesHandlerTests
 		var guildClient = new FakeGuildClient();
 		var repository = new FakeMessageRepository();
 		var attachmentRepository = new FakeAttachmentRepository();
+		var reactionRepository = new FakeReactionRepository();
 		var clock = new FakeClock();
 
 		var handler = HandlerFactory.CreateQuery<GetChannelMessagesQuery, Result<IReadOnlyList<ChannelMessageResponse>>>(
-			currentUser, guildClient, repository, attachmentRepository, clock);
+			currentUser, guildClient, repository, attachmentRepository, reactionRepository, clock);
 
-		return (new Harness(currentUser, guildClient, repository, attachmentRepository, clock), handler);
+		return (new Harness(currentUser, guildClient, repository, attachmentRepository, reactionRepository, clock), handler);
 	}
 
 	private static Message SeedMessage(FakeMessageRepository repo, long id, long channelId, DateTimeOffset createdAt, bool isDeleted = false)
@@ -142,6 +144,37 @@ public sealed class GetChannelMessagesHandlerTests
 		// the other message hydrates to an empty list, not null
 		var withoutAttachment = Assert.Single(result.Value, m => m.Id == "1");
 		Assert.Empty(withoutAttachment.Attachments);
+	}
+
+	[Fact]
+	public async Task HydratesReactions_PerMessage_WithMeReactedForCaller()
+	{
+		var (h, handler) = BuildHandler(userId: 42);
+		h.GuildClient.Result = new ChannelMembership(IsMember: true, GuildId: 5, Permissions: ReadMessagesPermission);
+
+		var anchor = new DateTimeOffset(2026, 1, 1, 12, 0, 0, TimeSpan.Zero);
+		SeedMessage(h.Repository, id: 1, channelId: 100, createdAt: anchor.AddMinutes(-10));
+		SeedMessage(h.Repository, id: 2, channelId: 100, createdAt: anchor.AddMinutes(-5));
+
+		// message 1: the caller reacted; message 2: someone else reacted, caller didn't
+		h.ReactionRepository.Seed(channelId: 100, messageId: 1, emoji: "👍", userId: 42);
+		h.ReactionRepository.Seed(channelId: 100, messageId: 2, emoji: "🔥", userId: 7);
+
+		var result = await handler.HandleAsync(new GetChannelMessagesQuery(ChannelId: 100, BeforeTime: anchor, Limit: 50));
+
+		Assert.True(result.Succeeded);
+
+		var withMyReaction = Assert.Single(result.Value, m => m.Id == "1");
+		var reaction1 = Assert.Single(withMyReaction.Reactions);
+		Assert.Equal("👍", reaction1.Emoji);
+		Assert.Equal(1, reaction1.Count);
+		Assert.True(reaction1.MeReacted);
+
+		var withOthersReaction = Assert.Single(result.Value, m => m.Id == "2");
+		var reaction2 = Assert.Single(withOthersReaction.Reactions);
+		Assert.Equal("🔥", reaction2.Emoji);
+		Assert.Equal(1, reaction2.Count);
+		Assert.False(reaction2.MeReacted);
 	}
 
 	[Fact]

--- a/services/chat/tests/Chat.UnitTests/Application/GetChannelMessagesHandlerTests.cs
+++ b/services/chat/tests/Chat.UnitTests/Application/GetChannelMessagesHandlerTests.cs
@@ -178,6 +178,25 @@ public sealed class GetChannelMessagesHandlerTests
 	}
 
 	[Fact]
+	public async Task AddThenRemoveReaction_ReturnsNoReactions_NoGhostZeroCountEntry()
+	{
+		var (h, handler) = BuildHandler(userId: 42);
+		h.GuildClient.Result = new ChannelMembership(IsMember: true, GuildId: 5, Permissions: ReadMessagesPermission);
+
+		var anchor = new DateTimeOffset(2026, 1, 1, 12, 0, 0, TimeSpan.Zero);
+		SeedMessage(h.Repository, id: 1, channelId: 100, createdAt: anchor.AddMinutes(-10));
+
+		await h.ReactionRepository.AddAsync(channelId: 100, messageId: 1, userId: 42, emoji: "👍", now: anchor, ct: default);
+		await h.ReactionRepository.RemoveAsync(channelId: 100, messageId: 1, userId: 42, emoji: "👍", ct: default);
+
+		var result = await handler.HandleAsync(new GetChannelMessagesQuery(ChannelId: 100, BeforeTime: anchor, Limit: 50));
+
+		Assert.True(result.Succeeded);
+		var message = Assert.Single(result.Value, m => m.Id == "1");
+		Assert.Empty(message.Reactions);
+	}
+
+	[Fact]
 	public async Task Administrator_BypassesReadPermissionCheck()
 	{
 		var (h, handler) = BuildHandler();

--- a/services/chat/tests/Chat.UnitTests/Application/RemoveReactionHandlerTests.cs
+++ b/services/chat/tests/Chat.UnitTests/Application/RemoveReactionHandlerTests.cs
@@ -1,0 +1,200 @@
+using Chat.Application.Abstractions;
+using Chat.Application.Abstractions.Messaging;
+using Chat.Application.Features.Channels.Common;
+using Chat.Application.Features.Reactions.RemoveReaction;
+using Chat.Domain.Messages;
+using Chat.Domain.Results;
+using Chat.UnitTests.Fakes;
+using Xunit;
+
+namespace Chat.UnitTests.Application;
+
+public sealed class RemoveReactionHandlerTests
+{
+	private const long ReadMessagesPermission = 1L << 1;
+	private const long AdministratorPermission = 1L << 8;
+
+	private sealed record Harness(
+		FakeCurrentUser CurrentUser,
+		FakeMessageRepository Repository,
+		FakeReactionRepository ReactionRepository,
+		FakeGuildClient GuildClient,
+		FakeChannelBroadcaster Broadcaster);
+
+	private static (Harness Harness, ICommandHandler<RemoveReactionCommand, Result<ReactionResponse>> Handler)
+		BuildHandler(long userId = 42)
+	{
+		var currentUser = new FakeCurrentUser { UserId = userId };
+		var repository = new FakeMessageRepository();
+		var reactionRepository = new FakeReactionRepository();
+		var guildClient = new FakeGuildClient();
+		var broadcaster = new FakeChannelBroadcaster();
+
+		var handler = HandlerFactory.CreateCommand<RemoveReactionCommand, Result<ReactionResponse>>(
+			currentUser, repository, reactionRepository, guildClient, broadcaster);
+
+		return (new Harness(currentUser, repository, reactionRepository, guildClient, broadcaster), handler);
+	}
+
+	private static Message SeedChannelMessage(FakeMessageRepository repo, long id = 1, long channelId = 100, long authorId = 99, bool isDeleted = false)
+	{
+		var message = Message.Reconstitute(
+			id: id, containerId: channelId, authorId: authorId, recipientId: null,
+			content: "hello", replyToId: null, editedAt: null,
+			isDeleted: isDeleted, createdAt: DateTimeOffset.UtcNow);
+		repo.Seed(message);
+		return message;
+	}
+
+	private static Message SeedDirectMessage(FakeMessageRepository repo, long id, long conversationId, long authorId, long recipientId)
+	{
+		var message = Message.Reconstitute(
+			id: id, containerId: conversationId, authorId: authorId, recipientId: recipientId,
+			content: "hello", replyToId: null, editedAt: null,
+			isDeleted: false, createdAt: DateTimeOffset.UtcNow);
+		repo.Seed(message);
+		return message;
+	}
+
+	[Fact]
+	public async Task EmptyEmoji_ReturnsEmojiRequired_NoSideEffects()
+	{
+		var (h, handler) = BuildHandler();
+		SeedChannelMessage(h.Repository);
+
+		var result = await handler.HandleAsync(new RemoveReactionCommand(MessageId: 1, Emoji: "   "));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal(ReactionFailures.EmojiRequired, result.Error);
+		Assert.Empty(h.Broadcaster.ReactionRemovedBroadcasts);
+	}
+
+	[Fact]
+	public async Task EmojiTooLong_ReturnsEmojiTooLong_NoSideEffects()
+	{
+		var (h, handler) = BuildHandler();
+		SeedChannelMessage(h.Repository);
+
+		var result = await handler.HandleAsync(new RemoveReactionCommand(MessageId: 1, Emoji: new string('x', 33)));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal(ReactionFailures.EmojiTooLong, result.Error);
+		Assert.Empty(h.Broadcaster.ReactionRemovedBroadcasts);
+	}
+
+	[Fact]
+	public async Task MessageNotFound_ReturnsNotFound_NoSideEffects()
+	{
+		var (h, handler) = BuildHandler();
+
+		var result = await handler.HandleAsync(new RemoveReactionCommand(MessageId: 999, Emoji: "👍"));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal(MessageFailures.NotFound, result.Error);
+		Assert.Empty(h.Broadcaster.ReactionRemovedBroadcasts);
+	}
+
+	[Fact]
+	public async Task DeletedMessage_ReturnsNotFound_NoSideEffects()
+	{
+		var (h, handler) = BuildHandler();
+		SeedChannelMessage(h.Repository, isDeleted: true);
+
+		var result = await handler.HandleAsync(new RemoveReactionCommand(MessageId: 1, Emoji: "👍"));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal(MessageFailures.NotFound, result.Error);
+	}
+
+	[Fact]
+	public async Task DirectMessage_ReturnsIsDirectMessage_NoSideEffects()
+	{
+		var (h, handler) = BuildHandler(userId: 42);
+		SeedDirectMessage(h.Repository, id: 1, conversationId: 555, authorId: 42, recipientId: 100);
+
+		var result = await handler.HandleAsync(new RemoveReactionCommand(MessageId: 1, Emoji: "👍"));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal(ReactionFailures.IsDirectMessage, result.Error);
+		Assert.Empty(h.Broadcaster.ReactionRemovedBroadcasts);
+	}
+
+	[Fact]
+	public async Task NotAMember_ReturnsMissingReadPermission_NoSideEffects()
+	{
+		var (h, handler) = BuildHandler();
+		SeedChannelMessage(h.Repository);
+		h.GuildClient.Result = new ChannelMembership(IsMember: false, GuildId: 5, Permissions: ReadMessagesPermission);
+
+		var result = await handler.HandleAsync(new RemoveReactionCommand(MessageId: 1, Emoji: "👍"));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal(MessageFailures.MissingReadPermission, result.Error);
+	}
+
+	[Fact]
+	public async Task MemberWithoutReadPermission_ReturnsMissingReadPermission_NoSideEffects()
+	{
+		var (h, handler) = BuildHandler();
+		SeedChannelMessage(h.Repository);
+		h.GuildClient.Result = new ChannelMembership(IsMember: true, GuildId: 5, Permissions: 0);
+
+		var result = await handler.HandleAsync(new RemoveReactionCommand(MessageId: 1, Emoji: "👍"));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal(MessageFailures.MissingReadPermission, result.Error);
+	}
+
+	[Fact]
+	public async Task Administrator_BypassesReadPermissionCheck()
+	{
+		var (h, handler) = BuildHandler(userId: 42);
+		SeedChannelMessage(h.Repository, id: 1, channelId: 100);
+		h.GuildClient.Result = new ChannelMembership(IsMember: true, GuildId: 5, Permissions: AdministratorPermission);
+		h.ReactionRepository.Seed(channelId: 100, messageId: 1, emoji: "👍", userId: 42);
+
+		var result = await handler.HandleAsync(new RemoveReactionCommand(MessageId: 1, Emoji: "👍"));
+
+		Assert.True(result.Succeeded);
+	}
+
+	[Fact]
+	public async Task HappyPath_RemovesReaction_Broadcasts_ReturnsMeReactedFalse()
+	{
+		var (h, handler) = BuildHandler(userId: 42);
+		SeedChannelMessage(h.Repository, id: 1, channelId: 100);
+		h.GuildClient.Result = new ChannelMembership(IsMember: true, GuildId: 5, Permissions: ReadMessagesPermission);
+		h.ReactionRepository.Seed(channelId: 100, messageId: 1, emoji: "👍", userId: 42);
+		h.ReactionRepository.Seed(channelId: 100, messageId: 1, emoji: "👍", userId: 7);
+
+		var result = await handler.HandleAsync(new RemoveReactionCommand(MessageId: 1, Emoji: "👍"));
+
+		Assert.True(result.Succeeded);
+		Assert.Equal("👍", result.Value.Emoji);
+		Assert.Equal(1, result.Value.Count);
+		Assert.False(result.Value.MeReacted);
+
+		var (channelId, evt) = Assert.Single(h.Broadcaster.ReactionRemovedBroadcasts);
+		Assert.Equal(100L, channelId);
+		Assert.Equal("1", evt.MessageId);
+		Assert.Equal("100", evt.ChannelId);
+		Assert.Equal("42", evt.UserId);
+		Assert.Equal("👍", evt.Emoji);
+		Assert.Equal(1, evt.Count);
+	}
+
+	[Fact]
+	public async Task NotReacted_IsIdempotent_NoBroadcast_ReturnsCurrentCount()
+	{
+		var (h, handler) = BuildHandler(userId: 42);
+		SeedChannelMessage(h.Repository, id: 1, channelId: 100);
+		h.GuildClient.Result = new ChannelMembership(IsMember: true, GuildId: 5, Permissions: ReadMessagesPermission);
+
+		var result = await handler.HandleAsync(new RemoveReactionCommand(MessageId: 1, Emoji: "👍"));
+
+		Assert.True(result.Succeeded);
+		Assert.Equal(0, result.Value.Count);
+		Assert.False(result.Value.MeReacted);
+		Assert.Empty(h.Broadcaster.ReactionRemovedBroadcasts);
+	}
+}

--- a/services/chat/tests/Chat.UnitTests/Application/SendChannelMessageHandlerTests.cs
+++ b/services/chat/tests/Chat.UnitTests/Application/SendChannelMessageHandlerTests.cs
@@ -24,7 +24,8 @@ public sealed class SendChannelMessageHandlerTests
 		FakeIdGenerator IdGenerator,
 		FakeClock Clock,
 		FakeEventBus EventBus,
-		FakeChannelBroadcaster Broadcaster);
+		FakeChannelBroadcaster Broadcaster,
+		FakeReactionRepository ReactionRepository);
 
 	private static (Harness Harness,
 		Chat.Application.Abstractions.Messaging.ICommandHandler<SendChannelMessageCommand, Result<ChannelMessageResponse>> Handler)
@@ -38,11 +39,12 @@ public sealed class SendChannelMessageHandlerTests
 		var clock = new FakeClock();
 		var eventBus = new FakeEventBus();
 		var broadcaster = new FakeChannelBroadcaster();
+		var reactionRepository = new FakeReactionRepository();
 
 		var handler = HandlerFactory.CreateCommand<SendChannelMessageCommand, Result<ChannelMessageResponse>>(
-			currentUser, repository, attachmentRepository, ids, clock, guildClient, eventBus, broadcaster);
+			currentUser, repository, attachmentRepository, ids, clock, guildClient, eventBus, broadcaster, reactionRepository);
 
-		return (new Harness(currentUser, guildClient, repository, attachmentRepository, ids, clock, eventBus, broadcaster), handler);
+		return (new Harness(currentUser, guildClient, repository, attachmentRepository, ids, clock, eventBus, broadcaster, reactionRepository), handler);
 	}
 
 	[Fact]
@@ -197,6 +199,30 @@ public sealed class SendChannelMessageHandlerTests
 		Assert.Single(h.Repository.Saved);
 		Assert.Empty(h.EventBus.Published);
 		Assert.Empty(h.Broadcaster.Broadcasts);
+	}
+
+	[Fact]
+	public async Task NonceDedupHit_WithAccruedReactions_HydratesRealReactions()
+	{
+		var (h, handler) = BuildHandler(userId: 42);
+		h.GuildClient.Result = new ChannelMembership(IsMember: true, GuildId: 9, Permissions: SendMessagesPermission);
+
+		var first = await handler.HandleAsync(new SendChannelMessageCommand(ChannelId: 100, Content: "hello", ReplyToId: null, AttachmentIds: [], Nonce: "my-nonce"));
+		Assert.True(first.Succeeded);
+		Assert.Empty(first.Value.Reactions);
+
+		// another user reacted to the message after the original send, before the client retried
+		var saved = Assert.Single(h.Repository.Saved);
+		h.ReactionRepository.Seed(saved.ContainerId, saved.Id, "👍", userId: 7);
+
+		var second = await handler.HandleAsync(new SendChannelMessageCommand(ChannelId: 100, Content: "hello", ReplyToId: null, AttachmentIds: [], Nonce: "my-nonce"));
+
+		Assert.True(second.Succeeded);
+		Assert.Equal(first.Value.Id, second.Value.Id);
+		var reaction = Assert.Single(second.Value.Reactions);
+		Assert.Equal("👍", reaction.Emoji);
+		Assert.Equal(1, reaction.Count);
+		Assert.False(reaction.MeReacted);
 	}
 
 	[Fact]

--- a/services/chat/tests/Chat.UnitTests/Fakes/FakeChannelBroadcaster.cs
+++ b/services/chat/tests/Chat.UnitTests/Fakes/FakeChannelBroadcaster.cs
@@ -8,16 +8,22 @@ public sealed class FakeChannelBroadcaster : IChannelBroadcaster
 	private readonly List<(long ChannelId, ChannelMessageResponse Message)> _broadcasts = [];
 	private readonly List<(long ChannelId, ChannelMessageEditedEvent Evt)> _editedBroadcasts = [];
 	private readonly List<(long ChannelId, long MessageId)> _deletedBroadcasts = [];
+	private readonly List<(long ChannelId, ReactionAddedEvent Evt)> _reactionAddedBroadcasts = [];
+	private readonly List<(long ChannelId, ReactionRemovedEvent Evt)> _reactionRemovedBroadcasts = [];
 
 	public IReadOnlyList<(long ChannelId, ChannelMessageResponse Message)> Broadcasts => _broadcasts;
 	public IReadOnlyList<(long ChannelId, ChannelMessageEditedEvent Evt)> EditedBroadcasts => _editedBroadcasts;
 	public IReadOnlyList<(long ChannelId, long MessageId)> DeletedBroadcasts => _deletedBroadcasts;
+	public IReadOnlyList<(long ChannelId, ReactionAddedEvent Evt)> ReactionAddedBroadcasts => _reactionAddedBroadcasts;
+	public IReadOnlyList<(long ChannelId, ReactionRemovedEvent Evt)> ReactionRemovedBroadcasts => _reactionRemovedBroadcasts;
 
 	public void Reset()
 	{
 		_broadcasts.Clear();
 		_editedBroadcasts.Clear();
 		_deletedBroadcasts.Clear();
+		_reactionAddedBroadcasts.Clear();
+		_reactionRemovedBroadcasts.Clear();
 	}
 
 	public Task BroadcastMessageAsync(long channelId, ChannelMessageResponse message, CancellationToken ct)
@@ -35,6 +41,18 @@ public sealed class FakeChannelBroadcaster : IChannelBroadcaster
 	public Task BroadcastMessageDeletedAsync(long channelId, long messageId, CancellationToken ct)
 	{
 		_deletedBroadcasts.Add((channelId, messageId));
+		return Task.CompletedTask;
+	}
+
+	public Task BroadcastReactionAddedAsync(long channelId, ReactionAddedEvent evt, CancellationToken ct)
+	{
+		_reactionAddedBroadcasts.Add((channelId, evt));
+		return Task.CompletedTask;
+	}
+
+	public Task BroadcastReactionRemovedAsync(long channelId, ReactionRemovedEvent evt, CancellationToken ct)
+	{
+		_reactionRemovedBroadcasts.Add((channelId, evt));
 		return Task.CompletedTask;
 	}
 }

--- a/services/chat/tests/Chat.UnitTests/Fakes/FakeReactionRepository.cs
+++ b/services/chat/tests/Chat.UnitTests/Fakes/FakeReactionRepository.cs
@@ -1,0 +1,67 @@
+using Chat.Application.Abstractions.Persistence;
+using Chat.Domain.Reactions;
+
+namespace Chat.UnitTests.Fakes;
+
+/// <summary>
+/// in-memory <see cref="IReactionRepository"/>. mirrors the real repo's per-user
+/// set semantics: adding/removing returns whether the set actually changed, so
+/// handler idempotency (no-op repeat calls, no double broadcast) is exercisable
+/// </summary>
+public sealed class FakeReactionRepository : IReactionRepository
+{
+	private readonly Dictionary<(long ChannelId, long MessageId, string Emoji), HashSet<long>> _reactions = [];
+
+	public void Reset() => _reactions.Clear();
+
+	/// <summary>seed an existing reaction, e.g. to test the idempotent no-op path</summary>
+	public void Seed(long channelId, long messageId, string emoji, long userId)
+	{
+		if (!_reactions.TryGetValue((channelId, messageId, emoji), out var set))
+			_reactions[(channelId, messageId, emoji)] = set = [];
+		set.Add(userId);
+	}
+
+	public Task<bool> AddAsync(long channelId, long messageId, long userId, string emoji, DateTimeOffset now, CancellationToken ct)
+	{
+		if (!_reactions.TryGetValue((channelId, messageId, emoji), out var set))
+			_reactions[(channelId, messageId, emoji)] = set = [];
+		return Task.FromResult(set.Add(userId));
+	}
+
+	public Task<bool> RemoveAsync(long channelId, long messageId, long userId, string emoji, CancellationToken ct)
+	{
+		var applied = _reactions.TryGetValue((channelId, messageId, emoji), out var set) && set.Remove(userId);
+		return Task.FromResult(applied);
+	}
+
+	public Task<long> GetCountAsync(long channelId, long messageId, string emoji, CancellationToken ct)
+	{
+		var count = _reactions.TryGetValue((channelId, messageId, emoji), out var set) ? set.Count : 0;
+		return Task.FromResult((long)count);
+	}
+
+	public Task<IReadOnlyList<ReactionSummary>> GetMessageReactionsAsync(
+		long channelId, long messageId, long currentUserId, CancellationToken ct)
+	{
+		IReadOnlyList<ReactionSummary> result = _reactions
+			.Where(e => e.Key.ChannelId == channelId && e.Key.MessageId == messageId)
+			.Select(e => new ReactionSummary(e.Key.Emoji, e.Value.Count, e.Value.Contains(currentUserId)))
+			.ToList();
+
+		return Task.FromResult(result);
+	}
+
+	public Task<ILookup<long, ReactionSummary>> GetMessagesReactionsAsync(
+		long channelId, IReadOnlyList<long> messageIds, long currentUserId, CancellationToken ct)
+	{
+		var wanted = messageIds.ToHashSet();
+
+		var lookup = _reactions
+			.Where(e => e.Key.ChannelId == channelId && wanted.Contains(e.Key.MessageId))
+			.Select(e => (e.Key.MessageId, Summary: new ReactionSummary(e.Key.Emoji, e.Value.Count, e.Value.Contains(currentUserId))))
+			.ToLookup(x => x.MessageId, x => x.Summary);
+
+		return Task.FromResult(lookup);
+	}
+}

--- a/services/chat/tests/Chat.UnitTests/Fakes/FakeReactionRepository.cs
+++ b/services/chat/tests/Chat.UnitTests/Fakes/FakeReactionRepository.cs
@@ -45,7 +45,7 @@ public sealed class FakeReactionRepository : IReactionRepository
 		long channelId, long messageId, long currentUserId, CancellationToken ct)
 	{
 		IReadOnlyList<ReactionSummary> result = _reactions
-			.Where(e => e.Key.ChannelId == channelId && e.Key.MessageId == messageId)
+			.Where(e => e.Key.ChannelId == channelId && e.Key.MessageId == messageId && e.Value.Count > 0)
 			.Select(e => new ReactionSummary(e.Key.Emoji, e.Value.Count, e.Value.Contains(currentUserId)))
 			.ToList();
 
@@ -58,7 +58,7 @@ public sealed class FakeReactionRepository : IReactionRepository
 		var wanted = messageIds.ToHashSet();
 
 		var lookup = _reactions
-			.Where(e => e.Key.ChannelId == channelId && wanted.Contains(e.Key.MessageId))
+			.Where(e => e.Key.ChannelId == channelId && wanted.Contains(e.Key.MessageId) && e.Value.Count > 0)
 			.Select(e => (e.Key.MessageId, Summary: new ReactionSummary(e.Key.Emoji, e.Value.Count, e.Value.Contains(currentUserId))))
 			.ToLookup(x => x.MessageId, x => x.Summary);
 


### PR DESCRIPTION
## About

Implements message reactions — add/remove an emoji on a channel message — on top of the unified message handling from #289.

> Blocked by #289

## Changes

- `PUT`/`DELETE /messages/{id}/reactions/{emoji}` — idempotent add/remove. Backed by `message_reactions` (per-user row, doubles as the idempotency guard via a Cassandra LWT) and `message_reaction_counts` (COUNTER, only touched when the LWT actually applied, so repeat calls never drift the count). Broadcasts `ReactionAdded`/`ReactionRemoved` only when the mutation actually applied.
- `GET /channels/{id}/messages` now hydrates real `reactions: [{emoji, count, me_reacted}]` per message, replacing the hardcoded `[]` placeholder (`GetChannelMessagesHandler`, batched via `IReactionRepository.GetMessagesReactionsAsync`).
- Nonce-replay sends now hydrate the message's *current* reactions instead of always returning `[]` — it may have accrued some since the original send. See the added note in `docs/contracts/chat.md`.
- Reactions are channel-only per contract: `DirectMessageResponse` carries no `reactions` field at all, and reacting to a DM returns 404 (`Reaction.IsDirectMessage`, same status as "message not found").

## Notes

> The per-page `me_reacted` batch read uses `ALLOW FILTERING` on `message_reactions` (filters on `user_id` while skipping the leading `emoji` clustering column). Safe here — it's scoped to the page's `message_id IN (...)` list under a single `channel_id`, not a full-table scan.

Close #71