### PR TITLE
feat(chat/guild): add read states (channels + DMs)

### DIFF
--- a/docs/contracts/chat.md
+++ b/docs/contracts/chat.md
@@ -412,6 +412,8 @@ Advance the caller's read cursor for a channel to a specific message. Idempotent
 
 Mark a DM conversation as read up to a specific message. Mirrors `PUT /channels/{id}/read` for channels; the implicit alternative (auto-reset on `GET /dms/{user_id}/messages`) is rejected because infinite-scroll into older history shouldn't reset unread, and other devices need an explicit signal to update their badge.
 
+Unlike the channel side, this is a whole-conversation reset rather than a precise "messages after cursor" recount: `dm_unread_counts` is a monotonic counter (incremented on send, reset on read), not a value that can express "read up to message 10 of 15, 5 still unread." Marking any `message_id` as read - even one older than the most recent message - zeroes the badge for the whole conversation. `unread_count` in the response below is therefore always `0` on success.
+
 **Request body:**
 ```json
 {

--- a/docs/contracts/guild.md
+++ b/docs/contracts/guild.md
@@ -1006,6 +1006,33 @@ Check if a user is a member of the guild that owns this channel, and get their e
 
 ---
 
+### GET /internal/users/{user_id}/channels
+
+Every channel the user can see, across every guild they belong to. Called by Chat Service to back `GET /channels/read-states` in one round-trip instead of walking `GET /guilds/me` -> `GET /guilds/{id}/channels` -> per-channel membership.
+
+**Auth required:** None. Not reachable through the API Gateway: the gateway only forwards `/api/{service}/vN/...`, and `/internal/...` has no version segment. Callers reach this directly over the docker network (e.g. `http://guild:8080/internal/users/{user_id}/channels`).
+
+**Response `200`:**
+```json
+[
+  {
+    "id": "<snowflake>",
+    "guild_id": "<snowflake>",
+    "category_id": "<snowflake|null>",
+    "name": "general",
+    "type": "text",
+    "topic": null,
+    "position": 0,
+    "is_nsfw": false,
+    "slowmode_seconds": 0
+  }
+]
+```
+
+Same shape as `GET /guilds/{id}/channels`. A channel is included when the user's effective permissions on it include `READ_MESSAGES` (owner and `ADMINISTRATOR` short-circuit to all bits, per-channel overwrites applied - same resolution as `GET /internal/channels/{channel_id}/membership`). Returns `[]` (not 404) for a guild-less or unknown user. Order is unspecified.
+
+---
+
 ## RabbitMQ Events Published
 
 | Event | Payload | Trigger |

--- a/services/chat/src/Chat.Application/Abstractions/IGuildClient.cs
+++ b/services/chat/src/Chat.Application/Abstractions/IGuildClient.cs
@@ -3,6 +3,7 @@ namespace Chat.Application.Abstractions;
 public interface IGuildClient
 {
 	Task<ChannelMembership?> GetMembershipAsync(long channelId, long userId, CancellationToken ct);
+	Task<IReadOnlyList<long>> GetVisibleChannelIdsAsync(long userId, CancellationToken ct);
 }
 
 public sealed record ChannelMembership(bool IsMember, long GuildId, long Permissions);

--- a/services/chat/src/Chat.Application/Abstractions/IUserBroadcaster.cs
+++ b/services/chat/src/Chat.Application/Abstractions/IUserBroadcaster.cs
@@ -1,3 +1,6 @@
+using Chat.Application.Features.Channels.Common;
+using Chat.Application.Features.DirectMessages.Common;
+
 namespace Chat.Application.Abstractions;
 
 /// <summary>
@@ -9,6 +12,9 @@ public interface IUserBroadcaster
 {
 	Task BroadcastGuildJoinedAsync(long userId, long guildId, string guildName, CancellationToken ct);
 	Task BroadcastGuildLeftAsync(long userId, long guildId, CancellationToken ct);
+
+	Task BroadcastChannelReadStateUpdatedAsync(long userId, ChannelReadStateResponse response, CancellationToken ct);
+	Task BroadcastDmReadStateUpdatedAsync(long userId, DmReadStateResponse response, CancellationToken ct);
 
 	/// <summary>
 	/// force-terminates every active connection of <paramref name="userId"/> at

--- a/services/chat/src/Chat.Application/Abstractions/Persistence/IReadStateRepository.cs
+++ b/services/chat/src/Chat.Application/Abstractions/Persistence/IReadStateRepository.cs
@@ -44,4 +44,10 @@ public interface IReadStateRepository
 
 	/// <summary>Increments the recipient's dm_unread_counts row on a new DM send.</summary>
 	Task IncrementDmUnreadCountAsync(long userId, long partnerId, CancellationToken ct);
+
+	/// <summary>
+	/// Purges every read-cursor row for this user across channel_read_states,
+	/// dm_read_states and dm_unread_counts. Called on account deletion.
+	/// </summary>
+	Task DeleteAllForUserAsync(long userId, CancellationToken ct);
 }

--- a/services/chat/src/Chat.Application/Abstractions/Persistence/IReadStateRepository.cs
+++ b/services/chat/src/Chat.Application/Abstractions/Persistence/IReadStateRepository.cs
@@ -45,6 +45,9 @@ public interface IReadStateRepository
 	/// <summary>Increments the recipient's dm_unread_counts row on a new DM send.</summary>
 	Task IncrementDmUnreadCountAsync(long userId, long partnerId, CancellationToken ct);
 
+	/// <summary>Every dm_unread_counts row for this user, keyed by partner id; backs the sidebar's per-conversation badge.</summary>
+	Task<IReadOnlyDictionary<long, int>> GetDmUnreadCountsForUserAsync(long userId, CancellationToken ct);
+
 	/// <summary>
 	/// Purges every read-cursor row for this user across channel_read_states,
 	/// dm_read_states and dm_unread_counts. Called on account deletion.

--- a/services/chat/src/Chat.Application/Abstractions/Persistence/IReadStateRepository.cs
+++ b/services/chat/src/Chat.Application/Abstractions/Persistence/IReadStateRepository.cs
@@ -1,0 +1,47 @@
+using Chat.Domain.ReadStates;
+
+namespace Chat.Application.Abstractions.Persistence;
+
+/// <summary>
+/// Persistence for per-user read cursors, backing <c>PUT /channels/{id}/read</c>,
+/// <c>PUT /dms/{user_id}/read</c> and <c>GET /channels/read-states</c>. Channel
+/// and DM cursors live in separate tables (<c>channel_read_states</c> /
+/// <c>dm_read_states</c>) but share one C# surface via <see cref="ReadState"/>'s
+/// <c>ContainerId</c> + <c>IsDm</c> discriminator, mirroring how <c>Message</c>
+/// unifies channel messages and DMs.
+/// </summary>
+public interface IReadStateRepository
+{
+	/// <summary>
+	/// Advances the caller's read cursor for <paramref name="containerId"/> (a channel id,
+	/// or the partner's user id when <paramref name="isDm"/>) to <paramref name="messageId"/>
+	/// if it is newer than the current one (or none exists yet); otherwise a no-op.
+	/// Always returns the resulting (possibly unchanged) cursor.
+	/// </summary>
+	Task<ReadState> UpsertIfNewerAsync(
+		long userId, long containerId, bool isDm, long messageId, DateTimeOffset readAt, CancellationToken ct);
+
+	/// <summary>Every channel_read_states row for this user; backs the bulk sidebar fetch.</summary>
+	Task<IReadOnlyList<ReadState>> GetChannelReadStatesForUserAsync(long userId, CancellationToken ct);
+
+	/// <summary>
+	/// Count of messages in <paramref name="channelId"/> with <c>created_at &gt; after</c>.
+	/// Server-side COUNT(*) over the channel's clustering range - no ALLOW FILTERING
+	/// needed since created_at is a clustering column. Soft-deleted messages are not
+	/// excluded (would require ALLOW FILTERING on a non-key column over an unbounded
+	/// partition); a deleted message inflates the count by at most itself until read
+	/// past, an accepted skew given this is a badge count, not a ledger.
+	/// </summary>
+	Task<int> CountChannelMessagesAfterAsync(long channelId, DateTimeOffset after, CancellationToken ct);
+
+	/// <summary>
+	/// Resets the caller's dm_unread_counts row for this partner to 0. Cassandra
+	/// counters can only be reset by deleting the row - a missing row reads back as 0.
+	/// No channel equivalent: channel unread is computed on read via
+	/// <see cref="CountChannelMessagesAfterAsync"/> instead of a maintained counter.
+	/// </summary>
+	Task ResetDmUnreadCountAsync(long userId, long partnerId, CancellationToken ct);
+
+	/// <summary>Increments the recipient's dm_unread_counts row on a new DM send.</summary>
+	Task IncrementDmUnreadCountAsync(long userId, long partnerId, CancellationToken ct);
+}

--- a/services/chat/src/Chat.Application/Features/Channels/Common/ChannelReadStateResponse.cs
+++ b/services/chat/src/Chat.Application/Features/Channels/Common/ChannelReadStateResponse.cs
@@ -1,0 +1,8 @@
+namespace Chat.Application.Features.Channels.Common;
+
+/// <summary>
+/// wire shape for both PUT /channels/{id}/read and one entry of
+/// GET /channels/read-states. LastReadMessageId is null when the channel has
+/// never been read.
+/// </summary>
+public sealed record ChannelReadStateResponse(string ChannelId, string? LastReadMessageId, int UnreadCount);

--- a/services/chat/src/Chat.Application/Features/Channels/GetReadStates/GetChannelReadStatesHandler.cs
+++ b/services/chat/src/Chat.Application/Features/Channels/GetReadStates/GetChannelReadStatesHandler.cs
@@ -1,0 +1,41 @@
+using Chat.Application.Abstractions;
+using Chat.Application.Abstractions.Authentication;
+using Chat.Application.Abstractions.Messaging;
+using Chat.Application.Abstractions.Persistence;
+using Chat.Application.Features.Channels.Common;
+using Chat.Domain.Results;
+
+namespace Chat.Application.Features.Channels.GetReadStates;
+
+internal sealed class GetChannelReadStatesHandler(
+	ICurrentUser currentUser,
+	IGuildClient guildClient,
+	IReadStateRepository readStates)
+	: IQueryHandler<GetChannelReadStatesQuery, Result<IReadOnlyList<ChannelReadStateResponse>>>
+{
+	// no message ever predates the Unix epoch (Snowflake timestamps use a later
+	// custom epoch); used as the "since always" lower bound for unread channels
+	private static readonly DateTimeOffset SinceAlways = DateTimeOffset.UnixEpoch;
+
+	public async Task<Result<IReadOnlyList<ChannelReadStateResponse>>> HandleAsync(
+		GetChannelReadStatesQuery query, CancellationToken cancellationToken = default)
+	{
+		var userId = currentUser.UserId;
+
+		var visibleChannelIds = await guildClient.GetVisibleChannelIdsAsync(userId, cancellationToken);
+		var existingStates = await readStates.GetChannelReadStatesForUserAsync(userId, cancellationToken);
+		var statesByChannel = existingStates.ToDictionary(s => s.ContainerId);
+
+		var responses = new List<ChannelReadStateResponse>(visibleChannelIds.Count);
+		foreach (var channelId in visibleChannelIds)
+		{
+			var since = statesByChannel.TryGetValue(channelId, out var state) ? state.LastReadAt : null;
+			var unreadCount = await readStates.CountChannelMessagesAfterAsync(channelId, since ?? SinceAlways, cancellationToken);
+
+			responses.Add(new ChannelReadStateResponse(
+				channelId.ToString(), state?.LastReadMessageId?.ToString(), unreadCount));
+		}
+
+		return Result.Ok<IReadOnlyList<ChannelReadStateResponse>>(responses);
+	}
+}

--- a/services/chat/src/Chat.Application/Features/Channels/GetReadStates/GetChannelReadStatesQuery.cs
+++ b/services/chat/src/Chat.Application/Features/Channels/GetReadStates/GetChannelReadStatesQuery.cs
@@ -1,0 +1,7 @@
+using Chat.Application.Abstractions.Messaging;
+using Chat.Application.Features.Channels.Common;
+using Chat.Domain.Results;
+
+namespace Chat.Application.Features.Channels.GetReadStates;
+
+public sealed record GetChannelReadStatesQuery : IQuery<Result<IReadOnlyList<ChannelReadStateResponse>>>;

--- a/services/chat/src/Chat.Application/Features/Channels/UpdateReadState/UpdateChannelReadStateCommand.cs
+++ b/services/chat/src/Chat.Application/Features/Channels/UpdateReadState/UpdateChannelReadStateCommand.cs
@@ -1,0 +1,8 @@
+using Chat.Application.Abstractions.Messaging;
+using Chat.Application.Features.Channels.Common;
+using Chat.Domain.Results;
+
+namespace Chat.Application.Features.Channels.UpdateReadState;
+
+public sealed record UpdateChannelReadStateCommand(long ChannelId, long MessageId)
+	: ICommand<Result<ChannelReadStateResponse>>;

