### PR TITLE
Fix(gdpr): sign data-export download URLs against a browser-reachable MinIO endpoint

### DIFF
--- a/infra/nginx/nginx.conf
+++ b/infra/nginx/nginx.conf
@@ -132,4 +132,23 @@ http {
             proxy_set_header X-Forwarded-Proto $scheme;
         }
     }
+
+    # Dedicated S3 endpoint for MinIO presigned URLs (GDPR data-export
+    # downloads). Unlike /s3/ on 1443 this does NOT strip a path prefix and
+    # forwards the full Host including port via $http_host, so an AWS SigV4
+    # presigned URL signed against https://localhost:9443/{bucket}/{key}
+    # validates at MinIO. The user service signs these with MINIO_PUBLIC_ENDPOINT.
+    server {
+        listen 9443 ssl;
+        server_name localhost;
+        client_max_body_size 26m;
+
+        location / {
+            proxy_pass http://127.0.0.1:9000;
+            proxy_set_header Host $http_host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+    }
 }

--- a/services/user/compose.yaml
+++ b/services/user/compose.yaml
@@ -45,6 +45,9 @@ services:
     environment:
       BASE_URL: ${BASE_URL}
       MINIO_ENDPOINT: http://minio:9000
+      # browser-reachable S3 endpoint used only to sign data-export download
+      # URLs (nginx :9443 proxies to MinIO, preserving Host+path so SigV4 holds)
+      MINIO_PUBLIC_ENDPOINT: https://localhost:9443
       MINIO_ACCESS_KEY: ${MINIO_ACCESS_KEY}
       MINIO_SECRET_KEY: ${MINIO_SECRET_KEY}
       MINIO_USER_BUCKET: ${MINIO_USER_BUCKET}

--- a/services/user/src/config/env.ts
+++ b/services/user/src/config/env.ts
@@ -9,6 +9,7 @@ export interface ValidatedEnv {
   JWT_SECRET: string;
   BASE_URL: string;
   MINIO_ENDPOINT: string;
+  MINIO_PUBLIC_ENDPOINT: string;
   MINIO_ACCESS_KEY: string;
   MINIO_SECRET_KEY: string;
   MINIO_USER_BUCKET: string;
@@ -46,6 +47,10 @@ export function validateEnv(env: EnvInput): ValidatedEnv {
     JWT_SECRET: required('JWT_SECRET', env.JWT_SECRET),
     BASE_URL: required('BASE_URL', env.BASE_URL),
     MINIO_ENDPOINT: required('MINIO_ENDPOINT', env.MINIO_ENDPOINT),
+    MINIO_PUBLIC_ENDPOINT: required(
+      'MINIO_PUBLIC_ENDPOINT',
+      env.MINIO_PUBLIC_ENDPOINT,
+    ),
     MINIO_ACCESS_KEY: required('MINIO_ACCESS_KEY', env.MINIO_ACCESS_KEY),
     MINIO_SECRET_KEY: required('MINIO_SECRET_KEY', env.MINIO_SECRET_KEY),
     MINIO_USER_BUCKET: required('MINIO_USER_BUCKET', env.MINIO_USER_BUCKET),

--- a/services/user/src/users/data-export.storage.ts
+++ b/services/user/src/users/data-export.storage.ts
@@ -10,18 +10,31 @@ import { ValidatedEnv } from '../config/env';
 
 @Injectable()
 export class DataExportStorageService {
+  // internal client: reaches MinIO by service name for uploads
   private readonly client: S3Client;
+  // public client: only used to presign download URLs. It signs against the
+  // browser-reachable endpoint (nginx :9443 -> MinIO) so the resulting SigV4
+  // URL validates when a user opens it, instead of baking in the internal
+  // `minio:9000` host which a browser can't resolve.
+  private readonly presignClient: S3Client;
   private readonly bucket: string;
 
   constructor(private readonly config: ConfigService<ValidatedEnv, true>) {
+    const credentials = {
+      accessKeyId: this.config.getOrThrow('MINIO_ACCESS_KEY'),
+      secretAccessKey: this.config.getOrThrow('MINIO_SECRET_KEY'),
+    };
     this.client = new S3Client({
       region: 'us-east-1',
       endpoint: this.config.getOrThrow('MINIO_ENDPOINT'),
       forcePathStyle: true,
-      credentials: {
-        accessKeyId: this.config.getOrThrow('MINIO_ACCESS_KEY'),
-        secretAccessKey: this.config.getOrThrow('MINIO_SECRET_KEY'),
-      },
+      credentials,
+    });
+    this.presignClient = new S3Client({
+      region: 'us-east-1',
+      endpoint: this.config.getOrThrow('MINIO_PUBLIC_ENDPOINT'),
+      forcePathStyle: true,
+      credentials,
     });
     this.bucket = this.config.getOrThrow('MINIO_EXPORTS_BUCKET');
   }
@@ -46,7 +59,7 @@ export class DataExportStorageService {
     expiresInSeconds: number,
   ): Promise<string> {
     return getSignedUrl(
-      this.client,
+      this.presignClient,
       new GetObjectCommand({
         Bucket: this.bucket,
         Key: objectKey,


### PR DESCRIPTION
[QA pass 1]

The GDPR data-export email (and the in-app "Download my data" button) handed the user a presigned URL like http://minio:9000/exports/..., whose host is the internal Docker service name that a browser can't resolve (DNS_PROBE_FINISHED_NXDOMAIN); the export was generated correctly, only the link was unusable.
Root cause: DataExportStorageService used a single S3Client bound to the internal MINIO_ENDPOINT for both upload and presign, so the SigV4 signature baked in the minio:9000 host, and the existing /s3/ route on :1443 can't help because it strips the /s3 prefix and invalidates the signature (403).

This adds a dedicated listen 9443 ssl nginx server that proxies to MinIO without stripping a prefix and forwards the full Host (incl. port) via $http_host, plus a presign-only S3Client in the user service pointed at a new validated MINIO_PUBLIC_ENDPOINT (https://localhost:9443, wired in services/user/compose.yaml) while
uploads keep using the internal client. Touches infra/nginx/nginx.conf, services/user/src/users/data-export.storage.ts, services/user/src/config/env.ts, and services/user/compose.yaml.
Verified end to end: the returned download_url now uses https://localhost:9443/... and opening it returns HTTP 200 with the full JSON bundle; avatars/banners are unaffected since they are public-read objects served over the existing /s3/ route.