### PR TITLE
Fix(chat): DM + mention notifications

### DIFF
--- a/services/chat/src/Chat.Application/Features/Channels/SendMessage/SendChannelMessageHandler.cs
+++ b/services/chat/src/Chat.Application/Features/Channels/SendMessage/SendChannelMessageHandler.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using Chat.Application.Abstractions;
 using Chat.Application.Abstractions.Authentication;
 using Chat.Application.Abstractions.Persistence;
@@ -79,9 +80,30 @@ internal sealed class SendChannelMessageHandler(
 				AuthorId: AuthorId,
 				MessageId: message.Id,
 				Content: message.Content ?? string.Empty,
-				Mentions: []),
+				Mentions: ParseMentions(message.Content, AuthorId)),
 			ct);
 
 		await broadcaster.BroadcastMessageAsync(command.ChannelId, response, ct);
+	}
+
+	// matches the Discord-style mention tokens the frontend inserts on @-select
+	// (<@123>). extract the snowflake ids, dedup, and drop the author so a
+	// self-mention never notifies. channel membership is not re-checked here:
+	// the Notification Service already suppresses blocked pairs.
+	private static readonly Regex MentionPattern = new(@"<@(\d{1,20})>", RegexOptions.Compiled);
+
+	private static long[] ParseMentions(string? content, long authorId)
+	{
+		if (string.IsNullOrEmpty(content))
+			return [];
+
+		var ids = new HashSet<long>();
+		foreach (Match match in MentionPattern.Matches(content))
+		{
+			if (long.TryParse(match.Groups[1].Value, out var id) && id != authorId)
+				ids.Add(id);
+		}
+
+		return ids.Count == 0 ? [] : [.. ids];
 	}
 }

--- a/services/chat/src/Chat.Infrastructure/DependencyInjection.cs
+++ b/services/chat/src/Chat.Infrastructure/DependencyInjection.cs
@@ -84,6 +84,7 @@ public static class DependencyInjection
 					RawSerializerOptions.AddTransportHeaders | RawSerializerOptions.CopyHeaders);
 
 				cfg.Message<ChatMessageSent>(m => m.SetEntityName("chat.message_sent"));
+				cfg.Message<ChatDmSent>(m => m.SetEntityName("chat.dm_sent"));
 				cfg.Message<CallIncoming>(m => m.SetEntityName("call.incoming"));
 				cfg.Message<UserOnline>(m => m.SetEntityName("user.online"));
 				cfg.Message<UserOffline>(m => m.SetEntityName("user.offline"));

--- a/services/chat/tests/Chat.UnitTests/Application/SendChannelMessageHandlerTests.cs
+++ b/services/chat/tests/Chat.UnitTests/Application/SendChannelMessageHandlerTests.cs
@@ -147,6 +147,29 @@ public sealed class SendChannelMessageHandlerTests
 	}
 
 	[Fact]
+	public async Task Mentions_ParsedFromContent_Deduped_ExcludingAuthor()
+	{
+		var (h, handler) = BuildHandler(userId: 42);
+		h.GuildClient.Result = new ChannelMembership(IsMember: true, GuildId: 9, Permissions: SendMessagesPermission);
+
+		var result = await handler.HandleAsync(new SendChannelMessageCommand(
+			ChannelId: 100,
+			Content: "hey <@7> and <@8>, also <@42> (self) and <@7> again",
+			ReplyToId: null,
+			AttachmentIds: [],
+			Nonce: null));
+
+		Assert.True(result.Succeeded);
+		var evt = Assert.Single(h.EventBus.PublishedOf<ChatMessageSent>());
+
+		// parsed and deduped; the author (42) never self-mentions
+		Assert.Equal(2, evt.Mentions.Length);
+		Assert.Contains(7L, evt.Mentions);
+		Assert.Contains(8L, evt.Mentions);
+		Assert.DoesNotContain(42L, evt.Mentions);
+	}
+
+	[Fact]
 	public async Task Nonce64Chars_MaxAllowed_Succeeds()
 	{
 		var (h, handler) = BuildHandler();


### PR DESCRIPTION
[QA pass 2]

Two notification-delivery fixes found during backend QA pass 2:

- **`fix(chat)`: DM notifications**: `ChatDmSent` was missing from the chat `SetEntityName` map, so DM events published to MassTransit's default `Chat.Application.Contracts:ChatDmSent` exchange while the notification queue binds `chat.dm_sent`. Events were silently dropped; no DM notification ever fired. Added the mapping so `ChatDmSent` publishes to `chat.dm_sent`.
- **`feat(chat)`: mention notifications**: `ChatMessageSent` hardcoded `Mentions: []`, so the notification service's mention path never had anything to act on. Now parses `<@id>` tokens from message content (deduped, author excluded) and populates the event. Covered by a unit test.

Verified live: DM and mention notifications both deliver, self-mentions don't notify; full chat unit suite green (22/22). Scoped to notification delivery only; the frontend @-autocomplete/mention-pill UI is a separate task.