--- a/services/chat/src/Chat.Application/Features/Channels/UpdateReadState/UpdateChannelReadStateHandler.cs
+++ b/services/chat/src/Chat.Application/Features/Channels/UpdateReadState/UpdateChannelReadStateHandler.cs
@@ -11,7 +11,8 @@ internal sealed class UpdateChannelReadStateHandler(
 	ICurrentUser currentUser,
 	IGuildClient guildClient,
 	IMessageRepository messageRepository,
-	IReadStateRepository readStates)
+	IReadStateRepository readStates,
+	IUserBroadcaster broadcaster)
 	: ICommandHandler<UpdateChannelReadStateCommand, Result<ChannelReadStateResponse>>
 {
 	private const long ReadMessages = 1L << 1;
@@ -45,7 +46,11 @@ internal sealed class UpdateChannelReadStateHandler(
 		var unreadCount = await readStates.CountChannelMessagesAfterAsync(
 			command.ChannelId, state.LastReadAt!.Value, cancellationToken);
 
-		return new ChannelReadStateResponse(
+		var response = new ChannelReadStateResponse(
 			command.ChannelId.ToString(), state.LastReadMessageId?.ToString(), unreadCount);
+
+		await broadcaster.BroadcastChannelReadStateUpdatedAsync(userId, response, cancellationToken);
+
+		return response;
 	}
 }

--- a/services/chat/src/Chat.Application/Features/Channels/UpdateReadState/UpdateChannelReadStateHandler.cs
+++ b/services/chat/src/Chat.Application/Features/Channels/UpdateReadState/UpdateChannelReadStateHandler.cs
@@ -1,0 +1,51 @@
+using Chat.Application.Abstractions;
+using Chat.Application.Abstractions.Authentication;
+using Chat.Application.Abstractions.Messaging;
+using Chat.Application.Abstractions.Persistence;
+using Chat.Application.Features.Channels.Common;
+using Chat.Domain.Results;
+
+namespace Chat.Application.Features.Channels.UpdateReadState;
+
+internal sealed class UpdateChannelReadStateHandler(
+	ICurrentUser currentUser,
+	IGuildClient guildClient,
+	IMessageRepository messageRepository,
+	IReadStateRepository readStates)
+	: ICommandHandler<UpdateChannelReadStateCommand, Result<ChannelReadStateResponse>>
+{
+	private const long ReadMessages = 1L << 1;
+	private const long Administrator = 1L << 8;
+
+	public async Task<Result<ChannelReadStateResponse>> HandleAsync(
+		UpdateChannelReadStateCommand command, CancellationToken cancellationToken = default)
+	{
+		var userId = currentUser.UserId;
+		var membership = await guildClient.GetMembershipAsync(command.ChannelId, userId, cancellationToken);
+
+		if (membership is null)
+			return MessageFailures.ChannelNotFound;
+
+		if (!membership.IsMember)
+			return MessageFailures.NotAMember;
+
+		if ((membership.Permissions & (ReadMessages | Administrator)) == 0)
+			return MessageFailures.MissingReadPermission;
+
+		var message = await messageRepository.GetByIdAsync(command.MessageId, cancellationToken);
+		if (message is null || message.IsDeleted || message.IsDirectMessage || message.ContainerId != command.ChannelId)
+			return MessageFailures.NotFound;
+
+		// last_read_at is the target message's own timestamp, not the wall-clock
+		// time of this call - CountChannelMessagesAfterAsync compares against it
+		// to find messages newer than what the user actually read
+		var state = await readStates.UpsertIfNewerAsync(
+			userId, command.ChannelId, isDm: false, command.MessageId, message.CreatedAt, cancellationToken);
+
+		var unreadCount = await readStates.CountChannelMessagesAfterAsync(
+			command.ChannelId, state.LastReadAt!.Value, cancellationToken);
+
+		return new ChannelReadStateResponse(
+			command.ChannelId.ToString(), state.LastReadMessageId?.ToString(), unreadCount);
+	}
+}

--- a/services/chat/src/Chat.Application/Features/DirectMessages/Common/DmConversationResponse.cs
+++ b/services/chat/src/Chat.Application/Features/DirectMessages/Common/DmConversationResponse.cs
@@ -10,11 +10,10 @@ public sealed record DmConversationResponse(
 	int UnreadCount,
 	bool IsArchived)
 {
-	// TODO: wire up unread_count once read-state (#154) lands
-	public static DmConversationResponse From(DmConversation conversation) => new(
+	public static DmConversationResponse From(DmConversation conversation, int unreadCount) => new(
 		PartnerId: conversation.PartnerId.ToString(),
 		LastPreview: conversation.LastPreview,
 		LastMessageAt: conversation.LastMessageAt,
-		UnreadCount: 0,
+		UnreadCount: unreadCount,
 		IsArchived: conversation.IsArchived);
 }

--- a/services/chat/src/Chat.Application/Features/DirectMessages/Common/DmReadStateResponse.cs
+++ b/services/chat/src/Chat.Application/Features/DirectMessages/Common/DmReadStateResponse.cs
@@ -1,0 +1,4 @@
+namespace Chat.Application.Features.DirectMessages.Common;
+
+/// <summary>wire shape for PUT /dms/{user_id}/read.</summary>
+public sealed record DmReadStateResponse(string PartnerId, string? LastReadMessageId, int UnreadCount);

--- a/services/chat/src/Chat.Application/Features/DirectMessages/ListConversations/ListDmConversationsHandler.cs
+++ b/services/chat/src/Chat.Application/Features/DirectMessages/ListConversations/ListDmConversationsHandler.cs
@@ -8,7 +8,8 @@ namespace Chat.Application.Features.DirectMessages.ListConversations;
 
 internal sealed class ListDmConversationsHandler(
 	ICurrentUser currentUser,
-	IMessageRepository repository)
+	IMessageRepository repository,
+	IReadStateRepository readStates)
 	: IQueryHandler<ListDmConversationsQuery, Result<IReadOnlyList<DmConversationResponse>>>
 {
 	public async Task<Result<IReadOnlyList<DmConversationResponse>>> HandleAsync(
@@ -18,9 +19,11 @@ internal sealed class ListDmConversationsHandler(
 		var conversations = await repository.GetConversationsAsync(currentUser.UserId, cancellationToken);
 		var filtered = query.IncludeArchived ? conversations : conversations.Where(c => !c.IsArchived);
 
+		var unreadCounts = await readStates.GetDmUnreadCountsForUserAsync(currentUser.UserId, cancellationToken);
+
 		return filtered
 			.OrderByDescending(c => c.LastMessageAt)
-			.Select(DmConversationResponse.From)
+			.Select(c => DmConversationResponse.From(c, unreadCounts.GetValueOrDefault(c.PartnerId, 0)))
 			.ToList();
 	}
 }

--- a/services/chat/src/Chat.Application/Features/DirectMessages/SendMessage/SendDirectMessageHandler.cs
+++ b/services/chat/src/Chat.Application/Features/DirectMessages/SendMessage/SendDirectMessageHandler.cs
@@ -13,6 +13,7 @@ internal sealed class SendDirectMessageHandler(
 	ICurrentUser currentUser,
 	IMessageRepository repository,
 	IAttachmentRepository attachmentRepository,
+	IReadStateRepository readStates,
 	ISnowflakeIdGenerator ids,
 	IClock clock,
 	IUserClient userClient,
@@ -62,6 +63,8 @@ internal sealed class SendDirectMessageHandler(
 	protected override async Task PublishAndNotifyAsync(
 		SendDirectMessageCommand command, NoContext context, Message message, DirectMessageResponse response, CancellationToken ct)
 	{
+		await readStates.IncrementDmUnreadCountAsync(command.RecipientId, AuthorId, ct);
+
 		await eventBus.PublishAsync(
 			new ChatDmSent(
 				ConversationId: message.ContainerId,

--- a/services/chat/src/Chat.Application/Features/DirectMessages/UpdateReadState/UpdateDmReadStateCommand.cs
+++ b/services/chat/src/Chat.Application/Features/DirectMessages/UpdateReadState/UpdateDmReadStateCommand.cs
@@ -1,0 +1,8 @@
+using Chat.Application.Abstractions.Messaging;
+using Chat.Application.Features.DirectMessages.Common;
+using Chat.Domain.Results;
+
+namespace Chat.Application.Features.DirectMessages.UpdateReadState;
+
+public sealed record UpdateDmReadStateCommand(long PartnerId, long MessageId)
+	: ICommand<Result<DmReadStateResponse>>;

--- a/services/chat/src/Chat.Application/Features/DirectMessages/UpdateReadState/UpdateDmReadStateHandler.cs
+++ b/services/chat/src/Chat.Application/Features/DirectMessages/UpdateReadState/UpdateDmReadStateHandler.cs
@@ -1,0 +1,42 @@
+using Chat.Application.Abstractions.Authentication;
+using Chat.Application.Abstractions.Messaging;
+using Chat.Application.Abstractions.Persistence;
+using Chat.Application.Features.DirectMessages.Common;
+using Chat.Domain.Results;
+
+namespace Chat.Application.Features.DirectMessages.UpdateReadState;
+
+internal sealed class UpdateDmReadStateHandler(
+	ICurrentUser currentUser,
+	IMessageRepository messageRepository,
+	IReadStateRepository readStates)
+	: ICommandHandler<UpdateDmReadStateCommand, Result<DmReadStateResponse>>
+{
+	public async Task<Result<DmReadStateResponse>> HandleAsync(
+		UpdateDmReadStateCommand command, CancellationToken cancellationToken = default)
+	{
+		// No "caller is not a participant" check: the conversation is resolved from
+		// the (caller, partner) pair itself, so there is no path that could ever
+		// reach a conversation the caller isn't part of.
+		var userId = currentUser.UserId;
+
+		var conversationId = await messageRepository.FindConversationAsync(userId, command.PartnerId, cancellationToken);
+		if (conversationId is null)
+			return MessageFailures.ConversationNotFound;
+
+		var message = await messageRepository.GetByIdAsync(command.MessageId, cancellationToken);
+		if (message is null || message.IsDeleted || !message.IsDirectMessage || message.ContainerId != conversationId.Value)
+			return MessageFailures.NotFound;
+
+		// see UpdateChannelReadStateHandler: last_read_at is the message's own
+		// timestamp, not the wall-clock time of this call
+		var state = await readStates.UpsertIfNewerAsync(
+			userId, command.PartnerId, isDm: true, command.MessageId, message.CreatedAt, cancellationToken);
+
+		// resets unconditionally, even on a no-op (older/equal message_id): the
+		// call is idempotent and the badge should always read 0 after a successful read
+		await readStates.ResetDmUnreadCountAsync(userId, command.PartnerId, cancellationToken);
+
+		return new DmReadStateResponse(command.PartnerId.ToString(), state.LastReadMessageId?.ToString(), UnreadCount: 0);
+	}
+}

--- a/services/chat/src/Chat.Application/Features/DirectMessages/UpdateReadState/UpdateDmReadStateHandler.cs
+++ b/services/chat/src/Chat.Application/Features/DirectMessages/UpdateReadState/UpdateDmReadStateHandler.cs
@@ -1,3 +1,4 @@
+using Chat.Application.Abstractions;
 using Chat.Application.Abstractions.Authentication;
 using Chat.Application.Abstractions.Messaging;
 using Chat.Application.Abstractions.Persistence;
@@ -9,7 +10,8 @@ namespace Chat.Application.Features.DirectMessages.UpdateReadState;
 internal sealed class UpdateDmReadStateHandler(
 	ICurrentUser currentUser,
 	IMessageRepository messageRepository,
-	IReadStateRepository readStates)
+	IReadStateRepository readStates,
+	IUserBroadcaster broadcaster)
 	: ICommandHandler<UpdateDmReadStateCommand, Result<DmReadStateResponse>>
 {
 	public async Task<Result<DmReadStateResponse>> HandleAsync(
@@ -37,6 +39,10 @@ internal sealed class UpdateDmReadStateHandler(
 		// call is idempotent and the badge should always read 0 after a successful read
 		await readStates.ResetDmUnreadCountAsync(userId, command.PartnerId, cancellationToken);
 
-		return new DmReadStateResponse(command.PartnerId.ToString(), state.LastReadMessageId?.ToString(), UnreadCount: 0);
+		var response = new DmReadStateResponse(command.PartnerId.ToString(), state.LastReadMessageId?.ToString(), UnreadCount: 0);
+
+		await broadcaster.BroadcastDmReadStateUpdatedAsync(userId, response, cancellationToken);
+
+		return response;
 	}
 }

--- a/services/chat/src/Chat.Application/Features/DirectMessages/UpdateReadState/UpdateDmReadStateHandler.cs
+++ b/services/chat/src/Chat.Application/Features/DirectMessages/UpdateReadState/UpdateDmReadStateHandler.cs
@@ -35,8 +35,9 @@ internal sealed class UpdateDmReadStateHandler(
 		var state = await readStates.UpsertIfNewerAsync(
 			userId, command.PartnerId, isDm: true, command.MessageId, message.CreatedAt, cancellationToken);
 
-		// resets unconditionally, even on a no-op (older/equal message_id): the
-		// call is idempotent and the badge should always read 0 after a successful read
+		// unlike the channel side, this is a whole-conversation reset, not a
+		// precise "messages after cursor" recount: dm_unread_counts is a monotonic
+		// counter (increment on send, reset on read)
 		await readStates.ResetDmUnreadCountAsync(userId, command.PartnerId, cancellationToken);
 
 		var response = new DmReadStateResponse(command.PartnerId.ToString(), state.LastReadMessageId?.ToString(), UnreadCount: 0);

--- a/services/chat/src/Chat.Domain/ReadStates/ReadState.cs
+++ b/services/chat/src/Chat.Domain/ReadStates/ReadState.cs
@@ -1,0 +1,11 @@
+namespace Chat.Domain.ReadStates;
+
+/// <summary>
+/// A user's last-read cursor for one channel or DM conversation.
+/// <see cref="ContainerId"/> is the channel id or the partner's user id
+/// depending on <see cref="IsDm"/> - mirrors <c>Message.ContainerId</c>'s
+/// discriminator shape. <see cref="LastReadMessageId"/> and
+/// <see cref="LastReadAt"/> are both <c>null</c> when the user has never
+/// read the channel/conversation - there is no row yet.
+/// </summary>
+public sealed record ReadState(long ContainerId, bool IsDm, long? LastReadMessageId, DateTimeOffset? LastReadAt);

--- a/services/chat/src/Chat.Infrastructure/Http/GuildClient.cs
+++ b/services/chat/src/Chat.Infrastructure/Http/GuildClient.cs
@@ -26,4 +26,12 @@ internal sealed class GuildClient(HttpClient http) : IGuildClient
 			return null;
 		}
 	}
+
+	public async Task<IReadOnlyList<long>> GetVisibleChannelIdsAsync(long userId, CancellationToken ct)
+	{
+		var channels = await http.GetFromJsonAsync<List<ChannelSummary>>($"users/{userId}/channels", JsonOptions, ct);
+		return channels?.Select(c => long.Parse(c.Id)).ToList() ?? [];
+	}
+
+	private sealed record ChannelSummary(string Id);
 }

--- a/services/chat/src/Chat.Infrastructure/Messaging/Consumers/MembershipConsumers.cs
+++ b/services/chat/src/Chat.Infrastructure/Messaging/Consumers/MembershipConsumers.cs
@@ -74,6 +74,7 @@ public sealed class UserLoggedOutConsumer(
 public sealed class UserDeletedConsumer(
 	IUserBroadcaster broadcaster,
 	IMessageRepository messages,
+	IReadStateRepository readStates,
 	ILogger<UserDeletedConsumer> logger): IConsumer<UserDeleted>
 {
 	public async Task Consume(ConsumeContext<UserDeleted> context)
@@ -83,7 +84,7 @@ public sealed class UserDeletedConsumer(
 		var disconnected = await broadcaster.DisconnectUserAsync(msg.UserId, context.CancellationToken);
 
 		await messages.DeleteConversationAsync(msg.UserId, context.CancellationToken);
-		// TODO: delete channel_read_states, and dm_unread_counts once the read-state feature lands
+		await readStates.DeleteAllForUserAsync(msg.UserId, context.CancellationToken);
 
 		logger.LogDebug(
 			"user.deleted consumed: user_id={UserId} disconnected_connections={Disconnected}"

--- a/services/chat/src/Chat.Persistence/DependencyInjection.cs
+++ b/services/chat/src/Chat.Persistence/DependencyInjection.cs
@@ -36,6 +36,8 @@ public static class DependencyInjection
 		services.AddScoped<IAttachmentRepository, AttachmentRepository>();
 		services.AddSingleton<DataExportStatements>();
 		services.AddScoped<IDataExportRepository, DataExportRepository>();
+		services.AddSingleton<ReadStateStatements>();
+		services.AddScoped<IReadStateRepository, ReadStateRepository>();
 		return services;
 	}
 

--- a/services/chat/src/Chat.Persistence/Repositories/ReadStateRepository.cs
+++ b/services/chat/src/Chat.Persistence/Repositories/ReadStateRepository.cs
@@ -1,0 +1,70 @@
+using Cassandra;
+using Chat.Application.Abstractions.Persistence;
+using Chat.Domain.ReadStates;
+
+namespace Chat.Persistence.Repositories;
+
+/// <summary>
+/// Monotonic-if-newer is a plain read-then-write rather than a lightweight
+/// transaction: a genuine race only happens when the same user advances their
+/// own cursor from two devices at nearly the same instant, and the worst
+/// outcome is a momentarily stale badge that self-corrects on the next read -
+/// not worth the complexity of a check-then-insert-if-not-exists /
+/// update-if-newer LWT dance for a per-user cursor.
+/// </summary>
+internal sealed class ReadStateRepository(ISession session, ReadStateStatements statements) : IReadStateRepository
+{
+	public async Task<ReadState> UpsertIfNewerAsync(
+		long userId, long containerId, bool isDm, long messageId, DateTimeOffset readAt, CancellationToken ct)
+	{
+		var selectStmt = await (isDm ? statements.SelectDmReadState : statements.SelectChannelReadState).Value;
+		var row = (await session.ExecuteAsync(selectStmt.Bind(userId, containerId))).FirstOrDefault();
+
+		var currentId = row?.GetValue<long?>("last_read_message_id");
+		if (currentId is not null && messageId <= currentId)
+			return new ReadState(
+				containerId, isDm, currentId, new DateTimeOffset(row!.GetValue<DateTime>("last_read_at"), TimeSpan.Zero));
+
+		var upsertStmt = await (isDm ? statements.UpsertDmReadState : statements.UpsertChannelReadState).Value;
+		await session.ExecuteAsync(upsertStmt.Bind(userId, containerId, messageId, readAt.UtcDateTime));
+
+		return new ReadState(containerId, isDm, messageId, readAt);
+	}
+
+	/* # Channels methods # */
+
+	public async Task<IReadOnlyList<ReadState>> GetChannelReadStatesForUserAsync(long userId, CancellationToken ct)
+	{
+		var stmt = await statements.SelectChannelReadStatesForUser.Value;
+		var rows = await session.ExecuteAsync(stmt.Bind(userId));
+
+		return rows.Select(row => new ReadState(
+			row.GetValue<long>("channel_id"),
+			false,
+			row.GetValue<long?>("last_read_message_id"),
+			row.GetValue<DateTime?>("last_read_at") is { } at ? new DateTimeOffset(at, TimeSpan.Zero) : null))
+			.ToList();
+	}
+
+	public async Task<int> CountChannelMessagesAfterAsync(long channelId, DateTimeOffset after, CancellationToken ct)
+	{
+		var stmt = await statements.CountChannelMessagesAfter.Value;
+		var row = (await session.ExecuteAsync(stmt.Bind(channelId, after.UtcDateTime))).First();
+		return (int)row.GetValue<long>("count");
+	}
+
+
+	/* # Direct Messages methods # */
+
+	public async Task ResetDmUnreadCountAsync(long userId, long partnerId, CancellationToken ct)
+	{
+		var stmt = await statements.ResetDmUnreadCount.Value;
+		await session.ExecuteAsync(stmt.Bind(userId, partnerId));
+	}
+
+	public async Task IncrementDmUnreadCountAsync(long userId, long partnerId, CancellationToken ct)
+	{
+		var stmt = await statements.IncrementDmUnreadCount.Value;
+		await session.ExecuteAsync(stmt.Bind(userId, partnerId));
+	}
+}

--- a/services/chat/src/Chat.Persistence/Repositories/ReadStateRepository.cs
+++ b/services/chat/src/Chat.Persistence/Repositories/ReadStateRepository.cs
@@ -67,4 +67,16 @@ internal sealed class ReadStateRepository(ISession session, ReadStateStatements 
 		var stmt = await statements.IncrementDmUnreadCount.Value;
 		await session.ExecuteAsync(stmt.Bind(userId, partnerId));
 	}
+
+	public async Task DeleteAllForUserAsync(long userId, CancellationToken ct)
+	{
+		var channelStmt = await statements.DeleteChannelReadStatesForUser.Value;
+		var dmStmt = await statements.DeleteDmReadStatesForUser.Value;
+		var unreadStmt = await statements.DeleteDmUnreadCountsForUser.Value;
+
+		await Task.WhenAll(
+			session.ExecuteAsync(channelStmt.Bind(userId)),
+			session.ExecuteAsync(dmStmt.Bind(userId)),
+			session.ExecuteAsync(unreadStmt.Bind(userId)));
+	}
 }

--- a/services/chat/src/Chat.Persistence/Repositories/ReadStateRepository.cs
+++ b/services/chat/src/Chat.Persistence/Repositories/ReadStateRepository.cs
@@ -68,6 +68,16 @@ internal sealed class ReadStateRepository(ISession session, ReadStateStatements 
 		await session.ExecuteAsync(stmt.Bind(userId, partnerId));
 	}
 
+	public async Task<IReadOnlyDictionary<long, int>> GetDmUnreadCountsForUserAsync(long userId, CancellationToken ct)
+	{
+		var stmt = await statements.SelectDmUnreadCountsForUser.Value;
+		var rows = await session.ExecuteAsync(stmt.Bind(userId));
+
+		return rows.ToDictionary(
+			row => row.GetValue<long>("partner_id"),
+			row => (int)row.GetValue<long>("count"));
+	}
+
 	public async Task DeleteAllForUserAsync(long userId, CancellationToken ct)
 	{
 		var channelStmt = await statements.DeleteChannelReadStatesForUser.Value;

--- a/services/chat/src/Chat.Persistence/Repositories/ReadStateStatements.cs
+++ b/services/chat/src/Chat.Persistence/Repositories/ReadStateStatements.cs
@@ -18,6 +18,9 @@ internal sealed class ReadStateStatements(ISession session)
 	public Lazy<Task<PreparedStatement>> SelectChannelReadStatesForUser { get; } = new(() => session.PrepareAsync(
 		"SELECT channel_id, last_read_message_id, last_read_at FROM channel_read_states WHERE user_id = ?"));
 
+	public Lazy<Task<PreparedStatement>> DeleteChannelReadStatesForUser { get; } = new(() => session.PrepareAsync(
+		"DELETE FROM channel_read_states WHERE user_id = ?"));
+
 	public Lazy<Task<PreparedStatement>> UpsertChannelReadState { get; } = new(() => session.PrepareAsync(
 		"INSERT INTO channel_read_states (user_id, channel_id, last_read_message_id, last_read_at) " +
 		"VALUES (?, ?, ?, ?)"));
@@ -35,6 +38,9 @@ internal sealed class ReadStateStatements(ISession session)
 		"INSERT INTO dm_read_states (user_id, partner_id, last_read_message_id, last_read_at) " +
 		"VALUES (?, ?, ?, ?)"));
 
+	public Lazy<Task<PreparedStatement>> DeleteDmReadStatesForUser { get; } = new(() => session.PrepareAsync(
+		"DELETE FROM dm_read_states WHERE user_id = ?"));
+
 	/* ### DM unread counter ### */
 
 	public Lazy<Task<PreparedStatement>> IncrementDmUnreadCount { get; } = new(() => session.PrepareAsync(
@@ -43,4 +49,7 @@ internal sealed class ReadStateStatements(ISession session)
 	// counters can only be reset by deleting the row - a missing row reads back as 0
 	public Lazy<Task<PreparedStatement>> ResetDmUnreadCount { get; } = new(() => session.PrepareAsync(
 		"DELETE FROM dm_unread_counts WHERE user_id = ? AND partner_id = ?"));
+
+	public Lazy<Task<PreparedStatement>> DeleteDmUnreadCountsForUser { get; } = new(() => session.PrepareAsync(
+		"DELETE FROM dm_unread_counts WHERE user_id = ?"));
 }

--- a/services/chat/src/Chat.Persistence/Repositories/ReadStateStatements.cs
+++ b/services/chat/src/Chat.Persistence/Repositories/ReadStateStatements.cs
@@ -1,0 +1,46 @@
+using Cassandra;
+
+namespace Chat.Persistence.Repositories;
+
+/// <summary>
+/// Prepared statements for channel and DM read cursors, plus the DM unread
+/// COUNTER table. See ReadStateRepository for the monotonic-upsert logic
+/// these statements are combined into.
+/// </summary>
+internal sealed class ReadStateStatements(ISession session)
+{
+	/* ### Channel read states ### */
+
+	public Lazy<Task<PreparedStatement>> SelectChannelReadState { get; } = new(() => session.PrepareAsync(
+		"SELECT last_read_message_id, last_read_at FROM channel_read_states " +
+		"WHERE user_id = ? AND channel_id = ?"));
+
+	public Lazy<Task<PreparedStatement>> SelectChannelReadStatesForUser { get; } = new(() => session.PrepareAsync(
+		"SELECT channel_id, last_read_message_id, last_read_at FROM channel_read_states WHERE user_id = ?"));
+
+	public Lazy<Task<PreparedStatement>> UpsertChannelReadState { get; } = new(() => session.PrepareAsync(
+		"INSERT INTO channel_read_states (user_id, channel_id, last_read_message_id, last_read_at) " +
+		"VALUES (?, ?, ?, ?)"));
+
+	public Lazy<Task<PreparedStatement>> CountChannelMessagesAfter { get; } = new(() => session.PrepareAsync(
+		"SELECT COUNT(*) FROM messages WHERE channel_id = ? AND created_at > ?"));
+
+	/* ### DM read states ### */
+
+	public Lazy<Task<PreparedStatement>> SelectDmReadState { get; } = new(() => session.PrepareAsync(
+		"SELECT last_read_message_id, last_read_at FROM dm_read_states " +
+		"WHERE user_id = ? AND partner_id = ?"));
+
+	public Lazy<Task<PreparedStatement>> UpsertDmReadState { get; } = new(() => session.PrepareAsync(
+		"INSERT INTO dm_read_states (user_id, partner_id, last_read_message_id, last_read_at) " +
+		"VALUES (?, ?, ?, ?)"));
+
+	/* ### DM unread counter ### */
+
+	public Lazy<Task<PreparedStatement>> IncrementDmUnreadCount { get; } = new(() => session.PrepareAsync(
+		"UPDATE dm_unread_counts SET count = count + 1 WHERE user_id = ? AND partner_id = ?"));
+
+	// counters can only be reset by deleting the row - a missing row reads back as 0
+	public Lazy<Task<PreparedStatement>> ResetDmUnreadCount { get; } = new(() => session.PrepareAsync(
+		"DELETE FROM dm_unread_counts WHERE user_id = ? AND partner_id = ?"));
+}

--- a/services/chat/src/Chat.Persistence/Repositories/ReadStateStatements.cs
+++ b/services/chat/src/Chat.Persistence/Repositories/ReadStateStatements.cs
@@ -52,4 +52,7 @@ internal sealed class ReadStateStatements(ISession session)
 
 	public Lazy<Task<PreparedStatement>> DeleteDmUnreadCountsForUser { get; } = new(() => session.PrepareAsync(
 		"DELETE FROM dm_unread_counts WHERE user_id = ?"));
+
+	public Lazy<Task<PreparedStatement>> SelectDmUnreadCountsForUser { get; } = new(() => session.PrepareAsync(
+		"SELECT partner_id, count FROM dm_unread_counts WHERE user_id = ?"));
 }

--- a/services/chat/src/Chat.Presentation/Endpoints/MessagesEndpoint.cs
+++ b/services/chat/src/Chat.Presentation/Endpoints/MessagesEndpoint.cs
@@ -15,11 +15,11 @@ public sealed class MessagesEndpoint : ICarterModule
 {
 	public void AddRoutes(IEndpointRouteBuilder endpoints)
 	{
-		var channelGroup = endpoints.MapGroup("/channels/{channelId:long}/messages");
+		var channelGroup = endpoints.MapGroup("/channels/{channelId:long}/messages").WithTags("Channel Messages");
 		channelGroup.MapGet("/", GetChannelHistoryAsync);
 		channelGroup.MapPost("/", SendAsync);
 
-		var messageGroup = endpoints.MapGroup("/messages");
+		var messageGroup = endpoints.MapGroup("/messages").WithTags("Messages");
 		messageGroup.MapPatch("/{messageId:long}", EditAsync);
 		messageGroup.MapDelete("/{messageId:long}", DeleteAsync);
 	}

--- a/services/chat/src/Chat.Presentation/Endpoints/ReadStatesEndpoint.cs
+++ b/services/chat/src/Chat.Presentation/Endpoints/ReadStatesEndpoint.cs
@@ -1,0 +1,87 @@
+using Carter;
+using Chat.Application.Abstractions.Messaging;
+using Chat.Application.Features.Channels.Common;
+using Chat.Application.Features.Channels.GetReadStates;
+using Chat.Application.Features.Channels.UpdateReadState;
+using Chat.Application.Features.DirectMessages.Common;
+using Chat.Application.Features.DirectMessages.UpdateReadState;
+using Chat.Domain.Results;
+using Microsoft.AspNetCore.Http.HttpResults;
+
+namespace Chat.Presentation.Endpoints;
+
+public sealed class ReadStatesEndpoint : ICarterModule
+{
+	public void AddRoutes(IEndpointRouteBuilder app)
+	{
+		app.MapPut("/channels/{channelId:long}/read", UpdateChannelReadStateAsync).WithTags("Read States");
+		app.MapGet("/channels/read-states", GetChannelReadStatesAsync).WithTags("Read States");
+		app.MapPut("/dms/{userId:long}/read", UpdateDmReadStateAsync).WithTags("Read States");
+	}
+
+	private static async Task<Results<Ok<ChannelReadStateResponse>, BadRequest<ErrorBody>, JsonHttpResult<ErrorBody>, NotFound<ErrorBody>>>
+	UpdateChannelReadStateAsync(
+		long channelId,
+		UpdateReadStateRequest request,
+		ICommandHandler<UpdateChannelReadStateCommand, Result<ChannelReadStateResponse>> handler,
+		CancellationToken cancellationToken)
+	{
+		if (request.MessageId is not ({ } messageId and > 0))
+			return TypedResults.BadRequest(new ErrorBody("message_id is required and must be a positive snowflake."));
+
+		var result = await handler.HandleAsync(new UpdateChannelReadStateCommand(channelId, messageId), cancellationToken);
+
+		return result.Succeeded
+			? TypedResults.Ok(result.Value)
+			: MapChannelError(result.Error);
+	}
+
+	private static async Task<Results<Ok<IReadOnlyList<ChannelReadStateResponse>>, BadRequest<ErrorBody>>>
+	GetChannelReadStatesAsync(
+		IQueryHandler<GetChannelReadStatesQuery, Result<IReadOnlyList<ChannelReadStateResponse>>> handler,
+		CancellationToken cancellationToken)
+	{
+		var result = await handler.HandleAsync(new GetChannelReadStatesQuery(), cancellationToken);
+
+		return result.Succeeded
+			? TypedResults.Ok(result.Value)
+			: TypedResults.BadRequest(new ErrorBody(result.Error.Message));
+	}
+
+	private static async Task<Results<Ok<DmReadStateResponse>, BadRequest<ErrorBody>, NotFound<ErrorBody>>>
+	UpdateDmReadStateAsync(
+		long userId,
+		UpdateReadStateRequest request,
+		ICommandHandler<UpdateDmReadStateCommand, Result<DmReadStateResponse>> handler,
+		CancellationToken cancellationToken)
+	{
+		if (request.MessageId is not ({ } messageId and > 0))
+			return TypedResults.BadRequest(new ErrorBody("message_id is required and must be a positive snowflake."));
+
+		var result = await handler.HandleAsync(new UpdateDmReadStateCommand(userId, messageId), cancellationToken);
+
+		return result.Succeeded
+			? TypedResults.Ok(result.Value)
+			: MapDmError(result.Error);
+	}
+
+	private static Results<Ok<ChannelReadStateResponse>, BadRequest<ErrorBody>, JsonHttpResult<ErrorBody>, NotFound<ErrorBody>>
+		MapChannelError(Failure failure) => failure.Code switch
+		{
+			"Message.ChannelNotFound" or
+			"Message.NotFound" => TypedResults.NotFound(new ErrorBody(failure.Message)),
+			"Message.NotAMember" or
+			"Message.MissingReadPermission" => TypedResults.Json(new ErrorBody(failure.Message), statusCode: StatusCodes.Status403Forbidden),
+			_ => TypedResults.BadRequest(new ErrorBody(failure.Message)),
+		};
+
+	private static Results<Ok<DmReadStateResponse>, BadRequest<ErrorBody>, NotFound<ErrorBody>>
+		MapDmError(Failure failure) => failure.Code switch
+		{
+			"Message.ConversationNotFound" or
+			"Message.NotFound" => TypedResults.NotFound(new ErrorBody(failure.Message)),
+			_ => TypedResults.BadRequest(new ErrorBody(failure.Message)),
+		};
+
+	private sealed record UpdateReadStateRequest(long? MessageId);
+}

--- a/services/chat/src/Chat.Presentation/Hubs/IChatClient.cs
+++ b/services/chat/src/Chat.Presentation/Hubs/IChatClient.cs
@@ -16,6 +16,9 @@ public interface IChatClient
 
 	Task TypingStarted(string userId, string scope, string id, DateTimeOffset expiresAt);
 
+	Task ReadStateUpdated(ChannelReadStateResponse response);
+	Task DmReadStateUpdated(DmReadStateResponse response);
+
 	Task GuildJoined(string guildId, string guildName);
 	Task GuildLeft(string guildId);
 	Task Error(string code, string message);

--- a/services/chat/src/Chat.Presentation/Hubs/SignalRUserBroadcaster.cs
+++ b/services/chat/src/Chat.Presentation/Hubs/SignalRUserBroadcaster.cs
@@ -1,4 +1,6 @@
 using Chat.Application.Abstractions;
+using Chat.Application.Features.Channels.Common;
+using Chat.Application.Features.DirectMessages.Common;
 using Microsoft.AspNetCore.SignalR;
 
 namespace Chat.Presentation.Hubs;
@@ -29,6 +31,12 @@ internal sealed class SignalRUserBroadcaster(
 
 		return Task.FromResult(contexts.Count);
 	}
+
+	public Task BroadcastChannelReadStateUpdatedAsync(long userId, ChannelReadStateResponse response, CancellationToken ct) =>
+		hub.Clients.User(userId.ToString()).ReadStateUpdated(response);
+
+	public Task BroadcastDmReadStateUpdatedAsync(long userId, DmReadStateResponse response, CancellationToken ct) =>
+		hub.Clients.User(userId.ToString()).DmReadStateUpdated(response);
 
 	public async Task<int> EvictFromGuildChannelsAsync(long userId, long guildId, CancellationToken ct)
 	{

--- a/services/chat/tests/Chat.FunctionalTests/Endpoints/GetChannelReadStatesEndpointTests.cs
+++ b/services/chat/tests/Chat.FunctionalTests/Endpoints/GetChannelReadStatesEndpointTests.cs
@@ -3,6 +3,7 @@ using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text.Json;
 using Chat.Application.Features.Channels.Common;
+using Chat.Domain.ReadStates;
 using Chat.FunctionalTests.Infrastructure;
 using Xunit;
 
@@ -69,5 +70,25 @@ public sealed class GetChannelReadStatesEndpointTests(ChatApiFactory factory)
 		Assert.Equal("100", entry.ChannelId);
 		Assert.Null(entry.LastReadMessageId);
 		Assert.Equal(4, entry.UnreadCount);
+	}
+
+	[Fact]
+	public async Task Get_ChannelAlreadyRead_ReturnsCursor_AndCountSinceCursor()
+	{
+		factory.GuildClient.VisibleChannelIds = [100];
+		factory.ReadStateRepository.SeedChannelReadState(42, new ReadState(
+			ContainerId: 100, IsDm: false, LastReadMessageId: 5,
+			LastReadAt: new DateTimeOffset(2026, 1, 1, 12, 0, 0, TimeSpan.Zero)));
+		factory.ReadStateRepository.ChannelMessageCountsAfter[100] = 2;
+		var client = BuildClient(userId: 42);
+
+		var response = await client.GetAsync("/v1/channels/read-states");
+
+		Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+		var body = await response.Content.ReadFromJsonAsync<List<ChannelReadStateResponse>>(JsonOptions);
+		var entry = Assert.Single(body!);
+		Assert.Equal("100", entry.ChannelId);
+		Assert.Equal("5", entry.LastReadMessageId);
+		Assert.Equal(2, entry.UnreadCount);
 	}
 }

--- a/services/chat/tests/Chat.FunctionalTests/Endpoints/GetChannelReadStatesEndpointTests.cs
+++ b/services/chat/tests/Chat.FunctionalTests/Endpoints/GetChannelReadStatesEndpointTests.cs
@@ -1,0 +1,73 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Chat.Application.Features.Channels.Common;
+using Chat.FunctionalTests.Infrastructure;
+using Xunit;
+
+namespace Chat.FunctionalTests.Endpoints;
+
+public sealed class GetChannelReadStatesEndpointTests(ChatApiFactory factory)
+	: IClassFixture<ChatApiFactory>, IAsyncLifetime
+{
+	private static readonly JsonSerializerOptions JsonOptions = new()
+	{
+		PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+		PropertyNameCaseInsensitive = true,
+	};
+
+	public Task InitializeAsync()
+	{
+		factory.GuildClient.VisibleChannelIds = [];
+		factory.ReadStateRepository.Reset();
+		return Task.CompletedTask;
+	}
+
+	public Task DisposeAsync() => Task.CompletedTask;
+
+	private HttpClient BuildClient(long userId)
+	{
+		var client = factory.CreateClient();
+		var token = TestTokens.Issue(ChatApiFactory.JwtSecret, userId: userId);
+		client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+		return client;
+	}
+
+	[Fact]
+	public async Task Get_WithoutToken_Returns401()
+	{
+		var response = await factory.CreateClient().GetAsync("/v1/channels/read-states");
+
+		Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+	}
+
+	[Fact]
+	public async Task Get_NoVisibleChannels_ReturnsEmptyArray()
+	{
+		var client = BuildClient(userId: 42);
+
+		var response = await client.GetAsync("/v1/channels/read-states");
+
+		Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+		var body = await response.Content.ReadFromJsonAsync<List<ChannelReadStateResponse>>(JsonOptions);
+		Assert.Empty(body!);
+	}
+
+	[Fact]
+	public async Task Get_ChannelNeverRead_ReturnsNullCursor_AndTotalCount()
+	{
+		factory.GuildClient.VisibleChannelIds = [100];
+		factory.ReadStateRepository.ChannelMessageCountsAfter[100] = 4;
+		var client = BuildClient(userId: 42);
+
+		var response = await client.GetAsync("/v1/channels/read-states");
+
+		Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+		var body = await response.Content.ReadFromJsonAsync<List<ChannelReadStateResponse>>(JsonOptions);
+		var entry = Assert.Single(body!);
+		Assert.Equal("100", entry.ChannelId);
+		Assert.Null(entry.LastReadMessageId);
+		Assert.Equal(4, entry.UnreadCount);
+	}
+}

--- a/services/chat/tests/Chat.FunctionalTests/Endpoints/ListDmConversationsEndpointTests.cs
+++ b/services/chat/tests/Chat.FunctionalTests/Endpoints/ListDmConversationsEndpointTests.cs
@@ -20,6 +20,7 @@ public sealed class ListDmConversationsEndpointTests(ChatApiFactory factory)
 	public Task InitializeAsync()
 	{
 		factory.MessageRepository.Reset();
+		factory.ReadStateRepository.Reset();
 		return Task.CompletedTask;
 	}
 
@@ -120,6 +121,26 @@ public sealed class ListDmConversationsEndpointTests(ChatApiFactory factory)
 		Assert.NotNull(body);
 		Assert.Equal(2, body!.Count);
 		Assert.Contains(body, c => c.PartnerId == "200" && c.IsArchived);
+	}
+
+	[Fact]
+	public async Task Get_UnreadCount_ReflectsDmReadStateRepository_PerPartner()
+	{
+		var anchor = DateTimeOffset.UtcNow;
+
+		factory.MessageRepository.WithConversationSummary(42, new DmConversation(
+			PartnerId: 100, LastMessageAt: anchor, LastPreview: "hey", IsArchived: false));
+		factory.MessageRepository.WithConversationSummary(42, new DmConversation(
+			PartnerId: 200, LastMessageAt: anchor, LastPreview: "yo", IsArchived: false));
+		factory.ReadStateRepository.SeedDmUnreadCount(userId: 42, partnerId: 100, count: 5);
+
+		var client = BuildClient(userId: 42);
+		var response = await client.GetAsync("/v1/dms");
+
+		var body = await response.Content.ReadFromJsonAsync<List<DmConversationBody>>(JsonOptions);
+		Assert.NotNull(body);
+		Assert.Equal(5, body!.Single(c => c.PartnerId == "100").UnreadCount);
+		Assert.Equal(0, body!.Single(c => c.PartnerId == "200").UnreadCount);
 	}
 
 	[Fact]

--- a/services/chat/tests/Chat.FunctionalTests/Endpoints/UpdateChannelReadStateEndpointTests.cs
+++ b/services/chat/tests/Chat.FunctionalTests/Endpoints/UpdateChannelReadStateEndpointTests.cs
@@ -1,0 +1,120 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Chat.Application.Abstractions;
+using Chat.Application.Features.Channels.Common;
+using Chat.Domain.Messages;
+using Chat.FunctionalTests.Infrastructure;
+using Xunit;
+
+namespace Chat.FunctionalTests.Endpoints;
+
+public sealed class UpdateChannelReadStateEndpointTests(ChatApiFactory factory)
+	: IClassFixture<ChatApiFactory>, IAsyncLifetime
+{
+	private const long ReadMessagesPermission = 1L << 1;
+
+	private static readonly JsonSerializerOptions JsonOptions = new()
+	{
+		PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+		PropertyNameCaseInsensitive = true,
+	};
+
+	private static readonly DateTimeOffset PastDate = new(2025, 6, 1, 12, 0, 0, TimeSpan.Zero);
+
+	public Task InitializeAsync()
+	{
+		factory.GuildClient.Result = null;
+		factory.MessageRepository.Reset();
+		factory.ReadStateRepository.Reset();
+		return Task.CompletedTask;
+	}
+
+	public Task DisposeAsync() => Task.CompletedTask;
+
+	private HttpClient BuildClient(long userId)
+	{
+		var client = factory.CreateClient();
+		var token = TestTokens.Issue(ChatApiFactory.JwtSecret, userId: userId);
+		client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+		return client;
+	}
+
+	private static void SeedMessage(ChatApiFactory f, long id, long channelId, DateTimeOffset? createdAt = null)
+	{
+		var message = Message.Reconstitute(
+			id: id, containerId: channelId, authorId: 99, recipientId: null,
+			content: "hello", replyToId: null, editedAt: null,
+			isDeleted: false, createdAt: createdAt ?? PastDate);
+		f.MessageRepository.Seed(message);
+	}
+
+	[Fact]
+	public async Task Put_WithoutToken_Returns401()
+	{
+		var response = await factory.CreateClient().PutAsJsonAsync("/v1/channels/100/read", new { message_id = 1 });
+
+		Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+	}
+
+	[Fact]
+	public async Task Put_MissingMessageId_Returns400()
+	{
+		var client = BuildClient(userId: 42);
+
+		var response = await client.PutAsJsonAsync("/v1/channels/100/read", new { });
+
+		Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+	}
+
+	[Fact]
+	public async Task Put_ChannelNotFound_Returns404()
+	{
+		factory.GuildClient.Result = null;
+		var client = BuildClient(userId: 42);
+
+		var response = await client.PutAsJsonAsync("/v1/channels/100/read", new { message_id = 1 });
+
+		Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+	}
+
+	[Fact]
+	public async Task Put_NotAMember_Returns403()
+	{
+		factory.GuildClient.Result = new ChannelMembership(IsMember: false, GuildId: 5, Permissions: ReadMessagesPermission);
+		var client = BuildClient(userId: 42);
+
+		var response = await client.PutAsJsonAsync("/v1/channels/100/read", new { message_id = 1 });
+
+		Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+	}
+
+	[Fact]
+	public async Task Put_MessageNotFound_Returns404()
+	{
+		factory.GuildClient.Result = new ChannelMembership(IsMember: true, GuildId: 5, Permissions: ReadMessagesPermission);
+		var client = BuildClient(userId: 42);
+
+		var response = await client.PutAsJsonAsync("/v1/channels/100/read", new { message_id = 999 });
+
+		Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+	}
+
+	[Fact]
+	public async Task Put_HappyPath_Returns200_AdvancesCursor()
+	{
+		factory.GuildClient.Result = new ChannelMembership(IsMember: true, GuildId: 5, Permissions: ReadMessagesPermission);
+		SeedMessage(factory, id: 1, channelId: 100);
+		var client = BuildClient(userId: 42);
+
+		var response = await client.PutAsJsonAsync("/v1/channels/100/read", new { message_id = 1 });
+
+		Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+		var body = await response.Content.ReadFromJsonAsync<ChannelReadStateResponse>(JsonOptions);
+		Assert.NotNull(body);
+		Assert.Equal("100", body.ChannelId);
+		Assert.Equal("1", body.LastReadMessageId);
+		Assert.Equal(0, body.UnreadCount);
+	}
+}

--- a/services/chat/tests/Chat.FunctionalTests/Endpoints/UpdateChannelReadStateEndpointTests.cs
+++ b/services/chat/tests/Chat.FunctionalTests/Endpoints/UpdateChannelReadStateEndpointTests.cs
@@ -102,6 +102,21 @@ public sealed class UpdateChannelReadStateEndpointTests(ChatApiFactory factory)
 	}
 
 	[Fact]
+	public async Task Put_DeletedMessage_Returns404()
+	{
+		factory.GuildClient.Result = new ChannelMembership(IsMember: true, GuildId: 5, Permissions: ReadMessagesPermission);
+		var deleted = Message.Reconstitute(
+			id: 1, containerId: 100, authorId: 99, recipientId: null,
+			content: null, replyToId: null, editedAt: null, isDeleted: true, createdAt: PastDate);
+		factory.MessageRepository.Seed(deleted);
+		var client = BuildClient(userId: 42);
+
+		var response = await client.PutAsJsonAsync("/v1/channels/100/read", new { message_id = 1 });
+
+		Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+	}
+
+	[Fact]
 	public async Task Put_HappyPath_Returns200_AdvancesCursor()
 	{
 		factory.GuildClient.Result = new ChannelMembership(IsMember: true, GuildId: 5, Permissions: ReadMessagesPermission);

--- a/services/chat/tests/Chat.FunctionalTests/Endpoints/UpdateDmReadStateEndpointTests.cs
+++ b/services/chat/tests/Chat.FunctionalTests/Endpoints/UpdateDmReadStateEndpointTests.cs
@@ -1,0 +1,97 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Chat.Application.Features.DirectMessages.Common;
+using Chat.Domain.Messages;
+using Chat.FunctionalTests.Infrastructure;
+using Xunit;
+
+namespace Chat.FunctionalTests.Endpoints;
+
+public sealed class UpdateDmReadStateEndpointTests(ChatApiFactory factory)
+	: IClassFixture<ChatApiFactory>, IAsyncLifetime
+{
+	private static readonly JsonSerializerOptions JsonOptions = new()
+	{
+		PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+		PropertyNameCaseInsensitive = true,
+	};
+
+	private static readonly DateTimeOffset PastDate = new(2025, 6, 1, 12, 0, 0, TimeSpan.Zero);
+
+	public Task InitializeAsync()
+	{
+		factory.MessageRepository.Reset();
+		factory.ReadStateRepository.Reset();
+		return Task.CompletedTask;
+	}
+
+	public Task DisposeAsync() => Task.CompletedTask;
+
+	private HttpClient BuildClient(long userId)
+	{
+		var client = factory.CreateClient();
+		var token = TestTokens.Issue(ChatApiFactory.JwtSecret, userId: userId);
+		client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+		return client;
+	}
+
+	[Fact]
+	public async Task Put_WithoutToken_Returns401()
+	{
+		var response = await factory.CreateClient().PutAsJsonAsync("/v1/dms/100/read", new { message_id = 1 });
+
+		Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+	}
+
+	[Fact]
+	public async Task Put_MissingMessageId_Returns400()
+	{
+		var client = BuildClient(userId: 42);
+
+		var response = await client.PutAsJsonAsync("/v1/dms/100/read", new { });
+
+		Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+	}
+
+	[Fact]
+	public async Task Put_NoConversation_Returns404()
+	{
+		var client = BuildClient(userId: 42);
+
+		var response = await client.PutAsJsonAsync("/v1/dms/100/read", new { message_id = 1 });
+
+		Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+	}
+
+	[Fact]
+	public async Task Put_MessageNotFound_Returns404()
+	{
+		factory.MessageRepository.WithConversation(42, 100, conversationId: 555);
+		var client = BuildClient(userId: 42);
+
+		var response = await client.PutAsJsonAsync("/v1/dms/100/read", new { message_id = 999 });
+
+		Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+	}
+
+	[Fact]
+	public async Task Put_HappyPath_Returns200_AdvancesCursor_ResetsUnread()
+	{
+		factory.MessageRepository.WithConversation(42, 100, conversationId: 555);
+		factory.MessageRepository.Seed(Message.Reconstitute(
+			id: 1, containerId: 555, authorId: 100, recipientId: 42,
+			content: "hi", replyToId: null, editedAt: null, isDeleted: false, createdAt: PastDate));
+		var client = BuildClient(userId: 42);
+
+		var response = await client.PutAsJsonAsync("/v1/dms/100/read", new { message_id = 1 });
+
+		Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+		var body = await response.Content.ReadFromJsonAsync<DmReadStateResponse>(JsonOptions);
+		Assert.NotNull(body);
+		Assert.Equal("100", body.PartnerId);
+		Assert.Equal("1", body.LastReadMessageId);
+		Assert.Equal(0, body.UnreadCount);
+	}
+}

--- a/services/chat/tests/Chat.FunctionalTests/Infrastructure/ChatApiFactory.cs
+++ b/services/chat/tests/Chat.FunctionalTests/Infrastructure/ChatApiFactory.cs
@@ -46,6 +46,7 @@ public sealed class ChatApiFactory : WebApplicationFactory<Program>
 	public FakeClock Clock { get; } = new();
 	public FakeIdGenerator IdGenerator { get; } = new();
 	public FakeConversationUnicast ConversationUnicast { get; } = new();
+	public FakeReadStateRepository ReadStateRepository { get; } = new();
 
 	public IReadOnlyList<Message> SavedMessages => MessageRepository.Saved.Where(m => !m.IsDirectMessage).ToList();
 	public IReadOnlyList<Message> SavedDirectMessages => MessageRepository.Saved.Where(m => m.IsDirectMessage).ToList();
@@ -216,6 +217,9 @@ public sealed class ChatApiFactory : WebApplicationFactory<Program>
 
 			services.RemoveAll<ISnowflakeIdGenerator>();
 			services.AddSingleton<ISnowflakeIdGenerator>(IdGenerator);
+
+			services.RemoveAll<IReadStateRepository>();
+			services.AddSingleton<IReadStateRepository>(ReadStateRepository);
 		});
 	}
 

--- a/services/chat/tests/Chat.UnitTests/Application/GetChannelReadStatesHandlerTests.cs
+++ b/services/chat/tests/Chat.UnitTests/Application/GetChannelReadStatesHandlerTests.cs
@@ -58,9 +58,9 @@ public sealed class GetChannelReadStatesHandlerTests
 	{
 		var (h, handler) = BuildHandler(userId: 42);
 		h.GuildClient.VisibleChannelIds = [100];
+		var lastReadAt = new DateTimeOffset(2026, 1, 1, 12, 0, 0, TimeSpan.Zero);
 		h.ReadStates.SeedChannelReadState(42, new ReadState(
-			ContainerId: 100, IsDm: false, LastReadMessageId: 5,
-			LastReadAt: new DateTimeOffset(2026, 1, 1, 12, 0, 0, TimeSpan.Zero)));
+			ContainerId: 100, IsDm: false, LastReadMessageId: 5, LastReadAt: lastReadAt));
 		h.ReadStates.ChannelMessageCountsAfter[100] = 2;
 
 		var result = await handler.HandleAsync(new GetChannelReadStatesQuery());
@@ -70,6 +70,22 @@ public sealed class GetChannelReadStatesHandlerTests
 		Assert.Equal("100", entry.ChannelId);
 		Assert.Equal("5", entry.LastReadMessageId);
 		Assert.Equal(2, entry.UnreadCount);
+
+		// must count from the stored cursor, not the "never read" epoch sentinel
+		var call = Assert.Single(h.ReadStates.CountCalls);
+		Assert.Equal(lastReadAt, call.After);
+	}
+
+	[Fact]
+	public async Task ChannelWithNoReadStateRow_CountsFromUnixEpoch()
+	{
+		var (h, handler) = BuildHandler(userId: 42);
+		h.GuildClient.VisibleChannelIds = [100];
+
+		await handler.HandleAsync(new GetChannelReadStatesQuery());
+
+		var call = Assert.Single(h.ReadStates.CountCalls);
+		Assert.Equal(DateTimeOffset.UnixEpoch, call.After);
 	}
 
 	[Fact]
