### PR TITLE
Fix(chat): SignalR JSON formatting and DM unread-count reset

### DIFF
--- a/services/chat/src/Chat.Infrastructure/SnowflakeJsonConverter.cs
+++ b/services/chat/src/Chat.Infrastructure/SnowflakeJsonConverter.cs
@@ -7,7 +7,7 @@ namespace Chat.Infrastructure;
 // ID policy (docs/contracts): snowflakes travel as quoted strings on the JSON
 // wire. Writes longs as strings; reads both forms so consumers stay compatible
 // with publishers that still send bare numbers.
-internal sealed class SnowflakeJsonConverter : JsonConverter<long>
+public sealed class SnowflakeJsonConverter : JsonConverter<long>
 {
 	public override long Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) =>
 		reader.TokenType == JsonTokenType.String

--- a/services/chat/src/Chat.Persistence/Repositories/ReadStateRepository.cs
+++ b/services/chat/src/Chat.Persistence/Repositories/ReadStateRepository.cs
@@ -58,8 +58,14 @@ internal sealed class ReadStateRepository(ISession session, ReadStateStatements 
 
 	public async Task ResetDmUnreadCountAsync(long userId, long partnerId, CancellationToken ct)
 	{
-		var stmt = await statements.ResetDmUnreadCount.Value;
-		await session.ExecuteAsync(stmt.Bind(userId, partnerId));
+		var selectStmt = await statements.SelectDmUnreadCount.Value;
+		var row = (await session.ExecuteAsync(selectStmt.Bind(userId, partnerId))).FirstOrDefault();
+		var current = row?.GetValue<long>("count") ?? 0;
+		if (current == 0)
+			return;
+
+		var decrementStmt = await statements.DecrementDmUnreadCount.Value;
+		await session.ExecuteAsync(decrementStmt.Bind(current, userId, partnerId));
 	}
 
 	public async Task IncrementDmUnreadCountAsync(long userId, long partnerId, CancellationToken ct)

--- a/services/chat/src/Chat.Persistence/Repositories/ReadStateStatements.cs
+++ b/services/chat/src/Chat.Persistence/Repositories/ReadStateStatements.cs
@@ -46,9 +46,14 @@ internal sealed class ReadStateStatements(ISession session)
 	public Lazy<Task<PreparedStatement>> IncrementDmUnreadCount { get; } = new(() => session.PrepareAsync(
 		"UPDATE dm_unread_counts SET count = count + 1 WHERE user_id = ? AND partner_id = ?"));
 
-	// counters can only be reset by deleting the row - a missing row reads back as 0
-	public Lazy<Task<PreparedStatement>> ResetDmUnreadCount { get; } = new(() => session.PrepareAsync(
-		"DELETE FROM dm_unread_counts WHERE user_id = ? AND partner_id = ?"));
+	public Lazy<Task<PreparedStatement>> SelectDmUnreadCount { get; } = new(() => session.PrepareAsync(
+		"SELECT count FROM dm_unread_counts WHERE user_id = ? AND partner_id = ?"));
+
+	// never DELETE a counter cell that will be incremented again, it will
+	// always fail as no op later. Decrementing back to zero keeps the cell
+	// alive instead.
+	public Lazy<Task<PreparedStatement>> DecrementDmUnreadCount { get; } = new(() => session.PrepareAsync(
+		"UPDATE dm_unread_counts SET count = count - ? WHERE user_id = ? AND partner_id = ?"));
 
 	public Lazy<Task<PreparedStatement>> DeleteDmUnreadCountsForUser { get; } = new(() => session.PrepareAsync(
 		"DELETE FROM dm_unread_counts WHERE user_id = ?"));

--- a/services/chat/src/Chat.Presentation/Program.cs
+++ b/services/chat/src/Chat.Presentation/Program.cs
@@ -27,7 +27,14 @@ builder.Services.ConfigureHttpJsonOptions(o =>
 builder.Services.AddOpenApi();
 builder.Services.AddHealthChecks()
 	.AddPersistenceHealthChecks();
-builder.Services.AddSignalR();
+builder.Services.AddSignalR()
+	.AddJsonProtocol(o =>
+	{
+		o.PayloadSerializerOptions.PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower;
+		// hub method args (e.g. JoinChannel(long), Typing(string, long)) arrive as
+		// quoted strings from the frontend, same snowflake wire convention as REST/MassTransit
+		o.PayloadSerializerOptions.Converters.Add(new SnowflakeJsonConverter());
+	});
 builder.Services.AddApplication()
 	.AddInfrastructure()
 	.AddPersistence();

--- a/services/chat/tests/Chat.FunctionalTests/Infrastructure/HubConnectionHelper.cs
+++ b/services/chat/tests/Chat.FunctionalTests/Infrastructure/HubConnectionHelper.cs
@@ -1,5 +1,7 @@
+using Chat.Infrastructure;
 using Microsoft.AspNetCore.Http.Connections;
 using Microsoft.AspNetCore.SignalR.Client;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Chat.FunctionalTests.Infrastructure;
 
@@ -34,6 +36,15 @@ internal static class HubConnectionHelper
 
 					return await wsClient.ConnectAsync(uri, ct);
 				};
+			})
+			// server payloads are snake_case with quoted snowflakes (see Program.cs
+			// AddJsonProtocol); match that here rather than relying on case-insensitive
+			// fallback, since the deserializer used against typed test DTOs otherwise
+			// silently leaves properties null (or throws on quoted longs) instead of erroring clearly.
+			.AddJsonProtocol(o =>
+			{
+				o.PayloadSerializerOptions.PropertyNamingPolicy = System.Text.Json.JsonNamingPolicy.SnakeCaseLower;
+				o.PayloadSerializerOptions.Converters.Add(new SnowflakeJsonConverter());
 			})
 			.Build();
 	}


### PR DESCRIPTION
## Summary
- SignalR's hub JSON protocol wasn't configured, so it fell back to default property naming/number encoding while REST used snake_case and quoted snowflakes. Hub broadcasts (`ReceiveMessage`, `ReactionAdded`, etc.) now use `JsonNamingPolicy.SnakeCaseLower`, and hub method invocations (`JoinChannel(long)`, `Typing(string, long)`, ...) now accept the quoted snowflake strings the frontend sends, via the shared `SnowflakeJsonConverter` (made `public` so both MassTransit and SignalR can use it).

- Resetting a DM's unread badge (`PUT /dms/{user_id}/read`) deleted the `dm_unread_counts` counter row. Cassandra/Scylla counter cells can't be safely resurrected after a delete — the tombstone silently shadows every later `count = count + 1`, so the badge got stuck at 0 after the first reset. Reset now reads the current count and decrements by that amount instead of deleting, keeping the cell alive.
