### PR TITLE
Feat(frontend): guild channels management

### DIFF
--- a/docs/frontend-backend-backlog.md
+++ b/docs/frontend-backend-backlog.md
@@ -95,10 +95,10 @@ Goal: connect the guild sidebar and guild page to live guild data.
   - [x] add edit guild settings with `PATCH /guilds/{id}`
   - [x] add delete guild with owner-only confirmation
   - [x] add roles and categories management UI on top of existing endpoints
-- [ ] Channel management (never scoped before, no UI or API wrapper exists)
-  - [ ] wire channel creation with `POST /guilds/{id}/channels`
-  - [ ] wire channel rename/topic/nsfw/slowmode edits with `PATCH /guilds/{id}/channels/{channel_id}`
-  - [ ] wire channel delete with `DELETE /guilds/{id}/channels/{channel_id}`
+- [x] Channel management
+  - [x] wire channel creation with `POST /guilds/{id}/channels`
+  - [x] wire channel rename/topic/nsfw/slowmode edits with `PATCH /guilds/{id}/channels/{channel_id}`
+  - [x] wire channel delete with `DELETE /guilds/{id}/channels/{channel_id}`
 
 ## Epic 4 - Chat history, composer, and realtime transport
 

--- a/frontend/app/guilds/page.tsx
+++ b/frontend/app/guilds/page.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { GuildIcon } from '../../src/components/guild/guild-icon';
 import { GuildBansPanel } from '../../src/components/guild/guild-bans-panel';
 import { GuildCategoriesPanel } from '../../src/components/guild/guild-categories-panel';
+import { GuildChannelsPanel } from '../../src/components/guild/guild-channels-panel';
 import { GuildCreateForm, GuildJoinForm } from '../../src/components/guild/guild-forms';
 import { GuildInvitesPanel } from '../../src/components/guild/guild-invites-panel';
 import { GuildMembersPanel } from '../../src/components/guild/guild-members-panel';
@@ -20,6 +21,7 @@ const TABS = [
   { id: 'invites', label: 'Invites' },
   { id: 'roles', label: 'Roles' },
   { id: 'categories', label: 'Categories' },
+  { id: 'channels', label: 'Channels' },
   { id: 'settings', label: 'Settings' }
 ] as const;
 