@@ -84,5 +100,30 @@ public sealed class GetChannelReadStatesHandlerTests
 		Assert.Equal(2, result.Value.Count);
 		Assert.Contains(result.Value, r => r.ChannelId == "100");
 		Assert.Contains(result.Value, r => r.ChannelId == "200");
+	}
+
+	[Fact]
+	public async Task MixedChannels_OneWithRow_OneWithout_EachComputedIndependently()
+	{
+		var (h, handler) = BuildHandler(userId: 42);
+		h.GuildClient.VisibleChannelIds = [100, 200];
+		h.ReadStates.SeedChannelReadState(42, new ReadState(
+			ContainerId: 100, IsDm: false, LastReadMessageId: 5,
+			LastReadAt: new DateTimeOffset(2026, 1, 1, 12, 0, 0, TimeSpan.Zero)));
+		h.ReadStates.ChannelMessageCountsAfter[100] = 1;
+		h.ReadStates.ChannelMessageCountsAfter[200] = 9;
+
+		var result = await handler.HandleAsync(new GetChannelReadStatesQuery());
+
+		Assert.True(result.Succeeded);
+		Assert.Equal(2, result.Value.Count);
+
+		var withRow = result.Value.Single(r => r.ChannelId == "100");
+		Assert.Equal("5", withRow.LastReadMessageId);
+		Assert.Equal(1, withRow.UnreadCount);
+
+		var withoutRow = result.Value.Single(r => r.ChannelId == "200");
+		Assert.Null(withoutRow.LastReadMessageId);
+		Assert.Equal(9, withoutRow.UnreadCount);
 	}
 }

