### PR TITLE
Refactor(frontend): dedupe chat-workspace and its shared UI patterns

### DIFF
--- a/frontend/src/components/avatar-with-status.tsx
+++ b/frontend/src/components/avatar-with-status.tsx
@@ -1,0 +1,81 @@
+import Image from 'next/image';
+import { getAccentClasses, type ChatMessageData } from './chat-message';
+
+export type PresenceStatus = 'online' | 'idle' | 'offline';
+
+export function getDmStatusClasses(status: PresenceStatus) {
+  switch (status) {
+    case 'online':
+      return 'bg-lime';
+    case 'idle':
+      return 'bg-yellow';
+    default:
+      return 'bg-muted';
+  }
+}
+
+const SIZE_CONFIG = {
+  sm: {
+    dimension: 40,
+    dimensionClassName: 'h-10 w-10',
+    avatarClassName: 'h-10 w-10 text-sm font-bold',
+    dotClassName: 'h-3.5 w-3.5 -bottom-0.5 -right-0.5 border-2'
+  },
+  md: {
+    dimension: 44,
+    dimensionClassName: 'h-11 w-11',
+    avatarClassName: 'h-11 w-11 text-sm font-bold',
+    dotClassName: 'h-3.5 w-3.5 -bottom-0.5 -right-0.5 border-2'
+  },
+  lg: {
+    dimension: 80,
+    dimensionClassName: 'h-20 w-20',
+    avatarClassName: 'h-20 w-20 text-3xl font-bold border-4 border-secondary-bg',
+    dotClassName: 'h-4 w-4 bottom-1 right-1 border-2'
+  }
+} as const;
+
+type AvatarWithStatusProps = {
+  name: string;
+  accent: ChatMessageData['accent'];
+  status: PresenceStatus;
+  size?: keyof typeof SIZE_CONFIG;
+  avatarUrl?: string | null;
+};
+
+// the accent-initial bubble + online-status dot pairing used for DMs,
+// friends, guild members, and profile cards - identical shape, only the
+// size (and whether a real avatar image is available) differs per caller
+export function AvatarWithStatus({
+  name,
+  accent,
+  status,
+  size = 'md',
+  avatarUrl
+}: AvatarWithStatusProps) {
+  const { dimension, dimensionClassName, avatarClassName, dotClassName } = SIZE_CONFIG[size];
+
+  return (
+    <span className="relative shrink-0">
+      {avatarUrl ? (
+        <Image
+          src={avatarUrl}
+          alt=""
+          width={dimension}
+          height={dimension}
+          unoptimized
+          className={`rounded-full object-cover ${dimensionClassName}`}
+        />
+      ) : (
+        <span
+          className={`flex items-center justify-center rounded-full ${avatarClassName} ${getAccentClasses(accent)}`}
+        >
+          {name.slice(0, 1).toUpperCase()}
+        </span>
+      )}
+      <span
+        className={`absolute rounded-full border-secondary-bg ${dotClassName} ${getDmStatusClasses(status)}`}
+      />
+    </span>
+  );
+}

--- a/frontend/src/components/channel-list.tsx
+++ b/frontend/src/components/channel-list.tsx
@@ -9,10 +9,10 @@ import {
   Headphones,
   Mic,
   MicOff,
-  Search,
   Settings,
   UserRound
 } from 'lucide-react';
