### PR TITLE
Refactor(frontend): split chat-workspace into presentational components

### DIFF
--- a/frontend/src/components/chat-workspace.tsx
+++ b/frontend/src/components/chat-workspace.tsx
@@ -3,8 +3,9 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { ArrowRight, CornerUpLeft, MessageCircle, Paperclip, Smile, X } from 'lucide-react';
-import { ChatMessage, type ChatMessageData, type ReplyPreview } from './chat-message';
+import { type ChatMessageData } from './chat-message';
 import { ConversationHeader } from './chat/conversation-header';
+import { MessageList } from './chat/message-list';
 import { ChannelList, getChannelName } from './channel-list';
 import { DmList, getDmDetails, getDmName } from './dm-list';
 import {
@@ -34,35 +35,11 @@ import { IncomingCallOverlay } from './call/incoming-call-overlay';
 import { CallWindow } from './call/call-window';
 
 const LAST_CHAT_MODE_KEY = 'ft_transcendence_last_chat_mode';
-const MESSAGE_GROUP_THRESHOLD_MINUTES = 5;
 const TOP_THRESHOLD_PX = 96;
 
 type ChatMode = 'guild' | 'dm';
 
 const emojiOptions = ['😀', '😅', '🤣', '😂', '🙂', '🙃', '🤔', '😎', '🥳', '😍', '😘', '😉'];
-
-function getTimestampMinutes(timestamp: string) {
-  const [hours, minutes] = timestamp.split(':').map(Number);
-
-  if (!Number.isFinite(hours) || !Number.isFinite(minutes)) {
-    return null;
-  }
-
-  return hours * 60 + minutes;
-}
-
-function getMinutesBetween(previousTimestamp: string, currentTimestamp: string) {
-  const previousMinutes = getTimestampMinutes(previousTimestamp);
-  const currentMinutes = getTimestampMinutes(currentTimestamp);
-
-  if (previousMinutes === null || currentMinutes === null) {
-    return Number.POSITIVE_INFINITY;
-  }
-
-  return currentMinutes >= previousMinutes
-    ? currentMinutes - previousMinutes
-    : currentMinutes + 24 * 60 - previousMinutes;
-}
 
 export function ChatWorkspace() {
   const router = useRouter();
@@ -268,28 +245,6 @@ export function ChatWorkspace() {
   const sidePanelAriaLabel =  chatMode === 'dm'
       ? isDmProfileOpen ? 'Hide profile' : 'Show profile'
       : isMemberListOpen ? 'Hide member list' : 'Show member list';
-
-  const activeMessageItems = useMemo(() => {
-    const messagesById = new Map(activeMessages.map((message) => [message.id, message]));
-
-    return activeMessages.map((message, index) => {
-      const previousMessage = activeMessages[index - 1];
-      const isGrouped =
-        previousMessage?.author === message.author &&
-        getMinutesBetween(previousMessage.timestamp, message.timestamp) <=
-          MESSAGE_GROUP_THRESHOLD_MINUTES;
-
-      let replyPreview: ReplyPreview | null = null;
-      if (message.replyToId) {
-        const target = messagesById.get(message.replyToId);
-        replyPreview = target
-          ? { author: target.author, snippet: target.content[0] ?? '' }
-          : { author: '', snippet: 'an earlier message' };
-      }
-
-      return { message, isGrouped, replyPreview };
-    });
-  }, [activeMessages]);
 
   function handleMessagesScroll() {
     scroll.rememberConversationScrollPosition(activeConversationId);
@@ -608,67 +563,30 @@ export function ChatWorkspace() {
               onStartVideoCall={() => startDmCall('video')}
             />
 
-            <div
-              ref={scroll.messagesViewportRef}
+            <MessageList
+              viewportRef={scroll.messagesViewportRef}
               onScroll={handleMessagesScroll}
-              className="min-h-0 flex-1 overflow-auto px-5 py-7 sm:px-7"
-            >
-              {isDmEmptyState ? (
-                <div className="flex min-h-full flex-col items-center justify-center px-6 text-center">
-                  <div className="flex h-16 w-16 items-center justify-center rounded-full bg-panel text-[#8b8b8f]">
-                    <MessageCircle className="h-7 w-7" strokeWidth={1.8} />
-                  </div>
-                  <h3 className="mt-5 text-[1.25rem] font-bold tracking-[-0.03em] text-white">
-                    No DM selected
-                  </h3>
-                  <p className="mt-2 max-w-[22rem] text-sm leading-6 text-white/40">
-                    Select a conversation from the DM list to start reading or sending messages.
-                  </p>
-                </div>
-              ) : (
-                <div>
-                  {activeMessageItems.map(({ message, isGrouped, replyPreview }) => {
-                    const isOwnMessage =
-                      message.authorId != null && message.authorId === currentUserId;
-                    const isEditing = editingMessageId === message.id;
-
-                    return (
-                      <ChatMessage
-                        key={message.id}
-                        message={message}
-                        replyPreview={replyPreview}
-                        isGrouped={isGrouped}
-                        isOwnMessage={isOwnMessage}
-                        isEditing={isEditing}
-                        isHighlighted={highlightedMessageId === message.id}
-                        editingDraft={editingDraft}
-                        canReact={chatMode === 'guild'}
-                        onEditDraftChange={setEditingDraft}
-                        onStartEdit={handleStartEdit}
-                        onSaveEdit={handleSaveEdit}
-                        onCancelEdit={handleCancelEdit}
-                        onDelete={handleDeleteMessage}
-                        onToggleReaction={conversationHistory.toggleReaction}
-                        onReply={handleStartReply}
-                        onJumpToReply={handleJumpToMessage}
-                        onRetryMessage={conversationHistory.retryMessage}
-                        onOpenAuthorProfile={handleOpenAuthorProfile}
-                        setMessageRef={scroll.setMessageRef}
-                      />
-                    );
-                  })}
-                </div>
-              )}
-              {!scroll.isNearBottom ? (
-                <button
-                  type="button"
-                  onClick={scroll.scrollToBottom}
-                  className="mono-detail sticky bottom-0 z-10 ml-auto flex h-10 items-center rounded-full border border-aqua/40 bg-panel px-4 text-sm font-bold text-aqua shadow-lg shadow-black/30 transition hover:border-aqua hover:text-white"
-                >
-                  Jump to bottom
-                </button>
-              ) : null}
-            </div>
+              isDmEmptyState={isDmEmptyState}
+              activeMessages={activeMessages}
+              currentUserId={currentUserId}
+              editingMessageId={editingMessageId}
+              editingDraft={editingDraft}
+              highlightedMessageId={highlightedMessageId}
+              canReact={chatMode === 'guild'}
+              isNearBottom={scroll.isNearBottom}
+              setMessageRef={scroll.setMessageRef}
+              onEditDraftChange={setEditingDraft}
+              onStartEdit={handleStartEdit}
+              onSaveEdit={handleSaveEdit}
+              onCancelEdit={handleCancelEdit}
+              onDelete={handleDeleteMessage}
+              onToggleReaction={conversationHistory.toggleReaction}
+              onReply={handleStartReply}
+              onJumpToReply={handleJumpToMessage}
+              onRetryMessage={conversationHistory.retryMessage}
+              onOpenAuthorProfile={handleOpenAuthorProfile}
+              onScrollToBottom={scroll.scrollToBottom}
+            />
 
             <div className="shrink-0 border-t border-white/8 px-4 py-4 sm:px-5">
               <input

--- a/frontend/src/components/chat-workspace.tsx
+++ b/frontend/src/components/chat-workspace.tsx
@@ -2,9 +2,9 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { ArrowRight, CornerUpLeft, MessageCircle, Paperclip, Smile, X } from 'lucide-react';
 import { type ChatMessageData } from './chat-message';
 import { ConversationHeader } from './chat/conversation-header';
+import { MessageComposer } from './chat/message-composer';
 import { MessageList } from './chat/message-list';
 import { ChannelList, getChannelName } from './channel-list';
 import { DmList, getDmDetails, getDmName } from './dm-list';
@@ -38,8 +38,6 @@ const LAST_CHAT_MODE_KEY = 'ft_transcendence_last_chat_mode';
 const TOP_THRESHOLD_PX = 96;
 
 type ChatMode = 'guild' | 'dm';
-
-const emojiOptions = ['😀', '😅', '🤣', '😂', '🙂', '🙃', '🤔', '😎', '🥳', '😍', '😘', '😉'];
 
 export function ChatWorkspace() {
   const router = useRouter();
@@ -242,9 +240,14 @@ export function ChatWorkspace() {
   const isSidePanelOpen =
     (chatMode === 'guild' && isMemberListOpen) || (chatMode === 'dm' && isDmProfileOpen);
   const isSidePanelToggleDisabled = chatMode === 'dm' && !activeDmProfileMember;
-  const sidePanelAriaLabel =  chatMode === 'dm'
-      ? isDmProfileOpen ? 'Hide profile' : 'Show profile'
-      : isMemberListOpen ? 'Hide member list' : 'Show member list';
+  const sidePanelAriaLabel =
+    chatMode === 'dm'
+      ? isDmProfileOpen
+        ? 'Hide profile'
+        : 'Show profile'
+      : isMemberListOpen
+        ? 'Hide member list'
+        : 'Show member list';
 
   function handleMessagesScroll() {
     scroll.rememberConversationScrollPosition(activeConversationId);
@@ -588,141 +591,27 @@ export function ChatWorkspace() {
               onScrollToBottom={scroll.scrollToBottom}
             />
 
-            <div className="shrink-0 border-t border-white/8 px-4 py-4 sm:px-5">
-              <input
-                ref={fileInputRef}
-                type="file"
-                multiple
-                onChange={handleFilesSelected}
-                className="hidden"
-              />
-              {replyTarget ? (
-                <div className="mb-3 flex items-center justify-between gap-3 rounded-md border border-white/10 bg-panel px-3 py-2 text-xs text-white/60">
-                  <span className="flex min-w-0 items-center gap-1.5">
-                    <CornerUpLeft className="h-3.5 w-3.5 shrink-0" strokeWidth={2} />
-                    <span className="truncate">
-                      Replying to <span className="text-white/85">{replyTarget.author}</span>:{' '}
-                      {replyTarget.content[0] ?? ''}
-                    </span>
-                  </span>
-                  <button
-                    type="button"
-                    onClick={handleCancelReply}
-                    aria-label="Cancel reply"
-                    className="shrink-0 text-white/40 hover:text-white"
-                  >
-                    <X className="h-3.5 w-3.5" strokeWidth={2} />
-                  </button>
-                </div>
-              ) : null}
-              {conversationHistory.pendingAttachments.length > 0 ? (
-                <div className="mb-3 flex flex-wrap gap-2">
-                  {conversationHistory.pendingAttachments.map((attachment) => (
-                    <span
-                      key={attachment.id}
-                      className={`flex h-8 items-center gap-2 rounded-full border px-3 text-xs ${
-                        attachment.status === 'error'
-                          ? 'border-pink/40 text-pink'
-                          : 'border-white/10 text-white/70'
-                      }`}
-                    >
-                      <span className="max-w-[10rem] truncate">{attachment.filename}</span>
-                      {attachment.status === 'uploading' ? <span>Uploading…</span> : null}
-                      {attachment.status === 'error' ? <span>Failed</span> : null}
-                      <button
-                        type="button"
-                        onClick={() => conversationHistory.removePendingAttachment(attachment.id)}
-                        aria-label={`Remove ${attachment.filename}`}
-                        className="text-white/40 hover:text-white"
-                      >
-                        <X className="h-3 w-3" strokeWidth={2} />
-                      </button>
-                    </span>
-                  ))}
-                </div>
-              ) : null}
-              {isEmojiOpen ? (
-                <div className="mb-3 rounded-xl border border-white/10 bg-panel p-3">
-                  <div className="grid grid-cols-6 gap-2">
-                    {emojiOptions.map((emoji) => (
-                      <button
-                        key={emoji}
-                        type="button"
-                        onClick={() => appendEmoji(emoji)}
-                        className="rounded-lg bg-frame px-2 py-2 text-2xl transition hover:bg-white/10"
-                      >
-                        {emoji}
-                      </button>
-                    ))}
-                  </div>
-                </div>
-              ) : null}
-              <div className="flex h-14 items-center rounded-md bg-panel px-4 text-muted">
-                <textarea
-                  ref={scroll.composerRef}
-                  value={activeDraft}
-                  onChange={(event) => handleDraftChange(event.target.value)}
-                  onKeyDown={(event) => {
-                    if (event.key === 'Enter' && !event.shiftKey) {
-                      event.preventDefault();
-                      handleSubmitMessage();
-                    }
-                  }}
-                  disabled={isComposerDisabled}
-                  placeholder={
-                    isActiveDmArchived
-                      ? 'This conversation is archived -- send a message to unarchive it.'
-                      : `Message ${chatMode === 'dm' ? '@' : '#'}${activeConversationName}`
-                  }
-                  rows={1}
-                  className="h-full min-h-0 w-full resize-none overflow-y-auto bg-transparent py-4 text-lg leading-6 text-white outline-none placeholder:text-muted disabled:cursor-not-allowed disabled:text-white/30"
-                />
-                <div className="ml-auto flex items-center gap-4">
-                  <button
-                    type="button"
-                    onClick={() => fileInputRef.current?.click()}
-                    disabled={isComposerDisabled}
-                    className="text-[#7e7e82] transition hover:text-white disabled:cursor-not-allowed disabled:text-[#535353]"
-                    aria-label="Attach files"
-                  >
-                    <Paperclip className="h-5 w-5" strokeWidth={1.8} />
-                  </button>
-                  <button
-                    type="button"
-                    onClick={handleToggleEmojiPicker}
-                    className="text-[#7e7e82] transition hover:text-white"
-                    aria-label="Toggle emoji picker"
-                  >
-                    <Smile className="h-5 w-5" strokeWidth={1.8} />
-                  </button>
-                  <button
-                    type="button"
-                    onClick={handleSubmitMessage}
-                    disabled={isSendDisabled}
-                    className="text-aqua transition hover:text-white disabled:cursor-not-allowed disabled:text-[#535353]"
-                    aria-label="Send message"
-                  >
-                    <ArrowRight
-                      className="h-5 w-5 rounded-full border border-aqua p-0.5"
-                      strokeWidth={2}
-                    />
-                  </button>
-                </div>
-              </div>
-              <div className="mt-3 flex justify-between text-xs text-white/35">
-                <span>
-                  {chatMode === 'dm' ? 'Conversation directe locale' : 'Canal interactif local'}
-                </span>
-                <button
-                  type="button"
-                  onClick={handleShowMobileSidebar}
-                  className="inline-flex items-center gap-2 md:hidden"
-                >
-                  <MessageCircle className="h-4 w-4" strokeWidth={1.8} />
-                  {chatMode === 'dm' ? 'DMs' : 'Channels'}
-                </button>
-              </div>
-            </div>
+            <MessageComposer
+              fileInputRef={fileInputRef}
+              composerRef={scroll.composerRef}
+              chatMode={chatMode}
+              activeConversationName={activeConversationName}
+              activeDraft={activeDraft}
+              isComposerDisabled={isComposerDisabled}
+              isSendDisabled={isSendDisabled}
+              isActiveDmArchived={isActiveDmArchived}
+              replyTarget={replyTarget}
+              pendingAttachments={conversationHistory.pendingAttachments}
+              isEmojiOpen={isEmojiOpen}
+              onFilesSelected={handleFilesSelected}
+              onRemovePendingAttachment={conversationHistory.removePendingAttachment}
+              onCancelReply={handleCancelReply}
+              onToggleEmojiPicker={handleToggleEmojiPicker}
+              onAppendEmoji={appendEmoji}
+              onDraftChange={handleDraftChange}
+              onSubmitMessage={handleSubmitMessage}
+              onShowMobileSidebar={handleShowMobileSidebar}
+            />
           </section>
 
           {chatMode === 'guild' && isMemberListOpen ? (

--- a/frontend/src/components/chat-workspace.tsx
+++ b/frontend/src/components/chat-workspace.tsx
@@ -2,21 +2,9 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
-import {
-  ArrowLeft,
-  ArrowRight,
-  CircleEllipsis,
-  CornerUpLeft,
-  MessageCircle,
-  Paperclip,
-  Phone,
-  Smile,
-  UserRound,
-  Video,
-  X
-} from 'lucide-react';
+import { ArrowRight, CornerUpLeft, MessageCircle, Paperclip, Smile, X } from 'lucide-react';
 import { ChatMessage, type ChatMessageData, type ReplyPreview } from './chat-message';
-import { AvatarWithStatus } from './avatar-with-status';
+import { ConversationHeader } from './chat/conversation-header';
 import { ChannelList, getChannelName } from './channel-list';
 import { DmList, getDmDetails, getDmName } from './dm-list';
 import {
@@ -277,6 +265,10 @@ export function ChatWorkspace() {
   const isSidePanelOpen =
     (chatMode === 'guild' && isMemberListOpen) || (chatMode === 'dm' && isDmProfileOpen);
   const isSidePanelToggleDisabled = chatMode === 'dm' && !activeDmProfileMember;
+  const sidePanelAriaLabel =  chatMode === 'dm'
+      ? isDmProfileOpen ? 'Hide profile' : 'Show profile'
+      : isMemberListOpen ? 'Hide member list' : 'Show member list';
+
   const activeMessageItems = useMemo(() => {
     const messagesById = new Map(activeMessages.map((message) => [message.id, message]));
 
@@ -603,86 +595,18 @@ export function ChatWorkspace() {
               mobilePane === 'messages' ? 'flex' : 'hidden'
             } min-h-0 flex-1 flex-col overflow-hidden rounded-[1rem] bg-secondary-bg ring-1 ring-white/5 md:flex`}
           >
-            <div className="flex h-[4.9rem] shrink-0 items-center justify-between border-b border-white/8 px-5 sm:px-7">
-              <div className="flex items-center gap-3">
-                <button
-                  type="button"
-                  onClick={handleShowMobileSidebar}
-                  className="flex h-11 w-11 items-center justify-center rounded-xl border border-frame text-[#7e7e82] md:hidden"
-                  aria-label={chatMode === 'dm' ? 'Show DMs' : 'Show channels'}
-                >
-                  <ArrowLeft className="h-5 w-5" strokeWidth={1.9} />
-                </button>
-                {chatMode === 'dm' && activeDmDetails ? (
-                  <div className="flex min-w-0 items-center gap-3">
-                    <AvatarWithStatus
-                      name={activeDmDetails.name}
-                      accent={activeDmDetails.accent}
-                      status={activeDmDetails.status}
-                    />
-                    <span className="min-w-0">
-                      <span className="block truncate text-[1.2rem] font-bold tracking-[-0.03em] text-white">
-                        {activeDmDetails.name}
-                      </span>
-                      <span className="font-category block text-[0.72rem] uppercase tracking-[0.14em] text-white/35">
-                        {activeDmDetails.status}
-                      </span>
-                    </span>
-                  </div>
-                ) : chatMode === 'dm' ? (
-                  <h2 className="text-[1.25rem] font-bold tracking-[-0.03em] text-white">
-                    Direct Messages
-                  </h2>
-                ) : (
-                  <h2 className="mono-detail text-[1.85rem] font-bold tracking-[-0.05em] text-white">
-                    # {activeConversationName}
-                  </h2>
-                )}
-              </div>
-              <div className="flex items-center gap-4 text-[#8c8c90]">
-                {chatMode === 'dm' && activeDmDetails ? (
-                  <>
-                    <button
-                      type="button"
-                      onClick={() => startDmCall('audio')}
-                      className="transition hover:text-white"
-                      aria-label="Start voice call"
-                    >
-                      <Phone className="h-5 w-5" strokeWidth={1.8} />
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() => startDmCall('video')}
-                      className="transition hover:text-white"
-                      aria-label="Start video call"
-                    >
-                      <Video className="h-5 w-5" strokeWidth={1.8} />
-                    </button>
-                  </>
-                ) : null}
-                <button
-                  type="button"
-                  onClick={handleToggleSidePanel}
-                  className={`transition hover:text-white ${
-                    isSidePanelOpen ? 'text-aqua' : 'text-[#8c8c90]'
-                  } ${isSidePanelToggleDisabled ? 'cursor-not-allowed opacity-45' : ''}`}
-                  disabled={isSidePanelToggleDisabled}
-                  aria-label={
-                    chatMode === 'dm'
-                      ? isDmProfileOpen
-                        ? 'Hide profile'
-                        : 'Show profile'
-                      : isMemberListOpen
-                        ? 'Hide member list'
-                        : 'Show member list'
-                  }
-                  aria-pressed={isSidePanelOpen}
-                >
-                  <UserRound className="h-5 w-5" strokeWidth={1.8} />
-                </button>
-                <CircleEllipsis className="h-5 w-5" strokeWidth={1.8} />
-              </div>
-            </div>
+            <ConversationHeader
+              chatMode={chatMode}
+              activeDmDetails={activeDmDetails}
+              activeConversationName={activeConversationName}
+              isSidePanelOpen={isSidePanelOpen}
+              isSidePanelToggleDisabled={isSidePanelToggleDisabled}
+              sidePanelAriaLabel={sidePanelAriaLabel}
+              onShowMobileSidebar={handleShowMobileSidebar}
+              onToggleSidePanel={handleToggleSidePanel}
+              onStartAudioCall={() => startDmCall('audio')}
+              onStartVideoCall={() => startDmCall('video')}
+            />
 
             <div
               ref={scroll.messagesViewportRef}

--- a/frontend/src/components/chat/conversation-header.tsx
+++ b/frontend/src/components/chat/conversation-header.tsx
@@ -1,0 +1,102 @@
+import { ArrowLeft, CircleEllipsis, Phone, UserRound, Video } from 'lucide-react';
+import { AvatarWithStatus } from '../avatar-with-status';
+import type { DirectMessage } from '../dm-list';
+
+type ConversationHeaderProps = {
+  chatMode: 'guild' | 'dm';
+  activeDmDetails: DirectMessage | null;
+  activeConversationName: string;
+  isSidePanelOpen: boolean;
+  isSidePanelToggleDisabled: boolean;
+  sidePanelAriaLabel: string;
+  onShowMobileSidebar: () => void;
+  onToggleSidePanel: () => void;
+  onStartAudioCall: () => void;
+  onStartVideoCall: () => void;
+};
+
+export function ConversationHeader({
+  chatMode,
+  activeDmDetails,
+  activeConversationName,
+  isSidePanelOpen,
+  isSidePanelToggleDisabled,
+  sidePanelAriaLabel,
+  onShowMobileSidebar,
+  onToggleSidePanel,
+  onStartAudioCall,
+  onStartVideoCall
+}: ConversationHeaderProps) {
+  return (
+    <div className="flex h-[4.9rem] shrink-0 items-center justify-between border-b border-white/8 px-5 sm:px-7">
+      <div className="flex items-center gap-3">
+        <button
+          type="button"
+          onClick={onShowMobileSidebar}
+          className="flex h-11 w-11 items-center justify-center rounded-xl border border-frame text-[#7e7e82] md:hidden"
+          aria-label={chatMode === 'dm' ? 'Show DMs' : 'Show channels'}
+        >
+          <ArrowLeft className="h-5 w-5" strokeWidth={1.9} />
+        </button>
+        {chatMode === 'dm' && activeDmDetails ? (
+          <div className="flex min-w-0 items-center gap-3">
+            <AvatarWithStatus
+              name={activeDmDetails.name}
+              accent={activeDmDetails.accent}
+              status={activeDmDetails.status}
+            />
+            <span className="min-w-0">
+              <span className="block truncate text-[1.2rem] font-bold tracking-[-0.03em] text-white">
+                {activeDmDetails.name}
+              </span>
+              <span className="font-category block text-[0.72rem] uppercase tracking-[0.14em] text-white/35">
+                {activeDmDetails.status}
+              </span>
+            </span>
+          </div>
+        ) : chatMode === 'dm' ? (
+          <h2 className="text-[1.25rem] font-bold tracking-[-0.03em] text-white">Direct Messages</h2>
+        ) : (
+          <h2 className="mono-detail text-[1.85rem] font-bold tracking-[-0.05em] text-white">
+            # {activeConversationName}
+          </h2>
+        )}
+      </div>
+      <div className="flex items-center gap-4 text-[#8c8c90]">
+        {chatMode === 'dm' && activeDmDetails ? (
+          <>
+            <button
+              type="button"
+              onClick={onStartAudioCall}
+              className="transition hover:text-white"
+              aria-label="Start voice call"
+            >
+              <Phone className="h-5 w-5" strokeWidth={1.8} />
+            </button>
+            <button
+              type="button"
+              onClick={onStartVideoCall}
+              className="transition hover:text-white"
+              aria-label="Start video call"
+            >
+              <Video className="h-5 w-5" strokeWidth={1.8} />
+            </button>
+          </>
+        ) : null}
+        <button
+          type="button"
+          onClick={onToggleSidePanel}
+          className={`transition hover:text-white ${
+            isSidePanelOpen ? 'text-aqua' : 'text-[#8c8c90]'
+          } ${isSidePanelToggleDisabled ? 'cursor-not-allowed opacity-45' : ''}`}
+          disabled={isSidePanelToggleDisabled}
+          aria-label={sidePanelAriaLabel}
+          aria-pressed={isSidePanelOpen}
+        >
+          <UserRound className="h-5 w-5" strokeWidth={1.8} />
+        </button>
+        <CircleEllipsis className="h-5 w-5" strokeWidth={1.8} />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/chat/message-composer.tsx
+++ b/frontend/src/components/chat/message-composer.tsx
@@ -1,0 +1,177 @@
+import type { RefObject } from 'react';
+import { ArrowRight, CornerUpLeft, MessageCircle, Paperclip, Smile, X } from 'lucide-react';
+import type { ChatMessageData } from '../chat-message';
+import type { PendingAttachment } from '../../shared/hooks/use-conversation-history';
+
+const emojiOptions = ['😀', '😅', '🤣', '😂', '🙂', '🙃', '🤔', '😎', '🥳', '😍', '😘', '😉'];
+
+type MessageComposerProps = {
+  fileInputRef: RefObject<HTMLInputElement | null>;
+  composerRef: RefObject<HTMLTextAreaElement | null>;
+  chatMode: 'guild' | 'dm';
+  activeConversationName: string;
+  activeDraft: string;
+  isComposerDisabled: boolean;
+  isSendDisabled: boolean;
+  isActiveDmArchived: boolean;
+  replyTarget: ChatMessageData | null;
+  pendingAttachments: PendingAttachment[];
+  isEmojiOpen: boolean;
+  onFilesSelected: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  onRemovePendingAttachment: (attachmentId: string) => void;
+  onCancelReply: () => void;
+  onToggleEmojiPicker: () => void;
+  onAppendEmoji: (emoji: string) => void;
+  onDraftChange: (value: string) => void;
+  onSubmitMessage: () => void;
+  onShowMobileSidebar: () => void;
+};
+
+export function MessageComposer({
+  fileInputRef,
+  composerRef,
+  chatMode,
+  activeConversationName,
+  activeDraft,
+  isComposerDisabled,
+  isSendDisabled,
+  isActiveDmArchived,
+  replyTarget,
+  pendingAttachments,
+  isEmojiOpen,
+  onFilesSelected,
+  onRemovePendingAttachment,
+  onCancelReply,
+  onToggleEmojiPicker,
+  onAppendEmoji,
+  onDraftChange,
+  onSubmitMessage,
+  onShowMobileSidebar
+}: MessageComposerProps) {
+  return (
+    <div className="shrink-0 border-t border-white/8 px-4 py-4 sm:px-5">
+      <input ref={fileInputRef} type="file" multiple onChange={onFilesSelected} className="hidden" />
+      {replyTarget ? (
+        <div className="mb-3 flex items-center justify-between gap-3 rounded-md border border-white/10 bg-panel px-3 py-2 text-xs text-white/60">
+          <span className="flex min-w-0 items-center gap-1.5">
+            <CornerUpLeft className="h-3.5 w-3.5 shrink-0" strokeWidth={2} />
+            <span className="truncate">
+              Replying to <span className="text-white/85">{replyTarget.author}</span>:{' '}
+              {replyTarget.content[0] ?? ''}
+            </span>
+          </span>
+          <button
+            type="button"
+            onClick={onCancelReply}
+            aria-label="Cancel reply"
+            className="shrink-0 text-white/40 hover:text-white"
+          >
+            <X className="h-3.5 w-3.5" strokeWidth={2} />
+          </button>
+        </div>
+      ) : null}
+      {pendingAttachments.length > 0 ? (
+        <div className="mb-3 flex flex-wrap gap-2">
+          {pendingAttachments.map((attachment) => (
+            <span
+              key={attachment.id}
+              className={`flex h-8 items-center gap-2 rounded-full border px-3 text-xs ${
+                attachment.status === 'error'
+                  ? 'border-pink/40 text-pink'
+                  : 'border-white/10 text-white/70'
+              }`}
+            >
+              <span className="max-w-[10rem] truncate">{attachment.filename}</span>
+              {attachment.status === 'uploading' ? <span>Uploading…</span> : null}
+              {attachment.status === 'error' ? <span>Failed</span> : null}
+              <button
+                type="button"
+                onClick={() => onRemovePendingAttachment(attachment.id)}
+                aria-label={`Remove ${attachment.filename}`}
+                className="text-white/40 hover:text-white"
+              >
+                <X className="h-3 w-3" strokeWidth={2} />
+              </button>
+            </span>
+          ))}
+        </div>
+      ) : null}
+      {isEmojiOpen ? (
+        <div className="mb-3 rounded-xl border border-white/10 bg-panel p-3">
+          <div className="grid grid-cols-6 gap-2">
+            {emojiOptions.map((emoji) => (
+              <button
+                key={emoji}
+                type="button"
+                onClick={() => onAppendEmoji(emoji)}
+                className="rounded-lg bg-frame px-2 py-2 text-2xl transition hover:bg-white/10"
+              >
+                {emoji}
+              </button>
+            ))}
+          </div>
+        </div>
+      ) : null}
+      <div className="flex h-14 items-center rounded-md bg-panel px-4 text-muted">
+        <textarea
+          ref={composerRef}
+          value={activeDraft}
+          onChange={(event) => onDraftChange(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.key === 'Enter' && !event.shiftKey) {
+              event.preventDefault();
+              onSubmitMessage();
+            }
+          }}
+          disabled={isComposerDisabled}
+          placeholder={
+            isActiveDmArchived
+              ? 'This conversation is archived -- send a message to unarchive it.'
+              : `Message ${chatMode === 'dm' ? '@' : '#'}${activeConversationName}`
+          }
+          rows={1}
+          className="h-full min-h-0 w-full resize-none overflow-y-auto bg-transparent py-4 text-lg leading-6 text-white outline-none placeholder:text-muted disabled:cursor-not-allowed disabled:text-white/30"
+        />
+        <div className="ml-auto flex items-center gap-4">
+          <button
+            type="button"
+            onClick={() => fileInputRef.current?.click()}
+            disabled={isComposerDisabled}
+            className="text-[#7e7e82] transition hover:text-white disabled:cursor-not-allowed disabled:text-[#535353]"
+            aria-label="Attach files"
+          >
+            <Paperclip className="h-5 w-5" strokeWidth={1.8} />
+          </button>
+          <button
+            type="button"
+            onClick={onToggleEmojiPicker}
+            className="text-[#7e7e82] transition hover:text-white"
+            aria-label="Toggle emoji picker"
+          >
+            <Smile className="h-5 w-5" strokeWidth={1.8} />
+          </button>
+          <button
+            type="button"
+            onClick={onSubmitMessage}
+            disabled={isSendDisabled}
+            className="text-aqua transition hover:text-white disabled:cursor-not-allowed disabled:text-[#535353]"
+            aria-label="Send message"
+          >
+            <ArrowRight className="h-5 w-5 rounded-full border border-aqua p-0.5" strokeWidth={2} />
+          </button>
+        </div>
+      </div>
+      <div className="mt-3 flex justify-between text-xs text-white/35">
+        <span>{chatMode === 'dm' ? 'Conversation directe locale' : 'Canal interactif local'}</span>
+        <button
+          type="button"
+          onClick={onShowMobileSidebar}
+          className="inline-flex items-center gap-2 md:hidden"
+        >
+          <MessageCircle className="h-4 w-4" strokeWidth={1.8} />
+          {chatMode === 'dm' ? 'DMs' : 'Channels'}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/chat/message-list.tsx
+++ b/frontend/src/components/chat/message-list.tsx
@@ -1,0 +1,163 @@
+import { useMemo, type RefObject } from 'react';
+import { MessageCircle } from 'lucide-react';
+import { ChatMessage, type ChatMessageData, type ReplyPreview } from '../chat-message';
+
+const MESSAGE_GROUP_THRESHOLD_MINUTES = 5;
+
+function getTimestampMinutes(timestamp: string) {
+  const [hours, minutes] = timestamp.split(':').map(Number);
+
+  if (!Number.isFinite(hours) || !Number.isFinite(minutes)) {
+    return null;
+  }
+
+  return hours * 60 + minutes;
+}
+
+function getMinutesBetween(previousTimestamp: string, currentTimestamp: string) {
+  const previousMinutes = getTimestampMinutes(previousTimestamp);
+  const currentMinutes = getTimestampMinutes(currentTimestamp);
+
+  if (previousMinutes === null || currentMinutes === null) {
+    return Number.POSITIVE_INFINITY;
+  }
+
+  return currentMinutes >= previousMinutes
+    ? currentMinutes - previousMinutes
+    : currentMinutes + 24 * 60 - previousMinutes;
+}
+
+type MessageListProps = {
+  viewportRef: RefObject<HTMLDivElement | null>;
+  onScroll: () => void;
+  isDmEmptyState: boolean;
+  activeMessages: ChatMessageData[];
+  currentUserId: string | null;
+  editingMessageId: string | null;
+  editingDraft: string;
+  highlightedMessageId: string | null;
+  canReact: boolean;
+  isNearBottom: boolean;
+  setMessageRef: (messageId: string, element: HTMLElement | null) => void;
+  onEditDraftChange: (value: string) => void;
+  onStartEdit: (message: ChatMessageData) => void;
+  onSaveEdit: (messageId: string) => Promise<void>;
+  onCancelEdit: () => void;
+  onDelete: (messageId: string) => Promise<void>;
+  onToggleReaction: (messageId: string, emoji: string) => Promise<void>;
+  onReply: (message: ChatMessageData) => void;
+  onJumpToReply: (messageId: string) => void;
+  onRetryMessage: (messageId: string) => Promise<void>;
+  onOpenAuthorProfile: (message: ChatMessageData) => void;
+  onScrollToBottom: () => void;
+};
+
+export function MessageList({
+  viewportRef,
+  onScroll,
+  isDmEmptyState,
+  activeMessages,
+  currentUserId,
+  editingMessageId,
+  editingDraft,
+  highlightedMessageId,
+  canReact,
+  isNearBottom,
+  setMessageRef,
+  onEditDraftChange,
+  onStartEdit,
+  onSaveEdit,
+  onCancelEdit,
+  onDelete,
+  onToggleReaction,
+  onReply,
+  onJumpToReply,
+  onRetryMessage,
+  onOpenAuthorProfile,
+  onScrollToBottom
+}: MessageListProps) {
+  const activeMessageItems = useMemo(() => {
+    const messagesById = new Map(activeMessages.map((message) => [message.id, message]));
+
+    return activeMessages.map((message, index) => {
+      const previousMessage = activeMessages[index - 1];
+      const isGrouped =
+        previousMessage?.author === message.author &&
+        getMinutesBetween(previousMessage.timestamp, message.timestamp) <=
+          MESSAGE_GROUP_THRESHOLD_MINUTES;
+
+      let replyPreview: ReplyPreview | null = null;
+      if (message.replyToId) {
+        const target = messagesById.get(message.replyToId);
+        replyPreview = target
+          ? { author: target.author, snippet: target.content[0] ?? '' }
+          : { author: '', snippet: 'an earlier message' };
+      }
+
+      return { message, isGrouped, replyPreview };
+    });
+  }, [activeMessages]);
+
+  return (
+    <div
+      ref={viewportRef}
+      onScroll={onScroll}
+      className="min-h-0 flex-1 overflow-auto px-5 py-7 sm:px-7"
+    >
+      {isDmEmptyState ? (
+        <div className="flex min-h-full flex-col items-center justify-center px-6 text-center">
+          <div className="flex h-16 w-16 items-center justify-center rounded-full bg-panel text-[#8b8b8f]">
+            <MessageCircle className="h-7 w-7" strokeWidth={1.8} />
+          </div>
+          <h3 className="mt-5 text-[1.25rem] font-bold tracking-[-0.03em] text-white">
+            No DM selected
+          </h3>
+          <p className="mt-2 max-w-[22rem] text-sm leading-6 text-white/40">
+            Select a conversation from the DM list to start reading or sending messages.
+          </p>
+        </div>
+      ) : (
+        <div>
+          {activeMessageItems.map(({ message, isGrouped, replyPreview }) => {
+            const isOwnMessage = message.authorId != null && message.authorId === currentUserId;
+            const isEditing = editingMessageId === message.id;
+
+            return (
+              <ChatMessage
+                key={message.id}
+                message={message}
+                replyPreview={replyPreview}
+                isGrouped={isGrouped}
+                isOwnMessage={isOwnMessage}
+                isEditing={isEditing}
+                isHighlighted={highlightedMessageId === message.id}
+                editingDraft={editingDraft}
+                canReact={canReact}
+                onEditDraftChange={onEditDraftChange}
+                onStartEdit={onStartEdit}
+                onSaveEdit={onSaveEdit}
+                onCancelEdit={onCancelEdit}
+                onDelete={onDelete}
+                onToggleReaction={onToggleReaction}
+                onReply={onReply}
+                onJumpToReply={onJumpToReply}
+                onRetryMessage={onRetryMessage}
+                onOpenAuthorProfile={onOpenAuthorProfile}
+                setMessageRef={setMessageRef}
+              />
+            );
+          })}
+        </div>
+      )}
+      {!isNearBottom ? (
+        <button
+          type="button"
+          onClick={onScrollToBottom}
+          className="mono-detail sticky bottom-0 z-10 ml-auto flex h-10 items-center rounded-full border border-aqua/40 bg-panel px-4 text-sm font-bold text-aqua shadow-lg shadow-black/30 transition hover:border-aqua hover:text-white"
+        >
+          Jump to bottom
+        </button>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/shared/hooks/use-scroll-preservation.ts
+++ b/frontend/src/shared/hooks/use-scroll-preservation.ts
@@ -103,6 +103,8 @@ export function useScrollPreservation(
 
   useLayoutEffect(() => {
     if (!activeConversationId) {
+      // nothing to scroll to (e.g. a guild with no channels yet), treat as "near bottom"
+      setIsNearBottom(true);
       return;
     }
 


### PR DESCRIPTION
`chat-workspace.tsx` was still 837 lines after the duplication pass - the remaining size was architectural, not redundant: one file mixing full orchestration with a very large JSX return block. Splits the JSX into presentational sub-components (props-in, no data-fetching of their own), matching the existing `GuildSidebar`/`DmList`/`ChannelList`/`ChatMessage` pattern.

> Blocked by PR #322 
Was based on `refactor/front/chat-workspace-cleanup`, need to rebase on main after #322 merge.

## What changed
New `components/chat/` subdirectory (mirrors the existing `components/guild/` convention for a parent's own sub-pieces):
- **`ConversationHeader`**: the header block (mobile back button, DM avatar+name or channel title, member-list/profile toggle button). Pure props-in.
- **`MessageList`**: the scrollable message viewport (empty state, message-by-message render, jump-to-bottom button). The message-grouping computation (`activeMessageItems`, `MESSAGE_GROUP_THRESHOLD_MINUTES`/`getTimestampMinutes`/`getMinutesBetween`) and the inline `isOwnMessage`/`isEditing` checks moved with it.
- **`MessageComposer`**: the composer footer (file input, reply banner, pending-attachments strip, emoji picker, textarea, attach/emoji/send buttons, footer text). The `emojiOptions` constant moved with it.

`chat-workspace.tsx`: 837 -> 587 lines. What stays: all hook composition, all transient UI state/refs, all derived values and handlers, and the top-level JSX composing the sidebar/list/header/message-list/composer/modals.

**Explicitly not done:**
A `useMessageComposer` hook for the draft/reply/edit state - it's already tightly coupled to `scroll`/`conversationHistory`/`dmWorkspace`, and wrapping it in a hook would relocate complexity, not reduce it; the JSX-density problem is fixed by the component split alone.

## Bugfix included
Now treated as "near bottom" when there's nothing to scroll to, same as the existing no-viewport fallback.
> `isNearBottom` only got (re)computed inside a `useLayoutEffect` that early-returned when there was no active conversation - so with zero channels in a guild, it stayed stuck at its initial `false` forever, showing "Jump to bottom" with no conversation and no messages to jump to.