--- a/services/chat/tests/Chat.UnitTests/Application/GetChannelReadStatesHandlerTests.cs
+++ b/services/chat/tests/Chat.UnitTests/Application/GetChannelReadStatesHandlerTests.cs
@@ -1,0 +1,88 @@
+using Chat.Application.Abstractions;
+using Chat.Application.Abstractions.Messaging;
+using Chat.Application.Features.Channels.Common;
+using Chat.Application.Features.Channels.GetReadStates;
+using Chat.Domain.ReadStates;
+using Chat.Domain.Results;
+using Chat.UnitTests.Fakes;
+using Xunit;
+
+namespace Chat.UnitTests.Application;
+
+public sealed class GetChannelReadStatesHandlerTests
+{
+	private sealed record Harness(FakeCurrentUser CurrentUser, FakeGuildClient GuildClient, FakeReadStateRepository ReadStates);
+
+	private static (Harness Harness, IQueryHandler<GetChannelReadStatesQuery, Result<IReadOnlyList<ChannelReadStateResponse>>> Handler)
+		BuildHandler(long userId = 42)
+	{
+		var currentUser = new FakeCurrentUser { UserId = userId };
+		var guildClient = new FakeGuildClient();
+		var readStates = new FakeReadStateRepository();
+
+		var handler = HandlerFactory.CreateQuery<GetChannelReadStatesQuery, Result<IReadOnlyList<ChannelReadStateResponse>>>(
+			currentUser, guildClient, readStates);
+
+		return (new Harness(currentUser, guildClient, readStates), handler);
+	}
+
+	[Fact]
+	public async Task NoVisibleChannels_ReturnsEmptyList()
+	{
+		var (_, handler) = BuildHandler();
+
+		var result = await handler.HandleAsync(new GetChannelReadStatesQuery());
+
+		Assert.True(result.Succeeded);
+		Assert.Empty(result.Value);
+	}
+
+	[Fact]
+	public async Task ChannelWithNoReadStateRow_ReturnsNullCursor_AndTotalCount()
+	{
+		var (h, handler) = BuildHandler(userId: 42);
+		h.GuildClient.VisibleChannelIds = [100];
+		h.ReadStates.ChannelMessageCountsAfter[100] = 7;
+
+		var result = await handler.HandleAsync(new GetChannelReadStatesQuery());
+
+		Assert.True(result.Succeeded);
+		var entry = Assert.Single(result.Value);
+		Assert.Equal("100", entry.ChannelId);
+		Assert.Null(entry.LastReadMessageId);
+		Assert.Equal(7, entry.UnreadCount);
+	}
+
+	[Fact]
+	public async Task ChannelWithReadStateRow_ReturnsCursor_AndCountSinceCursor()
+	{
+		var (h, handler) = BuildHandler(userId: 42);
+		h.GuildClient.VisibleChannelIds = [100];
+		h.ReadStates.SeedChannelReadState(42, new ReadState(
+			ContainerId: 100, IsDm: false, LastReadMessageId: 5,
+			LastReadAt: new DateTimeOffset(2026, 1, 1, 12, 0, 0, TimeSpan.Zero)));
+		h.ReadStates.ChannelMessageCountsAfter[100] = 2;
+
+		var result = await handler.HandleAsync(new GetChannelReadStatesQuery());
+
+		Assert.True(result.Succeeded);
+		var entry = Assert.Single(result.Value);
+		Assert.Equal("100", entry.ChannelId);
+		Assert.Equal("5", entry.LastReadMessageId);
+		Assert.Equal(2, entry.UnreadCount);
+	}
+
+	[Fact]
+	public async Task MultipleVisibleChannels_ReturnsOneEntryEach()
+	{
+		var (h, handler) = BuildHandler(userId: 42);
+		h.GuildClient.VisibleChannelIds = [100, 200];
+
+		var result = await handler.HandleAsync(new GetChannelReadStatesQuery());
+
+		Assert.True(result.Succeeded);
+		Assert.Equal(2, result.Value.Count);
+		Assert.Contains(result.Value, r => r.ChannelId == "100");
+		Assert.Contains(result.Value, r => r.ChannelId == "200");
+	}
+}

