### PR TITLE
Front/guild

### DIFF
--- a/docs/frontend-backend-backlog.md
+++ b/docs/frontend-backend-backlog.md
@@ -73,27 +73,27 @@ Goal: replace all local friend/profile placeholders with real user-service data.
 
 Goal: connect the guild sidebar and guild page to live guild data.
 
-- [ ] Guild sidebar
-  - [ ] fetch `GET /guilds/me` on login
-  - [ ] sort guilds by `joined_at` and preserve selection
-  - [ ] replace the random guild generator with live guild creation
-- [ ] Guild landing page
-  - [ ] show the selected guild details from `GET /guilds/{id}`
-  - [ ] add create-guild form using `POST /guilds`
-  - [ ] add join-guild via invite code using `POST /guilds/{id}/join`
-- [ ] Guild membership list
-  - [ ] fetch `GET /guilds/{id}/members`
-  - [ ] hydrate members via `GET /users?ids=...`
-  - [ ] display nicknames, avatars, roles, and join timestamps
-- [ ] Guild admin actions
-  - [ ] wire nickname edits with `PATCH /guilds/{id}/members/{user_id}`
-  - [ ] wire member kick with `DELETE /guilds/{id}/members/{user_id}`
-  - [ ] wire bans list, ban creation, and unban actions
-  - [ ] wire invite creation, listing, preview, and revoke
-- [ ] Guild settings
-  - [ ] add edit guild settings with `PATCH /guilds/{id}`
-  - [ ] add delete guild with owner-only confirmation
-  - [ ] add roles and categories management UI on top of existing endpoints
+- [x] Guild sidebar
+  - [x] fetch `GET /guilds/me` on login
+  - [x] sort guilds by `joined_at` and preserve selection
+  - [x] replace the random guild generator with live guild creation
+- [x] Guild landing page
+  - [x] show the selected guild details from `GET /guilds/{id}`
+  - [x] add create-guild form using `POST /guilds`
+  - [x] add join-guild via invite code using `POST /guilds/{id}/join`
+- [x] Guild membership list
+  - [x] fetch `GET /guilds/{id}/members`
+  - [x] hydrate members via `GET /users?ids=...`
+  - [x] display nicknames, avatars, roles, and join timestamps
+- [x] Guild admin actions
+  - [x] wire nickname edits with `PATCH /guilds/{id}/members/{user_id}`
+  - [x] wire member kick with `DELETE /guilds/{id}/members/{user_id}`
+  - [x] wire bans list, ban creation, and unban actions
+  - [x] wire invite creation, listing, preview, and revoke
+- [x] Guild settings
+  - [x] add edit guild settings with `PATCH /guilds/{id}`
+  - [x] add delete guild with owner-only confirmation
+  - [x] add roles and categories management UI on top of existing endpoints
 
 ## Epic 4 - Chat history, composer, and realtime transport
 

--- a/frontend/app/auth/login/page.tsx
+++ b/frontend/app/auth/login/page.tsx
@@ -7,10 +7,12 @@ import { AuthCard } from '../../../src/components/auth-card';
 import { login } from '../../../src/shared/api/auth';
 import { establishSession } from '../../../src/shared/lib/session';
 import { describeLoginError } from '../../../src/shared/lib/auth-errors';
