### PR TITLE
feat(frontend): landing page + Terms of Service & Privacy Policy pages

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -46,13 +46,35 @@ button {
 
 .app-shell {
   min-height: 100vh;
-  background:
-    radial-gradient(circle at 50% 52%, rgba(169, 220, 118, 0.14), transparent 22%),
+  background: radial-gradient(circle at 50% 52%, rgba(169, 220, 118, 0.14), transparent 22%),
     radial-gradient(circle at 42% 60%, rgba(120, 220, 232, 0.12), transparent 18%),
     radial-gradient(circle at 58% 78%, rgba(255, 216, 102, 0.12), transparent 16%),
     radial-gradient(circle at 50% 84%, rgba(171, 157, 242, 0.12), transparent 16%),
-    radial-gradient(circle at 50% 92%, rgba(255, 97, 136, 0.15), transparent 16%),
-    #191919;
+    radial-gradient(circle at 50% 92%, rgba(255, 97, 136, 0.15), transparent 16%), #191919;
+}
+
+.legal-prose h2 {
+  @apply mt-10 text-2xl font-bold tracking-[-0.04em] text-white first:mt-0;
+}
+
+.legal-prose p {
+  @apply mt-4 text-base leading-relaxed text-white/65;
+}
+
+.legal-prose ul {
+  @apply mt-4 grid list-disc gap-2 pl-5 text-base leading-relaxed text-white/65;
+}
+
+.legal-prose strong {
+  @apply font-semibold text-white/85;
+}
+
+.legal-prose a {
+  @apply text-aqua underline decoration-aqua/40 underline-offset-4 transition hover:decoration-aqua;
+}
+
+.legal-prose hr {
+  @apply my-10 border-white/10;
 }
 
 .mono-detail {

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,6 +1,9 @@
 import Link from 'next/link';
+import { cookies } from 'next/headers';
 import { ArrowRight, Bell, Hash, MessageCircle, Video } from 'lucide-react';
 import { OAuthHandoff } from '../src/components/oauth-handoff';
+import { LogoutButton } from '../src/components/logout-button';
+import { SESSION_COOKIE_KEY } from '../src/shared/lib/session';
 
 const features = [
   {
@@ -29,31 +32,9 @@ const features = [
   }
 ];
 
-const footerColumns = [
-  {
-    heading: 'Produit',
-    links: [
-      { href: '/chat', label: 'Chat' },
-      { href: '/guilds', label: 'Guilds' }
-    ]
-  },
-  {
-    heading: 'Compte',
-    links: [
-      { href: '/auth/login', label: 'Login' },
-      { href: '/auth/register', label: 'Register' }
-    ]
-  },
-  {
-    heading: 'Légal',
-    links: [
-      { href: '/terms', label: 'Conditions d’utilisation' },
-      { href: '/privacy', label: 'Politique de confidentialité' }
-    ]
-  }
-];
+export default async function HomePage() {
+  const isLoggedIn = (await cookies()).has(SESSION_COOKIE_KEY);
 
-export default function HomePage() {
   return (
     <div className="h-screen overflow-y-auto">
       <OAuthHandoff />
@@ -62,37 +43,45 @@ export default function HomePage() {
         <Link href="/" className="text-xl font-extrabold tracking-[-0.05em] text-white">
           ft_discord
         </Link>
-        <Link
-          href="/auth/login"
-          className="rounded-full bg-white px-5 py-2 text-sm font-bold text-primary-bg transition hover:bg-aqua"
-        >
-          Login
-        </Link>
+        {isLoggedIn ? (
+          <LogoutButton />
+        ) : (
+          <Link
+            href="/auth/login"
+            className="rounded-full bg-white px-5 py-2 text-sm font-bold text-primary-bg transition hover:bg-aqua"
+          >
+            Login
+          </Link>
+        )}
       </header>
 
       <section className="mx-auto w-full max-w-6xl px-6 pb-20 pt-14 text-center md:pt-24">
         <p className="mono-detail text-aqua">ft_transcendence · École 42</p>
         <h1 className="mx-auto mt-5 max-w-4xl text-5xl font-extrabold uppercase tracking-[-0.05em] text-white md:text-8xl">
-          Un endroit pour parler et se retrouver
+          Un endroit pour échanger et se retrouver
         </h1>
         <p className="mx-auto mt-6 max-w-2xl text-lg text-white/65">
           ft_discord est une plateforme de communication en temps réel : guildes, salons, messages
           directs, amis et appels. Un projet étudiant, mais une vraie place pour ta communauté.
         </p>
         <div className="mt-10 flex flex-col items-center justify-center gap-4 sm:flex-row">
-          <Link
-            href="/auth/register"
-            className="inline-flex items-center gap-2 rounded-full bg-aqua px-7 py-3.5 text-base font-bold text-primary-bg shadow-glow transition hover:bg-white"
-          >
-            Créer un compte
-            <ArrowRight className="h-4 w-4" strokeWidth={2.5} />
-          </Link>
-          <Link
-            href="/chat"
-            className="inline-flex items-center gap-2 rounded-full border border-white/15 bg-panel px-7 py-3.5 text-base font-bold text-white transition hover:border-aqua/50 hover:bg-frame"
-          >
-            Ouvrir ft_discord dans le navigateur
-          </Link>
+          {isLoggedIn ? (
+            <Link
+              href="/chat"
+              className="inline-flex items-center gap-2 rounded-full bg-aqua px-7 py-3.5 text-base font-bold text-primary-bg shadow-glow transition hover:bg-white"
+            >
+              Ouvrir ft_discord dans le navigateur
+              <ArrowRight className="h-4 w-4" strokeWidth={2.5} />
+            </Link>
+          ) : (
+            <Link
+              href="/auth/register"
+              className="inline-flex items-center gap-2 rounded-full bg-aqua px-7 py-3.5 text-base font-bold text-primary-bg shadow-glow transition hover:bg-white"
+            >
+              Créer un compte
+              <ArrowRight className="h-4 w-4" strokeWidth={2.5} />
+            </Link>
+          )}
         </div>
       </section>
 
@@ -101,7 +90,7 @@ export default function HomePage() {
           {features.map((feature) => (
             <div
               key={feature.title}
-              className="rounded-[2rem] border border-white/8 bg-secondary-bg/90 p-8 shadow-2xl shadow-black/40 backdrop-blur transition hover:border-white/15 md:p-10"
+              className="rounded-[2rem] border border-white/8 bg-secondary-bg/90 p-8 shadow-2xl shadow-black/40 backdrop-blur md:p-10"
             >
               <feature.icon className={`h-8 w-8 ${feature.accent}`} strokeWidth={1.75} />
               <h2 className="mt-5 text-2xl font-bold tracking-[-0.04em] text-white md:text-3xl">
@@ -113,70 +102,16 @@ export default function HomePage() {
         </div>
       </section>
 
-      <section className="mx-auto w-full max-w-6xl px-6 pb-24">
-        <div className="rounded-[2rem] border border-white/8 bg-secondary-bg/90 p-10 text-center shadow-2xl shadow-black/40 backdrop-blur md:p-14">
-          <h2 className="text-3xl font-extrabold tracking-[-0.05em] text-white md:text-5xl">
-            Prêt à rejoindre la conversation ?
-          </h2>
-          <p className="mx-auto mt-4 max-w-xl text-base text-white/60">
-            Inscris-toi avec un email, ou connecte-toi via GitHub, Google ou l’intranet 42.
-          </p>
-          <Link
-            href="/auth/register"
-            className="mt-8 inline-flex items-center gap-2 rounded-full bg-lavender px-7 py-3.5 text-base font-bold text-primary-bg transition hover:bg-white"
-          >
-            Commencer maintenant
-            <ArrowRight className="h-4 w-4" strokeWidth={2.5} />
-          </Link>
-        </div>
-      </section>
-
       <footer className="border-t border-white/8 bg-secondary-bg/70">
-        <div className="mx-auto grid w-full max-w-6xl gap-10 px-6 py-14 md:grid-cols-[2fr_1fr_1fr_1fr]">
-          <div>
-            <p className="text-2xl font-extrabold tracking-[-0.05em] text-aqua">ft_discord</p>
-            <p className="mt-3 max-w-xs text-sm leading-relaxed text-white/50">
-              Projet étudiant réalisé dans le cadre du cursus ft_transcendence de l’École 42. Aucune
-              garantie de service — voir les conditions d’utilisation.
-            </p>
-            <a
-              href="mailto:yandry@student.42.fr"
-              className="mt-4 inline-block text-sm text-grey-link transition hover:text-white"
-            >
-              yandry@student.42.fr
-            </a>
-          </div>
-          {footerColumns.map((column) => (
-            <nav key={column.heading} aria-label={column.heading}>
-              <p className="font-category text-sm font-semibold uppercase tracking-wider text-category">
-                {column.heading}
-              </p>
-              <ul className="mt-4 grid gap-2.5">
-                {column.links.map((link) => (
-                  <li key={link.href}>
-                    <Link
-                      href={link.href}
-                      className="text-sm text-grey-link transition hover:text-white"
-                    >
-                      {link.label}
-                    </Link>
-                  </li>
-                ))}
-              </ul>
-            </nav>
-          ))}
-        </div>
-        <div className="border-t border-white/8">
-          <div className="mx-auto flex w-full max-w-6xl flex-col items-center justify-between gap-3 px-6 py-6 text-sm text-white/40 sm:flex-row">
-            <p>© 2026 ft_discord — projet étudiant, École 42</p>
-            <div className="flex gap-5">
-              <Link href="/terms" className="transition hover:text-white">
-                Terms of Service
-              </Link>
-              <Link href="/privacy" className="transition hover:text-white">
-                Privacy Policy
-              </Link>
-            </div>
+        <div className="mx-auto flex w-full max-w-6xl flex-col items-center justify-between gap-3 px-6 py-6 text-sm text-white/40 sm:flex-row">
+          <p>© 2026 ft_discord - projet étudiant, École 42</p>
+          <div className="flex gap-5">
+            <Link href="/terms" className="transition hover:text-white">
+              Terms of Service
+            </Link>
+            <Link href="/privacy" className="transition hover:text-white">
+              Privacy Policy
+            </Link>
           </div>
         </div>
       </footer>

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,37 +1,185 @@
 import Link from 'next/link';
+import { ArrowRight, Bell, Hash, MessageCircle, Video } from 'lucide-react';
 import { OAuthHandoff } from '../src/components/oauth-handoff';
+
+const features = [
+  {
+    icon: Hash,
+    accent: 'text-aqua',
+    title: 'Des guildes et des salons',
+    text: 'Crée ta guilde, organise-la en catégories et salons, et garde chaque sujet à sa place. Rôles, permissions et modération intégrés.'
+  },
+  {
+    icon: MessageCircle,
+    accent: 'text-lavender',
+    title: 'Messages directs et amis',
+    text: 'Discute en temps réel avec tes amis, gère tes demandes et tes blocages, et retrouve tes conversations où tu les as laissées.'
+  },
+  {
+    icon: Video,
+    accent: 'text-pink',
+    title: 'Appels voix et vidéo',
+    text: 'Passe en vocal ou en vidéo en un clic, directement depuis une conversation, grâce au WebRTC pair-à-pair.'
+  },
+  {
+    icon: Bell,
+    accent: 'text-yellow',
+    title: 'Notifications en temps réel',
+    text: 'Mentions, demandes d’amis, invitations : tout arrive instantanément via WebSocket, sans recharger la page.'
+  }
+];
+
+const footerColumns = [
+  {
+    heading: 'Produit',
+    links: [
+      { href: '/chat', label: 'Chat' },
+      { href: '/guilds', label: 'Guilds' }
+    ]
+  },
+  {
+    heading: 'Compte',
+    links: [
+      { href: '/auth/login', label: 'Login' },
+      { href: '/auth/register', label: 'Register' }
+    ]
+  },
+  {
+    heading: 'Légal',
+    links: [
+      { href: '/terms', label: 'Conditions d’utilisation' },
+      { href: '/privacy', label: 'Politique de confidentialité' }
+    ]
+  }
+];
 
 export default function HomePage() {
   return (
-    <section className="mx-auto flex min-h-screen w-full max-w-6xl items-center px-6 py-12">
+    <div className="h-screen overflow-y-auto">
       <OAuthHandoff />
-      <div className="w-full rounded-[2rem] border border-white/8 bg-secondary-bg/90 p-8 shadow-2xl shadow-black/40 backdrop-blur md:p-12">
-        <p className="mono-detail text-aqua">ft_transcendence</p>
-        <h1 className="mt-4 max-w-3xl text-5xl font-extrabold tracking-[-0.07em] text-white md:text-7xl">
-          Interface utilisable construite à partir des maquettes.
+
+      <header className="mx-auto flex w-full max-w-6xl items-center justify-between px-6 py-6">
+        <Link href="/" className="text-xl font-extrabold tracking-[-0.05em] text-white">
+          ft_discord
+        </Link>
+        <Link
+          href="/auth/login"
+          className="rounded-full bg-white px-5 py-2 text-sm font-bold text-primary-bg transition hover:bg-aqua"
+        >
+          Login
+        </Link>
+      </header>
+
+      <section className="mx-auto w-full max-w-6xl px-6 pb-20 pt-14 text-center md:pt-24">
+        <p className="mono-detail text-aqua">ft_transcendence · École 42</p>
+        <h1 className="mx-auto mt-5 max-w-4xl text-5xl font-extrabold uppercase tracking-[-0.05em] text-white md:text-8xl">
+          Un endroit pour parler et se retrouver
         </h1>
-        <p className="mt-5 max-w-2xl text-lg text-white/65">
-          Auth interactive, chat responsive sur route réelle, et structure de pages prête à
-          raccorder aux services backend.
+        <p className="mx-auto mt-6 max-w-2xl text-lg text-white/65">
+          ft_discord est une plateforme de communication en temps réel : guildes, salons, messages
+          directs, amis et appels. Un projet étudiant, mais une vraie place pour ta communauté.
         </p>
-        <div className="mt-10 grid gap-4 md:grid-cols-2 xl:grid-cols-4">
-          {[
-            { href: '/auth/register', title: 'Register', text: 'Création de compte avec validation' },
-            { href: '/auth/login', title: 'Login', text: 'Connexion branchée à l’API auth' },
-            { href: '/chat', title: 'Chat', text: 'Page responsive utilisable immédiatement' },
-            { href: '/guilds', title: 'Guilds', text: 'Point d’entrée guildes' }
-          ].map((item) => (
-            <Link
-              key={item.href}
-              href={item.href}
-              className="rounded-2xl border border-white/8 bg-panel p-5 transition hover:border-aqua/50 hover:bg-frame"
+        <div className="mt-10 flex flex-col items-center justify-center gap-4 sm:flex-row">
+          <Link
+            href="/auth/register"
+            className="inline-flex items-center gap-2 rounded-full bg-aqua px-7 py-3.5 text-base font-bold text-primary-bg shadow-glow transition hover:bg-white"
+          >
+            Créer un compte
+            <ArrowRight className="h-4 w-4" strokeWidth={2.5} />
+          </Link>
+          <Link
+            href="/chat"
+            className="inline-flex items-center gap-2 rounded-full border border-white/15 bg-panel px-7 py-3.5 text-base font-bold text-white transition hover:border-aqua/50 hover:bg-frame"
+          >
+            Ouvrir ft_discord dans le navigateur
+          </Link>
+        </div>
+      </section>
+
+      <section className="mx-auto w-full max-w-6xl px-6 pb-24">
+        <div className="grid gap-4 md:grid-cols-2">
+          {features.map((feature) => (
+            <div
+              key={feature.title}
+              className="rounded-[2rem] border border-white/8 bg-secondary-bg/90 p-8 shadow-2xl shadow-black/40 backdrop-blur transition hover:border-white/15 md:p-10"
             >
-              <h2 className="text-2xl font-bold tracking-[-0.05em] text-white">{item.title}</h2>
-              <p className="mt-2 text-white/55">{item.text}</p>
-            </Link>
+              <feature.icon className={`h-8 w-8 ${feature.accent}`} strokeWidth={1.75} />
+              <h2 className="mt-5 text-2xl font-bold tracking-[-0.04em] text-white md:text-3xl">
+                {feature.title}
+              </h2>
+              <p className="mt-3 text-base leading-relaxed text-white/60">{feature.text}</p>
+            </div>
           ))}
         </div>
-      </div>
-    </section>
+      </section>
+
+      <section className="mx-auto w-full max-w-6xl px-6 pb-24">
+        <div className="rounded-[2rem] border border-white/8 bg-secondary-bg/90 p-10 text-center shadow-2xl shadow-black/40 backdrop-blur md:p-14">
+          <h2 className="text-3xl font-extrabold tracking-[-0.05em] text-white md:text-5xl">
+            Prêt à rejoindre la conversation ?
+          </h2>
+          <p className="mx-auto mt-4 max-w-xl text-base text-white/60">
+            Inscris-toi avec un email, ou connecte-toi via GitHub, Google ou l’intranet 42.
+          </p>
+          <Link
+            href="/auth/register"
+            className="mt-8 inline-flex items-center gap-2 rounded-full bg-lavender px-7 py-3.5 text-base font-bold text-primary-bg transition hover:bg-white"
+          >
+            Commencer maintenant
+            <ArrowRight className="h-4 w-4" strokeWidth={2.5} />
+          </Link>
+        </div>
+      </section>
+
+      <footer className="border-t border-white/8 bg-secondary-bg/70">
+        <div className="mx-auto grid w-full max-w-6xl gap-10 px-6 py-14 md:grid-cols-[2fr_1fr_1fr_1fr]">
+          <div>
+            <p className="text-2xl font-extrabold tracking-[-0.05em] text-aqua">ft_discord</p>
+            <p className="mt-3 max-w-xs text-sm leading-relaxed text-white/50">
+              Projet étudiant réalisé dans le cadre du cursus ft_transcendence de l’École 42. Aucune
+              garantie de service — voir les conditions d’utilisation.
+            </p>
+            <a
+              href="mailto:yandry@student.42.fr"
+              className="mt-4 inline-block text-sm text-grey-link transition hover:text-white"
+            >
+              yandry@student.42.fr
+            </a>
+          </div>
+          {footerColumns.map((column) => (
+            <nav key={column.heading} aria-label={column.heading}>
+              <p className="font-category text-sm font-semibold uppercase tracking-wider text-category">
+                {column.heading}
+              </p>
+              <ul className="mt-4 grid gap-2.5">
+                {column.links.map((link) => (
+                  <li key={link.href}>
+                    <Link
+                      href={link.href}
+                      className="text-sm text-grey-link transition hover:text-white"
+                    >
+                      {link.label}
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            </nav>
+          ))}
+        </div>
+        <div className="border-t border-white/8">
+          <div className="mx-auto flex w-full max-w-6xl flex-col items-center justify-between gap-3 px-6 py-6 text-sm text-white/40 sm:flex-row">
+            <p>© 2026 ft_discord — projet étudiant, École 42</p>
+            <div className="flex gap-5">
+              <Link href="/terms" className="transition hover:text-white">
+                Terms of Service
+              </Link>
+              <Link href="/privacy" className="transition hover:text-white">
+                Privacy Policy
+              </Link>
+            </div>
+          </div>
+        </div>
+      </footer>
+    </div>
   );
 }

--- a/frontend/app/privacy/page.tsx
+++ b/frontend/app/privacy/page.tsx
@@ -3,13 +3,13 @@ import Link from 'next/link';
 import { LegalPage } from '../../src/components/legal-page';
 
 export const metadata: Metadata = {
-  title: 'Privacy Policy — ft_discord',
+  title: 'Privacy Policy - ft_discord',
   description: 'How ft_discord collects, uses, and protects your personal data under the GDPR.'
 };
 
 export default function PrivacyPage() {
   return (
-    <LegalPage eyebrow="ft_discord — legal" title="Privacy Policy" lastUpdated="7 July 2026">
+    <LegalPage eyebrow="ft_discord - legal" title="Privacy Policy" lastUpdated="7 July 2026">
       <p>
         This document explains what personal data ft_discord processes, why, for how long, and how
         you can exercise your rights under the GDPR.

--- a/frontend/app/privacy/page.tsx
+++ b/frontend/app/privacy/page.tsx
@@ -1,0 +1,171 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { LegalPage } from '../../src/components/legal-page';
+
+export const metadata: Metadata = {
+  title: 'Privacy Policy — ft_discord',
+  description: 'How ft_discord collects, uses, and protects your personal data under the GDPR.'
+};
+
+export default function PrivacyPage() {
+  return (
+    <LegalPage eyebrow="ft_discord — legal" title="Privacy Policy" lastUpdated="7 July 2026">
+      <p>
+        This document explains what personal data ft_discord processes, why, for how long, and how
+        you can exercise your rights under the GDPR.
+      </p>
+
+      <h2>1. Who is responsible for your data</h2>
+      <p>
+        ft_discord is a non-commercial student project built by the ft_discord team to satisfy the
+        ft_transcendence project of the École 42 common core. The data controller for this policy is
+        Yanis Andry, contactable at <a href="mailto:yandry@student.42.fr">yandry@student.42.fr</a>.
+        There is no separate corporate entity behind the Service.
+      </p>
+
+      <h2>2. What data we collect</h2>
+      <p>We collect the following personal data that you provide directly:</p>
+      <ul>
+        <li>
+          Your email address and password (hashed; we never store or have access to the plaintext),
+          or, if you register through GitHub, Google, or the 42 intranet, the identifier and profile
+          information that provider shares with us
+        </li>
+        <li>Your username, display name, avatar, banner, and bio</li>
+        <li>The guilds, channels, and categories you create, including their names and icons</li>
+        <li>Messages you send, and any files you attach to them</li>
+        <li>Your friends list and the users you block</li>
+        <li>
+          The reason you give when banning another user in a guild you moderate (see Section 5 for
+          how this is handled if your account is later deleted)
+        </li>
+      </ul>
+      <p>
+        If you sign in through a third-party provider (GitHub, Google, 42), that provider&rsquo;s
+        own terms of service and privacy policy govern the data you share with them; we only receive
+        what you authorize them to disclose to us.
+      </p>
+      <p>We do not use third-party analytics, advertising, or tracking services.</p>
+      <p>
+        We also process your IP address at the point each request is made, to apply rate limiting
+        and prevent abuse of the Service. This is not retained for longer than necessary for that
+        security purpose.
+      </p>
+      <p>
+        <em>Legal basis:</em> performance of a contract, and, for optional fields such as bio or
+        avatar, your consent in choosing to provide them. Processing your IP address for rate
+        limiting is based on our legitimate interest in keeping the Service secure and available.
+      </p>
+
+      <h2>3. Cookies</h2>
+      <p>
+        The Service sets cookies solely for technical purposes required to keep you signed in. They
+        are not used for tracking, profiling, or advertising.
+      </p>
+
+      <h2>4. How long we keep your data</h2>
+      <p>
+        Your data is kept for as long as your account is active. If you stop using the Service
+        without deleting your account, your data simply remains as-is; there is currently no
+        automatic inactivity-based deletion.
+      </p>
+
+      <h2>5. What happens when you delete your account</h2>
+      <p>Deleting your account triggers the following:</p>
+      <ul>
+        <li>
+          Your login credentials are deactivated immediately and your session is revoked. Your email
+          is freed for re-registration.
+        </li>
+        <li>Your profile, friendships, and blocks are deleted outright.</li>
+        <li>
+          Your guild memberships, role assignments, invite codes, and channel-level permission
+          overrides are deleted. Guilds you <em>own</em> cannot be deleted this way, you must
+          transfer ownership or delete the guild first before your account can be removed.
+        </li>
+        <li>
+          If you&rsquo;ve banned other users, the ban itself stays in force (it protects the guild,
+          not you), but the record of <em>who issued it</em> is erased.
+        </li>
+        <li>Your notifications, and any notification triggered by your actions, are deleted.</li>
+        <li>
+          Your messages are <strong>not</strong> deleted. They remain visible to other participants
+          in the channel or conversation, but your identity becomes unresolvable, the interface will
+          show them as sent by &ldquo;Deleted User.&rdquo; This preserves conversation context for
+          other users while removing your identifying information from the record.
+        </li>
+      </ul>
+      <p>
+        This reference-scrubbing on deletion is the Service&rsquo;s anonymization mechanism: your
+        identity is removed from content and records that other users depend on, without deleting
+        content those users have a legitimate interest in retaining (a conversation, a ban record).
+        It is triggered by account deletion rather than offered as a separate action, by design: it
+        protects your identity, not your content, so there is no meaningful &ldquo;anonymize but
+        keep the account&rdquo; state to offer.
+      </p>
+
+      <h2>6. Your rights</h2>
+      <p>Under the GDPR, you have the right to:</p>
+      <ul>
+        <li>
+          <strong>Access</strong> the data we hold about you
+        </li>
+        <li>
+          <strong>Rectify</strong> inaccurate data (most profile fields are user-editable directly
+          in the app)
+        </li>
+        <li>
+          <strong>Erase</strong> your data (see Section 5, account deletion)
+        </li>
+        <li>
+          <strong>Restrict or object to</strong> processing
+        </li>
+        <li>
+          <strong>Data portability</strong>, receive your data in a structured format
+        </li>
+      </ul>
+      <p>
+        You can access and download your data yourself at any time using the &ldquo;Download my
+        data&rdquo; button in the app. For any right not covered by that self-service flow
+        (rectification of data you can&rsquo;t edit directly, restriction, or objection), contact{' '}
+        <a href="mailto:yandry@student.42.fr">yandry@student.42.fr</a>.
+      </p>
+      <p>
+        We respond to any request under this section within 30 days, as required by GDPR Article
+        12(3).
+      </p>
+
+      <h2>7. Security</h2>
+      <p>
+        Passwords are hashed and never stored in plaintext. Authentication tokens are short-lived
+        and rotated regularly to limit the impact of any compromise.
+      </p>
+
+      <h2>8. Children</h2>
+      <p>
+        The Service does not knowingly collect data from children under 15 without the parental
+        consent required under French law, and does not target children as an audience. See the{' '}
+        <Link href="/terms">Terms of Service</Link> for the eligibility statement.
+      </p>
+
+      <h2>9. Changes to this policy</h2>
+      <p>
+        This policy will be updated as the application&rsquo;s data handling changes. Material
+        changes will be reflected here with an updated date.
+      </p>
+
+      <h2>10. Contact</h2>
+      <p>
+        <a href="mailto:yandry@student.42.fr">yandry@student.42.fr</a>
+      </p>
+      <p>
+        You also have the right to lodge a complaint with the CNIL (Commission Nationale de
+        l&rsquo;Informatique et des Libertés), the French data protection authority, at{' '}
+        <a href="https://www.cnil.fr" target="_blank" rel="noreferrer">
+          www.cnil.fr
+        </a>
+        .
+      </p>
+    </LegalPage>
+  );
+}

--- a/frontend/app/terms/page.tsx
+++ b/frontend/app/terms/page.tsx
@@ -3,13 +3,13 @@ import Link from 'next/link';
 import { LegalPage } from '../../src/components/legal-page';
 
 export const metadata: Metadata = {
-  title: 'Terms of Service — ft_discord',
+  title: 'Terms of Service - ft_discord',
   description: 'Terms of Service for ft_discord, a student project built at École 42.'
 };
 
 export default function TermsPage() {
   return (
-    <LegalPage eyebrow="ft_discord — legal" title="Terms of Service" lastUpdated="7 July 2026">
+    <LegalPage eyebrow="ft_discord - legal" title="Terms of Service" lastUpdated="7 July 2026">
       <h2>1. What this is</h2>
       <p>
         ft_discord (&ldquo;the Service&rdquo;) is a student project built to fulfill the

--- a/frontend/app/terms/page.tsx
+++ b/frontend/app/terms/page.tsx
@@ -1,0 +1,128 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { LegalPage } from '../../src/components/legal-page';
+
+export const metadata: Metadata = {
+  title: 'Terms of Service — ft_discord',
+  description: 'Terms of Service for ft_discord, a student project built at École 42.'
+};
+
+export default function TermsPage() {
+  return (
+    <LegalPage eyebrow="ft_discord — legal" title="Terms of Service" lastUpdated="7 July 2026">
+      <h2>1. What this is</h2>
+      <p>
+        ft_discord (&ldquo;the Service&rdquo;) is a student project built to fulfill the
+        ft_transcendence project of the École 42 common core curriculum. It is a real-time
+        communication platform (accounts, guilds/channels, direct messages, friends, notifications)
+        built for educational purposes: to demonstrate microservice architecture, authentication,
+        WebSocket handling, and related engineering practice.
+      </p>
+      <p>
+        The Service is not a commercial product. It carries no uptime guarantee, no service-level
+        agreement, and may be taken offline, reset, or have its data wiped without notice, including
+        for grading, redeployment, or the end of the evaluation period. Do not rely on it to store
+        anything you need to keep.
+      </p>
+
+      <h2>2. Eligibility</h2>
+      <p>
+        Under French and EU data protection law, a person may consent to the processing of their own
+        personal data online from age 15. If you are under 15, you may not create an account. If you
+        are between 15 and 18, you confirm you are legally permitted to use online services of this
+        kind under the law that applies to you.
+      </p>
+      <p>
+        The Service does not currently perform age verification. This is a statement of eligibility,
+        not a representation that age is checked.
+      </p>
+
+      <h2>3. Accounts</h2>
+      <p>
+        You can create an account with an email and password, or via OAuth through GitHub, Google,
+        or the 42 intranet. You&rsquo;re responsible for whatever happens under your account and for
+        keeping your credentials confidential. Contact us if you think your account has been
+        compromised.
+      </p>
+      <p>
+        You may delete your account at any time. This is permanent. See the{' '}
+        <Link href="/privacy">Privacy Policy</Link> for exactly what happens to your data when you
+        do.
+      </p>
+
+      <h2>4. Acceptable use</h2>
+      <p>You agree not to:</p>
+      <ul>
+        <li>Use the Service to harass, threaten, or abuse other users</li>
+        <li>
+          Post content that is illegal under French law, including content that infringes someone
+          else&rsquo;s rights
+        </li>
+        <li>Attempt to bypass rate limiting, authentication, or permission checks</li>
+        <li>
+          Use the Service to distribute malware or attempt to compromise other users&rsquo; accounts
+          or the underlying infrastructure
+        </li>
+        <li>Impersonate another person or entity</li>
+      </ul>
+      <p>
+        Guild owners and members with the relevant role permissions can moderate their own guilds
+        (kick, ban, manage roles, delete messages) using the tools built into the platform. We do
+        not pre-screen content in guilds or DMs.
+      </p>
+
+      <h2>5. Content</h2>
+      <p>
+        You retain ownership of whatever you post (messages, avatars, banners, guild names and
+        icons). By posting it, you grant the Service the license needed to store, transmit, and
+        display it to the other users you&rsquo;ve shared it with (channel members, DM recipients,
+        guild members), for as long as your account and that content exist.
+      </p>
+      <p>
+        Deleting a message removes it from the interface for other users going forward. It does not
+        undo the fact that other users may have already seen or copied it before you deleted it.
+      </p>
+
+      <h2>6. Termination</h2>
+      <p>
+        We may suspend or terminate accounts that violate Section 4, without prior notice,
+        particularly where continued access poses a risk to other users or to the integrity of the
+        Service.
+      </p>
+      <p>You may terminate your own account at any time via account deletion.</p>
+
+      <h2>7. No warranty</h2>
+      <p>
+        This is a student project. The Service is provided &ldquo;as is,&rdquo; without warranty of
+        any kind, express or implied, including fitness for a particular purpose, availability, or
+        data durability. To the extent permitted by French law, the developers are not liable for
+        any damages arising from use of, or inability to use, the Service.
+      </p>
+
+      <h2>8. Changes</h2>
+      <p>
+        These terms may change as the project evolves. Material changes will be reflected here with
+        an updated date.
+      </p>
+
+      <h2>9. Governing law</h2>
+      <p>
+        These terms are governed by French law. Any dispute is subject to the exclusive jurisdiction
+        of the competent French courts.
+      </p>
+
+      <h2>10. Contact</h2>
+      <p>
+        <a href="mailto:yandry@student.42.fr">yandry@student.42.fr</a>
+      </p>
+
+      <hr />
+      <p>
+        <em>
+          See also: the <Link href="/privacy">Privacy Policy</Link> for how your data is collected,
+          used, and how to exercise your rights under the GDPR.
+        </em>
+      </p>
+    </LegalPage>
+  );
+}

--- a/frontend/proxy.ts
+++ b/frontend/proxy.ts
@@ -4,8 +4,15 @@ import { SESSION_COOKIE_KEY } from './src/shared/lib/session';
 
 const AUTH_PATHS = new Set(['/auth/login', '/auth/register']);
 
+// landing and legal pages must stay readable without an account
+const PUBLIC_PATHS = new Set(['/', '/terms', '/privacy']);
+
 function isProtectedPath(pathname: string) {
   if (pathname.startsWith('/_next') || pathname === '/favicon.ico') {
+    return false;
+  }
+
+  if (PUBLIC_PATHS.has(pathname)) {
     return false;
   }
 

--- a/frontend/src/components/legal-page.tsx
+++ b/frontend/src/components/legal-page.tsx
@@ -1,0 +1,35 @@
+import Link from 'next/link';
+import { ArrowLeft } from 'lucide-react';
+
+type LegalPageProps = {
+  eyebrow: string;
+  title: string;
+  lastUpdated: string;
+  children: React.ReactNode;
+};
+
+export function LegalPage({ eyebrow, title, lastUpdated, children }: LegalPageProps) {
+  return (
+    <div className="h-screen overflow-y-auto">
+      <div className="mx-auto w-full max-w-3xl px-6 py-12 md:py-16">
+        <Link
+          href="/"
+          className="inline-flex items-center gap-2 text-sm font-semibold text-grey-link transition hover:text-white"
+        >
+          <ArrowLeft className="h-4 w-4" strokeWidth={2} />
+          Retour à l’accueil
+        </Link>
+        <header className="mt-8">
+          <p className="mono-detail text-aqua">{eyebrow}</p>
+          <h1 className="mt-3 text-4xl font-extrabold tracking-[-0.05em] text-white md:text-5xl">
+            {title}
+          </h1>
+          <p className="mt-3 text-sm text-white/45">Last updated: {lastUpdated}</p>
+        </header>
+        <article className="legal-prose mt-10 rounded-[2rem] border border-white/8 bg-secondary-bg/90 p-8 shadow-2xl shadow-black/40 backdrop-blur md:p-12">
+          {children}
+        </article>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/logout-button.tsx
+++ b/frontend/src/components/logout-button.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { LogOut } from 'lucide-react';
+import { logout } from '../shared/api/auth';
+import { clearSession } from '../shared/lib/session';
+
+export function LogoutButton() {
+  const router = useRouter();
+
+  async function handleLogout() {
+    try {
+      await logout();
+    } catch {
+      // best-effort revoke; clear the local session regardless
+    }
+    clearSession();
+    router.refresh();
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleLogout}
+      className="inline-flex items-center gap-2 rounded-full border border-white/15 bg-panel px-5 py-2 text-sm font-bold text-white transition hover:border-pink/50 hover:text-pink"
+    >
+      <LogOut className="h-4 w-4" strokeWidth={2} />
+      Déconnexion
+    </button>
+  );
+}

--- a/frontend/src/shared/lib/use-notifications.ts
+++ b/frontend/src/shared/lib/use-notifications.ts
@@ -237,7 +237,7 @@ export function useNotifications() {
       const delay = Math.min(RECONNECT_BASE_DELAY_MS * 2 ** (attempt - 1), RECONNECT_MAX_DELAY_MS);
       retryTimer = window.setTimeout(() => {
         // this request goes through apiFetch, which refreshes an expired
-        // access token on 401 — so the stream reopens with valid credentials
+        // access token on 401 - so the stream reopens with valid credentials
         getUnreadNotificationCount()
           .then(({ count }) => setUnreadCount(count))
           .catch(() => {})
@@ -369,8 +369,7 @@ export function useNotifications() {
       });
       setPreferences((current) => [
         ...current.filter(
-          (preference) =>
-            !(preference.scope_type === scopeType && preference.scope_id === scopeId)
+          (preference) => !(preference.scope_type === scopeType && preference.scope_id === scopeId)
         ),
         updated
       ]);


### PR DESCRIPTION
Resolves #104 
Resolves #105 
Resolves #106 

- New Discord-style landing page on `/`: nav, hero, feature cards, and a footer
  linking to the legal pages
- New `/terms` and `/privacy` pages rendering the ft_discord Terms of Service
  and Privacy Policy
- Landing page is session-aware: logged out shows Login + "Créer un compte",
  logged in shows a Déconnexion button and a single "Ouvrir ft_discord" CTA
- Middleware now lets `/`, `/terms`, and `/privacy` through without a session
  so visitors can read them before signing up
- Removed the old `/guilds` mockup placeholder page