--- a/services/chat/tests/Chat.UnitTests/Application/ListDmConversationsHandlerTests.cs
+++ b/services/chat/tests/Chat.UnitTests/Application/ListDmConversationsHandlerTests.cs
@@ -10,18 +10,19 @@ namespace Chat.UnitTests.Application;
 
 public sealed class ListDmConversationsHandlerTests
 {
-	private sealed record Harness(FakeCurrentUser CurrentUser, FakeMessageRepository Repository);
+	private sealed record Harness(FakeCurrentUser CurrentUser, FakeMessageRepository Repository, FakeReadStateRepository ReadStates);
 
 	private static (Harness Harness, IQueryHandler<ListDmConversationsQuery, Result<IReadOnlyList<DmConversationResponse>>> Handler)
 		BuildHandler(long userId = 42)
 	{
 		var currentUser = new FakeCurrentUser { UserId = userId };
 		var repository = new FakeMessageRepository();
+		var readStates = new FakeReadStateRepository();
 
 		var handler = HandlerFactory.CreateQuery<ListDmConversationsQuery, Result<IReadOnlyList<DmConversationResponse>>>(
-			currentUser, repository);
+			currentUser, repository, readStates);
 
-		return (new Harness(currentUser, repository), handler);
+		return (new Harness(currentUser, repository, readStates), handler);
 	}
 
 	[Fact]
@@ -87,7 +88,7 @@ public sealed class ListDmConversationsHandlerTests
 	}
 
 	[Fact]
-	public async Task UnreadCount_IsAlwaysZero()
+	public async Task UnreadCount_DefaultsToZero_WhenNoCounterRow()
 	{
 		var (h, handler) = BuildHandler();
 
@@ -97,5 +98,22 @@ public sealed class ListDmConversationsHandlerTests
 		var result = await handler.HandleAsync(new ListDmConversationsQuery(IncludeArchived: false));
 
 		Assert.Equal(0, Assert.Single(result.Value).UnreadCount);
+	}
+
+	[Fact]
+	public async Task UnreadCount_IsSourcedFromReadStateRepository_PerPartner()
+	{
+		var (h, handler) = BuildHandler();
+
+		h.Repository.WithConversationSummary(42, new DmConversation(
+			PartnerId: 100, LastMessageAt: DateTimeOffset.UtcNow, LastPreview: "hey", IsArchived: false));
+		h.Repository.WithConversationSummary(42, new DmConversation(
+			PartnerId: 200, LastMessageAt: DateTimeOffset.UtcNow, LastPreview: "yo", IsArchived: false));
+		h.ReadStates.SeedDmUnreadCount(42, partnerId: 100, count: 3);
+
+		var result = await handler.HandleAsync(new ListDmConversationsQuery(IncludeArchived: false));
+
+		Assert.Equal(3, result.Value.Single(c => c.PartnerId == "100").UnreadCount);
+		Assert.Equal(0, result.Value.Single(c => c.PartnerId == "200").UnreadCount);
 	}
 }

--- a/services/chat/tests/Chat.UnitTests/Application/SendDirectMessageHandlerTests.cs
+++ b/services/chat/tests/Chat.UnitTests/Application/SendDirectMessageHandlerTests.cs
@@ -17,6 +17,7 @@ public sealed class SendDirectMessageHandlerTests
 		FakeCurrentUser CurrentUser,
 		FakeMessageRepository Repository,
 		FakeAttachmentRepository AttachmentRepository,
+		FakeReadStateRepository ReadStates,
 		FakeIdGenerator IdGenerator,
 		FakeUserClient UserClient,
 		FakeClock Clock,
@@ -37,11 +38,12 @@ public sealed class SendDirectMessageHandlerTests
 		var clock = new FakeClock();
 		var eventBus = new FakeEventBus();
 		var unicaster = new FakeConversationUnicast();
+		var readStates = new FakeReadStateRepository();
 
 		var handler = HandlerFactory.CreateCommand<SendDirectMessageCommand, Result<DirectMessageResponse>>(
-			currentUser, repository, attachmentRepository, ids, clock, userClient, eventBus, unicaster);
+			currentUser, repository, attachmentRepository, readStates, ids, clock, userClient, eventBus, unicaster);
 
-		return (new Harness(currentUser, repository, attachmentRepository, ids, userClient, clock, eventBus, unicaster), handler);
+		return (new Harness(currentUser, repository, attachmentRepository, readStates, ids, userClient, clock, eventBus, unicaster), handler);
 	}
 
 	[Fact]
@@ -73,6 +75,9 @@ public sealed class SendDirectMessageHandlerTests
 
 		var unicastMessage = Assert.Single(h.Unicaster.Unicasts);
 		Assert.Same(response, unicastMessage);
+
+		var incremented = Assert.Single(h.ReadStates.IncrementedDmUnreadCounts);
+		Assert.Equal((100L, 42L), incremented);
 	}
 
 	[Fact]
@@ -138,6 +143,7 @@ public sealed class SendDirectMessageHandlerTests
 		Assert.Single(h.Repository.Saved);
 		Assert.Empty(h.EventBus.Published);
 		Assert.Empty(h.Unicaster.Unicasts);
+		Assert.Single(h.ReadStates.IncrementedDmUnreadCounts); // dedup hit must not double-increment
 	}
 
 	[Fact]

--- a/services/chat/tests/Chat.UnitTests/Application/UpdateChannelReadStateHandlerTests.cs
+++ b/services/chat/tests/Chat.UnitTests/Application/UpdateChannelReadStateHandlerTests.cs
@@ -106,6 +106,37 @@ public sealed class UpdateChannelReadStateHandlerTests
 	}
 
 	[Fact]
+	public async Task DeletedMessage_ReturnsNotFound()
+	{
+		var (h, handler) = BuildHandler();
+		h.GuildClient.Result = new ChannelMembership(IsMember: true, GuildId: 5, Permissions: ReadMessagesPermission);
+		h.Repository.Seed(Message.Reconstitute(
+			id: 1, containerId: 100, authorId: 99, recipientId: null,
+			content: null, replyToId: null, editedAt: null, isDeleted: true, createdAt: DateTimeOffset.UtcNow));
+
+		var result = await handler.HandleAsync(new UpdateChannelReadStateCommand(ChannelId: 100, MessageId: 1));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal(MessageFailures.NotFound, result.Error);
+	}
+
+	[Fact]
+	public async Task DmMessageId_ReturnsNotFound()
+	{
+		var (h, handler) = BuildHandler();
+		h.GuildClient.Result = new ChannelMembership(IsMember: true, GuildId: 5, Permissions: ReadMessagesPermission);
+		// same numeric id as the channel, but it's a DM message - IsDirectMessage must reject it
+		h.Repository.Seed(Message.Reconstitute(
+			id: 1, containerId: 100, authorId: 99, recipientId: 7,
+			content: "hi", replyToId: null, editedAt: null, isDeleted: false, createdAt: DateTimeOffset.UtcNow));
+
+		var result = await handler.HandleAsync(new UpdateChannelReadStateCommand(ChannelId: 100, MessageId: 1));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal(MessageFailures.NotFound, result.Error);
+	}
+
+	[Fact]
 	public async Task HappyPath_AdvancesCursor_ReturnsZeroUnread()
 	{
 		var (h, handler) = BuildHandler(userId: 42);
@@ -127,6 +158,36 @@ public sealed class UpdateChannelReadStateHandlerTests
 	}
 
 	[Fact]
+	public async Task HappyPath_UnreadCount_ReflectsRepositoryCount()
+	{
+		var (h, handler) = BuildHandler(userId: 42);
+		h.GuildClient.Result = new ChannelMembership(IsMember: true, GuildId: 5, Permissions: ReadMessagesPermission);
+		var anchor = new DateTimeOffset(2026, 1, 1, 12, 0, 0, TimeSpan.Zero);
+		SeedMessage(h.Repository, id: 1, channelId: 100, createdAt: anchor);
+		h.ReadStates.ChannelMessageCountsAfter[100] = 5; // 5 messages arrived after this one
+
+		var result = await handler.HandleAsync(new UpdateChannelReadStateCommand(ChannelId: 100, MessageId: 1));
+
+		Assert.True(result.Succeeded);
+		Assert.Equal(5, result.Value.UnreadCount);
+	}
+
+	[Fact]
+	public async Task HappyPath_CountsMessagesAfter_TheTargetMessagesOwnTimestamp_NotWallClockTime()
+	{
+		var (h, handler) = BuildHandler(userId: 42);
+		h.GuildClient.Result = new ChannelMembership(IsMember: true, GuildId: 5, Permissions: ReadMessagesPermission);
+		var messageCreatedAt = new DateTimeOffset(2020, 1, 1, 12, 0, 0, TimeSpan.Zero); // long before "now"
+		SeedMessage(h.Repository, id: 1, channelId: 100, createdAt: messageCreatedAt);
+
+		await handler.HandleAsync(new UpdateChannelReadStateCommand(ChannelId: 100, MessageId: 1));
+
+		var call = Assert.Single(h.ReadStates.CountCalls);
+		Assert.Equal(100L, call.ChannelId);
+		Assert.Equal(messageCreatedAt, call.After);
+	}
+
+	[Fact]
 	public async Task OlderMessageId_IsNoOp_KeepsNewerCursor()
 	{
 		var (h, handler) = BuildHandler(userId: 42);
@@ -142,5 +203,8 @@ public sealed class UpdateChannelReadStateHandlerTests
 		var second = await handler.HandleAsync(new UpdateChannelReadStateCommand(ChannelId: 100, MessageId: 1));
 		Assert.True(second.Succeeded);
 		Assert.Equal("2", second.Value.LastReadMessageId); // unchanged, message 1 is older
+
+		// still broadcasts on a no-op: other devices get a harmless resync
+		Assert.Equal(2, h.Broadcaster.ReadStateCalls.Count);
 	}
 }

--- a/services/chat/tests/Chat.UnitTests/Application/UpdateChannelReadStateHandlerTests.cs
+++ b/services/chat/tests/Chat.UnitTests/Application/UpdateChannelReadStateHandlerTests.cs
@@ -17,7 +17,8 @@ public sealed class UpdateChannelReadStateHandlerTests
 		FakeCurrentUser CurrentUser,
 		FakeGuildClient GuildClient,
 		FakeMessageRepository Repository,
-		FakeReadStateRepository ReadStates);
+		FakeReadStateRepository ReadStates,
+		FakeUserBroadcaster Broadcaster);
 
 	private static (Harness Harness, ICommandHandler<UpdateChannelReadStateCommand, Result<ChannelReadStateResponse>> Handler)
 		BuildHandler(long userId = 42)
@@ -26,11 +27,12 @@ public sealed class UpdateChannelReadStateHandlerTests
 		var guildClient = new FakeGuildClient();
 		var repository = new FakeMessageRepository();
 		var readStates = new FakeReadStateRepository();
+		var broadcaster = new FakeUserBroadcaster();
 
 		var handler = HandlerFactory.CreateCommand<UpdateChannelReadStateCommand, Result<ChannelReadStateResponse>>(
-			currentUser, guildClient, repository, readStates);
+			currentUser, guildClient, repository, readStates, broadcaster);
 