+import { SearchInput } from './search-input';
 import { useGuilds } from '../shared/guilds/guild-store';
 
 export type TextChannel = {
@@ -113,15 +113,7 @@ export function ChannelList({
           <div className="h-full w-full bg-[linear-gradient(90deg,rgba(16,16,20,0.68),transparent_58%),radial-gradient(circle_at_78%_30%,rgba(255,216,102,0.5),transparent_26%),radial-gradient(circle_at_60%_78%,rgba(255,97,136,0.38),transparent_24%)]" />
         </div>
 
-        <label className="mt-6 flex h-11 items-center gap-3 rounded-md bg-panel px-4 text-muted">
-          <Search className="h-4 w-4 shrink-0" strokeWidth={1.75} />
-          <input
-            value={search}
-            onChange={(event) => setSearch(event.target.value)}
-            placeholder="Search"
-            className="mono-detail w-full min-w-0 bg-transparent text-xl text-white outline-none placeholder:text-muted"
-          />
-        </label>
+        <SearchInput value={search} onChange={setSearch} placeholder="Search" className="mt-6" />
       </div>
 
       <div className="min-h-0 flex-1 overflow-y-auto px-3 pb-5 sm:px-5">

--- a/frontend/src/components/chat-message.tsx
+++ b/frontend/src/components/chat-message.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef } from 'react';
 import { CornerUpLeft, FileText, Pencil, SmilePlus, Trash2 } from 'lucide-react';
 import type { MessageAttachmentDto } from '../shared/api/chat';
+import { isEscapeKey } from '../shared/hooks/use-close-on-escape';
 
 function formatFileSize(sizeBytes: number): string {
   if (sizeBytes < 1024) {
@@ -79,10 +80,6 @@ type ChatMessageProps = {
 };
 
 const QUICK_REACTION_EMOJI = '👍';
-
-function isEscapeKey(event: KeyboardEvent | React.KeyboardEvent) {
-  return event.key === 'Escape' || event.key === 'Esc' || event.code === 'Escape';
-}
 
 export function getAccentClasses(accent: ChatMessageData['accent']) {
   switch (accent) {

--- a/frontend/src/components/chat-workspace.tsx
+++ b/frontend/src/components/chat-workspace.tsx
@@ -358,6 +358,15 @@ export function ChatWorkspace() {
     });
   }
 
+  const handleShowMobileSidebar = () => setMobilePane('channels');
+  const handleToggleEmojiPicker = () => setIsEmojiOpen((current) => !current);
+  const handleOpenNotifications = () => setIsNotificationCardOpen(true);
+  const handleCloseNotifications = () => setIsNotificationCardOpen(false);
+  const handleOpenSettings = () => setIsSettingsOpen(true);
+  const handleCloseSettings = () => setIsSettingsOpen(false);
+  const handleCloseDmProfile = () => setIsDmProfileOpen(false);
+  const handleCloseAuthorProfile = () => setProfileMember(null);
+
   async function handleDisconnect() {
     try {
       await logout();
@@ -532,6 +541,20 @@ export function ChatWorkspace() {
     );
   }
 
+  // DmList and ChannelList render the same sidebar footer (account strip +
+  // voice controls) regardless of chat mode, so they share this exact prop set.
+  const sidebarFooterProps = {
+    mobilePane,
+    username,
+    isMicMuted,
+    isDeafened,
+    unreadNotifications: notificationFeed.unreadCount,
+    onToggleDeafen: handleToggleDeafen,
+    onToggleMicMute: handleToggleMicMute,
+    onOpenNotifications: handleOpenNotifications,
+    onOpenSettings: handleOpenSettings
+  };
+
   return (
     <div className="mx-auto flex h-screen w-full gap-4 px-3 py-4 md:px-5 md:py-9">
       {!isHydrated ? (
@@ -546,37 +569,21 @@ export function ChatWorkspace() {
 
           {chatMode === 'dm' ? (
             <DmList
+              {...sidebarFooterProps}
               activeDm={dmWorkspace.activeDm ?? ''}
               directMessages={dmWorkspace.dmConversations}
               showArchived={dmWorkspace.showArchivedDms}
               friends={friends}
-              mobilePane={mobilePane}
-              username={username}
-              isMicMuted={isMicMuted}
-              isDeafened={isDeafened}
-              unreadNotifications={notificationFeed.unreadCount}
-              onToggleDeafen={handleToggleDeafen}
-              onToggleMicMute={handleToggleMicMute}
-              onOpenNotifications={() => setIsNotificationCardOpen(true)}
-              onOpenSettings={() => setIsSettingsOpen(true)}
               onSelectDm={handleSelectDm}
               onToggleShowArchived={dmWorkspace.toggleShowArchivedDms}
               onArchiveDm={dmWorkspace.archiveDm}
             />
           ) : (
             <ChannelList
+              {...sidebarFooterProps}
               activeChannel={guildWorkspace.activeChannel ?? ''}
               categories={guildWorkspace.channelCategories}
               unreadCounts={channelUnreadCounts}
-              mobilePane={mobilePane}
-              username={username}
-              isMicMuted={isMicMuted}
-              isDeafened={isDeafened}
-              unreadNotifications={notificationFeed.unreadCount}
-              onToggleDeafen={handleToggleDeafen}
-              onToggleMicMute={handleToggleMicMute}
-              onOpenNotifications={() => setIsNotificationCardOpen(true)}
-              onOpenSettings={() => setIsSettingsOpen(true)}
               onSelectChannel={handleSelectChannel}
             />
           )}
@@ -590,7 +597,7 @@ export function ChatWorkspace() {
               <div className="flex items-center gap-3">
                 <button
                   type="button"
-                  onClick={() => setMobilePane('channels')}
+                  onClick={handleShowMobileSidebar}
                   className="flex h-11 w-11 items-center justify-center rounded-xl border border-frame text-[#7e7e82] md:hidden"
                   aria-label={chatMode === 'dm' ? 'Show DMs' : 'Show channels'}
                 >
@@ -854,7 +861,7 @@ export function ChatWorkspace() {
                   </button>
                   <button
                     type="button"
-                    onClick={() => setIsEmojiOpen((current) => !current)}
+                    onClick={handleToggleEmojiPicker}
                     className="text-[#7e7e82] transition hover:text-white"
                     aria-label="Toggle emoji picker"
                   >
@@ -880,7 +887,7 @@ export function ChatWorkspace() {
                 </span>
                 <button
                   type="button"
-                  onClick={() => setMobilePane('channels')}
+                  onClick={handleShowMobileSidebar}
                   className="inline-flex items-center gap-2 md:hidden"
                 >
                   <MessageCircle className="h-4 w-4" strokeWidth={1.8} />
@@ -898,25 +905,22 @@ export function ChatWorkspace() {
             <ProfileCard
               member={activeDmProfileMember}
               variant="side"
-              onClose={() => setIsDmProfileOpen(false)}
+              onClose={handleCloseDmProfile}
             />
           ) : null}
 
           {profileMember ? (
-            <ProfileCard member={profileMember} onClose={() => setProfileMember(null)} />
+            <ProfileCard member={profileMember} onClose={handleCloseAuthorProfile} />
           ) : null}
 
           {isNotificationCardOpen ? (
-            <NotificationCard
-              feed={notificationFeed}
-              onClose={() => setIsNotificationCardOpen(false)}
-            />
+            <NotificationCard feed={notificationFeed} onClose={handleCloseNotifications} />
           ) : null}
 
           {isSettingsOpen ? (
             <SettingsModal
               username={username}
-              onClose={() => setIsSettingsOpen(false)}
+              onClose={handleCloseSettings}
               onDisconnect={handleDisconnect}
             />
           ) : null}

--- a/frontend/src/components/chat-workspace.tsx
+++ b/frontend/src/components/chat-workspace.tsx
@@ -278,6 +278,9 @@ export function ChatWorkspace() {
         activity: activeDmDetails.lastMessage
       }
     : null;
+  const isSidePanelOpen =
+    (chatMode === 'guild' && isMemberListOpen) || (chatMode === 'dm' && isDmProfileOpen);
+  const isSidePanelToggleDisabled = chatMode === 'dm' && !activeDmProfileMember;
   const activeMessageItems = useMemo(() => {
     const messagesById = new Map(activeMessages.map((message) => [message.id, message]));
 
@@ -359,6 +362,17 @@ export function ChatWorkspace() {
   }
 
   const handleShowMobileSidebar = () => setMobilePane('channels');
+
+  const handleToggleSidePanel = () => {
+    if (chatMode === 'dm') {
+      if (activeDmProfileMember) {
+        setIsDmProfileOpen((current) => !current);
+      }
+      return;
+    }
+
+    setIsMemberListOpen((current) => !current);
+  };
   const handleToggleEmojiPicker = () => setIsEmojiOpen((current) => !current);
   const handleOpenNotifications = () => setIsNotificationCardOpen(true);
   const handleCloseNotifications = () => setIsNotificationCardOpen(false);
@@ -661,23 +675,11 @@ export function ChatWorkspace() {
                 ) : null}
                 <button
                   type="button"
-                  onClick={() => {
-                    if (chatMode === 'dm') {
-                      if (activeDmProfileMember) {
-                        setIsDmProfileOpen((current) => !current);
-                      }
-                      return;
-                    }
-
-                    setIsMemberListOpen((current) => !current);
-                  }}
+                  onClick={handleToggleSidePanel}
                   className={`transition hover:text-white ${
-                    (chatMode === 'guild' && isMemberListOpen) ||
-                    (chatMode === 'dm' && isDmProfileOpen)
-                      ? 'text-aqua'
-                      : 'text-[#8c8c90]'
-                  } ${chatMode === 'dm' && !activeDmProfileMember ? 'cursor-not-allowed opacity-45' : ''}`}
-                  disabled={chatMode === 'dm' && !activeDmProfileMember}
+                    isSidePanelOpen ? 'text-aqua' : 'text-[#8c8c90]'
+                  } ${isSidePanelToggleDisabled ? 'cursor-not-allowed opacity-45' : ''}`}
+                  disabled={isSidePanelToggleDisabled}
                   aria-label={
                     chatMode === 'dm'
                       ? isDmProfileOpen
@@ -687,10 +689,7 @@ export function ChatWorkspace() {
                         ? 'Hide member list'
                         : 'Show member list'
                   }
-                  aria-pressed={
-                    (chatMode === 'guild' && isMemberListOpen) ||
-                    (chatMode === 'dm' && isDmProfileOpen)
-                  }
+                  aria-pressed={isSidePanelOpen}
                 >
                   <UserRound className="h-5 w-5" strokeWidth={1.8} />
                 </button>

--- a/frontend/src/components/chat-workspace.tsx
+++ b/frontend/src/components/chat-workspace.tsx
@@ -15,14 +15,10 @@ import {
   Video,
   X
 } from 'lucide-react';
-import {
-  ChatMessage,
-  getAccentClasses,
-  type ChatMessageData,
-  type ReplyPreview
-} from './chat-message';
+import { ChatMessage, type ChatMessageData, type ReplyPreview } from './chat-message';
+import { AvatarWithStatus } from './avatar-with-status';
 import { ChannelList, getChannelName } from './channel-list';
-import { DmList, getDmDetails, getDmName, getDmStatusClasses } from './dm-list';
+import { DmList, getDmDetails, getDmName } from './dm-list';
 import {
   getGuildMemberByName,
   GuildMemberList,
@@ -619,20 +615,11 @@ export function ChatWorkspace() {
                 </button>
                 {chatMode === 'dm' && activeDmDetails ? (
                   <div className="flex min-w-0 items-center gap-3">
-                    <span className="relative shrink-0">
-                      <span
-                        className={`flex h-11 w-11 items-center justify-center rounded-full text-sm font-bold ${getAccentClasses(
-                          activeDmDetails.accent
-                        )}`}
-                      >
-                        {activeDmDetails.name.slice(0, 1).toUpperCase()}
-                      </span>
-                      <span
-                        className={`absolute -bottom-0.5 -right-0.5 h-3.5 w-3.5 rounded-full border-2 border-secondary-bg ${getDmStatusClasses(
-                          activeDmDetails.status
-                        )}`}
-                      />
-                    </span>
+                    <AvatarWithStatus
+                      name={activeDmDetails.name}
+                      accent={activeDmDetails.accent}
+                      status={activeDmDetails.status}
+                    />
                     <span className="min-w-0">
                       <span className="block truncate text-[1.2rem] font-bold tracking-[-0.03em] text-white">
                         {activeDmDetails.name}

--- a/frontend/src/components/dm-list.tsx
+++ b/frontend/src/components/dm-list.tsx
@@ -10,7 +10,6 @@ import {
   Headphones,
   Mic,
   MicOff,
-  Search,
   Settings,
   UserPlus,
   UserRound,
@@ -19,6 +18,7 @@ import {
 import { AvatarWithStatus } from './avatar-with-status';
 import type { ChatMessageData } from './chat-message';
 import { FriendsList, type Friend } from './friends-list';
+import { SearchInput } from './search-input';
 
 export type DirectMessage = {
   id: string;
@@ -180,15 +180,7 @@ export function DmList({
 
         {isFriendsView ? null : (
           <>
-            <label className="mt-4 flex h-11 items-center gap-3 rounded-md bg-panel px-4 text-muted">
-              <Search className="h-4 w-4 shrink-0" strokeWidth={1.75} />
-              <input
-                value={search}
-                onChange={(event) => setSearch(event.target.value)}
-                placeholder="Search DMs"
-                className="mono-detail w-full min-w-0 bg-transparent text-xl text-white outline-none placeholder:text-muted"
-              />
-            </label>
+            <SearchInput value={search} onChange={setSearch} placeholder="Search DMs" />
             <button
               type="button"
               onClick={onToggleShowArchived}

--- a/frontend/src/components/dm-list.tsx
+++ b/frontend/src/components/dm-list.tsx
@@ -16,7 +16,8 @@ import {
   UserRound,
   X
 } from 'lucide-react';
-import { getAccentClasses, type ChatMessageData } from './chat-message';
+import { AvatarWithStatus } from './avatar-with-status';
+import type { ChatMessageData } from './chat-message';
 import { FriendsList, type Friend } from './friends-list';
 
 export type DirectMessage = {
@@ -63,16 +64,7 @@ export function hasDm(dmId: string, dms: DirectMessage[]) {
   return dms.some((dm) => dm.id === dmId);
 }
 
-export function getDmStatusClasses(status: DirectMessage['status']) {
-  switch (status) {
-    case 'online':
-      return 'bg-lime';
-    case 'idle':
-      return 'bg-yellow';
-    default:
-      return 'bg-muted';
-  }
-}
+export { getDmStatusClasses } from './avatar-with-status';
 
 export function DmList({
   activeDm,
@@ -249,20 +241,7 @@ export function DmList({
                       onClick={() => onSelectDm(dm.id)}
                       className="flex min-w-0 flex-1 items-center gap-3 px-3 py-2 text-left"
                     >
-                      <span className="relative shrink-0">
-                        <span
-                          className={`flex h-11 w-11 items-center justify-center rounded-full text-sm font-bold ${getAccentClasses(
-                            dm.accent
-                          )}`}
-                        >
-                          {dm.name.slice(0, 1).toUpperCase()}
-                        </span>
-                        <span
-                          className={`absolute -bottom-0.5 -right-0.5 h-3.5 w-3.5 rounded-full border-2 border-secondary-bg ${getDmStatusClasses(
-                            dm.status
-                          )}`}
-                        />
-                      </span>
+                      <AvatarWithStatus name={dm.name} accent={dm.accent} status={dm.status} />
                       <span className="min-w-0 flex-1">
                         <span className="flex min-w-0 items-center justify-between gap-3">
                           <span className="block truncate text-[1rem] font-bold">{dm.name}</span>

--- a/frontend/src/components/friends-list.tsx
+++ b/frontend/src/components/friends-list.tsx
@@ -2,8 +2,9 @@
 
 import { useState } from 'react';
 import { Search, UserPlus } from 'lucide-react';
-import { getAccentClasses, type ChatMessageData } from './chat-message';
-import { getDmStatusClasses, type DirectMessage } from './dm-list';
+import { AvatarWithStatus } from './avatar-with-status';
+import type { ChatMessageData } from './chat-message';
+import type { DirectMessage } from './dm-list';
 
 export type Friend = {
   id: string;
@@ -60,20 +61,7 @@ export function FriendsList({ friends, search, onSearchChange }: FriendsListProp
                 type="button"
                 className="flex h-[4.25rem] w-full items-center gap-3 rounded-lg px-3 text-left text-grey-link transition hover:bg-frame/60 hover:text-white"
               >
-                <span className="relative shrink-0">
-                  <span
-                    className={`flex h-11 w-11 items-center justify-center rounded-full text-sm font-bold ${getAccentClasses(
-                      friend.accent
-                    )}`}
-                  >
-                    {friend.name.slice(0, 1).toUpperCase()}
-                  </span>
-                  <span
-                    className={`absolute -bottom-0.5 -right-0.5 h-3.5 w-3.5 rounded-full border-2 border-secondary-bg ${getDmStatusClasses(
-                      friend.status
-                    )}`}
-                  />
-                </span>
+                <AvatarWithStatus name={friend.name} accent={friend.accent} status={friend.status} />
                 <span className="min-w-0 flex-1">
                   <span className="block truncate text-[1rem] font-bold">{friend.name}</span>
                   <span className="mt-0.5 block truncate text-sm text-white/35">

--- a/frontend/src/components/friends-list.tsx
+++ b/frontend/src/components/friends-list.tsx
@@ -1,10 +1,11 @@
 'use client';
 
 import { useState } from 'react';
-import { Search, UserPlus } from 'lucide-react';
+import { UserPlus } from 'lucide-react';
 import { AvatarWithStatus } from './avatar-with-status';
 import type { ChatMessageData } from './chat-message';
 import type { DirectMessage } from './dm-list';
+import { SearchInput } from './search-input';
 
 export type Friend = {
   id: string;
@@ -32,15 +33,7 @@ export function FriendsList({ friends, search, onSearchChange }: FriendsListProp
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
-      <label className="mt-4 flex h-11 items-center gap-3 rounded-md bg-panel px-4 text-muted">
-        <Search className="h-4 w-4 shrink-0" strokeWidth={1.75} />
-        <input
-          value={search}
-          onChange={(event) => onSearchChange(event.target.value)}
-          placeholder="Search friends"
-          className="mono-detail w-full min-w-0 bg-transparent text-xl text-white outline-none placeholder:text-muted"
-        />
-      </label>
+      <SearchInput value={search} onChange={onSearchChange} placeholder="Search friends" />
 
       <div className="min-h-0 flex-1 overflow-y-auto px-3 pb-5 sm:px-5">
         {filteredFriends.length === 0 ? (

--- a/frontend/src/components/guild-member-list.tsx
+++ b/frontend/src/components/guild-member-list.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import Image from 'next/image';
 import { Crown, Shield } from 'lucide-react';
-import { getAccentClasses, type ChatMessageData } from './chat-message';
-import { getDmStatusClasses, type DirectMessage } from './dm-list';
+import { AvatarWithStatus } from './avatar-with-status';
+import type { ChatMessageData } from './chat-message';
+import type { DirectMessage } from './dm-list';
 import { guildMembers } from './mocks/guild-member-mocks';
 import type { UserStatus } from '../shared/api/user';
 import { useGuilds } from '../shared/guilds/guild-store';
@@ -85,31 +85,13 @@ function MemberRow({
       onClick={() => onOpenProfile(toProfileMember(member))}
       className="flex h-14 w-full items-center gap-3 rounded-md px-2 text-left text-grey-link transition hover:bg-frame/60 hover:text-white"
     >
-      <span className="relative shrink-0">
-        {member.avatarUrl ? (
-          <Image
-            src={member.avatarUrl}
-            alt=""
-            width={40}
-            height={40}
-            unoptimized
-            className="h-10 w-10 rounded-full object-cover"
-          />
-        ) : (
-          <span
-            className={`flex h-10 w-10 items-center justify-center rounded-full text-sm font-bold ${getAccentClasses(
-              getAccentForId(member.userId)
-            )}`}
-          >
-            {member.displayName.slice(0, 1).toUpperCase()}
-          </span>
-        )}
-        <span
-          className={`absolute -bottom-0.5 -right-0.5 h-3.5 w-3.5 rounded-full border-2 border-secondary-bg ${getDmStatusClasses(
-            toSidebarStatus(member.status)
-          )}`}
-        />
-      </span>
+      <AvatarWithStatus
+        size="sm"
+        name={member.displayName}
+        accent={getAccentForId(member.userId)}
+        status={toSidebarStatus(member.status)}
+        avatarUrl={member.avatarUrl}
+      />
       <span className="min-w-0 flex-1">
         <span className="flex min-w-0 items-center gap-1.5">
           <span className="block truncate text-[0.95rem] font-bold">{member.displayName}</span>

--- a/frontend/src/components/guild-member-list.tsx
+++ b/frontend/src/components/guild-member-list.tsx
@@ -8,6 +8,7 @@ import { guildMembers } from './mocks/guild-member-mocks';
 import type { UserStatus } from '../shared/api/user';
 import { useGuilds } from '../shared/guilds/guild-store';
 import { useGuildMembers, type HydratedGuildMember } from '../shared/guilds/use-guild-members';
+import { hashToIndex } from '../shared/lib/hash';
 
 export type GuildMember = {
   id: string;
@@ -26,12 +27,7 @@ export function getGuildMemberByName(name: string) {
 const ACCENTS: ChatMessageData['accent'][] = ['aqua', 'yellow', 'lime', 'lavender', 'pink'];
 
 function getAccentForId(id: string): ChatMessageData['accent'] {
-  let hash = 0;
-  for (const char of id) {
-    hash = (hash * 31 + char.charCodeAt(0)) % ACCENTS.length;
-  }
-
-  return ACCENTS[hash];
+  return ACCENTS[hashToIndex(id, ACCENTS.length)];
 }
 
 function toSidebarStatus(status: UserStatus): DirectMessage['status'] {

--- a/frontend/src/components/guild/add-guild-modal.tsx
+++ b/frontend/src/components/guild/add-guild-modal.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { Plus, X } from 'lucide-react';
 import { GuildCreateForm, GuildJoinForm } from './guild-forms';
+import { useCloseOnEscape } from '../../shared/hooks/use-close-on-escape';
 
 type AddGuildModalProps = {
   onClose: () => void;
@@ -11,16 +12,7 @@ type AddGuildModalProps = {
 export function AddGuildModal({ onClose }: AddGuildModalProps) {
   const [tab, setTab] = useState<'create' | 'join'>('create');
 
-  useEffect(() => {
-    function handleEscape(event: KeyboardEvent) {
-      if (event.key === 'Escape' || event.key === 'Esc') {
-        onClose();
-      }
-    }
-
-    window.addEventListener('keydown', handleEscape);
-    return () => window.removeEventListener('keydown', handleEscape);
-  }, [onClose]);
+  useCloseOnEscape(onClose);
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/55 px-4 py-6">

--- a/frontend/src/components/guild/guild-icon.tsx
+++ b/frontend/src/components/guild/guild-icon.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Image from 'next/image';
+import { hashToIndex } from '../../shared/lib/hash';
 
 const ACCENTS = [
   'bg-aqua/15 text-aqua',
@@ -11,12 +12,7 @@ const ACCENTS = [
 ];
 
 export function getGuildAccentClasses(guildId: string) {
-  let hash = 0;
-  for (const char of guildId) {
-    hash = (hash * 31 + char.charCodeAt(0)) % ACCENTS.length;
-  }
-
-  return ACCENTS[hash];
+  return ACCENTS[hashToIndex(guildId, ACCENTS.length)];
 }
 
 type GuildIconProps = {

--- a/frontend/src/components/notification-card.tsx
+++ b/frontend/src/components/notification-card.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import {
   AtSign,
   Bell,
@@ -27,6 +27,7 @@ import {
   type NotificationMuteScope,
   type UseNotificationsResult
 } from '../shared/lib/use-notifications';
+import { useCloseOnEscape } from '../shared/hooks/use-close-on-escape';
 
 type NotificationTone = 'aqua' | 'yellow' | 'pink';
 
@@ -448,18 +449,7 @@ export function NotificationCard({ feed, onClose }: NotificationCardProps) {
     }
   }
 
-  useEffect(() => {
-    function handleEscape(event: KeyboardEvent) {
-      if (event.key !== 'Escape' && event.key !== 'Esc' && event.code !== 'Escape') {
-        return;
-      }
-
-      onClose();
-    }
-
-    window.addEventListener('keydown', handleEscape);
-    return () => window.removeEventListener('keydown', handleEscape);
-  }, [onClose]);
+  useCloseOnEscape(onClose);
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/55 px-4 py-6">

--- a/frontend/src/components/profile-card.tsx
+++ b/frontend/src/components/profile-card.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import { useEffect } from 'react';
 import { MessageCircle, Shield, Trophy, X } from 'lucide-react';
 import { AvatarWithStatus } from './avatar-with-status';
 import type { GuildMember } from './guild-member-list';
+import { useCloseOnEscape } from '../shared/hooks/use-close-on-escape';
 
 type ProfileCardProps = {
   member: GuildMember;
@@ -12,18 +12,7 @@ type ProfileCardProps = {
 };
 
 export function ProfileCard({ member, variant = 'modal', onClose }: ProfileCardProps) {
-  useEffect(() => {
-    function handleEscape(event: KeyboardEvent) {
-      if (event.key !== 'Escape' && event.key !== 'Esc' && event.code !== 'Escape') {
-        return;
-      }
-
-      onClose();
-    }
-
-    window.addEventListener('keydown', handleEscape);
-    return () => window.removeEventListener('keydown', handleEscape);
-  }, [onClose]);
+  useCloseOnEscape(onClose);
 
   const card = (
     <section

--- a/frontend/src/components/profile-card.tsx
+++ b/frontend/src/components/profile-card.tsx
@@ -2,8 +2,7 @@
 
 import { useEffect } from 'react';
 import { MessageCircle, Shield, Trophy, X } from 'lucide-react';
-import { getAccentClasses } from './chat-message';
-import { getDmStatusClasses } from './dm-list';
+import { AvatarWithStatus } from './avatar-with-status';
 import type { GuildMember } from './guild-member-list';
 
 type ProfileCardProps = {
@@ -44,20 +43,7 @@ export function ProfileCard({ member, variant = 'modal', onClose }: ProfileCardP
 
       <div className="px-5 pb-5">
         <div className="-mt-10 flex items-end justify-between gap-4">
-          <span className="relative shrink-0">
-            <span
-              className={`flex h-20 w-20 items-center justify-center rounded-full border-4 border-secondary-bg text-3xl font-bold ${getAccentClasses(
-                member.accent
-              )}`}
-            >
-              {member.name.slice(0, 1).toUpperCase()}
-            </span>
-            <span
-              className={`absolute bottom-1 right-1 h-4 w-4 rounded-full border-2 border-secondary-bg ${getDmStatusClasses(
-                member.status
-              )}`}
-            />
-          </span>
+          <AvatarWithStatus size="lg" name={member.name} accent={member.accent} status={member.status} />
           <span className="font-category mb-2 rounded-full border border-white/10 bg-panel px-3 py-1 text-[0.68rem] uppercase tracking-[0.14em] text-white/45">
             {member.role}
           </span>

--- a/frontend/src/components/search-input.tsx
+++ b/frontend/src/components/search-input.tsx
@@ -1,0 +1,22 @@
+import { Search } from 'lucide-react';
+
+type SearchInputProps = {
+  value: string;
+  onChange: (value: string) => void;
+  placeholder: string;
+  className?: string;
+};
+
+export function SearchInput({ value, onChange, placeholder, className = 'mt-4' }: SearchInputProps) {
+  return (
+    <label className={`flex h-11 items-center gap-3 rounded-md bg-panel px-4 text-muted ${className}`}>
+      <Search className="h-4 w-4 shrink-0" strokeWidth={1.75} />
+      <input
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        placeholder={placeholder}
+        className="mono-detail w-full min-w-0 bg-transparent text-xl text-white outline-none placeholder:text-muted"
+      />
+    </label>
+  );
+}

--- a/frontend/src/components/settings-modal.tsx
+++ b/frontend/src/components/settings-modal.tsx
@@ -15,6 +15,7 @@ import {
   describeDeleteAccountError
 } from '../shared/lib/auth-errors';
 import { checkEmail, checkPassword } from '../shared/lib/validators/auth';
+import { useCloseOnEscape } from '../shared/hooks/use-close-on-escape';
 
 type SettingsModalProps = {
   username: string;
@@ -29,18 +30,7 @@ export function SettingsModal({ username, onClose, onDisconnect }: SettingsModal
   const [identity, setIdentity] = useState<AuthIdentity | null>(null);
   const [panel, setPanel] = useState<Panel>('menu');
 
-  useEffect(() => {
-    function handleEscape(event: KeyboardEvent) {
-      if (event.key !== 'Escape' && event.key !== 'Esc' && event.code !== 'Escape') {
-        return;
-      }
-
-      onClose();
-    }
-
-    window.addEventListener('keydown', handleEscape);
-    return () => window.removeEventListener('keydown', handleEscape);
-  }, [onClose]);
+  useCloseOnEscape(onClose);
 
   useEffect(() => {
     let active = true;

--- a/frontend/src/shared/hooks/use-close-on-escape.ts
+++ b/frontend/src/shared/hooks/use-close-on-escape.ts
@@ -1,0 +1,22 @@
+'use client';
+
+import { useEffect } from 'react';
+
+export function isEscapeKey(event: KeyboardEvent | React.KeyboardEvent) {
+  return event.key === 'Escape' || event.key === 'Esc' || event.code === 'Escape';
+}
+
+export function useCloseOnEscape(onClose: () => void) {
+  useEffect(() => {
+    function handleEscape(event: KeyboardEvent) {
+      if (!isEscapeKey(event)) {
+        return;
+      }
+
+      onClose();
+    }
+
+    window.addEventListener('keydown', handleEscape);
+    return () => window.removeEventListener('keydown', handleEscape);
+  }, [onClose]);
+}

--- a/frontend/src/shared/lib/hash.ts
+++ b/frontend/src/shared/lib/hash.ts
@@ -1,0 +1,11 @@
+// deterministic (not random) index into a fixed-length list, so the same id
+// always picks the same slot (accent color, etc.) - shared math, not shared
+// meaning: callers keep their own list and return shape
+export function hashToIndex(value: string, length: number): number {
+  let hash = 0;
+  for (let index = 0; index < value.length; index += 1) {
+    hash = (hash * 31 + value.charCodeAt(index)) | 0;
+  }
+
+  return Math.abs(hash) % length;
+}

--- a/frontend/src/shared/mappers/chat.ts
+++ b/frontend/src/shared/mappers/chat.ts
@@ -6,6 +6,7 @@ import type {
   DirectMessageDto,
   MessageReactionDto
 } from '../api/chat';
+import { hashToIndex } from '../lib/hash';
 
 type MessageAccent = ChatMessageData['accent'];
 
@@ -22,15 +23,8 @@ export function splitMessageLines(content: string): string[] {
   return content.split(/\r?\n/);
 }
 
-// deterministic (not random) so the same author always renders with the same accent color
 export function accentForAuthor(authorId: string): MessageAccent {
-  let hash = 0;
-
-  for (let index = 0; index < authorId.length; index += 1) {
-    hash = (hash * 31 + authorId.charCodeAt(index)) | 0;
-  }
-
-  return MESSAGE_ACCENTS[Math.abs(hash) % MESSAGE_ACCENTS.length];
+  return MESSAGE_ACCENTS[hashToIndex(authorId, MESSAGE_ACCENTS.length)];
 }
 
 // TODO: GET /users/{id} hydration yet (epic 2) - fall back to a raw-id placeholder


### PR DESCRIPTION
Pure cleanup, no behavior change intended: `chat-workspace.tsx`'s JSX had grown hard to read, and reviewing become difficult.

> Blocked by PR #321 
 Was based on `refactor/front/merge-guild-chat`, need to rebase on main after #321 merge.


## What changed
- **`DmList`/`ChannelList` shared props**: both received 8 byte-for-byte identical props (`mobilePane`, `username`, `isMicMuted`, `isDeafened`, `onToggleDeafen`, `onToggleMicMute`, `onOpenNotifications`, `onOpenSettings`) - extracted into one `sidebarFooterProps` object, spread into both.
- **Inline closures -> named handlers**: 11 `onClick={() => setX(...)}` closures hoisted into `handle<...>` functions, matching the convention every other interaction in the file already used. All handlers in the file are now `const handleX = (...) => {}`.
- **Side-panel toggle button**: recomputed the same three compound conditions up to three times each across `className`/`disabled`/`aria-pressed` - extracted `isSidePanelOpen`/`isSidePanelToggleDisabled` once.
- **`AvatarWithStatus`** (new `components/avatar-with-status.tsx`): the accent-bubble + status-dot pairing was duplicated verbatim, at 3 sizes, one with a real-avatar-image fallback, across `dm-list`, `friends-list`, `chat-workspace`, `guild-member-list`, and `profile-card`.
- **`useCloseOnEscape`** (new `shared/hooks/use-close-on-escape.ts`): the same close-on-Escape effect was reimplemented in 4 modals/cards - one copy (`add-guild-modal.tsx`) was missing the `event.code === 'Escape'` check the others had, a real (if minor) bug fixed by consolidating.
- **`hashToIndex`** (new `shared/lib/hash.ts`): the same string-hash-to-accent-index math, was implemented 3 times (`guild-member-list`, `guild-icon`, the chat mapper) - extracted the math only, each caller keeps its own accent list/return shape.
- **`SearchInput`** (new `components/search-input.tsx`): identical label+icon+input markup duplicated in `friends-list`, `channel-list`, `dm-list.