+import { useGuilds } from '../../../src/shared/guilds/guild-store';
 import { validateLoginForm, type LoginFormErrors } from '../../../src/shared/lib/validators/auth';
 
 export default function LoginPage() {
   const router = useRouter();
+  const { refreshGuilds } = useGuilds();
   const [errors, setErrors] = useState<LoginFormErrors>({});
   const [serverError, setServerError] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -31,6 +33,7 @@ export default function LoginPage() {
       setIsSubmitting(true);
       const { access_token, user_id } = await login({ email: email.trim(), password });
       establishSession(access_token, user_id);
+      void refreshGuilds();
       router.push('/chat');
     } catch (error) {
       setServerError(describeLoginError(error));

--- a/frontend/app/guilds/page.tsx
+++ b/frontend/app/guilds/page.tsx
@@ -1,24 +1,95 @@
+'use client';
+
 import Link from 'next/link';
+import { GuildIcon } from '../../src/components/guild/guild-icon';
+import { GuildCreateForm, GuildJoinForm } from '../../src/components/guild/guild-forms';
+import { GuildOverview } from '../../src/components/guild/guild-overview';
+import { useGuilds } from '../../src/shared/guilds/guild-store';
 
 export default function GuildsPage() {
+  const { guilds, isLoading, error, selectedGuildId, selectGuild } = useGuilds();
+
   return (
-    <section className="mx-auto flex min-h-screen w-full max-w-5xl items-center px-6 py-12">
-      <div className="w-full rounded-[2rem] border border-white/8 bg-secondary-bg/90 p-8 shadow-2xl shadow-black/40 md:p-12">
-        <p className="mono-detail text-aqua">Guilds</p>
-        <h1 className="mt-4 text-5xl font-extrabold tracking-[-0.07em] text-white md:text-6xl">
-          Espace guildes prêt à brancher.
-        </h1>
-        <p className="mt-5 max-w-2xl text-lg text-white/65">
-          La maquette chat est maintenant utilisée directement sur `/chat`. Cette route peut
-          accueillir la vraie liste de guildes dès que le service est exposé.
-        </p>
-        <div className="mt-8 flex flex-wrap gap-4">
+    <section className="mx-auto flex min-h-screen w-full max-w-5xl flex-col px-6 py-10">
+      <div className="w-full rounded-[2rem] border border-white/8 bg-secondary-bg/90 p-8 shadow-2xl shadow-black/40 md:p-10">
+        <div className="flex flex-wrap items-center justify-between gap-4">
+          <div>
+            <p className="mono-detail text-aqua">Guilds</p>
+            <h1 className="mt-2 text-4xl font-extrabold tracking-[-0.07em] text-white md:text-5xl">
+              Your guilds
+            </h1>
+          </div>
           <Link
             href="/chat"
             className="rounded-full border border-aqua/50 bg-aqua/10 px-5 py-3 font-semibold text-aqua transition hover:bg-aqua/20"
           >
             Ouvrir le chat
           </Link>
+        </div>
+
+        {error && guilds.length === 0 ? (
+          <p className="mt-6 rounded-md border border-pink/25 bg-pink/10 px-4 py-3 text-sm text-pink">
+            {error}
+          </p>
+        ) : null}
+
+        {guilds.length > 0 ? (
+          <div className="mt-6 flex flex-wrap gap-3">
+            {guilds.map((guild) => (
+              <button
+                key={guild.id}
+                type="button"
+                onClick={() => selectGuild(guild.id)}
+                className={`flex items-center gap-2 rounded-full border py-1.5 pl-1.5 pr-4 text-sm font-semibold transition ${
+                  guild.id === selectedGuildId
+                    ? 'border-aqua/60 bg-aqua/10 text-aqua'
+                    : 'border-white/10 bg-panel text-white/60 hover:text-white'
+                }`}
+              >
+                <GuildIcon
+                  guildId={guild.id}
+                  name={guild.name}
+                  iconUrl={guild.icon_url}
+                  className="h-7 w-7 overflow-hidden rounded-full text-xs"
+                />
+                {guild.name}
+              </button>
+            ))}
+          </div>
+        ) : null}
+
+        <div className="mt-8">
+          {selectedGuildId ? (
+            <GuildOverview guildId={selectedGuildId} />
+          ) : isLoading ? (
+            <div className="h-48 animate-pulse rounded-[1rem] bg-panel" />
+          ) : (
+            <p className="max-w-2xl text-lg text-white/65">
+              Tu n&apos;as pas encore de guilde. Crée la tienne ou rejoins-en une avec un code
+              d&apos;invitation.
+            </p>
+          )}
+        </div>
+
+        <div className="mt-10 grid gap-8 md:grid-cols-2">
+          <div className="rounded-[1rem] border border-white/8 bg-panel p-6">
+            <h2 className="text-xl font-bold tracking-[-0.03em] text-white">Create a guild</h2>
+            <p className="mt-1 text-sm text-white/45">
+              Démarre une nouvelle guilde dont tu seras propriétaire.
+            </p>
+            <div className="mt-5">
+              <GuildCreateForm />
+            </div>
+          </div>
+          <div className="rounded-[1rem] border border-white/8 bg-panel p-6">
+            <h2 className="text-xl font-bold tracking-[-0.03em] text-white">Join a guild</h2>
+            <p className="mt-1 text-sm text-white/45">
+              Utilise un code d&apos;invitation pour rejoindre une guilde existante.
+            </p>
+            <div className="mt-5">
+              <GuildJoinForm />
+            </div>
+          </div>
         </div>
       </div>
     </section>

--- a/frontend/app/guilds/page.tsx
+++ b/frontend/app/guilds/page.tsx
@@ -4,17 +4,23 @@ import { useState } from 'react';
 import Link from 'next/link';
 import { GuildIcon } from '../../src/components/guild/guild-icon';
 import { GuildBansPanel } from '../../src/components/guild/guild-bans-panel';
+import { GuildCategoriesPanel } from '../../src/components/guild/guild-categories-panel';
 import { GuildCreateForm, GuildJoinForm } from '../../src/components/guild/guild-forms';
 import { GuildInvitesPanel } from '../../src/components/guild/guild-invites-panel';
 import { GuildMembersPanel } from '../../src/components/guild/guild-members-panel';
 import { GuildOverview } from '../../src/components/guild/guild-overview';
+import { GuildRolesPanel } from '../../src/components/guild/guild-roles-panel';
+import { GuildSettingsPanel } from '../../src/components/guild/guild-settings-panel';
 import { useGuilds } from '../../src/shared/guilds/guild-store';
 
 const TABS = [
   { id: 'overview', label: 'Overview' },
   { id: 'members', label: 'Members' },
   { id: 'bans', label: 'Bans' },
-  { id: 'invites', label: 'Invites' }
+  { id: 'invites', label: 'Invites' },
+  { id: 'roles', label: 'Roles' },
+  { id: 'categories', label: 'Categories' },
+  { id: 'settings', label: 'Settings' }
 ] as const;
 
 type TabId = (typeof TABS)[number]['id'];
@@ -95,6 +101,11 @@ export default function GuildsPage() {
               {activeTab === 'members' ? <GuildMembersPanel guildId={selectedGuildId} /> : null}
               {activeTab === 'bans' ? <GuildBansPanel guildId={selectedGuildId} /> : null}
               {activeTab === 'invites' ? <GuildInvitesPanel guildId={selectedGuildId} /> : null}
+              {activeTab === 'roles' ? <GuildRolesPanel guildId={selectedGuildId} /> : null}
+              {activeTab === 'categories' ? (
+                <GuildCategoriesPanel guildId={selectedGuildId} />
+              ) : null}
+              {activeTab === 'settings' ? <GuildSettingsPanel guildId={selectedGuildId} /> : null}
             </>
           ) : isLoading ? (
             <div className="h-48 animate-pulse rounded-[1rem] bg-panel" />

--- a/frontend/app/guilds/page.tsx
+++ b/frontend/app/guilds/page.tsx
@@ -1,13 +1,27 @@
 'use client';
 
+import { useState } from 'react';
 import Link from 'next/link';
 import { GuildIcon } from '../../src/components/guild/guild-icon';
+import { GuildBansPanel } from '../../src/components/guild/guild-bans-panel';
 import { GuildCreateForm, GuildJoinForm } from '../../src/components/guild/guild-forms';
+import { GuildInvitesPanel } from '../../src/components/guild/guild-invites-panel';
+import { GuildMembersPanel } from '../../src/components/guild/guild-members-panel';
 import { GuildOverview } from '../../src/components/guild/guild-overview';
 import { useGuilds } from '../../src/shared/guilds/guild-store';
 
+const TABS = [
+  { id: 'overview', label: 'Overview' },
+  { id: 'members', label: 'Members' },
+  { id: 'bans', label: 'Bans' },
+  { id: 'invites', label: 'Invites' }
+] as const;
+
+type TabId = (typeof TABS)[number]['id'];
+
 export default function GuildsPage() {
   const { guilds, isLoading, error, selectedGuildId, selectGuild } = useGuilds();
+  const [activeTab, setActiveTab] = useState<TabId>('overview');
 
   return (
     <section className="mx-auto flex min-h-screen w-full max-w-5xl flex-col px-6 py-10">
@@ -60,7 +74,28 @@ export default function GuildsPage() {
 
         <div className="mt-8">
           {selectedGuildId ? (
-            <GuildOverview guildId={selectedGuildId} />
+            <>
+              <div className="mb-5 flex flex-wrap gap-2">
+                {TABS.map((tab) => (
+                  <button
+                    key={tab.id}
+                    type="button"
+                    onClick={() => setActiveTab(tab.id)}
+                    className={`h-9 rounded-md px-4 text-sm font-bold transition ${
+                      activeTab === tab.id
+                        ? 'bg-aqua/15 text-aqua'
+                        : 'bg-panel text-white/45 hover:text-white'
+                    }`}
+                  >
+                    {tab.label}
+                  </button>
+                ))}
+              </div>
+              {activeTab === 'overview' ? <GuildOverview guildId={selectedGuildId} /> : null}
+              {activeTab === 'members' ? <GuildMembersPanel guildId={selectedGuildId} /> : null}
+              {activeTab === 'bans' ? <GuildBansPanel guildId={selectedGuildId} /> : null}
+              {activeTab === 'invites' ? <GuildInvitesPanel guildId={selectedGuildId} /> : null}
+            </>
           ) : isLoading ? (
             <div className="h-48 animate-pulse rounded-[1rem] bg-panel" />
           ) : (

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import { Inter, JetBrains_Mono, Outfit } from 'next/font/google';
+import { GuildProvider } from '../src/shared/guilds/guild-store';
 import './globals.css';
 
 const inter = Inter({
@@ -29,7 +30,9 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en">
       <body className={`${inter.variable} ${outfit.variable} ${jetBrainsMono.variable}`}>
-        <main className="app-shell min-h-screen max-h-screen">{children}</main>
+        <GuildProvider>
+          <main className="app-shell min-h-screen max-h-screen">{children}</main>
+        </GuildProvider>
       </body>
     </html>
   );

--- a/frontend/src/components/channel-list.tsx
+++ b/frontend/src/components/channel-list.tsx
@@ -102,8 +102,9 @@ export function ChannelList({
             {selectedGuild?.name ?? 'server_name'}
           </h2>
           <div className="flex shrink-0 items-center gap-3 text-[#8c8c90]">
-            <UserRound className="h-5 w-5" strokeWidth={1.8} />
-            <CircleEllipsis className="h-5 w-5" strokeWidth={1.8} />
+            <Link href="/guilds" className="transition hover:text-white" aria-label="Manage guild">
+              <CircleEllipsis className="h-5 w-5" strokeWidth={1.8} />
+            </Link>
           </div>
         </div>
 

--- a/frontend/src/components/channel-list.tsx
+++ b/frontend/src/components/channel-list.tsx
@@ -14,6 +14,7 @@ import {
   UserRound
 } from 'lucide-react';
 import { channelCategories } from './mocks/channel-mocks';
+import { useGuilds } from '../shared/guilds/guild-store';
 
 export type TextChannel = {
   id: string;
@@ -65,6 +66,7 @@ export function ChannelList({
   onOpenSettings,
   onSelectChannel
 }: ChannelListProps) {
+  const { selectedGuild } = useGuilds();
   const [search, setSearch] = useState('');
 
   const filteredCategories = useMemo(() => {
@@ -97,7 +99,7 @@ export function ChannelList({
             Logo<span className="text-aqua">_</span>
           </Link>
           <h2 className="min-w-0 truncate font-display text-[2rem] font-medium tracking-[-0.05em] text-aqua sm:text-[2.2rem]">
-            server_name
+            {selectedGuild?.name ?? 'server_name'}
           </h2>
           <div className="flex shrink-0 items-center gap-3 text-[#8c8c90]">
             <UserRound className="h-5 w-5" strokeWidth={1.8} />

--- a/frontend/src/components/chat-workspace.tsx
+++ b/frontend/src/components/chat-workspace.tsx
@@ -12,18 +12,8 @@ import {
 } from 'lucide-react';
 import { ChatMessage, getAccentClasses, type ChatMessageData } from './chat-message';
 import { ChannelList, getChannelName, hasChannel } from './channel-list';
-import {
-  DmList,
-  getDmDetails,
-  getDmName,
-  getDmStatusClasses,
-  hasDm
-} from './dm-list';
-import {
-  getGuildMemberByName,
-  GuildMemberList,
-  type GuildMember
-} from './guild-member-list';
+import { DmList, getDmDetails, getDmName, getDmStatusClasses, hasDm } from './dm-list';
+import { getGuildMemberByName, GuildMemberList, type GuildMember } from './guild-member-list';
 import { GuildSidebar } from './guild-sidebar';
 import { NotificationCard } from './notification-card';
 import { ProfileCard } from './profile-card';
@@ -507,7 +497,8 @@ export function ChatWorkspace() {
               id: message.author.toLowerCase(),
               name: message.author,
               role: 'Member',
-              status: message.author.toLowerCase() === username.toLowerCase() ? 'online' : 'offline',
+              status:
+                message.author.toLowerCase() === username.toLowerCase() ? 'online' : 'offline',
               accent: message.accent,
               activity: 'No recent activity'
             })
@@ -773,10 +764,7 @@ export function ChatWorkspace() {
           </section>
 
           {chatMode === 'guild' && isMemberListOpen ? (
-            <GuildMemberList
-              onToggleVisibility={() => setIsMemberListOpen((current) => !current)}
-              onOpenProfile={setProfileMember}
-            />
+            <GuildMemberList onOpenProfile={setProfileMember} />
           ) : null}
 
           {chatMode === 'dm' && isDmProfileOpen && activeDmProfileMember ? (

--- a/frontend/src/components/guild-member-list.tsx
+++ b/frontend/src/components/guild-member-list.tsx
@@ -1,9 +1,16 @@
 'use client';
 
+import Image from 'next/image';
 import { Crown, Shield, UserRound } from 'lucide-react';
 import { getAccentClasses, type ChatMessageData } from './chat-message';
 import { getDmStatusClasses, type DirectMessage } from './dm-list';
 import { guildMembers } from './mocks/guild-member-mocks';
+import type { UserStatus } from '../shared/api/user';
+import { useGuilds } from '../shared/guilds/guild-store';
+import {
+  useGuildMembers,
+  type HydratedGuildMember
+} from '../shared/guilds/use-guild-members';
 
 export type GuildMember = {
   id: string;
@@ -14,33 +21,109 @@ export type GuildMember = {
   activity: string;
 };
 
+// TODO(api:chat): message authors still come from mocks until Epic 4 wires real chat history.
 export function getGuildMemberByName(name: string) {
   return guildMembers.find((member) => member.name.toLowerCase() === name.toLowerCase()) ?? null;
 }
 
-const memberGroups = [
-  {
-    id: 'staff',
-    title: 'Staff',
-    members: guildMembers.filter((member) => member.role !== 'Member')
-  },
-  {
-    id: 'members',
-    title: 'Members',
-    members: guildMembers.filter((member) => member.role === 'Member')
-  }
-];
+const ACCENTS: ChatMessageData['accent'][] = ['aqua', 'yellow', 'lime', 'lavender', 'pink'];
 
-function RoleIcon({ role }: { role: GuildMember['role'] }) {
-  if (role === 'Owner') {
-    return <Crown className="h-3.5 w-3.5 text-yellow" strokeWidth={1.9} />;
+function getAccentForId(id: string): ChatMessageData['accent'] {
+  let hash = 0;
+  for (const char of id) {
+    hash = (hash * 31 + char.charCodeAt(0)) % ACCENTS.length;
   }
 
-  if (role === 'Admin') {
-    return <Shield className="h-3.5 w-3.5 text-aqua" strokeWidth={1.9} />;
+  return ACCENTS[hash];
+}
+
+function toSidebarStatus(status: UserStatus): DirectMessage['status'] {
+  return status === 'dnd' ? 'idle' : status;
+}
+
+function formatJoinedAt(joinedAt: string) {
+  const date = new Date(joinedAt);
+  return Number.isNaN(date.getTime())
+    ? ''
+    : date.toLocaleDateString('fr-FR', { day: '2-digit', month: 'short', year: 'numeric' });
+}
+
+export function toProfileMember(member: HydratedGuildMember): GuildMember {
+  return {
+    id: member.userId,
+    name: member.displayName,
+    role: member.isOwner ? 'Owner' : member.roles.length > 0 ? 'Admin' : 'Member',
+    status: toSidebarStatus(member.status),
+    accent: getAccentForId(member.userId),
+    activity: member.joinedAt ? `Joined ${formatJoinedAt(member.joinedAt)}` : 'Member'
+  };
+}
+
+function RoleIcon({ member }: { member: HydratedGuildMember }) {
+  if (member.isOwner) {
+    return <Crown className="h-3.5 w-3.5 shrink-0 text-yellow" strokeWidth={1.9} />;
+  }
+
+  if (member.roles.length > 0) {
+    return <Shield className="h-3.5 w-3.5 shrink-0 text-aqua" strokeWidth={1.9} />;
   }
 
   return null;
+}
+
+function MemberRow({
+  member,
+  onOpenProfile
+}: {
+  member: HydratedGuildMember;
+  onOpenProfile: (member: GuildMember) => void;
+}) {
+  const topRole = member.isOwner ? 'Owner' : (member.roles[0]?.name ?? null);
+  const joined = formatJoinedAt(member.joinedAt);
+  const subtitle = [topRole, joined ? `Joined ${joined}` : null].filter(Boolean).join(' · ');
+
+  return (
+    <button
+      type="button"
+      onClick={() => onOpenProfile(toProfileMember(member))}
+      className="flex h-14 w-full items-center gap-3 rounded-md px-2 text-left text-grey-link transition hover:bg-frame/60 hover:text-white"
+    >
+      <span className="relative shrink-0">
+        {member.avatarUrl ? (
+          <Image
+            src={member.avatarUrl}
+            alt=""
+            width={40}
+            height={40}
+            unoptimized
+            className="h-10 w-10 rounded-full object-cover"
+          />
+        ) : (
+          <span
+            className={`flex h-10 w-10 items-center justify-center rounded-full text-sm font-bold ${getAccentClasses(
+              getAccentForId(member.userId)
+            )}`}
+          >
+            {member.displayName.slice(0, 1).toUpperCase()}
+          </span>
+        )}
+        <span
+          className={`absolute -bottom-0.5 -right-0.5 h-3.5 w-3.5 rounded-full border-2 border-secondary-bg ${getDmStatusClasses(
+            toSidebarStatus(member.status)
+          )}`}
+        />
+      </span>
+      <span className="min-w-0 flex-1">
+        <span className="flex min-w-0 items-center gap-1.5">
+          <span className="block truncate text-[0.95rem] font-bold">{member.displayName}</span>
+          <RoleIcon member={member} />
+        </span>
+        <span className="mt-0.5 block truncate text-xs text-white/35">
+          {member.isDeleted ? 'Deleted user' : subtitle || 'Member'}
+        </span>
+      </span>
+    </button>
+  );
 }
 
 type GuildMemberListProps = {
@@ -49,13 +132,26 @@ type GuildMemberListProps = {
 };
 
 export function GuildMemberList({ onToggleVisibility, onOpenProfile }: GuildMemberListProps) {
+  const { selectedGuild } = useGuilds();
+  const { members, isLoading, error } = useGuildMembers(
+    selectedGuild?.id ?? null,
+    selectedGuild?.owner_id ?? null
+  );
+
+  const staff = members.filter((member) => member.isOwner || member.roles.length > 0);
+  const regulars = members.filter((member) => !member.isOwner && member.roles.length === 0);
+  const memberGroups = [
+    { id: 'staff', title: 'Staff', members: staff },
+    { id: 'members', title: 'Members', members: regulars }
+  ].filter((group) => group.members.length > 0);
+
   return (
     <aside className="hidden min-h-0 w-[18rem] shrink-0 flex-col overflow-hidden rounded-[1rem] bg-secondary-bg ring-1 ring-white/5 xl:flex">
       <div className="flex h-[4.9rem] shrink-0 items-center justify-between border-b border-white/8 px-5">
         <div>
           <h2 className="text-[1.05rem] font-bold tracking-[-0.03em] text-white">Members</h2>
           <p className="font-category mt-1 text-[0.7rem] uppercase tracking-[0.14em] text-white/35">
-            {guildMembers.length} online and offline
+            {members.length} online and offline
           </p>
         </div>
         <button
@@ -70,51 +166,38 @@ export function GuildMemberList({ onToggleVisibility, onOpenProfile }: GuildMemb
       </div>
 
       <div className="min-h-0 flex-1 overflow-y-auto px-4 py-5">
-        <div className="space-y-6">
-          {memberGroups.map((group) => (
-            <section key={group.id}>
-              <p className="font-category px-1 text-[0.72rem] uppercase tracking-[0.16em] text-category">
-                {group.title} - {group.members.length}
-              </p>
-              <div className="mt-2 space-y-1">
-                {group.members.map((member) => (
-                  <button
-                    key={member.id}
-                    type="button"
-                    onClick={() => onOpenProfile(member)}
-                    className="flex h-14 w-full items-center gap-3 rounded-md px-2 text-left text-grey-link transition hover:bg-frame/60 hover:text-white"
-                  >
-                    <span className="relative shrink-0">
-                      <span
-                        className={`flex h-10 w-10 items-center justify-center rounded-full text-sm font-bold ${getAccentClasses(
-                          member.accent
-                        )}`}
-                      >
-                        {member.name.slice(0, 1).toUpperCase()}
-                      </span>
-                      <span
-                        className={`absolute -bottom-0.5 -right-0.5 h-3.5 w-3.5 rounded-full border-2 border-secondary-bg ${getDmStatusClasses(
-                          member.status
-                        )}`}
-                      />
-                    </span>
-                    <span className="min-w-0 flex-1">
-                      <span className="flex min-w-0 items-center gap-1.5">
-                        <span className="block truncate text-[0.95rem] font-bold">
-                          {member.name}
-                        </span>
-                        <RoleIcon role={member.role} />
-                      </span>
-                      <span className="mt-0.5 block truncate text-xs text-white/35">
-                        {member.activity}
-                      </span>
-                    </span>
-                  </button>
-                ))}
-              </div>
-            </section>
-          ))}
-        </div>
+        {isLoading && members.length === 0 ? (
+          <div className="space-y-2">
+            {[0, 1, 2, 3].map((index) => (
+              <div key={index} className="h-14 animate-pulse rounded-md bg-frame/50" />
+            ))}
+          </div>
+        ) : error && members.length === 0 ? (
+          <p className="rounded-md border border-pink/25 bg-pink/10 px-3 py-2 text-sm text-pink">
+            {error}
+          </p>
+        ) : !selectedGuild ? (
+          <p className="px-1 text-sm text-white/35">Select a guild to see its members.</p>
+        ) : (
+          <div className="space-y-6">
+            {memberGroups.map((group) => (
+              <section key={group.id}>
+                <p className="font-category px-1 text-[0.72rem] uppercase tracking-[0.16em] text-category">
+                  {group.title} - {group.members.length}
+                </p>
+                <div className="mt-2 space-y-1">
+                  {group.members.map((member) => (
+                    <MemberRow
+                      key={member.userId}
+                      member={member}
+                      onOpenProfile={onOpenProfile}
+                    />
+                  ))}
+                </div>
+              </section>
+            ))}
+          </div>
+        )}
       </div>
     </aside>
   );

--- a/frontend/src/components/guild-member-list.tsx
+++ b/frontend/src/components/guild-member-list.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Image from 'next/image';
-import { Crown, Shield, UserRound } from 'lucide-react';
+import { Crown, Shield } from 'lucide-react';
 import { getAccentClasses, type ChatMessageData } from './chat-message';
 import { getDmStatusClasses, type DirectMessage } from './dm-list';
 import { guildMembers } from './mocks/guild-member-mocks';
@@ -124,11 +124,10 @@ function MemberRow({
 }
 
 type GuildMemberListProps = {
-  onToggleVisibility: () => void;
   onOpenProfile: (member: GuildMember) => void;
 };
 
-export function GuildMemberList({ onToggleVisibility, onOpenProfile }: GuildMemberListProps) {
+export function GuildMemberList({ onOpenProfile }: GuildMemberListProps) {
   const { selectedGuild } = useGuilds();
   const { members, isLoading, error } = useGuildMembers(
     selectedGuild?.id ?? null,
@@ -151,15 +150,6 @@ export function GuildMemberList({ onToggleVisibility, onOpenProfile }: GuildMemb
             {members.length} online and offline
           </p>
         </div>
-        <button
-          type="button"
-          onClick={onToggleVisibility}
-          className="text-aqua transition hover:text-white"
-          aria-label="Hide member list"
-          aria-pressed
-        >
-          <UserRound className="h-5 w-5" strokeWidth={1.8} />
-        </button>
       </div>
 
       <div className="min-h-0 flex-1 overflow-y-auto px-4 py-5">

--- a/frontend/src/components/guild-member-list.tsx
+++ b/frontend/src/components/guild-member-list.tsx
@@ -7,10 +7,7 @@ import { getDmStatusClasses, type DirectMessage } from './dm-list';
 import { guildMembers } from './mocks/guild-member-mocks';
 import type { UserStatus } from '../shared/api/user';
 import { useGuilds } from '../shared/guilds/guild-store';
-import {
-  useGuildMembers,
-  type HydratedGuildMember
-} from '../shared/guilds/use-guild-members';
+import { useGuildMembers, type HydratedGuildMember } from '../shared/guilds/use-guild-members';
 
 export type GuildMember = {
   id: string;
@@ -187,11 +184,7 @@ export function GuildMemberList({ onToggleVisibility, onOpenProfile }: GuildMemb
                 </p>
                 <div className="mt-2 space-y-1">
                   {group.members.map((member) => (
-                    <MemberRow
-                      key={member.userId}
-                      member={member}
-                      onOpenProfile={onOpenProfile}
-                    />
+                    <MemberRow key={member.userId} member={member} onOpenProfile={onOpenProfile} />
                   ))}
                 </div>
               </section>

--- a/frontend/src/components/guild-sidebar.tsx
+++ b/frontend/src/components/guild-sidebar.tsx
@@ -116,7 +116,6 @@ export function GuildSidebar({ activeMode, onOpenDms, onOpenGuild }: GuildSideba
           {tooltip.name}
         </div>
       ) : null}
-      <div className="flex justify-center pt-5 text-3xl tracking-[0.4em] text-[#9f9f9f]">...</div>
       {isAddGuildOpen ? <AddGuildModal onClose={() => setIsAddGuildOpen(false)} /> : null}
     </aside>
   );

--- a/frontend/src/components/guild-sidebar.tsx
+++ b/frontend/src/components/guild-sidebar.tsx
@@ -2,15 +2,11 @@
 
 import { useRef, useState } from 'react';
 import type { MouseEvent } from 'react';
-import Image from 'next/image';
 import Link from 'next/link';
 import { MessageCircle, Plus } from 'lucide-react';
-
-type Guild = {
-  id: string;
-  name: string;
-  iconUrl: string;
-};
+import { AddGuildModal } from './guild/add-guild-modal';
+import { GuildIcon } from './guild/guild-icon';
+import { useGuilds } from '../shared/guilds/guild-store';
 
 type GuildSidebarProps = {
   activeMode: 'guild' | 'dm';
@@ -18,36 +14,15 @@ type GuildSidebarProps = {
   onOpenGuild: () => void;
 };
 
-const initialGuilds: Guild[] = [
-  {
-    id: 'default',
-    name: 'Default guild',
-    iconUrl: 'https://placehold.co/160x160/png?text=G'
-  }
-];
-
-const guildNames = ['Neon Arena', 'Pixel Club', 'Pong Squad', 'Byte House', 'Arcade Hub'];
-const guildColors = ['78dce8', 'a9dc76', 'ffd866', 'ff6188', 'ab9df2'];
-
-function createRandomGuild(): Guild {
-  const name = guildNames[Math.floor(Math.random() * guildNames.length)];
-  const color = guildColors[Math.floor(Math.random() * guildColors.length)];
-  const text = encodeURIComponent(name.slice(0, 1));
-
-  return {
-    id: `${name.toLowerCase().replace(/\s+/g, '-')}-${Date.now()}`,
-    name,
-    iconUrl: `https://placehold.co/160x160/${color}/101014/png?text=${text}`
-  };
-}
-
 export function GuildSidebar({ activeMode, onOpenDms, onOpenGuild }: GuildSidebarProps) {
   const sidebarRef = useRef<HTMLElement>(null);
-  const [guilds, setGuilds] = useState(initialGuilds);
+  const { guilds, isLoading, error, selectedGuildId, selectGuild } = useGuilds();
   const [tooltip, setTooltip] = useState<{ name: string; top: number } | null>(null);
+  const [isAddGuildOpen, setIsAddGuildOpen] = useState(false);
 
-  function handleAddGuild() {
-    setGuilds((current) => [...current, createRandomGuild()]);
+  function handleSelectGuild(guildId: string) {
+    selectGuild(guildId);
+    onOpenGuild();
   }
 
   function handleShowLabel(name: string, event: MouseEvent<HTMLButtonElement>) {
@@ -92,34 +67,43 @@ export function GuildSidebar({ activeMode, onOpenDms, onOpenGuild }: GuildSideba
           <MessageCircle className="h-8 w-8" strokeWidth={1.7} />
         </button>
         <div className="mx-1 border-t border-white/10" />
-        {guilds.map((guild, index) => (
+        {isLoading && guilds.length === 0 ? (
+          <div className="h-[4.9rem] shrink-0 animate-pulse rounded-xl border border-frame bg-panel" />
+        ) : null}
+        {error && guilds.length === 0 ? (
+          <p className="px-1 text-center text-xs text-pink/80" title={error}>
+            Guilds unavailable
+          </p>
+        ) : null}
+        {guilds.map((guild) => (
           <button
             key={guild.id}
             type="button"
-            onClick={onOpenGuild}
+            onClick={() => handleSelectGuild(guild.id)}
             onMouseEnter={(event) => handleShowLabel(guild.name, event)}
             onMouseLeave={() => setTooltip(null)}
             className={`h-[4.9rem] shrink-0 overflow-hidden rounded-xl border transition ${
-              index === 0 && activeMode === 'guild'
+              guild.id === selectedGuildId && activeMode === 'guild'
                 ? 'border-aqua shadow-[0_0_0_1px_rgba(120,220,232,0.2)]'
                 : 'border-frame'
             }`}
             aria-label={guild.name}
           >
-            <Image
-              src={guild.iconUrl}
-              alt=""
-              width={160}
-              height={160}
-              className="h-full w-full object-cover"
+            <GuildIcon
+              guildId={guild.id}
+              name={guild.name}
+              iconUrl={guild.icon_url}
+              className="h-full w-full text-2xl"
             />
           </button>
         ))}
         <button
           type="button"
-          onClick={handleAddGuild}
+          onClick={() => setIsAddGuildOpen(true)}
+          onMouseEnter={(event) => handleShowLabel('Add a guild', event)}
+          onMouseLeave={() => setTooltip(null)}
           className="flex h-[4.9rem] shrink-0 items-center justify-center rounded-xl bg-panel text-[#535353] transition hover:text-white"
-          aria-label="Add server"
+          aria-label="Add guild"
         >
           <Plus className="h-8 w-8" strokeWidth={1.5} />
         </button>
@@ -133,6 +117,7 @@ export function GuildSidebar({ activeMode, onOpenDms, onOpenGuild }: GuildSideba
         </div>
       ) : null}
       <div className="flex justify-center pt-5 text-3xl tracking-[0.4em] text-[#9f9f9f]">...</div>
+      {isAddGuildOpen ? <AddGuildModal onClose={() => setIsAddGuildOpen(false)} /> : null}
     </aside>
   );
 }

--- a/frontend/src/components/guild/add-guild-modal.tsx
+++ b/frontend/src/components/guild/add-guild-modal.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Plus, X } from 'lucide-react';
+import { GuildCreateForm, GuildJoinForm } from './guild-forms';
+
+type AddGuildModalProps = {
+  onClose: () => void;
+};
+
+export function AddGuildModal({ onClose }: AddGuildModalProps) {
+  const [tab, setTab] = useState<'create' | 'join'>('create');
+
+  useEffect(() => {
+    function handleEscape(event: KeyboardEvent) {
+      if (event.key === 'Escape' || event.key === 'Esc') {
+        onClose();
+      }
+    }
+
+    window.addEventListener('keydown', handleEscape);
+    return () => window.removeEventListener('keydown', handleEscape);
+  }, [onClose]);
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/55 px-4 py-6">
+      <button
+        type="button"
+        className="absolute inset-0 cursor-default"
+        onClick={onClose}
+        aria-label="Close add guild"
+      />
+      <section className="relative w-full max-w-[24rem] overflow-hidden rounded-[1rem] bg-secondary-bg shadow-2xl shadow-black/50 ring-1 ring-white/10">
+        <div className="flex h-[4.75rem] items-center justify-between border-b border-white/8 px-5">
+          <div className="flex min-w-0 items-center gap-3">
+            <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-md bg-aqua/10 text-aqua">
+              <Plus className="h-5 w-5" strokeWidth={1.9} />
+            </span>
+            <h2 className="truncate text-[1.15rem] font-bold tracking-[-0.03em] text-white">
+              Add a guild
+            </h2>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="flex h-9 w-9 items-center justify-center rounded-md text-[#8b8b8f] transition hover:bg-frame hover:text-white"
+            aria-label="Close add guild"
+          >
+            <X className="h-4 w-4" strokeWidth={2} />
+          </button>
+        </div>
+
+        <div className="px-5 py-5">
+          <div className="mb-5 flex gap-2">
+            {(['create', 'join'] as const).map((option) => (
+              <button
+                key={option}
+                type="button"
+                onClick={() => setTab(option)}
+                className={`h-9 flex-1 rounded-md text-sm font-bold transition ${
+                  tab === option
+                    ? 'bg-aqua/15 text-aqua'
+                    : 'bg-panel text-white/45 hover:text-white'
+                }`}
+              >
+                {option === 'create' ? 'Create' : 'Join with invite'}
+              </button>
+            ))}
+          </div>
+          {tab === 'create' ? (
+            <GuildCreateForm onCreated={onClose} />
+          ) : (
+            <GuildJoinForm onJoined={onClose} />
+          )}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/components/guild/guild-bans-panel.tsx
+++ b/frontend/src/components/guild/guild-bans-panel.tsx
@@ -1,0 +1,165 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import type { FormEvent } from 'react';
+import { Gavel } from 'lucide-react';
+import { banGuildMember, listGuildBans, unbanGuildMember, type GuildBanDto } from '../../shared/api/guild';
+import { getUsersByIds, type UserSummaryDto } from '../../shared/api/user';
+import { formatDate } from './guild-overview';
+import { FormError } from './guild-forms';
+
+const inputClasses =
+  'h-11 w-full rounded-md border border-transparent bg-input-bg px-4 text-base text-white outline-none transition placeholder:text-input-placeholder focus:border-aqua/35';
+
+type GuildBansPanelProps = {
+  guildId: string;
+};
+
+export function GuildBansPanel({ guildId }: GuildBansPanelProps) {
+  const [bans, setBans] = useState<GuildBanDto[]>([]);
+  const [usersById, setUsersById] = useState<Map<string, UserSummaryDto>>(new Map());
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [banUserId, setBanUserId] = useState('');
+  const [banReason, setBanReason] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const load = useCallback(async () => {
+    setIsLoading(true);
+    setError('');
+
+    try {
+      const rows = await listGuildBans(guildId, { limit: 100 });
+      setBans(rows);
+
+      const ids = rows.flatMap((ban) => [ban.user_id, ban.banned_by]).filter((id): id is string => Boolean(id));
+      const users = await getUsersByIds(ids);
+      setUsersById(new Map(users.map((user) => [user.id, user])));
+    } catch (loadError) {
+      setError(loadError instanceof Error ? loadError.message : 'Failed to load bans.');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [guildId]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  function describeUser(userId: string | null) {
+    if (!userId) {
+      return 'deleted moderator';
+    }
+
+    const user = usersById.get(userId);
+    return user ? `${user.display_name} (@${user.username})` : `user ${userId}`;
+  }
+
+  async function handleBan(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setError('');
+
+    const userId = banUserId.trim();
+    if (!userId) {
+      setError('A user id is required to create a ban.');
+      return;
+    }
+
+    try {
+      setIsSubmitting(true);
+      await banGuildMember(guildId, userId, banReason.trim() || undefined);
+      setBanUserId('');
+      setBanReason('');
+      await load();
+    } catch (banError) {
+      setError(banError instanceof Error ? banError.message : 'Failed to ban user.');
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  async function handleUnban(userId: string) {
+    if (!window.confirm(`Unban ${describeUser(userId)}?`)) {
+      return;
+    }
+
+    setError('');
+
+    try {
+      await unbanGuildMember(guildId, userId);
+      await load();
+    } catch (unbanError) {
+      setError(unbanError instanceof Error ? unbanError.message : 'Failed to unban user.');
+    }
+  }
+
+  return (
+    <div className="grid gap-5">
+      <form
+        onSubmit={handleBan}
+        className="grid gap-3 rounded-md border border-white/8 bg-panel p-4"
+      >
+        <h3 className="flex items-center gap-2 text-base font-bold text-white">
+          <Gavel className="h-4 w-4 text-pink" strokeWidth={1.9} />
+          Ban a user
+        </h3>
+        <div className="grid gap-3 sm:grid-cols-2">
+          <input
+            value={banUserId}
+            onChange={(event) => setBanUserId(event.target.value)}
+            placeholder="user id"
+            className={inputClasses}
+          />
+          <input
+            value={banReason}
+            onChange={(event) => setBanReason(event.target.value)}
+            placeholder="reason (optional)"
+            maxLength={512}
+            className={inputClasses}
+          />
+        </div>
+        <button
+          type="submit"
+          disabled={isSubmitting}
+          className="h-10 w-fit rounded-md border border-pink/25 bg-pink/10 px-5 text-sm font-bold text-pink transition hover:border-pink/45 hover:bg-pink/15 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {isSubmitting ? 'Banning...' : 'Ban user'}
+        </button>
+      </form>
+
+      {error ? <FormError message={error} /> : null}
+
+      {isLoading ? (
+        <div className="h-24 animate-pulse rounded-md bg-panel" />
+      ) : bans.length === 0 ? (
+        <p className="text-sm text-white/35">No banned users.</p>
+      ) : (
+        <ul className="grid gap-2">
+          {bans.map((ban) => (
+            <li
+              key={ban.user_id}
+              className="flex items-center gap-3 rounded-md border border-white/8 bg-panel px-3 py-2.5"
+            >
+              <div className="min-w-0 flex-1">
+                <p className="truncate text-[0.95rem] font-bold text-white">
+                  {describeUser(ban.user_id)}
+                </p>
+                <p className="truncate text-xs text-white/35">
+                  {ban.reason ? `"${ban.reason}" · ` : ''}
+                  banned by {describeUser(ban.banned_by)} · {formatDate(ban.banned_at)}
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={() => void handleUnban(ban.user_id)}
+                className="h-8 shrink-0 rounded-md border border-white/10 px-3 text-xs font-bold text-white/60 transition hover:border-aqua/40 hover:text-aqua"
+              >
+                Unban
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/guild/guild-bans-panel.tsx
+++ b/frontend/src/components/guild/guild-bans-panel.tsx
@@ -3,7 +3,12 @@
 import { useCallback, useEffect, useState } from 'react';
 import type { FormEvent } from 'react';
 import { Gavel } from 'lucide-react';
-import { banGuildMember, listGuildBans, unbanGuildMember, type GuildBanDto } from '../../shared/api/guild';
+import {
+  banGuildMember,
+  listGuildBans,
+  unbanGuildMember,
+  type GuildBanDto
+} from '../../shared/api/guild';
 import { getUsersByIds, type UserSummaryDto } from '../../shared/api/user';
 import { formatDate } from './guild-overview';
 import { FormError } from './guild-forms';
@@ -32,7 +37,9 @@ export function GuildBansPanel({ guildId }: GuildBansPanelProps) {
       const rows = await listGuildBans(guildId, { limit: 100 });
       setBans(rows);
 
-      const ids = rows.flatMap((ban) => [ban.user_id, ban.banned_by]).filter((id): id is string => Boolean(id));
+      const ids = rows
+        .flatMap((ban) => [ban.user_id, ban.banned_by])
+        .filter((id): id is string => Boolean(id));
       const users = await getUsersByIds(ids);
       setUsersById(new Map(users.map((user) => [user.id, user])));
     } catch (loadError) {

--- a/frontend/src/components/guild/guild-categories-panel.tsx
+++ b/frontend/src/components/guild/guild-categories-panel.tsx
@@ -1,0 +1,230 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import type { FormEvent } from 'react';
+import { Check, FolderPlus, Pencil, Trash2, X } from 'lucide-react';
+import {
+  createGuildCategory,
+  deleteGuildCategory,
+  listGuildCategories,
+  updateGuildCategory,
+  type GuildCategoryDto
+} from '../../shared/api/guild';
+import { FormError } from './guild-forms';
+
+const inputClasses =
+  'h-10 w-full rounded-md border border-transparent bg-input-bg px-3 text-sm text-white outline-none transition placeholder:text-input-placeholder focus:border-aqua/35';
+
+const iconButtonClasses =
+  'flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-[#8b8b8f] transition hover:bg-frame hover:text-white';
+
+type GuildCategoriesPanelProps = {
+  guildId: string;
+};
+
+export function GuildCategoriesPanel({ guildId }: GuildCategoriesPanelProps) {
+  const [categories, setCategories] = useState<GuildCategoryDto[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [newName, setNewName] = useState('');
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editName, setEditName] = useState('');
+  const [editPosition, setEditPosition] = useState('');
+  const [isBusy, setIsBusy] = useState(false);
+
+  const load = useCallback(async () => {
+    setIsLoading(true);
+    setError('');
+
+    try {
+      const rows = await listGuildCategories(guildId);
+      setCategories([...rows].sort((a, b) => a.position - b.position));
+    } catch (loadError) {
+      setError(loadError instanceof Error ? loadError.message : 'Failed to load categories.');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [guildId]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  async function handleCreate(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setError('');
+
+    const name = newName.trim();
+    if (!name) {
+      setError('Category name is required.');
+      return;
+    }
+
+    try {
+      setIsBusy(true);
+      await createGuildCategory(guildId, { name });
+      setNewName('');
+      await load();
+    } catch (createError) {
+      setError(createError instanceof Error ? createError.message : 'Failed to create category.');
+    } finally {
+      setIsBusy(false);
+    }
+  }
+
+  async function handleSaveEdit(categoryId: string) {
+    setError('');
+
+    const name = editName.trim();
+    if (!name) {
+      setError('Category name is required.');
+      return;
+    }
+
+    const position = editPosition.trim() === '' ? undefined : Number(editPosition);
+    if (position !== undefined && (!Number.isInteger(position) || position < 0)) {
+      setError('Position must be a non-negative whole number.');
+      return;
+    }
+
+    try {
+      setIsBusy(true);
+      await updateGuildCategory(guildId, categoryId, { name, position });
+      setEditingId(null);
+      await load();
+    } catch (updateError) {
+      setError(updateError instanceof Error ? updateError.message : 'Failed to update category.');
+    } finally {
+      setIsBusy(false);
+    }
+  }
+
+  async function handleDelete(category: GuildCategoryDto) {
+    if (!window.confirm(`Delete category "${category.name}"? Its channels become uncategorised.`)) {
+      return;
+    }
+
+    setError('');
+
+    try {
+      setIsBusy(true);
+      await deleteGuildCategory(guildId, category.id);
+      await load();
+    } catch (deleteError) {
+      setError(deleteError instanceof Error ? deleteError.message : 'Failed to delete category.');
+    } finally {
+      setIsBusy(false);
+    }
+  }
+
+  return (
+    <div className="grid gap-5">
+      <form
+        onSubmit={handleCreate}
+        className="grid gap-3 rounded-md border border-white/8 bg-panel p-4"
+      >
+        <h3 className="flex items-center gap-2 text-base font-bold text-white">
+          <FolderPlus className="h-4 w-4 text-aqua" strokeWidth={1.9} />
+          Create a category
+        </h3>
+        <div className="flex gap-3">
+          <input
+            value={newName}
+            onChange={(event) => setNewName(event.target.value)}
+            placeholder="category name"
+            maxLength={100}
+            className={inputClasses}
+          />
+          <button
+            type="submit"
+            disabled={isBusy}
+            className="h-10 shrink-0 rounded-md bg-aqua px-5 text-sm font-bold text-primary-bg transition hover:bg-white disabled:cursor-not-allowed disabled:bg-frame disabled:text-white/25"
+          >
+            {isBusy ? 'Working...' : 'Create'}
+          </button>
+        </div>
+      </form>
+
+      {error ? <FormError message={error} /> : null}
+
+      {isLoading ? (
+        <div className="h-24 animate-pulse rounded-md bg-panel" />
+      ) : categories.length === 0 ? (
+        <p className="text-sm text-white/35">No categories yet.</p>
+      ) : (
+        <ul className="grid gap-2">
+          {categories.map((category) => (
+            <li
+              key={category.id}
+              className="flex items-center gap-3 rounded-md border border-white/8 bg-panel px-3 py-2.5"
+            >
+              {editingId === category.id ? (
+                <>
+                  <input
+                    value={editName}
+                    onChange={(event) => setEditName(event.target.value)}
+                    maxLength={100}
+                    placeholder="category name"
+                    className={inputClasses}
+                  />
+                  <input
+                    value={editPosition}
+                    onChange={(event) => setEditPosition(event.target.value)}
+                    placeholder="position"
+                    inputMode="numeric"
+                    className={`${inputClasses} max-w-[6rem]`}
+                  />
+                  <button
+                    type="button"
+                    onClick={() => void handleSaveEdit(category.id)}
+                    disabled={isBusy}
+                    className={iconButtonClasses}
+                    aria-label="Save category"
+                  >
+                    <Check className="h-4 w-4 text-lime" strokeWidth={2} />
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setEditingId(null)}
+                    className={iconButtonClasses}
+                    aria-label="Cancel category edit"
+                  >
+                    <X className="h-4 w-4" strokeWidth={2} />
+                  </button>
+                </>
+              ) : (
+                <>
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate text-[0.95rem] font-bold text-white">{category.name}</p>
+                    <p className="text-xs text-white/35">position {category.position}</p>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setEditingId(category.id);
+                      setEditName(category.name);
+                      setEditPosition(String(category.position));
+                    }}
+                    className={iconButtonClasses}
+                    aria-label={`Edit category ${category.name}`}
+                  >
+                    <Pencil className="h-4 w-4" strokeWidth={1.9} />
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => void handleDelete(category)}
+                    disabled={isBusy}
+                    className={`${iconButtonClasses} hover:text-pink`}
+                    aria-label={`Delete category ${category.name}`}
+                  >
+                    <Trash2 className="h-4 w-4" strokeWidth={1.9} />
+                  </button>
+                </>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/guild/guild-forms.tsx
+++ b/frontend/src/components/guild/guild-forms.tsx
@@ -1,0 +1,151 @@
+'use client';
+
+import { useState } from 'react';
+import type { FormEvent } from 'react';
+import { Plus } from 'lucide-react';
+import type { GuildDto } from '../../shared/api/guild';
+import { useGuilds } from '../../shared/guilds/guild-store';
+
+const inputClasses =
+  'h-11 w-full rounded-md border border-transparent bg-input-bg px-4 text-base text-white outline-none transition placeholder:text-input-placeholder focus:border-aqua/35';
+
+const submitClasses =
+  'flex h-11 items-center justify-center gap-2 rounded-md bg-aqua px-5 text-sm font-bold text-primary-bg transition hover:bg-white disabled:cursor-not-allowed disabled:bg-frame disabled:text-white/25';
+
+export function FormError({ message }: { message: string }) {
+  return (
+    <p className="rounded-md border border-pink/25 bg-pink/10 px-3 py-2 text-sm text-pink">
+      {message}
+    </p>
+  );
+}
+
+type GuildCreateFormProps = {
+  onCreated?: (guild: GuildDto) => void;
+};
+
+export function GuildCreateForm({ onCreated }: GuildCreateFormProps) {
+  const { createGuild } = useGuilds();
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [iconUrl, setIconUrl] = useState('');
+  const [error, setError] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setError('');
+
+    const trimmedName = name.trim();
+    if (!trimmedName) {
+      setError('Guild name is required.');
+      return;
+    }
+
+    try {
+      setIsSubmitting(true);
+      const guild = await createGuild({
+        name: trimmedName,
+        description: description.trim() || undefined,
+        icon_url: iconUrl.trim() || undefined
+      });
+      setName('');
+      setDescription('');
+      setIconUrl('');
+      onCreated?.(guild);
+    } catch (submitError) {
+      setError(submitError instanceof Error ? submitError.message : 'Failed to create guild.');
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="grid gap-3">
+      <label className="grid gap-2">
+        <span className="text-sm font-semibold text-white/70">Guild name</span>
+        <input
+          value={name}
+          onChange={(event) => setName(event.target.value)}
+          placeholder="my guild"
+          maxLength={100}
+          className={inputClasses}
+        />
+      </label>
+      <label className="grid gap-2">
+        <span className="text-sm font-semibold text-white/70">Description (optional)</span>
+        <input
+          value={description}
+          onChange={(event) => setDescription(event.target.value)}
+          placeholder="what is this guild about?"
+          className={inputClasses}
+        />
+      </label>
+      <label className="grid gap-2">
+        <span className="text-sm font-semibold text-white/70">Icon URL (optional)</span>
+        <input
+          value={iconUrl}
+          onChange={(event) => setIconUrl(event.target.value)}
+          placeholder="https://..."
+          className={inputClasses}
+        />
+      </label>
+      {error ? <FormError message={error} /> : null}
+      <button type="submit" disabled={isSubmitting} className={submitClasses}>
+        <Plus className="h-4 w-4" strokeWidth={2} />
+        {isSubmitting ? 'Creating...' : 'Create guild'}
+      </button>
+    </form>
+  );
+}
+
+type GuildJoinFormProps = {
+  onJoined?: (guild: GuildDto) => void;
+};
+
+export function GuildJoinForm({ onJoined }: GuildJoinFormProps) {
+  const { joinGuildWithCode } = useGuilds();
+  const [code, setCode] = useState('');
+  const [error, setError] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setError('');
+
+    const trimmedCode = code.trim();
+    if (!trimmedCode) {
+      setError('Invite code is required.');
+      return;
+    }
+
+    try {
+      setIsSubmitting(true);
+      const guild = await joinGuildWithCode(trimmedCode);
+      setCode('');
+      onJoined?.(guild);
+    } catch (submitError) {
+      setError(submitError instanceof Error ? submitError.message : 'Failed to join guild.');
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="grid gap-3">
+      <label className="grid gap-2">
+        <span className="text-sm font-semibold text-white/70">Invite code</span>
+        <input
+          value={code}
+          onChange={(event) => setCode(event.target.value)}
+          placeholder="invite_code"
+          className={inputClasses}
+        />
+      </label>
+      {error ? <FormError message={error} /> : null}
+      <button type="submit" disabled={isSubmitting} className={submitClasses}>
+        {isSubmitting ? 'Joining...' : 'Join guild'}
+      </button>
+    </form>
+  );
+}

--- a/frontend/src/components/guild/guild-icon.tsx
+++ b/frontend/src/components/guild/guild-icon.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import Image from 'next/image';
+
+const ACCENTS = [
+  'bg-aqua/15 text-aqua',
+  'bg-lime/15 text-lime',
+  'bg-yellow/15 text-yellow',
+  'bg-pink/15 text-pink',
+  'bg-lavender/15 text-lavender'
+];
+
+export function getGuildAccentClasses(guildId: string) {
+  let hash = 0;
+  for (const char of guildId) {
+    hash = (hash * 31 + char.charCodeAt(0)) % ACCENTS.length;
+  }
+
+  return ACCENTS[hash];
+}
+
+type GuildIconProps = {
+  guildId: string;
+  name: string;
+  iconUrl?: string | null;
+  className?: string;
+};
+
+export function GuildIcon({ guildId, name, iconUrl, className = '' }: GuildIconProps) {
+  if (iconUrl) {
+    return (
+      <Image
+        src={iconUrl}
+        alt=""
+        width={160}
+        height={160}
+        unoptimized
+        className={`object-cover ${className}`}
+      />
+    );
+  }
+
+  return (
+    <span
+      className={`flex items-center justify-center font-bold ${getGuildAccentClasses(
+        guildId
+      )} ${className}`}
+    >
+      {name.slice(0, 1).toUpperCase()}
+    </span>
+  );
+}

--- a/frontend/src/components/guild/guild-invites-panel.tsx
+++ b/frontend/src/components/guild/guild-invites-panel.tsx
@@ -194,7 +194,8 @@ export function GuildInvitesPanel({ guildId }: GuildInvitesPanelProps) {
                   {invite.code}
                 </p>
                 <p className="truncate text-xs text-white/35">
-                  {invite.uses}/{invite.max_uses ?? '∞'} uses · by {describeCreator(invite.created_by)} ·{' '}
+                  {invite.uses}/{invite.max_uses ?? '∞'} uses · by{' '}
+                  {describeCreator(invite.created_by)} ·{' '}
                   {invite.expires_at ? `expires ${formatDate(invite.expires_at)}` : 'never expires'}
                 </p>
               </div>
@@ -246,7 +247,8 @@ export function GuildInvitesPanel({ guildId }: GuildInvitesPanelProps) {
               <p className="truncate text-[0.95rem] font-bold text-white">{preview.guild.name}</p>
               <p className="truncate text-xs text-white/35">
                 {preview.guild.member_count ?? '—'} members · invited by @{preview.inviter.username}{' '}
-                · {preview.expires_at ? `expires ${formatDate(preview.expires_at)}` : 'never expires'}
+                ·{' '}
+                {preview.expires_at ? `expires ${formatDate(preview.expires_at)}` : 'never expires'}
               </p>
             </div>
           </div>

--- a/frontend/src/components/guild/guild-invites-panel.tsx
+++ b/frontend/src/components/guild/guild-invites-panel.tsx
@@ -1,0 +1,257 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import type { FormEvent } from 'react';
+import { Link2, Search } from 'lucide-react';
+import {
+  createGuildInvite,
+  listGuildInvites,
+  previewInvite,
+  revokeGuildInvite,
+  type GuildInviteDto,
+  type InvitePreviewDto
+} from '../../shared/api/guild';
+import { getUsersByIds, type UserSummaryDto } from '../../shared/api/user';
+import { formatDate } from './guild-overview';
+import { GuildIcon } from './guild-icon';
+import { FormError } from './guild-forms';
+
+const inputClasses =
+  'h-11 w-full rounded-md border border-transparent bg-input-bg px-4 text-base text-white outline-none transition placeholder:text-input-placeholder focus:border-aqua/35';
+
+type GuildInvitesPanelProps = {
+  guildId: string;
+};
+
+export function GuildInvitesPanel({ guildId }: GuildInvitesPanelProps) {
+  const [invites, setInvites] = useState<GuildInviteDto[]>([]);
+  const [usersById, setUsersById] = useState<Map<string, UserSummaryDto>>(new Map());
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [maxUses, setMaxUses] = useState('');
+  const [expiresInHours, setExpiresInHours] = useState('');
+  const [isCreating, setIsCreating] = useState(false);
+  const [createdCode, setCreatedCode] = useState('');
+  const [previewCode, setPreviewCode] = useState('');
+  const [preview, setPreview] = useState<InvitePreviewDto | null>(null);
+  const [previewError, setPreviewError] = useState('');
+  const [isPreviewing, setIsPreviewing] = useState(false);
+
+  const load = useCallback(async () => {
+    setIsLoading(true);
+    setError('');
+
+    try {
+      const rows = await listGuildInvites(guildId);
+      setInvites(rows);
+
+      const users = await getUsersByIds(rows.map((invite) => invite.created_by));
+      setUsersById(new Map(users.map((user) => [user.id, user])));
+    } catch (loadError) {
+      setError(loadError instanceof Error ? loadError.message : 'Failed to load invites.');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [guildId]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  async function handleCreate(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setError('');
+    setCreatedCode('');
+
+    const parsedMaxUses = maxUses.trim() ? Number(maxUses) : undefined;
+    const parsedExpires = expiresInHours.trim() ? Number(expiresInHours) : undefined;
+
+    if (
+      (parsedMaxUses !== undefined && (!Number.isInteger(parsedMaxUses) || parsedMaxUses <= 0)) ||
+      (parsedExpires !== undefined && (!Number.isInteger(parsedExpires) || parsedExpires <= 0))
+    ) {
+      setError('Max uses and expiry must be positive whole numbers.');
+      return;
+    }
+
+    try {
+      setIsCreating(true);
+      const invite = await createGuildInvite(guildId, {
+        max_uses: parsedMaxUses,
+        expires_in_hours: parsedExpires
+      });
+      setCreatedCode(invite.code);
+      setMaxUses('');
+      setExpiresInHours('');
+      await load();
+    } catch (createError) {
+      setError(createError instanceof Error ? createError.message : 'Failed to create invite.');
+    } finally {
+      setIsCreating(false);
+    }
+  }
+
+  async function handleRevoke(code: string) {
+    if (!window.confirm(`Revoke invite ${code}? It becomes unusable immediately.`)) {
+      return;
+    }
+
+    setError('');
+
+    try {
+      await revokeGuildInvite(guildId, code);
+      await load();
+    } catch (revokeError) {
+      setError(revokeError instanceof Error ? revokeError.message : 'Failed to revoke invite.');
+    }
+  }
+
+  async function handlePreview(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setPreviewError('');
+    setPreview(null);
+
+    const code = previewCode.trim();
+    if (!code) {
+      setPreviewError('Enter an invite code to preview.');
+      return;
+    }
+
+    try {
+      setIsPreviewing(true);
+      setPreview(await previewInvite(code));
+    } catch (lookupError) {
+      setPreviewError(
+        lookupError instanceof Error ? lookupError.message : 'Invite not found or expired.'
+      );
+    } finally {
+      setIsPreviewing(false);
+    }
+  }
+
+  function describeCreator(userId: string) {
+    const user = usersById.get(userId);
+    return user ? `@${user.username}` : `user ${userId}`;
+  }
+
+  return (
+    <div className="grid gap-5">
+      <form
+        onSubmit={handleCreate}
+        className="grid gap-3 rounded-md border border-white/8 bg-panel p-4"
+      >
+        <h3 className="flex items-center gap-2 text-base font-bold text-white">
+          <Link2 className="h-4 w-4 text-aqua" strokeWidth={1.9} />
+          Create an invite
+        </h3>
+        <div className="grid gap-3 sm:grid-cols-2">
+          <input
+            value={maxUses}
+            onChange={(event) => setMaxUses(event.target.value)}
+            placeholder="max uses (unlimited if empty)"
+            inputMode="numeric"
+            className={inputClasses}
+          />
+          <input
+            value={expiresInHours}
+            onChange={(event) => setExpiresInHours(event.target.value)}
+            placeholder="expires in hours (never if empty)"
+            inputMode="numeric"
+            className={inputClasses}
+          />
+        </div>
+        <div className="flex flex-wrap items-center gap-3">
+          <button
+            type="submit"
+            disabled={isCreating}
+            className="h-10 rounded-md bg-aqua px-5 text-sm font-bold text-primary-bg transition hover:bg-white disabled:cursor-not-allowed disabled:bg-frame disabled:text-white/25"
+          >
+            {isCreating ? 'Creating...' : 'Create invite'}
+          </button>
+          {createdCode ? (
+            <span className="mono-detail rounded-md border border-lime/30 bg-lime/10 px-3 py-2 text-sm text-lime">
+              Invite created: {createdCode}
+            </span>
+          ) : null}
+        </div>
+      </form>
+
+      {error ? <FormError message={error} /> : null}
+
+      {isLoading ? (
+        <div className="h-24 animate-pulse rounded-md bg-panel" />
+      ) : invites.length === 0 ? (
+        <p className="text-sm text-white/35">No active invites.</p>
+      ) : (
+        <ul className="grid gap-2">
+          {invites.map((invite) => (
+            <li
+              key={invite.code}
+              className="flex items-center gap-3 rounded-md border border-white/8 bg-panel px-3 py-2.5"
+            >
+              <div className="min-w-0 flex-1">
+                <p className="mono-detail truncate text-[0.95rem] font-bold text-white">
+                  {invite.code}
+                </p>
+                <p className="truncate text-xs text-white/35">
+                  {invite.uses}/{invite.max_uses ?? '∞'} uses · by {describeCreator(invite.created_by)} ·{' '}
+                  {invite.expires_at ? `expires ${formatDate(invite.expires_at)}` : 'never expires'}
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={() => void handleRevoke(invite.code)}
+                className="h-8 shrink-0 rounded-md border border-white/10 px-3 text-xs font-bold text-white/60 transition hover:border-pink/40 hover:text-pink"
+              >
+                Revoke
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <form
+        onSubmit={handlePreview}
+        className="grid gap-3 rounded-md border border-white/8 bg-panel p-4"
+      >
+        <h3 className="flex items-center gap-2 text-base font-bold text-white">
+          <Search className="h-4 w-4 text-lavender" strokeWidth={1.9} />
+          Preview an invite
+        </h3>
+        <div className="flex gap-3">
+          <input
+            value={previewCode}
+            onChange={(event) => setPreviewCode(event.target.value)}
+            placeholder="invite code"
+            className={inputClasses}
+          />
+          <button
+            type="submit"
+            disabled={isPreviewing}
+            className="h-11 shrink-0 rounded-md border border-white/10 px-5 text-sm font-bold text-white/70 transition hover:border-aqua/40 hover:text-aqua disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {isPreviewing ? 'Looking up...' : 'Preview'}
+          </button>
+        </div>
+        {previewError ? <FormError message={previewError} /> : null}
+        {preview ? (
+          <div className="flex items-center gap-3 rounded-md border border-white/10 bg-frame/50 px-3 py-2.5">
+            <GuildIcon
+              guildId={preview.guild.id}
+              name={preview.guild.name}
+              iconUrl={preview.guild.icon_url}
+              className="h-10 w-10 overflow-hidden rounded-xl text-sm"
+            />
+            <div className="min-w-0">
+              <p className="truncate text-[0.95rem] font-bold text-white">{preview.guild.name}</p>
+              <p className="truncate text-xs text-white/35">
+                {preview.guild.member_count ?? '—'} members · invited by @{preview.inviter.username}{' '}
+                · {preview.expires_at ? `expires ${formatDate(preview.expires_at)}` : 'never expires'}
+              </p>
+            </div>
+          </div>
+        ) : null}
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/components/guild/guild-members-panel.tsx
+++ b/frontend/src/components/guild/guild-members-panel.tsx
@@ -1,0 +1,240 @@
+'use client';
+
+import { useState } from 'react';
+import Image from 'next/image';
+import { Check, Crown, Gavel, Pencil, UserX, X } from 'lucide-react';
+import {
+  banGuildMember,
+  kickGuildMember,
+  updateGuildMemberNickname
+} from '../../shared/api/guild';
+import { useGuilds } from '../../shared/guilds/guild-store';
+import {
+  useGuildMembers,
+  type HydratedGuildMember
+} from '../../shared/guilds/use-guild-members';
+import { formatDate } from './guild-overview';
+import { getGuildAccentClasses } from './guild-icon';
+import { FormError } from './guild-forms';
+
+const iconButtonClasses =
+  'flex h-8 w-8 items-center justify-center rounded-md text-[#8b8b8f] transition hover:bg-frame hover:text-white';
+
+function MemberAvatar({ member }: { member: HydratedGuildMember }) {
+  if (member.avatarUrl) {
+    return (
+      <Image
+        src={member.avatarUrl}
+        alt=""
+        width={40}
+        height={40}
+        unoptimized
+        className="h-10 w-10 shrink-0 rounded-full object-cover"
+      />
+    );
+  }
+
+  return (
+    <span
+      className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-full text-sm font-bold ${getGuildAccentClasses(
+        member.userId
+      )}`}
+    >
+      {member.displayName.slice(0, 1).toUpperCase()}
+    </span>
+  );
+}
+
+type MemberRowProps = {
+  guildId: string;
+  member: HydratedGuildMember;
+  onChanged: () => void;
+  onError: (message: string) => void;
+};
+
+function MemberRow({ guildId, member, onChanged, onError }: MemberRowProps) {
+  const [isEditingNickname, setIsEditingNickname] = useState(false);
+  const [nicknameDraft, setNicknameDraft] = useState(member.nickname ?? '');
+  const [isBusy, setIsBusy] = useState(false);
+
+  async function run(action: () => Promise<unknown>, fallbackMessage: string) {
+    try {
+      setIsBusy(true);
+      await action();
+      onChanged();
+    } catch (actionError) {
+      onError(actionError instanceof Error ? actionError.message : fallbackMessage);
+    } finally {
+      setIsBusy(false);
+    }
+  }
+
+  async function handleSaveNickname() {
+    const nickname = nicknameDraft.trim();
+    await run(
+      () => updateGuildMemberNickname(guildId, member.userId, nickname || null),
+      'Failed to update nickname.'
+    );
+    setIsEditingNickname(false);
+  }
+
+  function handleKick() {
+    if (!window.confirm(`Kick ${member.displayName} from the guild?`)) {
+      return;
+    }
+
+    void run(() => kickGuildMember(guildId, member.userId), 'Failed to kick member.');
+  }
+
+  function handleBan() {
+    const reason = window.prompt(`Ban ${member.displayName}? Optional reason:`);
+    if (reason === null) {
+      return;
+    }
+
+    void run(
+      () => banGuildMember(guildId, member.userId, reason.trim() || undefined),
+      'Failed to ban member.'
+    );
+  }
+
+  return (
+    <li className="flex items-center gap-3 rounded-md border border-white/8 bg-panel px-3 py-2.5">
+      <MemberAvatar member={member} />
+      <div className="min-w-0 flex-1">
+        {isEditingNickname ? (
+          <div className="flex items-center gap-2">
+            <input
+              value={nicknameDraft}
+              onChange={(event) => setNicknameDraft(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === 'Enter') {
+                  void handleSaveNickname();
+                }
+                if (event.key === 'Escape') {
+                  setIsEditingNickname(false);
+                }
+              }}
+              maxLength={64}
+              placeholder="nickname (empty to clear)"
+              className="h-8 w-full max-w-[14rem] rounded-md border border-transparent bg-input-bg px-3 text-sm text-white outline-none focus:border-aqua/35"
+            />
+            <button
+              type="button"
+              onClick={() => void handleSaveNickname()}
+              disabled={isBusy}
+              className={iconButtonClasses}
+              aria-label="Save nickname"
+            >
+              <Check className="h-4 w-4 text-lime" strokeWidth={2} />
+            </button>
+            <button
+              type="button"
+              onClick={() => setIsEditingNickname(false)}
+              className={iconButtonClasses}
+              aria-label="Cancel nickname edit"
+            >
+              <X className="h-4 w-4" strokeWidth={2} />
+            </button>
+          </div>
+        ) : (
+          <>
+            <p className="flex items-center gap-1.5 truncate text-[0.95rem] font-bold text-white">
+              {member.displayName}
+              {member.isOwner ? (
+                <Crown className="h-3.5 w-3.5 shrink-0 text-yellow" strokeWidth={1.9} />
+              ) : null}
+            </p>
+            <p className="truncate text-xs text-white/35">
+              {member.username ? `@${member.username}` : 'deleted user'}
+              {member.nickname ? ` · nickname: ${member.nickname}` : ''}
+              {member.roles.length > 0
+                ? ` · ${member.roles.map((role) => role.name).join(', ')}`
+                : ''}
+              {` · joined ${formatDate(member.joinedAt)}`}
+            </p>
+          </>
+        )}
+      </div>
+      {!isEditingNickname ? (
+        <div className="flex shrink-0 items-center gap-1">
+          <button
+            type="button"
+            onClick={() => {
+              setNicknameDraft(member.nickname ?? '');
+              setIsEditingNickname(true);
+            }}
+            disabled={isBusy}
+            className={iconButtonClasses}
+            aria-label={`Edit nickname of ${member.displayName}`}
+            title="Edit nickname"
+          >
+            <Pencil className="h-4 w-4" strokeWidth={1.9} />
+          </button>
+          {!member.isOwner ? (
+            <>
+              <button
+                type="button"
+                onClick={handleKick}
+                disabled={isBusy}
+                className={iconButtonClasses}
+                aria-label={`Kick ${member.displayName}`}
+                title="Kick member"
+              >
+                <UserX className="h-4 w-4 text-orange" strokeWidth={1.9} />
+              </button>
+              <button
+                type="button"
+                onClick={handleBan}
+                disabled={isBusy}
+                className={iconButtonClasses}
+                aria-label={`Ban ${member.displayName}`}
+                title="Ban member"
+              >
+                <Gavel className="h-4 w-4 text-pink" strokeWidth={1.9} />
+              </button>
+            </>
+          ) : null}
+        </div>
+      ) : null}
+    </li>
+  );
+}
+
+type GuildMembersPanelProps = {
+  guildId: string;
+};
+
+export function GuildMembersPanel({ guildId }: GuildMembersPanelProps) {
+  const { selectedGuild } = useGuilds();
+  const { members, isLoading, error, refresh } = useGuildMembers(
+    guildId,
+    selectedGuild?.id === guildId ? selectedGuild.owner_id : null
+  );
+  const [actionError, setActionError] = useState('');
+
+  return (
+    <div className="grid gap-3">
+      {actionError ? <FormError message={actionError} /> : null}
+      {error ? <FormError message={error} /> : null}
+      {isLoading && members.length === 0 ? (
+        <div className="h-32 animate-pulse rounded-md bg-panel" />
+      ) : (
+        <ul className="grid gap-2">
+          {members.map((member) => (
+            <MemberRow
+              key={member.userId}
+              guildId={guildId}
+              member={member}
+              onChanged={() => {
+                setActionError('');
+                void refresh();
+              }}
+              onError={setActionError}
+            />
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/guild/guild-members-panel.tsx
+++ b/frontend/src/components/guild/guild-members-panel.tsx
@@ -3,16 +3,9 @@
 import { useState } from 'react';
 import Image from 'next/image';
 import { Check, Crown, Gavel, Pencil, UserX, X } from 'lucide-react';
-import {
-  banGuildMember,
-  kickGuildMember,
-  updateGuildMemberNickname
-} from '../../shared/api/guild';
+import { banGuildMember, kickGuildMember, updateGuildMemberNickname } from '../../shared/api/guild';
 import { useGuilds } from '../../shared/guilds/guild-store';
-import {
-  useGuildMembers,
-  type HydratedGuildMember
-} from '../../shared/guilds/use-guild-members';
+import { useGuildMembers, type HydratedGuildMember } from '../../shared/guilds/use-guild-members';
 import { formatDate } from './guild-overview';
 import { getGuildAccentClasses } from './guild-icon';
 import { FormError } from './guild-forms';

--- a/frontend/src/components/guild/guild-overview.tsx
+++ b/frontend/src/components/guild/guild-overview.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Crown, Users } from 'lucide-react';
+import { getGuild, type GuildDto } from '../../shared/api/guild';
+import { useGuilds } from '../../shared/guilds/guild-store';
+import { GuildIcon } from './guild-icon';
+
+export function formatDate(value: string | null | undefined) {
+  if (!value) {
+    return '—';
+  }
+
+  const date = new Date(value);
+  return Number.isNaN(date.getTime())
+    ? '—'
+    : date.toLocaleDateString('fr-FR', { day: '2-digit', month: 'short', year: 'numeric' });
+}
+
+type GuildOverviewProps = {
+  guildId: string;
+};
+
+export function GuildOverview({ guildId }: GuildOverviewProps) {
+  const { currentUserId } = useGuilds();
+  const [guild, setGuild] = useState<GuildDto | null>(null);
+  const [error, setError] = useState('');
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    let isCancelled = false;
+
+    setIsLoading(true);
+    setError('');
+    setGuild(null);
+
+    getGuild(guildId)
+      .then((details) => {
+        if (!isCancelled) {
+          setGuild(details);
+        }
+      })
+      .catch((loadError) => {
+        if (!isCancelled) {
+          setError(loadError instanceof Error ? loadError.message : 'Failed to load guild.');
+        }
+      })
+      .finally(() => {
+        if (!isCancelled) {
+          setIsLoading(false);
+        }
+      });
+
+    return () => {
+      isCancelled = true;
+    };
+  }, [guildId]);
+
+  if (isLoading) {
+    return <div className="h-48 animate-pulse rounded-[1rem] bg-panel" />;
+  }
+
+  if (error || !guild) {
+    return (
+      <p className="rounded-md border border-pink/25 bg-pink/10 px-4 py-3 text-sm text-pink">
+        {error || 'Guild not found.'}
+      </p>
+    );
+  }
+
+  return (
+    <div className="overflow-hidden rounded-[1rem] border border-white/8 bg-panel">
+      <div
+        className="h-28 bg-[linear-gradient(135deg,#232329_0%,#2b3141_38%,#24545b_68%,#78dce8_100%)] bg-cover bg-center"
+        style={guild.banner_url ? { backgroundImage: `url(${guild.banner_url})` } : undefined}
+      />
+      <div className="px-6 pb-6">
+        <div className="-mt-8 flex items-end gap-4">
+          <GuildIcon
+            guildId={guild.id}
+            name={guild.name}
+            iconUrl={guild.icon_url}
+            className="h-20 w-20 overflow-hidden rounded-2xl border-4 border-panel text-3xl"
+          />
+          <div className="min-w-0 pb-1">
+            <h2 className="flex items-center gap-2 truncate text-3xl font-extrabold tracking-[-0.05em] text-white">
+              {guild.name}
+              {currentUserId && guild.owner_id === currentUserId ? (
+                <Crown className="h-5 w-5 shrink-0 text-yellow" strokeWidth={1.9} aria-label="You own this guild" />
+              ) : null}
+            </h2>
+          </div>
+        </div>
+        {guild.description ? (
+          <p className="mt-4 max-w-2xl text-base text-white/65">{guild.description}</p>
+        ) : null}
+        <div className="mt-5 flex flex-wrap gap-x-6 gap-y-2 text-sm text-white/45">
+          <span className="inline-flex items-center gap-2">
+            <Users className="h-4 w-4" strokeWidth={1.8} />
+            {guild.member_count ?? '—'} member{(guild.member_count ?? 0) === 1 ? '' : 's'}
+          </span>
+          <span>Created {formatDate(guild.created_at)}</span>
+          <span className="mono-detail">id {guild.id}</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/guild/guild-overview.tsx
+++ b/frontend/src/components/guild/guild-overview.tsx
@@ -86,7 +86,11 @@ export function GuildOverview({ guildId }: GuildOverviewProps) {
             <h2 className="flex items-center gap-2 truncate text-3xl font-extrabold tracking-[-0.05em] text-white">
               {guild.name}
               {currentUserId && guild.owner_id === currentUserId ? (
-                <Crown className="h-5 w-5 shrink-0 text-yellow" strokeWidth={1.9} aria-label="You own this guild" />
+                <Crown
+                  className="h-5 w-5 shrink-0 text-yellow"
+                  strokeWidth={1.9}
+                  aria-label="You own this guild"
+                />
               ) : null}
             </h2>
           </div>

--- a/frontend/src/components/guild/guild-roles-panel.tsx
+++ b/frontend/src/components/guild/guild-roles-panel.tsx
@@ -1,0 +1,335 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { ShieldPlus, Trash2 } from 'lucide-react';
+import {
+  createGuildRole,
+  deleteGuildRole,
+  listGuildRoles,
+  updateGuildRole,
+  type GuildRoleDto
+} from '../../shared/api/guild';
+import { FormError } from './guild-forms';
+
+const inputClasses =
+  'h-10 w-full rounded-md border border-transparent bg-input-bg px-3 text-sm text-white outline-none transition placeholder:text-input-placeholder focus:border-aqua/35';
+
+const PERMISSION_FLAGS = [
+  { label: 'Send messages', value: 1 },
+  { label: 'Read messages', value: 2 },
+  { label: 'Manage messages', value: 4 },
+  { label: 'Manage channels', value: 8 },
+  { label: 'Kick members', value: 16 },
+  { label: 'Ban members', value: 32 },
+  { label: 'Manage roles', value: 64 },
+  { label: 'Manage guild', value: 128 },
+  { label: 'Administrator', value: 256 },
+  { label: 'Create invite', value: 512 },
+  { label: 'Mention everyone', value: 1024 },
+  { label: 'Manage nicknames', value: 2048 }
+];
+
+type RoleDraft = {
+  name: string;
+  color: string;
+  permissions: number;
+  isHoisted: boolean;
+  isMentionable: boolean;
+};
+
+const emptyDraft: RoleDraft = {
+  name: '',
+  color: '#78dce8',
+  permissions: 0,
+  isHoisted: false,
+  isMentionable: false
+};
+
+function draftFromRole(role: GuildRoleDto): RoleDraft {
+  return {
+    name: role.name,
+    color: role.color,
+    permissions: Number(role.permissions) || 0,
+    isHoisted: role.is_hoisted,
+    isMentionable: role.is_mentionable
+  };
+}
+
+type RoleEditorProps = {
+  draft: RoleDraft;
+  onChange: (draft: RoleDraft) => void;
+  onSubmit: () => void;
+  onCancel?: () => void;
+  submitLabel: string;
+  isBusy: boolean;
+};
+
+function RoleEditor({ draft, onChange, onSubmit, onCancel, submitLabel, isBusy }: RoleEditorProps) {
+  return (
+    <div className="grid gap-3">
+      <div className="grid gap-3 sm:grid-cols-[1fr_auto]">
+        <input
+          value={draft.name}
+          onChange={(event) => onChange({ ...draft, name: event.target.value })}
+          placeholder="role name"
+          maxLength={100}
+          className={inputClasses}
+        />
+        <label className="flex items-center gap-2 text-sm text-white/55">
+          Color
+          <input
+            type="color"
+            value={draft.color}
+            onChange={(event) => onChange({ ...draft, color: event.target.value })}
+            className="h-10 w-14 cursor-pointer rounded-md border border-white/10 bg-input-bg p-1"
+          />
+        </label>
+      </div>
+      <div className="grid grid-cols-2 gap-x-4 gap-y-1.5 sm:grid-cols-3">
+        {PERMISSION_FLAGS.map((flag) => (
+          <label key={flag.value} className="flex items-center gap-2 text-sm text-white/60">
+            <input
+              type="checkbox"
+              checked={(draft.permissions & flag.value) !== 0}
+              onChange={(event) =>
+                onChange({
+                  ...draft,
+                  permissions: event.target.checked
+                    ? draft.permissions | flag.value
+                    : draft.permissions & ~flag.value
+                })
+              }
+              className="h-4 w-4 accent-[#78dce8]"
+            />
+            {flag.label}
+          </label>
+        ))}
+      </div>
+      <div className="flex flex-wrap gap-4">
+        <label className="flex items-center gap-2 text-sm text-white/60">
+          <input
+            type="checkbox"
+            checked={draft.isHoisted}
+            onChange={(event) => onChange({ ...draft, isHoisted: event.target.checked })}
+            className="h-4 w-4 accent-[#78dce8]"
+          />
+          Display separately (hoisted)
+        </label>
+        <label className="flex items-center gap-2 text-sm text-white/60">
+          <input
+            type="checkbox"
+            checked={draft.isMentionable}
+            onChange={(event) => onChange({ ...draft, isMentionable: event.target.checked })}
+            className="h-4 w-4 accent-[#78dce8]"
+          />
+          Mentionable
+        </label>
+      </div>
+      <div className="flex gap-3">
+        <button
+          type="button"
+          onClick={onSubmit}
+          disabled={isBusy}
+          className="h-10 rounded-md bg-aqua px-5 text-sm font-bold text-primary-bg transition hover:bg-white disabled:cursor-not-allowed disabled:bg-frame disabled:text-white/25"
+        >
+          {submitLabel}
+        </button>
+        {onCancel ? (
+          <button
+            type="button"
+            onClick={onCancel}
+            className="h-10 rounded-md border border-white/10 px-5 text-sm font-bold text-white/60 transition hover:text-white"
+          >
+            Cancel
+          </button>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+type GuildRolesPanelProps = {
+  guildId: string;
+};
+
+export function GuildRolesPanel({ guildId }: GuildRolesPanelProps) {
+  const [roles, setRoles] = useState<GuildRoleDto[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [createDraft, setCreateDraft] = useState<RoleDraft>(emptyDraft);
+  const [editingRoleId, setEditingRoleId] = useState<string | null>(null);
+  const [editDraft, setEditDraft] = useState<RoleDraft>(emptyDraft);
+  const [isBusy, setIsBusy] = useState(false);
+
+  const load = useCallback(async () => {
+    setIsLoading(true);
+    setError('');
+
+    try {
+      const rows = await listGuildRoles(guildId);
+      setRoles([...rows].sort((a, b) => b.position - a.position));
+    } catch (loadError) {
+      setError(loadError instanceof Error ? loadError.message : 'Failed to load roles.');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [guildId]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  async function handleCreate() {
+    setError('');
+
+    if (!createDraft.name.trim()) {
+      setError('Role name is required.');
+      return;
+    }
+
+    try {
+      setIsBusy(true);
+      await createGuildRole(guildId, {
+        name: createDraft.name.trim(),
+        color: createDraft.color,
+        permissions: createDraft.permissions,
+        is_hoisted: createDraft.isHoisted,
+        is_mentionable: createDraft.isMentionable
+      });
+      setCreateDraft(emptyDraft);
+      await load();
+    } catch (createError) {
+      setError(createError instanceof Error ? createError.message : 'Failed to create role.');
+    } finally {
+      setIsBusy(false);
+    }
+  }
+
+  async function handleUpdate(roleId: string) {
+    setError('');
+
+    if (!editDraft.name.trim()) {
+      setError('Role name is required.');
+      return;
+    }
+
+    try {
+      setIsBusy(true);
+      await updateGuildRole(guildId, roleId, {
+        name: editDraft.name.trim(),
+        color: editDraft.color,
+        permissions: editDraft.permissions,
+        is_hoisted: editDraft.isHoisted,
+        is_mentionable: editDraft.isMentionable
+      });
+      setEditingRoleId(null);
+      await load();
+    } catch (updateError) {
+      setError(updateError instanceof Error ? updateError.message : 'Failed to update role.');
+    } finally {
+      setIsBusy(false);
+    }
+  }
+
+  async function handleDelete(role: GuildRoleDto) {
+    if (!window.confirm(`Delete role "${role.name}"?`)) {
+      return;
+    }
+
+    setError('');
+
+    try {
+      setIsBusy(true);
+      await deleteGuildRole(guildId, role.id);
+      await load();
+    } catch (deleteError) {
+      setError(deleteError instanceof Error ? deleteError.message : 'Failed to delete role.');
+    } finally {
+      setIsBusy(false);
+    }
+  }
+
+  return (
+    <div className="grid gap-5">
+      <div className="grid gap-3 rounded-md border border-white/8 bg-panel p-4">
+        <h3 className="flex items-center gap-2 text-base font-bold text-white">
+          <ShieldPlus className="h-4 w-4 text-aqua" strokeWidth={1.9} />
+          Create a role
+        </h3>
+        <RoleEditor
+          draft={createDraft}
+          onChange={setCreateDraft}
+          onSubmit={() => void handleCreate()}
+          submitLabel={isBusy ? 'Creating...' : 'Create role'}
+          isBusy={isBusy}
+        />
+      </div>
+
+      {error ? <FormError message={error} /> : null}
+
+      {isLoading ? (
+        <div className="h-24 animate-pulse rounded-md bg-panel" />
+      ) : (
+        <ul className="grid gap-2">
+          {roles.map((role) => (
+            <li key={role.id} className="rounded-md border border-white/8 bg-panel px-3 py-2.5">
+              {editingRoleId === role.id ? (
+                <RoleEditor
+                  draft={editDraft}
+                  onChange={setEditDraft}
+                  onSubmit={() => void handleUpdate(role.id)}
+                  onCancel={() => setEditingRoleId(null)}
+                  submitLabel={isBusy ? 'Saving...' : 'Save role'}
+                  isBusy={isBusy}
+                />
+              ) : (
+                <div className="flex items-center gap-3">
+                  <span
+                    className="h-3.5 w-3.5 shrink-0 rounded-full"
+                    style={{ backgroundColor: role.color || '#8b8b8f' }}
+                  />
+                  <div className="min-w-0 flex-1">
+                    <p className="truncate text-[0.95rem] font-bold text-white">
+                      {role.name}
+                      {role.is_default ? (
+                        <span className="ml-2 rounded bg-frame px-1.5 py-0.5 text-[0.65rem] font-bold uppercase tracking-wide text-white/40">
+                          default
+                        </span>
+                      ) : null}
+                    </p>
+                    <p className="truncate text-xs text-white/35">
+                      position {role.position} · permissions {Number(role.permissions) || 0}
+                      {role.is_hoisted ? ' · hoisted' : ''}
+                      {role.is_mentionable ? ' · mentionable' : ''}
+                    </p>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setEditDraft(draftFromRole(role));
+                      setEditingRoleId(role.id);
+                    }}
+                    className="h-8 shrink-0 rounded-md border border-white/10 px-3 text-xs font-bold text-white/60 transition hover:border-aqua/40 hover:text-aqua"
+                  >
+                    Edit
+                  </button>
+                  {!role.is_default ? (
+                    <button
+                      type="button"
+                      onClick={() => void handleDelete(role)}
+                      disabled={isBusy}
+                      className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-[#8b8b8f] transition hover:bg-frame hover:text-pink"
+                      aria-label={`Delete role ${role.name}`}
+                    >
+                      <Trash2 className="h-4 w-4" strokeWidth={1.9} />
+                    </button>
+                  ) : null}
+                </div>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/guild/guild-settings-panel.tsx
+++ b/frontend/src/components/guild/guild-settings-panel.tsx
@@ -1,0 +1,210 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import type { FormEvent } from 'react';
+import { AlertTriangle, Save } from 'lucide-react';
+import { deleteGuild, getGuild, updateGuild, type GuildDto } from '../../shared/api/guild';
+import { useGuilds } from '../../shared/guilds/guild-store';
+import { FormError } from './guild-forms';
+
+const inputClasses =
+  'h-11 w-full rounded-md border border-transparent bg-input-bg px-4 text-base text-white outline-none transition placeholder:text-input-placeholder focus:border-aqua/35';
+
+type GuildSettingsPanelProps = {
+  guildId: string;
+};
+
+export function GuildSettingsPanel({ guildId }: GuildSettingsPanelProps) {
+  const { currentUserId, refreshGuilds } = useGuilds();
+  const [guild, setGuild] = useState<GuildDto | null>(null);
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [iconUrl, setIconUrl] = useState('');
+  const [bannerUrl, setBannerUrl] = useState('');
+  const [error, setError] = useState('');
+  const [savedMessage, setSavedMessage] = useState('');
+  const [isSaving, setIsSaving] = useState(false);
+  const [deleteConfirm, setDeleteConfirm] = useState('');
+  const [deleteError, setDeleteError] = useState('');
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  useEffect(() => {
+    let isCancelled = false;
+
+    getGuild(guildId)
+      .then((details) => {
+        if (isCancelled) {
+          return;
+        }
+
+        setGuild(details);
+        setName(details.name);
+        setDescription(details.description ?? '');
+        setIconUrl(details.icon_url ?? '');
+        setBannerUrl(details.banner_url ?? '');
+      })
+      .catch((loadError) => {
+        if (!isCancelled) {
+          setError(loadError instanceof Error ? loadError.message : 'Failed to load guild.');
+        }
+      });
+
+    return () => {
+      isCancelled = true;
+    };
+  }, [guildId]);
+
+  // The server enforces ownership; without a resolved current user we still
+  // show the section so the fake-session dev flow can exercise it.
+  const canShowDelete = !currentUserId || guild?.owner_id === currentUserId;
+
+  async function handleSave(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setError('');
+    setSavedMessage('');
+
+    const trimmedName = name.trim();
+    if (!trimmedName) {
+      setError('Guild name is required.');
+      return;
+    }
+
+    try {
+      setIsSaving(true);
+      const updated = await updateGuild(guildId, {
+        name: trimmedName,
+        description: description.trim() || undefined,
+        icon_url: iconUrl.trim() || undefined,
+        banner_url: bannerUrl.trim() || undefined
+      });
+      setGuild(updated);
+      setSavedMessage('Guild settings saved.');
+      void refreshGuilds();
+    } catch (saveError) {
+      setError(saveError instanceof Error ? saveError.message : 'Failed to update guild.');
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  async function handleDelete(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setDeleteError('');
+
+    if (!guild || deleteConfirm.trim() !== guild.name) {
+      setDeleteError('Type the exact guild name to confirm deletion.');
+      return;
+    }
+
+    if (!window.confirm(`Delete "${guild.name}" permanently? This cannot be undone.`)) {
+      return;
+    }
+
+    try {
+      setIsDeleting(true);
+      await deleteGuild(guildId);
+      await refreshGuilds();
+    } catch (removeError) {
+      setDeleteError(
+        removeError instanceof Error ? removeError.message : 'Failed to delete guild.'
+      );
+    } finally {
+      setIsDeleting(false);
+    }
+  }
+
+  return (
+    <div className="grid gap-5">
+      <form
+        onSubmit={handleSave}
+        className="grid gap-3 rounded-md border border-white/8 bg-panel p-4"
+      >
+        <h3 className="text-base font-bold text-white">Guild settings</h3>
+        <label className="grid gap-2">
+          <span className="text-sm font-semibold text-white/70">Name</span>
+          <input
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+            maxLength={100}
+            className={inputClasses}
+          />
+        </label>
+        <label className="grid gap-2">
+          <span className="text-sm font-semibold text-white/70">Description</span>
+          <input
+            value={description}
+            onChange={(event) => setDescription(event.target.value)}
+            placeholder="describe your guild"
+            className={inputClasses}
+          />
+        </label>
+        <div className="grid gap-3 sm:grid-cols-2">
+          <label className="grid gap-2">
+            <span className="text-sm font-semibold text-white/70">Icon URL</span>
+            <input
+              value={iconUrl}
+              onChange={(event) => setIconUrl(event.target.value)}
+              placeholder="https://..."
+              className={inputClasses}
+            />
+          </label>
+          <label className="grid gap-2">
+            <span className="text-sm font-semibold text-white/70">Banner URL</span>
+            <input
+              value={bannerUrl}
+              onChange={(event) => setBannerUrl(event.target.value)}
+              placeholder="https://..."
+              className={inputClasses}
+            />
+          </label>
+        </div>
+        {error ? <FormError message={error} /> : null}
+        {savedMessage ? (
+          <p className="rounded-md border border-lime/30 bg-lime/10 px-3 py-2 text-sm text-lime">
+            {savedMessage}
+          </p>
+        ) : null}
+        <button
+          type="submit"
+          disabled={isSaving || !guild}
+          className="flex h-10 w-fit items-center gap-2 rounded-md bg-aqua px-5 text-sm font-bold text-primary-bg transition hover:bg-white disabled:cursor-not-allowed disabled:bg-frame disabled:text-white/25"
+        >
+          <Save className="h-4 w-4" strokeWidth={2} />
+          {isSaving ? 'Saving...' : 'Save changes'}
+        </button>
+      </form>
+
+      {canShowDelete ? (
+        <form
+          onSubmit={handleDelete}
+          className="grid gap-3 rounded-md border border-pink/25 bg-pink/5 p-4"
+        >
+          <h3 className="flex items-center gap-2 text-base font-bold text-pink">
+            <AlertTriangle className="h-4 w-4" strokeWidth={1.9} />
+            Danger zone
+          </h3>
+          <p className="text-sm text-white/55">
+            Deleting a guild is permanent and only the owner can do it. Type{' '}
+            <span className="mono-detail text-white">{guild?.name ?? '...'}</span> to confirm.
+          </p>
+          <div className="flex flex-wrap gap-3">
+            <input
+              value={deleteConfirm}
+              onChange={(event) => setDeleteConfirm(event.target.value)}
+              placeholder="guild name"
+              className={`${inputClasses} max-w-[18rem]`}
+            />
+            <button
+              type="submit"
+              disabled={isDeleting || !guild || deleteConfirm.trim() !== guild.name}
+              className="h-11 rounded-md border border-pink/25 bg-pink/10 px-5 text-sm font-bold text-pink transition hover:border-pink/45 hover:bg-pink/15 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {isDeleting ? 'Deleting...' : 'Delete guild'}
+            </button>
+          </div>
+          {deleteError ? <FormError message={deleteError} /> : null}
+        </form>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/shared/api/guild.ts
+++ b/frontend/src/shared/api/guild.ts
@@ -168,10 +168,7 @@ export function leaveGuild(guildId: string) {
   });
 }
 
-export function listGuildMembers(
-  guildId: string,
-  query?: { limit?: number; after?: string }
-) {
+export function listGuildMembers(guildId: string, query?: { limit?: number; after?: string }) {
   return apiFetch<GuildMemberDto[]>('guild', `/guilds/${guildId}/members`, { query });
 }
 

--- a/frontend/src/shared/api/guild.ts
+++ b/frontend/src/shared/api/guild.ts
@@ -5,9 +5,19 @@ export type GuildDto = {
   name: string;
   description?: string | null;
   icon_url?: string | null;
+  banner_url?: string | null;
   owner_id: string;
   member_count?: number;
   created_at: string;
+};
+
+export type MyGuildDto = {
+  id: string;
+  name: string;
+  icon_url?: string | null;
+  owner_id: string;
+  member_count?: number;
+  joined_at: string;
 };
 
 export type GuildMemberDto = {
@@ -15,6 +25,19 @@ export type GuildMemberDto = {
   nickname?: string | null;
   roles: string[];
   joined_at: string;
+};
+
+export type GuildMemberUpdateDto = {
+  user_id: string;
+  guild_id: string;
+  nickname: string | null;
+};
+
+export type GuildBanDto = {
+  user_id: string;
+  banned_by: string | null;
+  reason?: string | null;
+  banned_at: string;
 };
 
 export type GuildChannelDto = {
@@ -27,6 +50,13 @@ export type GuildChannelDto = {
   topic?: string | null;
   is_nsfw?: boolean;
   slowmode_seconds?: number;
+};
+
+export type GuildCategoryDto = {
+  id: string;
+  guild_id: string;
+  name: string;
+  position: number;
 };
 
 export type GuildRoleDto = {
@@ -45,6 +75,7 @@ export type CreateGuildPayload = {
   name: string;
   description?: string;
   icon_url?: string;
+  banner_url?: string;
 };
 
 export type UpdateGuildPayload = Partial<CreateGuildPayload>;
@@ -61,7 +92,44 @@ export type GuildInviteDto = {
   max_uses?: number | null;
   uses: number;
   expires_at?: string | null;
+  created_at?: string;
 };
+
+export type InvitePreviewDto = {
+  code: string;
+  guild: {
+    id: string;
+    name: string;
+    icon_url?: string | null;
+    member_count?: number;
+  };
+  inviter: {
+    id: string;
+    username: string;
+  };
+  expires_at: string | null;
+};
+
+export type CreateRolePayload = {
+  name: string;
+  color?: string;
+  permissions?: number;
+  is_hoisted?: boolean;
+  is_mentionable?: boolean;
+};
+
+export type UpdateRolePayload = Partial<CreateRolePayload>;
+
+export type CreateCategoryPayload = {
+  name: string;
+  position?: number;
+};
+
+export type UpdateCategoryPayload = Partial<CreateCategoryPayload>;
+
+export function listMyGuilds() {
+  return apiFetch<MyGuildDto[]>('guild', '/guilds/me');
+}
 
 export function createGuild(payload: CreateGuildPayload) {
   return apiFetch<GuildDto>('guild', '/guilds', {
@@ -107,12 +175,94 @@ export function listGuildMembers(
   return apiFetch<GuildMemberDto[]>('guild', `/guilds/${guildId}/members`, { query });
 }
 
+export function updateGuildMemberNickname(
+  guildId: string,
+  userId: string,
+  nickname: string | null
+) {
+  return apiFetch<GuildMemberUpdateDto>('guild', `/guilds/${guildId}/members/${userId}`, {
+    method: 'PATCH',
+    body: { nickname }
+  });
+}
+
+export function kickGuildMember(guildId: string, userId: string) {
+  return apiFetch<void>('guild', `/guilds/${guildId}/members/${userId}`, {
+    method: 'DELETE'
+  });
+}
+
+export function listGuildBans(guildId: string, query?: { limit?: number; after?: string }) {
+  return apiFetch<GuildBanDto[]>('guild', `/guilds/${guildId}/bans`, { query });
+}
+
+export function banGuildMember(guildId: string, userId: string, reason?: string) {
+  return apiFetch<void>('guild', `/guilds/${guildId}/bans/${userId}`, {
+    method: 'POST',
+    body: reason ? { reason } : {}
+  });
+}
+
+export function unbanGuildMember(guildId: string, userId: string) {
+  return apiFetch<void>('guild', `/guilds/${guildId}/bans/${userId}`, {
+    method: 'DELETE'
+  });
+}
+
 export function listGuildChannels(guildId: string) {
   return apiFetch<GuildChannelDto[]>('guild', `/guilds/${guildId}/channels`);
 }
 
+export function listGuildCategories(guildId: string) {
+  return apiFetch<GuildCategoryDto[]>('guild', `/guilds/${guildId}/categories`);
+}
+
+export function createGuildCategory(guildId: string, payload: CreateCategoryPayload) {
+  return apiFetch<GuildCategoryDto>('guild', `/guilds/${guildId}/categories`, {
+    method: 'POST',
+    body: payload
+  });
+}
+
+export function updateGuildCategory(
+  guildId: string,
+  categoryId: string,
+  payload: UpdateCategoryPayload
+) {
+  return apiFetch<GuildCategoryDto>('guild', `/guilds/${guildId}/categories/${categoryId}`, {
+    method: 'PATCH',
+    body: payload
+  });
+}
+
+export function deleteGuildCategory(guildId: string, categoryId: string) {
+  return apiFetch<void>('guild', `/guilds/${guildId}/categories/${categoryId}`, {
+    method: 'DELETE'
+  });
+}
+
 export function listGuildRoles(guildId: string) {
   return apiFetch<GuildRoleDto[]>('guild', `/guilds/${guildId}/roles`);
+}
+
+export function createGuildRole(guildId: string, payload: CreateRolePayload) {
+  return apiFetch<GuildRoleDto>('guild', `/guilds/${guildId}/roles`, {
+    method: 'POST',
+    body: payload
+  });
+}
+
+export function updateGuildRole(guildId: string, roleId: string, payload: UpdateRolePayload) {
+  return apiFetch<GuildRoleDto>('guild', `/guilds/${guildId}/roles/${roleId}`, {
+    method: 'PATCH',
+    body: payload
+  });
+}
+
+export function deleteGuildRole(guildId: string, roleId: string) {
+  return apiFetch<void>('guild', `/guilds/${guildId}/roles/${roleId}`, {
+    method: 'DELETE'
+  });
 }
 
 export function createGuildInvite(guildId: string, payload: CreateInvitePayload = {}) {
@@ -120,4 +270,18 @@ export function createGuildInvite(guildId: string, payload: CreateInvitePayload 
     method: 'POST',
     body: payload
   });
+}
+
+export function listGuildInvites(guildId: string) {
+  return apiFetch<GuildInviteDto[]>('guild', `/guilds/${guildId}/invites`);
+}
+
+export function revokeGuildInvite(guildId: string, code: string) {
+  return apiFetch<void>('guild', `/guilds/${guildId}/invites/${code}`, {
+    method: 'DELETE'
+  });
+}
+
+export function previewInvite(code: string) {
+  return apiFetch<InvitePreviewDto>('guild', `/invites/${code}`);
 }

--- a/frontend/src/shared/api/user.ts
+++ b/frontend/src/shared/api/user.ts
@@ -36,6 +36,37 @@ export type FriendshipDto = {
   created_at: string;
 };
 
+export type UserSummaryDto = {
+  id: string;
+  username: string;
+  display_name: string;
+  avatar_url?: string | null;
+  status: UserStatus;
+};
+
+const USERS_BATCH_LIMIT = 100;
+
+export async function getUsersByIds(ids: string[]): Promise<UserSummaryDto[]> {
+  const uniqueIds = Array.from(new Set(ids));
+
+  if (uniqueIds.length === 0) {
+    return [];
+  }
+
+  const chunks: string[][] = [];
+  for (let index = 0; index < uniqueIds.length; index += USERS_BATCH_LIMIT) {
+    chunks.push(uniqueIds.slice(index, index + USERS_BATCH_LIMIT));
+  }
+
+  const results = await Promise.all(
+    chunks.map((chunk) =>
+      apiFetch<UserSummaryDto[]>('user', '/users', { query: { ids: chunk.join(',') } })
+    )
+  );
+
+  return results.flat();
+}
+
 export function getCurrentUser() {
   return apiFetch<UserProfileDto>('user', '/users/me');
 }

--- a/frontend/src/shared/guilds/guild-store.tsx
+++ b/frontend/src/shared/guilds/guild-store.tsx
@@ -12,6 +12,7 @@ import {
   type MyGuildDto
 } from '../api/guild';
 import { getCurrentUser } from '../api/user';
+import { getAccessToken } from '../lib/session';
 
 export const LAST_GUILD_KEY = 'ft_transcendence_last_guild';
 

--- a/frontend/src/shared/guilds/guild-store.tsx
+++ b/frontend/src/shared/guilds/guild-store.tsx
@@ -12,7 +12,6 @@ import {
   type MyGuildDto
 } from '../api/guild';
 import { getCurrentUser } from '../api/user';
-import { getAccessToken, SESSION_USERNAME_KEY } from '../lib/session';
 
 export const LAST_GUILD_KEY = 'ft_transcendence_last_guild';
 
@@ -56,7 +55,7 @@ function hasSession() {
     return false;
   }
 
-  return Boolean(getAccessToken() ?? window.localStorage.getItem(SESSION_USERNAME_KEY));
+  return Boolean(getAccessToken());
 }
 
 function sortByJoinedAt(guilds: MyGuildDto[]) {

--- a/frontend/src/shared/guilds/guild-store.tsx
+++ b/frontend/src/shared/guilds/guild-store.tsx
@@ -1,0 +1,201 @@
+'use client';
+
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import type { ReactNode } from 'react';
+import {
+  createGuild as requestCreateGuild,
+  joinGuild,
+  listMyGuilds,
+  previewInvite,
+  type CreateGuildPayload,
+  type GuildDto,
+  type MyGuildDto
+} from '../api/guild';
+import { getCurrentUser } from '../api/user';
+import { getAccessToken, SESSION_USERNAME_KEY } from '../lib/session';
+
+export const LAST_GUILD_KEY = 'ft_transcendence_last_guild';
+
+type GuildStoreValue = {
+  guilds: MyGuildDto[];
+  isLoading: boolean;
+  error: string | null;
+  selectedGuildId: string | null;
+  selectedGuild: MyGuildDto | null;
+  currentUserId: string | null;
+  selectGuild: (guildId: string) => void;
+  refreshGuilds: () => Promise<void>;
+  createGuild: (payload: CreateGuildPayload) => Promise<GuildDto>;
+  joinGuildWithCode: (code: string) => Promise<GuildDto>;
+};
+
+const GuildStoreContext = createContext<GuildStoreValue | null>(null);
+
+function readStoredGuildId() {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  return window.sessionStorage.getItem(LAST_GUILD_KEY);
+}
+
+function persistGuildId(guildId: string | null) {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  if (guildId) {
+    window.sessionStorage.setItem(LAST_GUILD_KEY, guildId);
+  } else {
+    window.sessionStorage.removeItem(LAST_GUILD_KEY);
+  }
+}
+
+function hasSession() {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+
+  return Boolean(getAccessToken() ?? window.localStorage.getItem(SESSION_USERNAME_KEY));
+}
+
+function sortByJoinedAt(guilds: MyGuildDto[]) {
+  return [...guilds].sort(
+    (a, b) => new Date(b.joined_at).getTime() - new Date(a.joined_at).getTime()
+  );
+}
+
+export function GuildProvider({ children }: { children: ReactNode }) {
+  const [guilds, setGuilds] = useState<MyGuildDto[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedGuildId, setSelectedGuildId] = useState<string | null>(null);
+  const [currentUserId, setCurrentUserId] = useState<string | null>(null);
+
+  const applyGuilds = useCallback((nextGuilds: MyGuildDto[], preferredId?: string) => {
+    const sorted = sortByJoinedAt(nextGuilds);
+    setGuilds(sorted);
+    setSelectedGuildId((current) => {
+      const candidates = [preferredId, current, readStoredGuildId()];
+      const next =
+        candidates.find((id) => id && sorted.some((guild) => guild.id === id)) ??
+        sorted[0]?.id ??
+        null;
+
+      persistGuildId(next);
+      return next;
+    });
+  }, []);
+
+  const refreshGuilds = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      applyGuilds(await listMyGuilds());
+    } catch (refreshError) {
+      setError(refreshError instanceof Error ? refreshError.message : 'Failed to load guilds.');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [applyGuilds]);
+
+  useEffect(() => {
+    if (!hasSession()) {
+      return;
+    }
+
+    void refreshGuilds();
+    getCurrentUser()
+      .then((user) => setCurrentUserId(user.id))
+      .catch(() => setCurrentUserId(null));
+  }, [refreshGuilds]);
+
+  const selectGuild = useCallback((guildId: string) => {
+    setSelectedGuildId(guildId);
+    persistGuildId(guildId);
+  }, []);
+
+  const createGuild = useCallback(
+    async (payload: CreateGuildPayload) => {
+      const guild = await requestCreateGuild(payload);
+
+      try {
+        applyGuilds(await listMyGuilds(), guild.id);
+      } catch {
+        // The guild exists even if the refresh failed; surface it optimistically.
+        applyGuilds(
+          [
+            ...guilds,
+            {
+              id: guild.id,
+              name: guild.name,
+              icon_url: guild.icon_url,
+              owner_id: guild.owner_id,
+              member_count: guild.member_count ?? 1,
+              joined_at: guild.created_at
+            }
+          ],
+          guild.id
+        );
+      }
+
+      return guild;
+    },
+    [applyGuilds, guilds]
+  );
+
+  const joinGuildWithCode = useCallback(
+    async (code: string) => {
+      const preview = await previewInvite(code.trim());
+      const guild = await joinGuild(preview.guild.id, code.trim());
+      applyGuilds(await listMyGuilds(), guild.id);
+      return guild;
+    },
+    [applyGuilds]
+  );
+
+  const selectedGuild = useMemo(
+    () => guilds.find((guild) => guild.id === selectedGuildId) ?? null,
+    [guilds, selectedGuildId]
+  );
+
+  const value = useMemo(
+    () => ({
+      guilds,
+      isLoading,
+      error,
+      selectedGuildId,
+      selectedGuild,
+      currentUserId,
+      selectGuild,
+      refreshGuilds,
+      createGuild,
+      joinGuildWithCode
+    }),
+    [
+      guilds,
+      isLoading,
+      error,
+      selectedGuildId,
+      selectedGuild,
+      currentUserId,
+      selectGuild,
+      refreshGuilds,
+      createGuild,
+      joinGuildWithCode
+    ]
+  );
+
+  return <GuildStoreContext.Provider value={value}>{children}</GuildStoreContext.Provider>;
+}
+
+export function useGuilds() {
+  const context = useContext(GuildStoreContext);
+
+  if (!context) {
+    throw new Error('useGuilds must be used within a GuildProvider.');
+  }
+
+  return context;
+}

--- a/frontend/src/shared/guilds/use-guild-members.ts
+++ b/frontend/src/shared/guilds/use-guild-members.ts
@@ -1,0 +1,107 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import {
+  listGuildMembers,
+  listGuildRoles,
+  type GuildMemberDto,
+  type GuildRoleDto
+} from '../api/guild';
+import { getUsersByIds, type UserStatus } from '../api/user';
+
+const MEMBERS_PAGE_SIZE = 100;
+const MEMBERS_MAX_PAGES = 10;
+
+export type HydratedGuildMember = {
+  userId: string;
+  /** Nickname when set, otherwise the user's display name. */
+  displayName: string;
+  username: string | null;
+  nickname: string | null;
+  avatarUrl: string | null;
+  status: UserStatus;
+  roles: GuildRoleDto[];
+  joinedAt: string;
+  isOwner: boolean;
+  isDeleted: boolean;
+};
+
+async function fetchAllMembers(guildId: string) {
+  const members: GuildMemberDto[] = [];
+  let after: string | undefined;
+
+  for (let page = 0; page < MEMBERS_MAX_PAGES; page += 1) {
+    const batch = await listGuildMembers(guildId, { limit: MEMBERS_PAGE_SIZE, after });
+    members.push(...batch);
+
+    if (batch.length < MEMBERS_PAGE_SIZE) {
+      break;
+    }
+
+    after = batch[batch.length - 1].user_id;
+  }
+
+  return members;
+}
+
+export function useGuildMembers(guildId: string | null, ownerId?: string | null) {
+  const [members, setMembers] = useState<HydratedGuildMember[]>([]);
+  const [roles, setRoles] = useState<GuildRoleDto[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  const load = useCallback(async () => {
+    if (!guildId) {
+      setMembers([]);
+      setRoles([]);
+      return;
+    }
+
+    setIsLoading(true);
+    setError('');
+
+    try {
+      const [memberRows, guildRoles] = await Promise.all([
+        fetchAllMembers(guildId),
+        listGuildRoles(guildId)
+      ]);
+      const users = await getUsersByIds(memberRows.map((member) => member.user_id));
+      const usersById = new Map(users.map((user) => [user.id, user]));
+      const rolesById = new Map(guildRoles.map((role) => [role.id, role]));
+
+      const hydrated = memberRows.map<HydratedGuildMember>((member) => {
+        const user = usersById.get(member.user_id);
+        const memberRoles = member.roles
+          .map((roleId) => rolesById.get(roleId))
+          .filter((role): role is GuildRoleDto => Boolean(role))
+          .sort((a, b) => b.position - a.position);
+
+        return {
+          userId: member.user_id,
+          displayName: member.nickname ?? user?.display_name ?? 'Deleted User',
+          username: user?.username ?? null,
+          nickname: member.nickname ?? null,
+          avatarUrl: user?.avatar_url ?? null,
+          status: user?.status ?? 'offline',
+          roles: memberRoles,
+          joinedAt: member.joined_at,
+          isOwner: Boolean(ownerId) && member.user_id === ownerId,
+          isDeleted: !user
+        };
+      });
+
+      setRoles(guildRoles);
+      setMembers(hydrated);
+    } catch (loadError) {
+      setError(loadError instanceof Error ? loadError.message : 'Failed to load members.');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [guildId, ownerId]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  return { members, roles, isLoading, error, refresh: load };
+}


### PR DESCRIPTION
Connects the guild UI to the guild service (backlog Epic 3), replacing all guild mocks:

- **Sidebar**: fetches `GET /guilds/me` on login, sorts by `joined_at`, preserves the
  selected guild across refreshes; the `+` button now creates a guild or joins via
  invite code (no more random guild generator)
- **Guild page** (`/guilds`): live guild details, create/join forms, and admin tabs —
  members (nickname edit, kick, ban), bans, invites (create/list/preview/revoke),
  roles, categories, and settings (edit + owner-only delete)
- **Member list**: real members from `GET /guilds/{id}/members`, hydrated in one
  batch via `GET /users?ids=...`, with nicknames, avatars, roles and join dates
- **API layer**: guild/user clients extended to cover the full guild contract

Adapted to the merged real-auth work: the guild store uses the access token as its
session signal and refreshes guilds after login. Plus small UI cleanup (single
member-list toggle, chat header link to `/guilds`).

## Not in scope

Channel CRUD UI (in no epic yet — the chat channel list is still mocked, Epic 4
territory) and in-app invite delivery (needs DMs).

## How to test

1. `make re`, register/login, land on `/chat`
2. Create a guild via the sidebar `+` → it appears selected in the sidebar
3. Open `/guilds` (⋯ icon in the channel header) → walk the tabs: create an
   invite, redeem it from a second account, edit a nickname, kick/ban/unban,
   create a role and a category, edit settings, delete the guild (owner types
   the guild name to confirm)