-		return (new Harness(currentUser, guildClient, repository, readStates), handler);
+		return (new Harness(currentUser, guildClient, repository, readStates, broadcaster), handler);
 	}
 
 	private static Message SeedMessage(FakeMessageRepository repo, long id, long channelId, DateTimeOffset createdAt)
@@ -118,6 +120,10 @@ public sealed class UpdateChannelReadStateHandlerTests
 		Assert.Equal("100", result.Value.ChannelId);
 		Assert.Equal("1", result.Value.LastReadMessageId);
 		Assert.Equal(0, result.Value.UnreadCount);
+
+		var (broadcastUserId, broadcastResponse) = Assert.Single(h.Broadcaster.ReadStateCalls);
+		Assert.Equal(42L, broadcastUserId);
+		Assert.Same(result.Value, broadcastResponse);
 	}
 
 	[Fact]

--- a/services/chat/tests/Chat.UnitTests/Application/UpdateChannelReadStateHandlerTests.cs
+++ b/services/chat/tests/Chat.UnitTests/Application/UpdateChannelReadStateHandlerTests.cs
@@ -1,0 +1,140 @@
+using Chat.Application.Abstractions;
+using Chat.Application.Abstractions.Messaging;
+using Chat.Application.Features.Channels.Common;
+using Chat.Application.Features.Channels.UpdateReadState;
+using Chat.Domain.Messages;
+using Chat.Domain.Results;
+using Chat.UnitTests.Fakes;
+using Xunit;
+
+namespace Chat.UnitTests.Application;
+
+public sealed class UpdateChannelReadStateHandlerTests
+{
+	private const long ReadMessagesPermission = 1L << 1;
+
+	private sealed record Harness(
+		FakeCurrentUser CurrentUser,
+		FakeGuildClient GuildClient,
+		FakeMessageRepository Repository,
+		FakeReadStateRepository ReadStates);
+
+	private static (Harness Harness, ICommandHandler<UpdateChannelReadStateCommand, Result<ChannelReadStateResponse>> Handler)
+		BuildHandler(long userId = 42)
+	{
+		var currentUser = new FakeCurrentUser { UserId = userId };
+		var guildClient = new FakeGuildClient();
+		var repository = new FakeMessageRepository();
+		var readStates = new FakeReadStateRepository();
+
+		var handler = HandlerFactory.CreateCommand<UpdateChannelReadStateCommand, Result<ChannelReadStateResponse>>(
+			currentUser, guildClient, repository, readStates);
+
+		return (new Harness(currentUser, guildClient, repository, readStates), handler);
+	}
+
+	private static Message SeedMessage(FakeMessageRepository repo, long id, long channelId, DateTimeOffset createdAt)
+	{
+		var message = Message.Reconstitute(
+			id: id, containerId: channelId, authorId: 99, recipientId: null,
+			content: "hi", replyToId: null, editedAt: null, isDeleted: false, createdAt: createdAt);
+		repo.Seed(message);
+		return message;
+	}
+
+	[Fact]
+	public async Task ChannelNotFound_ReturnsChannelNotFound()
+	{
+		var (h, handler) = BuildHandler();
+		h.GuildClient.Result = null;
+
+		var result = await handler.HandleAsync(new UpdateChannelReadStateCommand(ChannelId: 100, MessageId: 1));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal(MessageFailures.ChannelNotFound, result.Error);
+	}
+
+	[Fact]
+	public async Task NotAMember_ReturnsNotAMember()
+	{
+		var (h, handler) = BuildHandler();
+		h.GuildClient.Result = new ChannelMembership(IsMember: false, GuildId: 5, Permissions: ReadMessagesPermission);
+
+		var result = await handler.HandleAsync(new UpdateChannelReadStateCommand(ChannelId: 100, MessageId: 1));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal(MessageFailures.NotAMember, result.Error);
+	}
+
+	[Fact]
+	public async Task MissingReadPermission_ReturnsMissingReadPermission()
+	{
+		var (h, handler) = BuildHandler();
+		h.GuildClient.Result = new ChannelMembership(IsMember: true, GuildId: 5, Permissions: 0);
+
+		var result = await handler.HandleAsync(new UpdateChannelReadStateCommand(ChannelId: 100, MessageId: 1));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal(MessageFailures.MissingReadPermission, result.Error);
+	}
+
+	[Fact]
+	public async Task UnknownMessage_ReturnsNotFound()
+	{
+		var (h, handler) = BuildHandler();
+		h.GuildClient.Result = new ChannelMembership(IsMember: true, GuildId: 5, Permissions: ReadMessagesPermission);
+
+		var result = await handler.HandleAsync(new UpdateChannelReadStateCommand(ChannelId: 100, MessageId: 999));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal(MessageFailures.NotFound, result.Error);
+	}
+
+	[Fact]
+	public async Task MessageInAnotherChannel_ReturnsNotFound()
+	{
+		var (h, handler) = BuildHandler();
+		h.GuildClient.Result = new ChannelMembership(IsMember: true, GuildId: 5, Permissions: ReadMessagesPermission);
+		SeedMessage(h.Repository, id: 1, channelId: 200, createdAt: DateTimeOffset.UtcNow);
+
+		var result = await handler.HandleAsync(new UpdateChannelReadStateCommand(ChannelId: 100, MessageId: 1));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal(MessageFailures.NotFound, result.Error);
+	}
+
+	[Fact]
+	public async Task HappyPath_AdvancesCursor_ReturnsZeroUnread()
+	{
+		var (h, handler) = BuildHandler(userId: 42);
+		h.GuildClient.Result = new ChannelMembership(IsMember: true, GuildId: 5, Permissions: ReadMessagesPermission);
+		var anchor = new DateTimeOffset(2026, 1, 1, 12, 0, 0, TimeSpan.Zero);
+		SeedMessage(h.Repository, id: 1, channelId: 100, createdAt: anchor);
+		h.ReadStates.ChannelMessageCountsAfter[100] = 0;
+
+		var result = await handler.HandleAsync(new UpdateChannelReadStateCommand(ChannelId: 100, MessageId: 1));
+
+		Assert.True(result.Succeeded);
+		Assert.Equal("100", result.Value.ChannelId);
+		Assert.Equal("1", result.Value.LastReadMessageId);
+		Assert.Equal(0, result.Value.UnreadCount);
+	}
+
+	[Fact]
+	public async Task OlderMessageId_IsNoOp_KeepsNewerCursor()
+	{
+		var (h, handler) = BuildHandler(userId: 42);
+		h.GuildClient.Result = new ChannelMembership(IsMember: true, GuildId: 5, Permissions: ReadMessagesPermission);
+		var anchor = new DateTimeOffset(2026, 1, 1, 12, 0, 0, TimeSpan.Zero);
+		SeedMessage(h.Repository, id: 1, channelId: 100, createdAt: anchor);
+		SeedMessage(h.Repository, id: 2, channelId: 100, createdAt: anchor.AddMinutes(1));
+
+		var first = await handler.HandleAsync(new UpdateChannelReadStateCommand(ChannelId: 100, MessageId: 2));
+		Assert.True(first.Succeeded);
+		Assert.Equal("2", first.Value.LastReadMessageId);
+
+		var second = await handler.HandleAsync(new UpdateChannelReadStateCommand(ChannelId: 100, MessageId: 1));
+		Assert.True(second.Succeeded);
+		Assert.Equal("2", second.Value.LastReadMessageId); // unchanged, message 1 is older
+	}
+}

--- a/services/chat/tests/Chat.UnitTests/Application/UpdateDmReadStateHandlerTests.cs
+++ b/services/chat/tests/Chat.UnitTests/Application/UpdateDmReadStateHandlerTests.cs
@@ -70,6 +70,38 @@ public sealed class UpdateDmReadStateHandlerTests
 	}
 
 	[Fact]
+	public async Task DeletedMessage_ReturnsNotFound()
+	{
+		var (h, handler) = BuildHandler(userId: 42);
+		h.Repository.WithConversation(42, 100, conversationId: 555);
+		h.Repository.Seed(Message.Reconstitute(
+			id: 1, containerId: 555, authorId: 100, recipientId: 42,
+			content: null, replyToId: null, editedAt: null, isDeleted: true, createdAt: DateTimeOffset.UtcNow));
+
+		var result = await handler.HandleAsync(new UpdateDmReadStateCommand(PartnerId: 100, MessageId: 1));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal(MessageFailures.NotFound, result.Error);
+	}
+
+	[Fact]
+	public async Task ChannelMessageId_ReturnsNotFound()
+	{
+		var (h, handler) = BuildHandler(userId: 42);
+		h.Repository.WithConversation(42, 100, conversationId: 555);
+		// same numeric id as the conversation, but it's a channel message - the
+		// !IsDirectMessage guard must reject it regardless of the id match
+		h.Repository.Seed(Message.Reconstitute(
+			id: 1, containerId: 555, authorId: 100, recipientId: null,
+			content: "hi", replyToId: null, editedAt: null, isDeleted: false, createdAt: DateTimeOffset.UtcNow));
+
+		var result = await handler.HandleAsync(new UpdateDmReadStateCommand(PartnerId: 100, MessageId: 1));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal(MessageFailures.NotFound, result.Error);
+	}
+
+	[Fact]
 	public async Task HappyPath_AdvancesCursor_ResetsUnread_ReturnsZero()
 	{
 		var (h, handler) = BuildHandler(userId: 42);
@@ -113,5 +145,6 @@ public sealed class UpdateDmReadStateHandlerTests
 		Assert.True(second.Succeeded);
 		Assert.Equal("2", second.Value.LastReadMessageId); // unchanged, message 1 is older
 		Assert.Equal(2, h.ReadStates.ResetDmUnreadCounts.Count); // still resets on every successful call
+		Assert.Equal(2, h.Broadcaster.DmReadStateCalls.Count); // still broadcasts on every successful call
 	}
 }

--- a/services/chat/tests/Chat.UnitTests/Application/UpdateDmReadStateHandlerTests.cs
+++ b/services/chat/tests/Chat.UnitTests/Application/UpdateDmReadStateHandlerTests.cs
@@ -1,0 +1,108 @@
+using Chat.Application.Abstractions.Messaging;
+using Chat.Application.Features.DirectMessages.Common;
+using Chat.Application.Features.DirectMessages.UpdateReadState;
+using Chat.Domain.Messages;
+using Chat.Domain.Results;
+using Chat.UnitTests.Fakes;
+using Xunit;
+
+namespace Chat.UnitTests.Application;
+
+public sealed class UpdateDmReadStateHandlerTests
+{
+	private sealed record Harness(FakeCurrentUser CurrentUser, FakeMessageRepository Repository, FakeReadStateRepository ReadStates);
+
+	private static (Harness Harness, ICommandHandler<UpdateDmReadStateCommand, Result<DmReadStateResponse>> Handler)
+		BuildHandler(long userId = 42)
+	{
+		var currentUser = new FakeCurrentUser { UserId = userId };
+		var repository = new FakeMessageRepository();
+		var readStates = new FakeReadStateRepository();
+
+		var handler = HandlerFactory.CreateCommand<UpdateDmReadStateCommand, Result<DmReadStateResponse>>(
+			currentUser, repository, readStates);
+
+		return (new Harness(currentUser, repository, readStates), handler);
+	}
+
+	[Fact]
+	public async Task NoConversation_ReturnsConversationNotFound()
+	{
+		var (_, handler) = BuildHandler(userId: 42);
+
+		var result = await handler.HandleAsync(new UpdateDmReadStateCommand(PartnerId: 100, MessageId: 1));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal(MessageFailures.ConversationNotFound, result.Error);
+	}
+
+	[Fact]
+	public async Task UnknownMessage_ReturnsNotFound()
+	{
+		var (h, handler) = BuildHandler(userId: 42);
+		h.Repository.WithConversation(42, 100, conversationId: 555);
+
+		var result = await handler.HandleAsync(new UpdateDmReadStateCommand(PartnerId: 100, MessageId: 999));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal(MessageFailures.NotFound, result.Error);
+	}
+
+	[Fact]
+	public async Task MessageInAnotherConversation_ReturnsNotFound()
+	{
+		var (h, handler) = BuildHandler(userId: 42);
+		h.Repository.WithConversation(42, 100, conversationId: 555);
+		h.Repository.Seed(Message.Reconstitute(
+			id: 1, containerId: 999, authorId: 100, recipientId: 7,
+			content: "hi", replyToId: null, editedAt: null, isDeleted: false,
+			createdAt: DateTimeOffset.UtcNow));
+
+		var result = await handler.HandleAsync(new UpdateDmReadStateCommand(PartnerId: 100, MessageId: 1));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal(MessageFailures.NotFound, result.Error);
+	}
+
+	[Fact]
+	public async Task HappyPath_AdvancesCursor_ResetsUnread_ReturnsZero()
+	{
+		var (h, handler) = BuildHandler(userId: 42);
+		h.Repository.WithConversation(42, 100, conversationId: 555);
+		h.Repository.Seed(Message.Reconstitute(
+			id: 1, containerId: 555, authorId: 100, recipientId: 42,
+			content: "hi", replyToId: null, editedAt: null, isDeleted: false,
+			createdAt: new DateTimeOffset(2026, 1, 1, 12, 0, 0, TimeSpan.Zero)));
+
+		var result = await handler.HandleAsync(new UpdateDmReadStateCommand(PartnerId: 100, MessageId: 1));
+
+		Assert.True(result.Succeeded);
+		Assert.Equal("100", result.Value.PartnerId);
+		Assert.Equal("1", result.Value.LastReadMessageId);
+		Assert.Equal(0, result.Value.UnreadCount);
+		Assert.Single(h.ReadStates.ResetDmUnreadCounts, (42L, 100L));
+	}
+
+	[Fact]
+	public async Task OlderMessageId_IsNoOp_KeepsNewerCursor_StillResetsUnread()
+	{
+		var (h, handler) = BuildHandler(userId: 42);
+		h.Repository.WithConversation(42, 100, conversationId: 555);
+		var anchor = new DateTimeOffset(2026, 1, 1, 12, 0, 0, TimeSpan.Zero);
+		h.Repository.Seed(Message.Reconstitute(
+			id: 1, containerId: 555, authorId: 100, recipientId: 42,
+			content: "hi", replyToId: null, editedAt: null, isDeleted: false, createdAt: anchor));
+		h.Repository.Seed(Message.Reconstitute(
+			id: 2, containerId: 555, authorId: 100, recipientId: 42,
+			content: "hi2", replyToId: null, editedAt: null, isDeleted: false, createdAt: anchor.AddMinutes(1)));
+
+		var first = await handler.HandleAsync(new UpdateDmReadStateCommand(PartnerId: 100, MessageId: 2));
+		Assert.True(first.Succeeded);
+		Assert.Equal("2", first.Value.LastReadMessageId);
+
+		var second = await handler.HandleAsync(new UpdateDmReadStateCommand(PartnerId: 100, MessageId: 1));
+		Assert.True(second.Succeeded);
+		Assert.Equal("2", second.Value.LastReadMessageId); // unchanged, message 1 is older
+		Assert.Equal(2, h.ReadStates.ResetDmUnreadCounts.Count); // still resets on every successful call
+	}
+}

--- a/services/chat/tests/Chat.UnitTests/Application/UpdateDmReadStateHandlerTests.cs
+++ b/services/chat/tests/Chat.UnitTests/Application/UpdateDmReadStateHandlerTests.cs
@@ -10,7 +10,11 @@ namespace Chat.UnitTests.Application;
 
 public sealed class UpdateDmReadStateHandlerTests
 {
-	private sealed record Harness(FakeCurrentUser CurrentUser, FakeMessageRepository Repository, FakeReadStateRepository ReadStates);
+	private sealed record Harness(
+		FakeCurrentUser CurrentUser,
+		FakeMessageRepository Repository,
+		FakeReadStateRepository ReadStates,
+		FakeUserBroadcaster Broadcaster);
 
 	private static (Harness Harness, ICommandHandler<UpdateDmReadStateCommand, Result<DmReadStateResponse>> Handler)
 		BuildHandler(long userId = 42)
@@ -18,11 +22,12 @@ public sealed class UpdateDmReadStateHandlerTests
 		var currentUser = new FakeCurrentUser { UserId = userId };
 		var repository = new FakeMessageRepository();
 		var readStates = new FakeReadStateRepository();
+		var broadcaster = new FakeUserBroadcaster();
 
 		var handler = HandlerFactory.CreateCommand<UpdateDmReadStateCommand, Result<DmReadStateResponse>>(
-			currentUser, repository, readStates);
+			currentUser, repository, readStates, broadcaster);
 
-		return (new Harness(currentUser, repository, readStates), handler);
+		return (new Harness(currentUser, repository, readStates, broadcaster), handler);
 	}
 
 	[Fact]