@@ -105,6 +107,7 @@ export default function GuildsPage() {
               {activeTab === 'categories' ? (
                 <GuildCategoriesPanel guildId={selectedGuildId} />
               ) : null}
+              {activeTab === 'channels' ? <GuildChannelsPanel guildId={selectedGuildId} /> : null}
               {activeTab === 'settings' ? <GuildSettingsPanel guildId={selectedGuildId} /> : null}
             </>
           ) : isLoading ? (

--- a/frontend/src/components/guild/guild-channels-panel.tsx
+++ b/frontend/src/components/guild/guild-channels-panel.tsx
@@ -1,0 +1,361 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import type { FormEvent } from 'react';
+import { Check, Hash, Pencil, Trash2, X } from 'lucide-react';
+import {
+  createGuildChannel,
+  deleteGuildChannel,
+  listGuildCategories,
+  listGuildChannels,
+  updateGuildChannel,
+  type GuildCategoryDto,
+  type GuildChannelDto
+} from '../../shared/api/guild';
+import { FormError } from './guild-forms';
+
+const inputClasses =
+  'h-10 w-full rounded-md border border-transparent bg-input-bg px-3 text-sm text-white outline-none transition placeholder:text-input-placeholder focus:border-aqua/35';
+
+const selectClasses =
+  'h-10 w-full rounded-md border border-transparent bg-input-bg px-3 text-sm text-white outline-none transition focus:border-aqua/35';
+
+const iconButtonClasses =
+  'flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-[#8b8b8f] transition hover:bg-frame hover:text-white';
+
+const UNCATEGORISED = '';
+
+type EditDraft = {
+  name: string;
+  categoryId: string;
+  topic: string;
+  isNsfw: boolean;
+  slowmodeSeconds: string;
+  position: string;
+};
+
+type GuildChannelsPanelProps = {
+  guildId: string;
+};
+
+function categoryName(categoryId: string | null | undefined, categories: GuildCategoryDto[]) {
+  if (!categoryId) {
+    return 'Uncategorised';
+  }
+  return categories.find((category) => category.id === categoryId)?.name ?? 'Uncategorised';
+}
+
+export function GuildChannelsPanel({ guildId }: GuildChannelsPanelProps) {
+  const [channels, setChannels] = useState<GuildChannelDto[]>([]);
+  const [categories, setCategories] = useState<GuildCategoryDto[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [newName, setNewName] = useState('');
+  const [newType, setNewType] = useState<'text' | 'announcement'>('text');
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editDraft, setEditDraft] = useState<EditDraft | null>(null);
+  const [isBusy, setIsBusy] = useState(false);
+
+  const load = useCallback(async () => {
+    setIsLoading(true);
+    setError('');
+
+    try {
+      const [channelRows, categoryRows] = await Promise.all([
+        listGuildChannels(guildId),
+        listGuildCategories(guildId)
+      ]);
+      setChannels([...channelRows].sort((a, b) => a.position - b.position));
+      setCategories(categoryRows);
+    } catch (loadError) {
+      setError(loadError instanceof Error ? loadError.message : 'Failed to load channels.');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [guildId]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  async function handleCreate(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setError('');
+
+    const name = newName.trim();
+    if (!name) {
+      setError('Channel name is required.');
+      return;
+    }
+
+    try {
+      setIsBusy(true);
+      await createGuildChannel(guildId, { name, type: newType });
+      setNewName('');
+      setNewType('text');
+      await load();
+    } catch (createError) {
+      setError(createError instanceof Error ? createError.message : 'Failed to create channel.');
+    } finally {
+      setIsBusy(false);
+    }
+  }
+
+  function startEdit(channel: GuildChannelDto) {
+    setEditingId(channel.id);
+    setEditDraft({
+      name: channel.name,
+      categoryId: channel.category_id ?? UNCATEGORISED,
+      topic: channel.topic ?? '',
+      isNsfw: channel.is_nsfw ?? false,
+      slowmodeSeconds: String(channel.slowmode_seconds ?? 0),
+      position: String(channel.position)
+    });
+  }
+
+  function cancelEdit() {
+    setEditingId(null);
+    setEditDraft(null);
+  }
+
+  async function handleSaveEdit(channelId: string) {
+    if (!editDraft) {
+      return;
+    }
+
+    setError('');
+
+    const name = editDraft.name.trim();
+    if (!name) {
+      setError('Channel name is required.');
+      return;
+    }
+
+    const slowmodeSeconds = Number(editDraft.slowmodeSeconds);
+    if (!Number.isInteger(slowmodeSeconds) || slowmodeSeconds < 0) {
+      setError('Slowmode must be a non-negative whole number of seconds.');
+      return;
+    }
+
+    const position = Number(editDraft.position);
+    if (!Number.isInteger(position) || position < 0) {
+      setError('Position must be a non-negative whole number.');
+      return;
+    }
+
+    try {
+      setIsBusy(true);
+      await updateGuildChannel(guildId, channelId, {
+        name,
+        category_id: editDraft.categoryId || null,
+        topic: editDraft.topic.trim() || null,
+        is_nsfw: editDraft.isNsfw,
+        slowmode_seconds: slowmodeSeconds,
+        position
+      });
+      cancelEdit();
+      await load();
+    } catch (updateError) {
+      setError(updateError instanceof Error ? updateError.message : 'Failed to update channel.');
+    } finally {
+      setIsBusy(false);
+    }
+  }
+
+  async function handleDelete(channel: GuildChannelDto) {
+    if (!window.confirm(`Delete channel "${channel.name}"? This cannot be undone.`)) {
+      return;
+    }
+
+    setError('');
+
+    try {
+      setIsBusy(true);
+      await deleteGuildChannel(guildId, channel.id);
+      await load();
+    } catch (deleteError) {
+      setError(deleteError instanceof Error ? deleteError.message : 'Failed to delete channel.');
+    } finally {
+      setIsBusy(false);
+    }
+  }
+
+  return (
+    <div className="grid gap-5">
+      <form
+        onSubmit={handleCreate}
+        className="grid gap-3 rounded-md border border-white/8 bg-panel p-4"
+      >
+        <h3 className="flex items-center gap-2 text-base font-bold text-white">
+          <Hash className="h-4 w-4 text-aqua" strokeWidth={1.9} />
+          Create a channel
+        </h3>
+        <div className="flex gap-3">
+          <input
+            value={newName}
+            onChange={(event) => setNewName(event.target.value)}
+            placeholder="channel name"
+            maxLength={100}
+            className={inputClasses}
+          />
+          <select
+            value={newType}
+            onChange={(event) => setNewType(event.target.value as 'text' | 'announcement')}
+            className={`${selectClasses} max-w-[10rem] shrink-0`}
+          >
+            <option value="text">Text</option>
+            <option value="announcement">Announcement</option>
+          </select>
+          <button
+            type="submit"
+            disabled={isBusy}
+            className="h-10 shrink-0 rounded-md bg-aqua px-5 text-sm font-bold text-primary-bg transition hover:bg-white disabled:cursor-not-allowed disabled:bg-frame disabled:text-white/25"
+          >
+            {isBusy ? 'Working...' : 'Create'}
+          </button>
+        </div>
+      </form>
+
+      {error ? <FormError message={error} /> : null}
+
+      {isLoading ? (
+        <div className="h-24 animate-pulse rounded-md bg-panel" />
+      ) : channels.length === 0 ? (
+        <p className="text-sm text-white/35">No channels yet.</p>
+      ) : (
+        <ul className="grid gap-2">
+          {channels.map((channel) => (
+            <li
+              key={channel.id}
+              className="grid gap-3 rounded-md border border-white/8 bg-panel px-3 py-2.5"
+            >
+              {editingId === channel.id && editDraft ? (
+                <div className="grid gap-3">
+                  <div className="flex flex-wrap gap-3">
+                    <input
+                      value={editDraft.name}
+                      onChange={(event) =>
+                        setEditDraft({ ...editDraft, name: event.target.value })
+                      }
+                      maxLength={100}
+                      placeholder="channel name"
+                      className={`${inputClasses} max-w-[16rem]`}
+                    />
+                    <select
+                      value={editDraft.categoryId}
+                      onChange={(event) =>
+                        setEditDraft({ ...editDraft, categoryId: event.target.value })
+                      }
+                      className={`${selectClasses} max-w-[12rem]`}
+                    >
+                      <option value={UNCATEGORISED}>Uncategorised</option>
+                      {categories.map((category) => (
+                        <option key={category.id} value={category.id}>
+                          {category.name}
+                        </option>
+                      ))}
+                    </select>
+                    <input
+                      value={editDraft.position}
+                      onChange={(event) =>
+                        setEditDraft({ ...editDraft, position: event.target.value })
+                      }
+                      placeholder="position"
+                      inputMode="numeric"
+                      className={`${inputClasses} max-w-[6rem]`}
+                    />
+                  </div>
+                  <div className="flex flex-wrap items-center gap-3">
+                    <input
+                      value={editDraft.topic}
+                      onChange={(event) =>
+                        setEditDraft({ ...editDraft, topic: event.target.value })
+                      }
+                      placeholder="topic"
+                      maxLength={200}
+                      className={`${inputClasses} max-w-[20rem]`}
+                    />
+                    <input
+                      value={editDraft.slowmodeSeconds}
+                      onChange={(event) =>
+                        setEditDraft({ ...editDraft, slowmodeSeconds: event.target.value })
+                      }
+                      placeholder="slowmode (s)"
+                      inputMode="numeric"
+                      className={`${inputClasses} max-w-[8rem]`}
+                    />
+                    <label className="flex items-center gap-2 text-sm text-white/60">
+                      <input
+                        type="checkbox"
+                        checked={editDraft.isNsfw}
+                        onChange={(event) =>
+                          setEditDraft({ ...editDraft, isNsfw: event.target.checked })
+                        }
+                        className="h-4 w-4 accent-[#78dce8]"
+                      />
+                      NSFW
+                    </label>
+                    <div className="ml-auto flex gap-1">
+                      <button
+                        type="button"
+                        onClick={() => void handleSaveEdit(channel.id)}
+                        disabled={isBusy}
+                        className={iconButtonClasses}
+                        aria-label="Save channel"
+                      >
+                        <Check className="h-4 w-4 text-lime" strokeWidth={2} />
+                      </button>
+                      <button
+                        type="button"
+                        onClick={cancelEdit}
+                        className={iconButtonClasses}
+                        aria-label="Cancel channel edit"
+                      >
+                        <X className="h-4 w-4" strokeWidth={2} />
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              ) : (
+                <div className="flex items-center gap-3">
+                  <div className="min-w-0 flex-1">
+                    <p className="flex items-center gap-1.5 truncate text-[0.95rem] font-bold text-white">
+                      <Hash className="h-3.5 w-3.5 shrink-0 text-white/35" strokeWidth={1.9} />
+                      {channel.name}
+                      {channel.type === 'announcement' ? (
+                        <span className="font-category rounded-full bg-aqua/15 px-2 py-0.5 text-[0.62rem] uppercase tracking-[0.1em] text-aqua">
+                          Announcement
+                        </span>
+                      ) : null}
+                    </p>
+                    <p className="text-xs text-white/35">
+                      {categoryName(channel.category_id, categories)} · position{' '}
+                      {channel.position}
+                    </p>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => startEdit(channel)}
+                    className={iconButtonClasses}
+                    aria-label={`Edit channel ${channel.name}`}
+                  >
+                    <Pencil className="h-4 w-4" strokeWidth={1.9} />
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => void handleDelete(channel)}
+                    disabled={isBusy}
+                    className={`${iconButtonClasses} hover:text-pink`}
+                    aria-label={`Delete channel ${channel.name}`}
+                  >
+                    <Trash2 className="h-4 w-4" strokeWidth={1.9} />
+                  </button>
+                </div>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/guild/guild-invites-panel.tsx
+++ b/frontend/src/components/guild/guild-invites-panel.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useState } from 'react';
 import type { FormEvent } from 'react';
-import { Link2, Search } from 'lucide-react';
+import { Check, Copy, Link2, Search } from 'lucide-react';
 import {
   createGuildInvite,
   listGuildInvites,
@@ -36,6 +36,17 @@ export function GuildInvitesPanel({ guildId }: GuildInvitesPanelProps) {
   const [preview, setPreview] = useState<InvitePreviewDto | null>(null);
   const [previewError, setPreviewError] = useState('');
   const [isPreviewing, setIsPreviewing] = useState(false);
+  const [copiedCode, setCopiedCode] = useState('');
+
+  async function handleCopyCode(code: string) {
+    try {
+      await navigator.clipboard.writeText(code);
+      setCopiedCode(code);
+      window.setTimeout(() => setCopiedCode((current) => (current === code ? '' : current)), 1500);
+    } catch {
+      // best effort: clipboard access can be denied, nothing to recover from
+    }
+  }
 
   const load = useCallback(async () => {
     setIsLoading(true);
@@ -169,8 +180,20 @@ export function GuildInvitesPanel({ guildId }: GuildInvitesPanelProps) {
             {isCreating ? 'Creating...' : 'Create invite'}
           </button>
           {createdCode ? (
-            <span className="mono-detail rounded-md border border-lime/30 bg-lime/10 px-3 py-2 text-sm text-lime">
+            <span className="mono-detail flex items-center gap-2 rounded-md border border-lime/30 bg-lime/10 px-3 py-2 text-sm text-lime">
               Invite created: {createdCode}
+              <button
+                type="button"
+                onClick={() => void handleCopyCode(createdCode)}
+                className="text-lime/70 transition hover:text-lime"
+                aria-label="Copy invite code"
+              >
+                {copiedCode === createdCode ? (
+                  <Check className="h-3.5 w-3.5" strokeWidth={2} />
+                ) : (
+                  <Copy className="h-3.5 w-3.5" strokeWidth={1.9} />
+                )}
+              </button>
             </span>
           ) : null}
         </div>
@@ -190,8 +213,20 @@ export function GuildInvitesPanel({ guildId }: GuildInvitesPanelProps) {
               className="flex items-center gap-3 rounded-md border border-white/8 bg-panel px-3 py-2.5"
             >
               <div className="min-w-0 flex-1">
-                <p className="mono-detail truncate text-[0.95rem] font-bold text-white">
+                <p className="mono-detail flex items-center gap-1.5 truncate text-[0.95rem] font-bold text-white">
                   {invite.code}
+                  <button
+                    type="button"
+                    onClick={() => void handleCopyCode(invite.code)}
+                    className="shrink-0 text-white/35 transition hover:text-white"
+                    aria-label={`Copy invite code ${invite.code}`}
+                  >
+                    {copiedCode === invite.code ? (
+                      <Check className="h-3.5 w-3.5 text-lime" strokeWidth={2} />
+                    ) : (
+                      <Copy className="h-3.5 w-3.5" strokeWidth={1.9} />
+                    )}
+                  </button>
                 </p>
                 <p className="truncate text-xs text-white/35">
                   {invite.uses}/{invite.max_uses ?? '∞'} uses · by{' '}

--- a/frontend/src/shared/api/guild.ts
+++ b/frontend/src/shared/api/guild.ts
@@ -52,6 +52,18 @@ export type GuildChannelDto = {
   slowmode_seconds?: number;
 };
 
+export type CreateChannelPayload = {
+  name: string;
+  type: 'text' | 'announcement';
+  category_id?: string | null;
+  position?: number;
+  topic?: string | null;
+  is_nsfw?: boolean;
+  slowmode_seconds?: number;
+};
+
+export type UpdateChannelPayload = Partial<CreateChannelPayload>;
+
 export type GuildCategoryDto = {
   id: string;
   guild_id: string;
@@ -208,6 +220,30 @@ export function unbanGuildMember(guildId: string, userId: string) {
 
 export function listGuildChannels(guildId: string) {
   return apiFetch<GuildChannelDto[]>('guild', `/guilds/${guildId}/channels`);
+}
+
+export function createGuildChannel(guildId: string, payload: CreateChannelPayload) {
+  return apiFetch<GuildChannelDto>('guild', `/guilds/${guildId}/channels`, {
+    method: 'POST',
+    body: payload
+  });
+}
+
+export function updateGuildChannel(
+  guildId: string,
+  channelId: string,
+  payload: UpdateChannelPayload
+) {
+  return apiFetch<GuildChannelDto>('guild', `/guilds/${guildId}/channels/${channelId}`, {
+    method: 'PATCH',
+    body: payload
+  });
+}
+
+export function deleteGuildChannel(guildId: string, channelId: string) {
+  return apiFetch<void>('guild', `/guilds/${guildId}/channels/${channelId}`, {
+    method: 'DELETE'
+  });
 }
 
 export function listGuildCategories(guildId: string) {


### PR DESCRIPTION
Wires channel create/edit/delete into the `/guilds` admin UI, closing the gap flagged in the Epic 3 backlog - the backend has supported this since #55, only the frontend never caught up. Also adds a copy-to-clipboard button for invite codes in the Invites tab, found while working the same area.

> Blocked by PR #323 
This branch is on top of it (`refactor/front/split-chat-workspace`) - the diff below will shrink to just this PR's own commits once that lands.

## What changed
- **API client** (`shared/api/guild.ts`): `createGuildChannel`/`updateGuildChannel`/`deleteGuildChannel` + `CreateChannelPayload`/`UpdateChannelPayload`, mirroring the existing category CRUD functions.
- **`GuildChannelsPanel`** (new `components/guild/guild-channels-panel.tsx`): structural copy of `guild-categories-panel.tsx` - create (name + type: text/announcement), inline edit (name, category assignment, topic, NSFW, slowmode, position), delete with confirm.
- **`/guilds` page**: new "Channels" tab, same two-line wiring as every other resource tab.
- **Invite codes**: copy-to-clipboard button (`navigator.clipboard.writeText`, brief checkmark feedback) next to the just-created invite banner and next to each code in the invites list.
- **Backlog**: flipped the 3 "Channel management" checkboxes in `docs/frontend-backend-backlog.md`.