@@ -81,6 +86,10 @@ public sealed class UpdateDmReadStateHandlerTests
 		Assert.Equal("1", result.Value.LastReadMessageId);
 		Assert.Equal(0, result.Value.UnreadCount);
 		Assert.Single(h.ReadStates.ResetDmUnreadCounts, (42L, 100L));
+
+		var (broadcastUserId, broadcastResponse) = Assert.Single(h.Broadcaster.DmReadStateCalls);
+		Assert.Equal(42L, broadcastUserId);
+		Assert.Same(result.Value, broadcastResponse);
 	}
 
 	[Fact]

--- a/services/chat/tests/Chat.UnitTests/Fakes/FakeGuildClient.cs
+++ b/services/chat/tests/Chat.UnitTests/Fakes/FakeGuildClient.cs
@@ -14,4 +14,9 @@ public sealed class FakeGuildClient : IGuildClient
 
 	public Task<ChannelMembership?> GetMembershipAsync(long channelId, long userId, CancellationToken ct)
 		=> Task.FromResult(_map.TryGetValue((channelId, userId), out var m) ? m : Result);
+
+	public List<long> VisibleChannelIds { get; set; } = [];
+
+	public Task<IReadOnlyList<long>> GetVisibleChannelIdsAsync(long userId, CancellationToken ct)
+		=> Task.FromResult<IReadOnlyList<long>>(VisibleChannelIds);
 }

--- a/services/chat/tests/Chat.UnitTests/Fakes/FakeReadStateRepository.cs
+++ b/services/chat/tests/Chat.UnitTests/Fakes/FakeReadStateRepository.cs
@@ -6,6 +6,7 @@ namespace Chat.UnitTests.Fakes;
 public sealed class FakeReadStateRepository : IReadStateRepository
 {
 	private readonly Dictionary<(long UserId, long ContainerId, bool IsDm), ReadState> _states = [];
+	private readonly Dictionary<(long UserId, long PartnerId), int> _dmUnreadCounts = [];
 
 	/// <summary>lets a test control what CountChannelMessagesAfterAsync returns per channel</summary>
 	public Dictionary<long, int> ChannelMessageCountsAfter { get; } = [];
@@ -20,6 +21,9 @@ public sealed class FakeReadStateRepository : IReadStateRepository
 	public void SeedChannelReadState(long userId, ReadState state) =>
 		_states[(userId, state.ContainerId, false)] = state;
 
+	public void SeedDmUnreadCount(long userId, long partnerId, int count) =>
+		_dmUnreadCounts[(userId, partnerId)] = count;
+
 	public void Reset()
 	{
 		_states.Clear();
@@ -28,6 +32,7 @@ public sealed class FakeReadStateRepository : IReadStateRepository
 		ResetDmUnreadCounts.Clear();
 		CountCalls.Clear();
 		DeletedAllForUsers.Clear();
+		_dmUnreadCounts.Clear();
 	}
 
 	public Task<ReadState> UpsertIfNewerAsync(
@@ -67,6 +72,14 @@ public sealed class FakeReadStateRepository : IReadStateRepository
 	{
 		IncrementedDmUnreadCounts.Add((userId, partnerId));
 		return Task.CompletedTask;
+	}
+
+	public Task<IReadOnlyDictionary<long, int>> GetDmUnreadCountsForUserAsync(long userId, CancellationToken ct)
+	{
+		IReadOnlyDictionary<long, int> counts = _dmUnreadCounts
+			.Where(kv => kv.Key.UserId == userId)
+			.ToDictionary(kv => kv.Key.PartnerId, kv => kv.Value);
+		return Task.FromResult(counts);
 	}
 
 	public Task DeleteAllForUserAsync(long userId, CancellationToken ct)

--- a/services/chat/tests/Chat.UnitTests/Fakes/FakeReadStateRepository.cs
+++ b/services/chat/tests/Chat.UnitTests/Fakes/FakeReadStateRepository.cs
@@ -16,6 +16,14 @@ public sealed class FakeReadStateRepository : IReadStateRepository
 	public void SeedChannelReadState(long userId, ReadState state) =>
 		_states[(userId, state.ContainerId, false)] = state;
 
+	public void Reset()
+	{
+		_states.Clear();
+		ChannelMessageCountsAfter.Clear();
+		IncrementedDmUnreadCounts.Clear();
+		ResetDmUnreadCounts.Clear();
+	}
+
 	public Task<ReadState> UpsertIfNewerAsync(
 		long userId, long containerId, bool isDm, long messageId, DateTimeOffset readAt, CancellationToken ct)
 	{

--- a/services/chat/tests/Chat.UnitTests/Fakes/FakeReadStateRepository.cs
+++ b/services/chat/tests/Chat.UnitTests/Fakes/FakeReadStateRepository.cs
@@ -12,6 +12,7 @@ public sealed class FakeReadStateRepository : IReadStateRepository
 
 	public List<(long UserId, long PartnerId)> IncrementedDmUnreadCounts { get; } = [];
 	public List<(long UserId, long PartnerId)> ResetDmUnreadCounts { get; } = [];
+	public List<long> DeletedAllForUsers { get; } = [];
 
 	/// <summary>records every CountChannelMessagesAfterAsync call so tests can assert the exact cursor passed in</summary>
 	public List<(long ChannelId, DateTimeOffset After)> CountCalls { get; } = [];
@@ -26,6 +27,7 @@ public sealed class FakeReadStateRepository : IReadStateRepository
 		IncrementedDmUnreadCounts.Clear();
 		ResetDmUnreadCounts.Clear();
 		CountCalls.Clear();
+		DeletedAllForUsers.Clear();
 	}
 
 	public Task<ReadState> UpsertIfNewerAsync(
@@ -64,6 +66,14 @@ public sealed class FakeReadStateRepository : IReadStateRepository
 	public Task IncrementDmUnreadCountAsync(long userId, long partnerId, CancellationToken ct)
 	{
 		IncrementedDmUnreadCounts.Add((userId, partnerId));
+		return Task.CompletedTask;
+	}
+
+	public Task DeleteAllForUserAsync(long userId, CancellationToken ct)
+	{
+		DeletedAllForUsers.Add(userId);
+		foreach (var key in _states.Keys.Where(k => k.UserId == userId).ToList())
+			_states.Remove(key);
 		return Task.CompletedTask;
 	}
 }

--- a/services/chat/tests/Chat.UnitTests/Fakes/FakeReadStateRepository.cs
+++ b/services/chat/tests/Chat.UnitTests/Fakes/FakeReadStateRepository.cs
@@ -13,6 +13,9 @@ public sealed class FakeReadStateRepository : IReadStateRepository
 	public List<(long UserId, long PartnerId)> IncrementedDmUnreadCounts { get; } = [];
 	public List<(long UserId, long PartnerId)> ResetDmUnreadCounts { get; } = [];
 
+	/// <summary>records every CountChannelMessagesAfterAsync call so tests can assert the exact cursor passed in</summary>
+	public List<(long ChannelId, DateTimeOffset After)> CountCalls { get; } = [];
+
 	public void SeedChannelReadState(long userId, ReadState state) =>
 		_states[(userId, state.ContainerId, false)] = state;
 
@@ -22,6 +25,7 @@ public sealed class FakeReadStateRepository : IReadStateRepository
 		ChannelMessageCountsAfter.Clear();
 		IncrementedDmUnreadCounts.Clear();
 		ResetDmUnreadCounts.Clear();
+		CountCalls.Clear();
 	}
 
 	public Task<ReadState> UpsertIfNewerAsync(
@@ -45,8 +49,11 @@ public sealed class FakeReadStateRepository : IReadStateRepository
 		return Task.FromResult(states);
 	}
 
-	public Task<int> CountChannelMessagesAfterAsync(long channelId, DateTimeOffset after, CancellationToken ct) =>
-		Task.FromResult(ChannelMessageCountsAfter.GetValueOrDefault(channelId, 0));
+	public Task<int> CountChannelMessagesAfterAsync(long channelId, DateTimeOffset after, CancellationToken ct)
+	{
+		CountCalls.Add((channelId, after));
+		return Task.FromResult(ChannelMessageCountsAfter.GetValueOrDefault(channelId, 0));
+	}
 
 	public Task ResetDmUnreadCountAsync(long userId, long partnerId, CancellationToken ct)
 	{

--- a/services/chat/tests/Chat.UnitTests/Fakes/FakeReadStateRepository.cs
+++ b/services/chat/tests/Chat.UnitTests/Fakes/FakeReadStateRepository.cs
@@ -1,0 +1,54 @@
+using Chat.Application.Abstractions.Persistence;
+using Chat.Domain.ReadStates;
+
+namespace Chat.UnitTests.Fakes;
+
+public sealed class FakeReadStateRepository : IReadStateRepository
+{
+	private readonly Dictionary<(long UserId, long ContainerId, bool IsDm), ReadState> _states = [];
+
+	/// <summary>lets a test control what CountChannelMessagesAfterAsync returns per channel</summary>
+	public Dictionary<long, int> ChannelMessageCountsAfter { get; } = [];
+
+	public List<(long UserId, long PartnerId)> IncrementedDmUnreadCounts { get; } = [];
+	public List<(long UserId, long PartnerId)> ResetDmUnreadCounts { get; } = [];
+
+	public void SeedChannelReadState(long userId, ReadState state) =>
+		_states[(userId, state.ContainerId, false)] = state;
+
+	public Task<ReadState> UpsertIfNewerAsync(
+		long userId, long containerId, bool isDm, long messageId, DateTimeOffset readAt, CancellationToken ct)
+	{
+		var key = (userId, containerId, isDm);
+		if (_states.TryGetValue(key, out var current) && current.LastReadMessageId >= messageId)
+			return Task.FromResult(current);
+
+		var updated = new ReadState(containerId, isDm, messageId, readAt);
+		_states[key] = updated;
+		return Task.FromResult(updated);
+	}
+
+	public Task<IReadOnlyList<ReadState>> GetChannelReadStatesForUserAsync(long userId, CancellationToken ct)
+	{
+		IReadOnlyList<ReadState> states = _states
+			.Where(kv => kv.Key.UserId == userId && !kv.Key.IsDm)
+			.Select(kv => kv.Value)
+			.ToList();
+		return Task.FromResult(states);
+	}
+
+	public Task<int> CountChannelMessagesAfterAsync(long channelId, DateTimeOffset after, CancellationToken ct) =>
+		Task.FromResult(ChannelMessageCountsAfter.GetValueOrDefault(channelId, 0));
+
+	public Task ResetDmUnreadCountAsync(long userId, long partnerId, CancellationToken ct)
+	{
+		ResetDmUnreadCounts.Add((userId, partnerId));
+		return Task.CompletedTask;
+	}
+
+	public Task IncrementDmUnreadCountAsync(long userId, long partnerId, CancellationToken ct)
+	{
+		IncrementedDmUnreadCounts.Add((userId, partnerId));
+		return Task.CompletedTask;
+	}
+}

--- a/services/chat/tests/Chat.UnitTests/Fakes/FakeUserBroadcaster.cs
+++ b/services/chat/tests/Chat.UnitTests/Fakes/FakeUserBroadcaster.cs
@@ -1,4 +1,6 @@
 using Chat.Application.Abstractions;
+using Chat.Application.Features.Channels.Common;
+using Chat.Application.Features.DirectMessages.Common;
 
 namespace Chat.UnitTests.Fakes;
 
@@ -9,12 +11,16 @@ public sealed class FakeUserBroadcaster : IUserBroadcaster
 	private readonly List<(long UserId, long GuildId)> _evictGuildCalls = [];
 	private readonly List<(long UserId, long ChannelId)> _evictChannelCalls = [];
 	private readonly List<long> _disconnectCalls = [];
+	private readonly List<(long UserId, ChannelReadStateResponse Response)> _readStateCalls = [];
+	private readonly List<(long UserId, DmReadStateResponse Response)> _dmReadStateCalls = [];
 
 	public IReadOnlyList<(long UserId, long GuildId, string GuildName)> JoinCalls => _joinCalls;
 	public IReadOnlyList<(long UserId, long GuildId)> LeftCalls => _leftCalls;
 	public IReadOnlyList<(long UserId, long GuildId)> EvictGuildCalls => _evictGuildCalls;
 	public IReadOnlyList<(long UserId, long ChannelId)> EvictChannelCalls => _evictChannelCalls;
 	public IReadOnlyList<long> DisconnectCalls => _disconnectCalls;
+	public IReadOnlyList<(long UserId, ChannelReadStateResponse Response)> ReadStateCalls => _readStateCalls;
+	public IReadOnlyList<(long UserId, DmReadStateResponse Response)> DmReadStateCalls => _dmReadStateCalls;
 
 	public Task BroadcastGuildJoinedAsync(long userId, long guildId, string guildName, CancellationToken ct)
 	{
@@ -25,6 +31,18 @@ public sealed class FakeUserBroadcaster : IUserBroadcaster
 	public Task BroadcastGuildLeftAsync(long userId, long guildId, CancellationToken ct)
 	{
 		_leftCalls.Add((userId, guildId));
+		return Task.CompletedTask;
+	}
+
+	public Task BroadcastChannelReadStateUpdatedAsync(long userId, ChannelReadStateResponse response, CancellationToken ct)
+	{
+		_readStateCalls.Add((userId, response));
+		return Task.CompletedTask;
+	}
+
+	public Task BroadcastDmReadStateUpdatedAsync(long userId, DmReadStateResponse response, CancellationToken ct)
+	{
+		_dmReadStateCalls.Add((userId, response));
 		return Task.CompletedTask;
 	}
 

--- a/services/chat/tests/Chat.UnitTests/Infrastructure/UserLifecycleConsumersTests.cs
+++ b/services/chat/tests/Chat.UnitTests/Infrastructure/UserLifecycleConsumersTests.cs
@@ -57,9 +57,11 @@ public sealed class UserDeletedConsumerTests
 	{
 		var broadcaster = new FakeUserBroadcaster { EvictedCount = 1 };
 		var messages = new FakeMessageRepository();
+		var readStates = new FakeReadStateRepository();
 		await using var provider = new ServiceCollection()
 			.AddSingleton<IUserBroadcaster>(broadcaster)
 			.AddSingleton<IMessageRepository>(messages)
+			.AddSingleton<IReadStateRepository>(readStates)
 			.AddMassTransitTestHarness(x => x.AddConsumer<UserDeletedConsumer>())
 			.BuildServiceProvider(true);
 
@@ -71,6 +73,7 @@ public sealed class UserDeletedConsumerTests
 		Assert.True(await harness.Consumed.Any<UserDeleted>());
 		Assert.Equal(99L, Assert.Single(broadcaster.DisconnectCalls));
 		Assert.Equal(99L, Assert.Single(messages.DeletedConversationsFor));
+		Assert.Equal(99L, Assert.Single(readStates.DeletedAllForUsers));
 	}
 
 	[Fact]
@@ -78,9 +81,11 @@ public sealed class UserDeletedConsumerTests
 	{
 		var broadcaster = new FakeUserBroadcaster();
 		var messages = new FakeMessageRepository();
+		var readStates = new FakeReadStateRepository();
 		await using var provider = new ServiceCollection()
 			.AddSingleton<IUserBroadcaster>(broadcaster)
 			.AddSingleton<IMessageRepository>(messages)
+			.AddSingleton<IReadStateRepository>(readStates)
 			.AddMassTransitTestHarness(x => x.AddConsumer<UserDeletedConsumer>())
 			.BuildServiceProvider(true);
 
@@ -92,5 +97,7 @@ public sealed class UserDeletedConsumerTests
 		Assert.True(await harness.Consumed.Any<UserDeleted>());
 		var deletedFor = Assert.Single(messages.DeletedConversationsFor);
 		Assert.Equal(7L, deletedFor);
+		var deletedReadStatesFor = Assert.Single(readStates.DeletedAllForUsers);
+		Assert.Equal(7L, deletedReadStatesFor);
 	}
 }

--- a/services/guild/src/Guild.Application/Abstractions/Persistence/IGuildRepository.cs
+++ b/services/guild/src/Guild.Application/Abstractions/Persistence/IGuildRepository.cs
@@ -26,6 +26,15 @@ public interface IGuildRepository
 	Task<IReadOnlyList<MyGuildSummary>> ListForMemberAsync(
 		long userId, CancellationToken cancellationToken = default);
 
+	/// <summary>
+	/// bare guild ids the user is a member of - no joined columns, no member
+	/// count. used by callers that only need to iterate guilds to resolve
+	/// per-guild data themselves (e.g. the visible-channels lookup), where
+	/// <see cref="ListForMemberAsync"/>'s correlated COUNT would be wasted work.
+	/// </summary>
+	Task<IReadOnlyList<long>> ListGuildIdsForMemberAsync(
+		long userId, CancellationToken cancellationToken = default);
+
 	Task<int> CountMembersAsync(long guildId, CancellationToken cancellationToken = default);
 	Task<int> CountOwnedByAsync(long userId, CancellationToken cancellationToken = default);
 	Task<bool> IsMemberAsync(long guildId, long userId, CancellationToken cancellationToken = default);

--- a/services/guild/src/Guild.Application/Features/Channels/VisibleChannels/GetVisibleChannelsHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Channels/VisibleChannels/GetVisibleChannelsHandler.cs
@@ -1,0 +1,56 @@
+using Guild.Application.Abstractions.Messaging;
+using Guild.Application.Abstractions.Persistence;
+using Guild.Application.Features.Channels.Common;
+using Guild.Application.Features.Channels.ListChannels;
+using Guild.Domain.Guild;
+using Guild.Domain.Results;
+
+namespace Guild.Application.Features.Channels.VisibleChannels;
+
+/// <summary>
+/// backs Chat Service's <c>GET /channels/read-states</c> sidebar fetch. resolves,
+/// for every guild the user belongs to, the channels where their effective
+/// permissions include <see cref="Permission.ReadMessages"/>. loads each guild's
+/// membership/roles, channels and overwrites via the existing lean per-guild
+/// reads (no full-member hydration, no N+1 across guilds) rather than looping
+/// the per-channel membership check.
+/// </summary>
+internal sealed class GetVisibleChannelsHandler(
+	IGuildRepository guilds,
+	IChannelRepository channels,
+	IChannelPermissionOverwriteRepository overwrites)
+	: IQueryHandler<GetVisibleChannelsQuery, Result<ChannelListResponse>>
+{
+	public async Task<Result<ChannelListResponse>> HandleAsync(
+		GetVisibleChannelsQuery query,
+		CancellationToken cancellationToken = default)
+	{
+		var guildIds = await guilds.ListGuildIdsForMemberAsync(query.UserId, cancellationToken);
+
+		var visible = new List<ChannelResponse>();
+		foreach (var guildId in guildIds)
+		{
+			var guild = await guilds.GetByIdWithMembershipAsNoTrackingAsync(guildId, cancellationToken);
+			if (guild is null)
+				continue;
+
+			var guildChannels = await channels.GetByGuildAsync(guildId, cancellationToken);
+			var guildOverwrites = await overwrites.GetForGuildAsync(guildId, cancellationToken);
+			var overwritesByChannel = guildOverwrites
+				.GroupBy(o => o.ChannelId)
+				.ToDictionary(g => g.Key, g => (IReadOnlyList<ChannelPermissionOverwrite>)g.ToList());
+
+			foreach (var channel in guildChannels)
+			{
+				var channelOverwrites = overwritesByChannel.TryGetValue(channel.Id, out var ows)
+					? ows
+					: [];
+				var permissions = PermissionResolver.Resolve(guild, query.UserId, channelOverwrites);
+				if (PermissionResolver.HasPermission(permissions, Permission.ReadMessages))
+					visible.Add(ChannelResponse.From(channel));
+			}
+		}
+
+		return new ChannelListResponse(visible);
+	}
+}

--- a/services/guild/src/Guild.Application/Features/Channels/VisibleChannels/GetVisibleChannelsQuery.cs
+++ b/services/guild/src/Guild.Application/Features/Channels/VisibleChannels/GetVisibleChannelsQuery.cs
@@ -1,0 +1,7 @@
+using Guild.Application.Abstractions.Messaging;
+using Guild.Application.Features.Channels.ListChannels;
+using Guild.Domain.Results;
+
+namespace Guild.Application.Features.Channels.VisibleChannels;
+
+public sealed record GetVisibleChannelsQuery(long UserId) : IQuery<Result<ChannelListResponse>>;

--- a/services/guild/src/Guild.Persistence/Repositories/GuildRepository.cs
+++ b/services/guild/src/Guild.Persistence/Repositories/GuildRepository.cs
@@ -113,6 +113,16 @@ internal sealed class GuildRepository(GuildDbContext context) : IGuildRepository
 			.ToListAsync(cancellationToken);
 	}
 
+	public async Task<IReadOnlyList<long>> ListGuildIdsForMemberAsync(
+		long userId, CancellationToken cancellationToken = default)
+	{
+		return await context.Members
+			.AsNoTracking()
+			.Where(m => m.UserId == userId)
+			.Select(m => m.GuildId)
+			.ToListAsync(cancellationToken);
+	}
+
 	public Task<int> CountMembersAsync(long guildId, CancellationToken cancellationToken = default)
 	{
 		return context.Members

--- a/services/guild/src/Guild.Presentation/Endpoints/VisibleChannelsEndpoint.cs
+++ b/services/guild/src/Guild.Presentation/Endpoints/VisibleChannelsEndpoint.cs
@@ -1,0 +1,43 @@
+using Guild.Application.Abstractions.Messaging;
+using Guild.Application.Features.Channels.Common;
+using Guild.Application.Features.Channels.ListChannels;
+using Guild.Application.Features.Channels.VisibleChannels;
+using Guild.Domain.Results;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+
+namespace Guild.Presentation.Endpoints;
+
+/// <summary>
+/// internal visible-channels lookup used by the Chat Service to back
+/// <c>GET /channels/read-states</c> without an N+1 chain over guilds/channels.
+/// not a Carter module so it stays out of the public <c>/v1</c> group; mounted
+/// under <c>/internal</c> by <c>Program.cs</c>. the API Gateway only forwards
+/// <c>/api/{service}/vN/...</c>, so <c>/internal/...</c> is unreachable from
+/// outside the docker network
+/// </summary>
+public static class VisibleChannelsEndpoint
+{
+	public static void MapInternalRoutes(IEndpointRouteBuilder endpoints)
+	{
+		endpoints.MapGet("/users/{userId:long}/channels", GetAsync);
+	}
+
+	private static async Task<Results<
+		Ok<IReadOnlyList<ChannelResponse>>,
+		BadRequest<ErrorBody>>>
+	GetAsync(
+		long userId,
+		IQueryHandler<GetVisibleChannelsQuery, Result<ChannelListResponse>> handler,
+		CancellationToken cancellationToken)
+	{
+		if (userId <= 0)
+			return TypedResults.BadRequest(new ErrorBody("user_id must be a positive snowflake."));
+
+		var result = await handler.HandleAsync(new GetVisibleChannelsQuery(userId), cancellationToken);
+
+		// guild-less/unknown users resolve to an empty guild-id list upstream, so
+		// a well-formed request always succeeds - same shape as owned-guilds-count
+		return TypedResults.Ok(result.Value.Items);
+	}
+}

--- a/services/guild/src/Guild.Presentation/Program.cs
+++ b/services/guild/src/Guild.Presentation/Program.cs
@@ -167,6 +167,7 @@ var internalRoutes = app.MapGroup("/internal").ExcludeFromDescription();
 ChannelMembershipEndpoint.MapInternalRoutes(internalRoutes);
 OwnedGuildsCountEndpoint.MapInternalRoutes(internalRoutes);
 UserDataExportEndpoint.MapInternalRoutes(internalRoutes);
+VisibleChannelsEndpoint.MapInternalRoutes(internalRoutes);
 
 app.Run();
 

--- a/services/guild/tests/Guild.FunctionalTests/Endpoints/GetVisibleChannelsTests.cs
+++ b/services/guild/tests/Guild.FunctionalTests/Endpoints/GetVisibleChannelsTests.cs
@@ -1,0 +1,78 @@
+using System.Net;
+using Guild.Domain.Guild;
+using Guild.FunctionalTests.Infrastructure;
+using Xunit;
+
+namespace Guild.FunctionalTests.Endpoints;
+
+public sealed class GetVisibleChannelsTests(GuildApiFactory factory) : IClassFixture<GuildApiFactory>
+{
+	[Fact]
+	public async Task GuildLessUser_Returns200EmptyArray()
+	{
+		var anon = factory.CreateClient();
+		var resp = await anon.GetAsync("/internal/users/777777/channels");
+
+		Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+		var body = await resp.ReadJsonAsync();
+		Assert.Equal(0, body.GetArrayLength());
+	}
+
+	[Fact]
+	public async Task NotReachableUnder_V1_PathPrefix()
+	{
+		var anon = factory.CreateClient();
+		var resp = await anon.GetAsync("/v1/users/1/channels");
+		Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+	}
+
+	[Fact]
+	public async Task Owner_SeesGuildChannels()
+	{
+		var owner = factory.CreateAuthenticatedClient(userId: 6001);
+		var created = await owner.CreateGuildAsync("guild");
+		var guildId = long.Parse(created.GetProperty("id").GetString()!);
+		var channelId = await factory.AddChannelAsync(guildId, categoryId: null, name: "general");
+
+		var anon = factory.CreateClient();
+		var resp = await anon.GetAsync("/internal/users/6001/channels");
+
+		Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+		var body = await resp.ReadJsonAsync();
+		Assert.Equal(1, body.GetArrayLength());
+		var item = body[0];
+		Assert.Equal(channelId.ToString(), item.GetProperty("id").GetString());
+		Assert.Equal(guildId.ToString(), item.GetProperty("guild_id").GetString());
+	}
+
+	[Fact]
+	public async Task MemberWithReadDenied_ChannelIsExcluded()
+	{
+		var owner = factory.CreateAuthenticatedClient(userId: 6002);
+		var created = await owner.CreateGuildAsync("guild");
+		var guildId = long.Parse(created.GetProperty("id").GetString()!);
+		var visibleChannelId = await factory.AddChannelAsync(guildId, categoryId: null, name: "general");
+		var hiddenChannelId = await factory.AddChannelAsync(guildId, categoryId: null, name: "secret");
+		await factory.AddBareMemberAsync(guildId, userId: 6003);
+
+		await factory.AddChannelOverwriteAsync(
+			hiddenChannelId, OverwriteTargetType.Member, targetId: 6003,
+			allow: 0L, deny: (long)Permission.ReadMessages);
+
+		var anon = factory.CreateClient();
+		var resp = await anon.GetAsync("/internal/users/6003/channels");
+
+		Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+		var body = await resp.ReadJsonAsync();
+		Assert.Equal(1, body.GetArrayLength());
+		Assert.Equal(visibleChannelId.ToString(), body[0].GetProperty("id").GetString());
+	}
+
+	[Fact]
+	public async Task InvalidUserId_Returns400()
+	{
+		var anon = factory.CreateClient();
+		var resp = await anon.GetAsync("/internal/users/-1/channels");
+		Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+	}
+}

--- a/services/guild/tests/Guild.UnitTests/Application/GetVisibleChannelsHandlerTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/GetVisibleChannelsHandlerTests.cs
@@ -1,0 +1,93 @@
+using Guild.Application.Features.Channels.Common;
+using Guild.Application.Features.Channels.ListChannels;
+using Guild.Application.Features.Channels.VisibleChannels;
+using Guild.Domain.Guild;
+using Guild.Domain.Results;
+using Guild.UnitTests.Fakes;
+using Xunit;
+using GuildEntity = Guild.Domain.Guild.Guild;
+
+namespace Guild.UnitTests.Application;
+
+public sealed class GetVisibleChannelsHandlerTests
+{
+	private static readonly DateTimeOffset Now =
+		new(2026, 1, 1, 0, 0, 0, TimeSpan.Zero);
+
+	[Fact]
+	public async Task GuildLessUser_ReturnsEmptyList()
+	{
+		var (handler, _, _, _) = MakeHandler();
+
+		var result = await handler.HandleAsync(new GetVisibleChannelsQuery(9999));
+
+		Assert.True(result.Succeeded);
+		Assert.Empty(result.Value.Items);
+	}
+
+	[Fact]
+	public async Task Owner_SeesAllGuildChannels()
+	{
+		var (handler, guilds, channels, _) = MakeHandler();
+		var guild = guilds.Store[100];
+		channels.Seed(Channel.Create(5, 100, null, "general", null, ChannelType.Text, 0, Now).Value);
+		channels.Seed(Channel.Create(6, 100, null, "announce", null, ChannelType.Announcement, 1, Now).Value);
+
+		var result = await handler.HandleAsync(new GetVisibleChannelsQuery(guild.OwnerId));
+
+		Assert.True(result.Succeeded);
+		Assert.Equal(2, result.Value.Items.Count);
+	}
+
+	[Fact]
+	public async Task NonMember_SeesNoChannels()
+	{
+		var (handler, guilds, channels, _) = MakeHandler();
+		channels.Seed(Channel.Create(5, 100, null, "general", null, ChannelType.Text, 0, Now).Value);
+
+		var result = await handler.HandleAsync(new GetVisibleChannelsQuery(424242));
+
+		Assert.True(result.Succeeded);
+		Assert.Empty(result.Value.Items);
+	}
+
+	[Fact]
+	public async Task MemberDeniedReadOnOneChannel_IsFilteredOut()
+	{
+		var (handler, guilds, channels, overwrites) = MakeHandler();
+		var guild = guilds.Store[100];
+		DomainSeed.AddMember(guild, userId: 2, joinedAt: Now);
+		channels.Seed(Channel.Create(5, 100, null, "general", null, ChannelType.Text, 0, Now).Value);
+		channels.Seed(Channel.Create(6, 100, null, "secret", null, ChannelType.Text, 1, Now).Value);
+
+		overwrites.Seed(ChannelPermissionOverwrite.Create(
+			id: 1, guildId: 100, channelId: 6, targetType: OverwriteTargetType.Member,
+			targetId: 2, allow: 0L, deny: (long)Permission.ReadMessages, now: Now).Value);
+
+		var result = await handler.HandleAsync(new GetVisibleChannelsQuery(2));
+
+		Assert.True(result.Succeeded);
+		var single = Assert.Single(result.Value.Items);
+		Assert.Equal("5", single.Id);
+	}
+
+	private static (
+		Guild.Application.Abstractions.Messaging.IQueryHandler<GetVisibleChannelsQuery, Result<ChannelListResponse>> Handler,
+		FakeGuildRepository Guilds,
+		FakeChannelRepository Channels,
+		FakeChannelPermissionOverwriteRepository Overwrites)
+		MakeHandler()
+	{
+		var guilds = new FakeGuildRepository();
+		var channels = new FakeChannelRepository();
+		var overwrites = new FakeChannelPermissionOverwriteRepository();
+		var guild = GuildEntity.Create(
+			id: 100, name: "Test", description: null, iconUrl: null, bannerUrl: null,
+			ownerId: 1, everyoneRoleId: 101, adminRoleId: 102, now: Now).Value;
+		guilds.Add(guild);
+
+		var handler = HandlerFactory.CreateQuery<GetVisibleChannelsQuery, Result<ChannelListResponse>>(
+			guilds, channels, overwrites);
+		return (handler, guilds, channels, overwrites);
+	}
+}

--- a/services/guild/tests/Guild.UnitTests/Fakes/FakeGuildRepository.cs
+++ b/services/guild/tests/Guild.UnitTests/Fakes/FakeGuildRepository.cs
@@ -50,6 +50,16 @@ internal sealed class FakeGuildRepository : IGuildRepository
 		return Task.FromResult<IReadOnlyList<MyGuildSummary>>(summaries);
 	}
 
+	public Task<IReadOnlyList<long>> ListGuildIdsForMemberAsync(
+		long userId, CancellationToken cancellationToken = default)
+	{
+		IReadOnlyList<long> ids = _store.Values
+			.Where(g => g.Members.Any(m => m.UserId == userId))
+			.Select(g => g.Id)
+			.ToList();
+		return Task.FromResult(ids);
+	}
+
 	public Task<int> CountMembersAsync(long guildId, CancellationToken cancellationToken = default)
 	{
 		return Task.FromResult(_store.TryGetValue(guildId, out var guild) ? guild.Members.Count : 0);


### PR DESCRIPTION
## About

Read-state tracking for channels and DMs: per-user last-read cursor, bulk unread lookup for the sidebar, and cross-device sync over SignalR.

> Blocked by #289

## Changes

### Guild
- `GET /internal/users/{user_id}/channels`: every channel a user can see across all their guilds, permission-resolved (`READ_MESSAGES`), in one call. Backs the Chat endpoint below without an N+1 walk over `GET /guilds/me` -> per-guild channels -> per-channel membership.

### Chat
- `PUT /channels/{id}/read` / `PUT /dms/{userId}/read`: advance the caller's read cursor. Idempotent and monotonic on the channel side (older `message_id` is a no-op); the DM side resets the whole conversation's `dm_unread_counts` counter instead, since a counter can't express "read up to message 10 of 15" (documented in `docs/contracts/chat.md`).
- `GET /channels/read-states`: bulk fetch, one entry per visible channel (including ones with no row yet — `last_read_message_id: null`, `unread_count` = total non-deleted messages).
- `dm_unread_counts` now increments on every DM send (`SendDirectMessageHandler`).
- `ReadStateUpdated` / `DmReadStateUpdated` broadcast to the caller's personal SignalR group on update, for cross-device sync.
- New `channel_read_states` persistence (`ReadStateRepository`/`ReadStateStatements`).

Close #154
Close #271
