### PR TITLE
Global front wiring and fixes including guild member roles

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -74,7 +74,7 @@ button {
 }
 
 .legal-prose hr {
-  @apply my-10 border-white/10;
+  @apply my-10 border-stroke;
 }
 
 .mono-detail {

--- a/frontend/app/guilds/not-found.tsx
+++ b/frontend/app/guilds/not-found.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link';
 export default function GuildsNotFound() {
   return (
     <section className="mx-auto flex min-h-screen w-full max-w-3xl items-center px-6 py-12">
-      <div className="w-full rounded-[2rem] border border-white/8 bg-secondary-bg/90 p-8 shadow-2xl shadow-black/40 md:p-12">
+      <div className="w-full rounded-[2rem] border border-stroke bg-secondary-bg/90 p-8 shadow-2xl shadow-black/40 md:p-12">
         <p className="mono-detail text-aqua">404</p>
         <h1 className="mt-4 text-4xl font-extrabold tracking-[-0.07em] text-white md:text-5xl">
           Guilds moved to chat

--- a/frontend/app/guilds/page.tsx
+++ b/frontend/app/guilds/page.tsx
@@ -33,7 +33,7 @@ export default function GuildsPage() {
 
   return (
     <section className="mx-auto flex min-h-screen w-full max-w-5xl flex-col px-6 py-10">
-      <div className="w-full rounded-[2rem] border border-white/8 bg-secondary-bg/90 p-8 shadow-2xl shadow-black/40 md:p-10">
+      <div className="w-full rounded-[2rem] border border-stroke bg-secondary-bg/90 p-8 shadow-2xl shadow-black/40 md:p-10">
         <div className="flex flex-wrap items-center justify-between gap-4">
           <div>
             <p className="mono-detail text-aqua">Guilds</p>
@@ -65,7 +65,7 @@ export default function GuildsPage() {
                 className={`flex items-center gap-2 rounded-full border py-1.5 pl-1.5 pr-4 text-sm font-semibold transition ${
                   guild.id === selectedGuildId
                     ? 'border-aqua/60 bg-aqua/10 text-aqua'
-                    : 'border-white/10 bg-panel text-white/60 hover:text-white'
+                    : 'border-stroke bg-panel text-white/60 hover:text-white'
                 }`}
               >
                 <GuildIcon
@@ -121,7 +121,7 @@ export default function GuildsPage() {
         </div>
 
         <div className="mt-10 grid gap-8 md:grid-cols-2">
-          <div className="rounded-[1rem] border border-white/8 bg-panel p-6">
+          <div className="rounded-[1rem] border border-stroke bg-panel p-6">
             <h2 className="text-xl font-bold tracking-[-0.03em] text-white">Create a guild</h2>
             <p className="mt-1 text-sm text-white/45">
               Démarre une nouvelle guilde dont tu seras propriétaire.
@@ -132,7 +132,7 @@ export default function GuildsPage() {
           </div>
           <div
             id="join-guild"
-            className="scroll-mt-6 rounded-[1rem] border border-white/8 bg-panel p-6"
+            className="scroll-mt-6 rounded-[1rem] border border-stroke bg-panel p-6"
           >
             <h2 className="text-xl font-bold tracking-[-0.03em] text-white">Join a guild</h2>
             <p className="mt-1 text-sm text-white/45">

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -91,7 +91,7 @@ export default async function HomePage() {
           {features.map((feature) => (
             <div
               key={feature.title}
-              className="rounded-[2rem] border border-white/8 bg-secondary-bg/90 p-8 shadow-2xl shadow-black/40 backdrop-blur md:p-10"
+              className="rounded-[2rem] border border-stroke bg-secondary-bg/90 p-8 shadow-2xl shadow-black/40 backdrop-blur md:p-10"
             >
               <feature.icon className={`h-8 w-8 ${feature.accent}`} strokeWidth={1.75} />
               <h2 className="mt-5 text-2xl font-bold tracking-[-0.04em] text-white md:text-3xl">
@@ -103,7 +103,7 @@ export default async function HomePage() {
         </div>
       </section>
 
-      <footer className="border-t border-white/8 bg-secondary-bg/70">
+      <footer className="border-t border-stroke bg-secondary-bg/70">
         <div className="mx-auto flex w-full max-w-6xl flex-col items-center justify-between gap-3 px-6 py-6 text-sm text-white/40 sm:flex-row">
           <p>© 2026 ft_discord - student project, 42</p>
           <div className="flex gap-5">

--- a/frontend/src/components/auth-card.tsx
+++ b/frontend/src/components/auth-card.tsx
@@ -20,7 +20,7 @@ const OAUTH_PROVIDERS: { slug: string; label: string; Icon: ComponentType<{ clas
 export function AuthCard({ title, subtitle, alternateHref, alternateLabel, children }: AuthCardProps) {
   return (
     <section className="mx-auto flex min-h-screen w-full max-w-6xl items-center justify-center px-4 py-6 sm:px-6 lg:px-8">
-      <div className="w-full max-w-[25rem] overflow-hidden rounded-[1rem] bg-secondary-bg p-5 shadow-2xl shadow-black/40 ring-1 ring-white/5 sm:p-7">
+      <div className="w-full max-w-[25rem] overflow-hidden rounded-[1rem] bg-secondary-bg p-5 shadow-2xl shadow-black/40 ring-1 ring-stroke sm:p-7">
           <div className="mb-8 flex items-center justify-between gap-4">
             <Link href="/" aria-label="Home" className="text-white">
               <FortyTwoIcon className="h-8 w-8" />

--- a/frontend/src/components/call/call-window.tsx
+++ b/frontend/src/components/call/call-window.tsx
@@ -42,8 +42,8 @@ function CallTile({
   const tileRing = speaking
     ? SPEAKING_RING
     : ringing
-      ? 'ring-1 ring-white/10 opacity-80'
-      : 'ring-1 ring-white/10';
+      ? 'ring-1 ring-stroke opacity-80'
+      : 'ring-1 ring-stroke';
 
   const avatarSize = compact ? 'h-14 w-14 text-xl' : 'h-24 w-24 text-3xl';
 
@@ -134,7 +134,7 @@ export function CallWindow({ resolvePeerName }: CallWindowProps) {
       } ${
         state.isMicMuted
           ? 'bg-pink/15 text-pink ring-pink/40 hover:bg-pink/25'
-          : 'bg-white/10 text-white ring-white/15 hover:bg-white/20'
+          : 'bg-white/10 text-white ring-stroke hover:bg-white/20'
       }`}
       aria-label={state.isMicMuted ? 'Unmute microphone' : 'Mute microphone'}
       aria-pressed={state.isMicMuted}
@@ -166,7 +166,7 @@ export function CallWindow({ resolvePeerName }: CallWindowProps) {
       <audio ref={remoteAudioRef} autoPlay className="hidden" />
 
       {minimized ? (
-        <div className="fixed bottom-4 right-4 z-[55] w-72 overflow-hidden rounded-[1rem] bg-secondary-bg shadow-2xl shadow-black/50 ring-1 ring-white/10">
+        <div className="fixed bottom-4 right-4 z-[55] w-72 overflow-hidden rounded-[1rem] bg-secondary-bg shadow-2xl shadow-black/50 ring-1 ring-stroke">
           <button
             type="button"
             onClick={() => setMinimized(false)}
@@ -206,7 +206,7 @@ export function CallWindow({ resolvePeerName }: CallWindowProps) {
           <button
             type="button"
             onClick={() => setMinimized(true)}
-            className="absolute right-5 top-5 z-10 flex h-10 w-10 items-center justify-center rounded-full bg-white/10 text-white ring-1 ring-white/15 transition hover:bg-white/20"
+            className="absolute right-5 top-5 z-10 flex h-10 w-10 items-center justify-center rounded-full bg-white/10 text-white ring-1 ring-stroke transition hover:bg-white/20"
             aria-label="Minimize call"
           >
             <Minimize2 className="h-5 w-5" strokeWidth={2} />
@@ -250,7 +250,7 @@ export function CallWindow({ resolvePeerName }: CallWindowProps) {
                 className={`flex h-14 w-14 items-center justify-center rounded-full ring-1 transition ${
                   state.isCameraOff
                     ? 'bg-pink/15 text-pink ring-pink/40 hover:bg-pink/25'
-                    : 'bg-white/10 text-white ring-white/15 hover:bg-white/20'
+                    : 'bg-white/10 text-white ring-stroke hover:bg-white/20'
                 }`}
                 aria-label={state.isCameraOff ? 'Turn camera on' : 'Turn camera off'}
                 aria-pressed={state.isCameraOff}

--- a/frontend/src/components/call/incoming-call-overlay.tsx
+++ b/frontend/src/components/call/incoming-call-overlay.tsx
@@ -20,7 +20,7 @@ export function IncomingCallOverlay({ resolvePeerName }: IncomingCallOverlayProp
 
   return (
     <div className="fixed inset-0 z-[60] flex items-center justify-center bg-black/60 px-4 py-6">
-      <section className="relative w-full max-w-[24rem] overflow-hidden rounded-[1rem] bg-secondary-bg p-6 text-center shadow-2xl shadow-black/50 ring-1 ring-white/10">
+      <section className="relative w-full max-w-[24rem] overflow-hidden rounded-[1rem] bg-secondary-bg p-6 text-center shadow-2xl shadow-black/50 ring-1 ring-stroke">
         <span className="mx-auto flex h-20 w-20 items-center justify-center rounded-full bg-aqua/10 text-2xl font-bold text-aqua ring-1 ring-aqua/30">
           {peerName.slice(0, 1).toUpperCase()}
         </span>

--- a/frontend/src/components/channel-list.tsx
+++ b/frontend/src/components/channel-list.tsx
@@ -94,7 +94,7 @@ export function ChannelList({
     <div
       className={`${
         mobilePane === 'channels' ? 'flex' : 'hidden'
-      } min-h-0 flex-1 flex-col overflow-hidden rounded-[1rem] bg-secondary-bg ring-1 ring-white/5 md:flex md:max-w-[25rem]`}
+      } min-h-0 flex-1 flex-col overflow-hidden rounded-[1rem] bg-secondary-bg ring-1 ring-stroke md:flex md:max-w-[25rem]`}
     >
       <div className="shrink-0 px-4 pb-4 pt-4 sm:px-6">
         <div className="flex items-center justify-between gap-4">
@@ -116,7 +116,7 @@ export function ChannelList({
           </div>
         </div>
 
-        <div className="mt-5 h-24 overflow-hidden rounded-lg border border-white/10 bg-[linear-gradient(135deg,#232329_0%,#2b3141_38%,#24545b_68%,#78dce8_100%)] shadow-inner shadow-black/40">
+        <div className="mt-5 h-24 overflow-hidden rounded-lg border border-stroke bg-[linear-gradient(135deg,#232329_0%,#2b3141_38%,#24545b_68%,#78dce8_100%)] shadow-inner shadow-black/40">
           <div className="h-full w-full bg-[linear-gradient(90deg,rgba(16,16,20,0.68),transparent_58%),radial-gradient(circle_at_78%_30%,rgba(255,216,102,0.5),transparent_26%),radial-gradient(circle_at_60%_78%,rgba(255,97,136,0.38),transparent_24%)]" />
         </div>
 
@@ -166,7 +166,7 @@ export function ChannelList({
         </div>
       </div>
 
-      <div className="shrink-0 border-t border-white/8 px-4 py-4">
+      <div className="shrink-0 border-t border-stroke px-4 py-4">
         <div className="flex items-center justify-between gap-3">
           <div className="flex min-w-0 items-center gap-3">
             <AvatarWithStatus

--- a/frontend/src/components/chat-message.tsx
+++ b/frontend/src/components/chat-message.tsx
@@ -192,7 +192,7 @@ export function ChatMessage({
         isGrouped ? 'mt-1 grid grid-cols-[3rem_minmax(0,1fr)] gap-4' : 'mt-6 flex gap-4 first:mt-0'
       } ${isHighlighted ? 'bg-aqua/10 ring-1 ring-aqua/40' : ''}`}
     >
-      <div className="absolute right-3 top-0 hidden -translate-y-1/2 overflow-hidden rounded-md border border-white/10 bg-panel shadow-lg shadow-black/30 group-hover:flex">
+      <div className="absolute right-3 top-0 hidden -translate-y-1/2 overflow-hidden rounded-md border border-stroke bg-panel shadow-lg shadow-black/30 group-hover:flex">
         {canReact ? (
           <button
             type="button"
@@ -244,7 +244,7 @@ export function ChatMessage({
           onClick={() => onOpenAuthorProfile?.(message)}
           className={`flex h-12 w-12 shrink-0 items-center justify-center rounded-full text-xl font-semibold ${getAccentClasses(
             message.accent
-          )} ${onOpenAuthorProfile ? 'transition hover:scale-105 hover:ring-2 hover:ring-white/25' : ''}`}
+          )} ${onOpenAuthorProfile ? 'transition hover:scale-105 hover:ring-2 hover:ring-stroke-strong' : ''}`}
           aria-label={`Open ${message.author} profile`}
         >
           {message.author.slice(0, 1).toUpperCase()}
@@ -353,7 +353,7 @@ export function ChatMessage({
                   onClick={() => {
                     void openAuthedAttachment(attachment.url).catch(() => {});
                   }}
-                  className="block max-w-[16rem] cursor-pointer overflow-hidden rounded-md border border-white/10 bg-transparent p-0"
+                  className="block max-w-[16rem] cursor-pointer overflow-hidden rounded-md border border-stroke bg-transparent p-0"
                 >
                   <AuthedImage
                     src={attachment.url}
@@ -370,7 +370,7 @@ export function ChatMessage({
                       () => {}
                     );
                   }}
-                  className="flex w-full cursor-pointer items-center gap-2 rounded-md border border-white/10 bg-panel px-3 py-2 text-left text-sm text-white/80 transition hover:border-aqua/40 hover:text-white"
+                  className="flex w-full cursor-pointer items-center gap-2 rounded-md border border-stroke bg-panel px-3 py-2 text-left text-sm text-white/80 transition hover:border-aqua/40 hover:text-white"
                 >
                   <FileText className="h-4 w-4 shrink-0" strokeWidth={1.8} />
                   <span className="truncate">{attachment.filename}</span>

--- a/frontend/src/components/chat-workspace.tsx
+++ b/frontend/src/components/chat-workspace.tsx
@@ -795,7 +795,7 @@ export function ChatWorkspace() {
   return (
     <div className="mx-auto flex h-screen w-full gap-4 px-3 py-4 md:px-5 md:py-9">
       {!isHydrated ? (
-        <div className="flex min-h-0 flex-1 rounded-[1rem] bg-secondary-bg ring-1 ring-white/5" />
+        <div className="flex min-h-0 flex-1 rounded-[1rem] bg-secondary-bg ring-1 ring-stroke" />
       ) : (
         <>
           <GuildSidebar
@@ -831,7 +831,7 @@ export function ChatWorkspace() {
           <section
             className={`${
               mobilePane === 'messages' ? 'flex' : 'hidden'
-            } min-h-0 flex-1 flex-col overflow-hidden rounded-[1rem] bg-secondary-bg ring-1 ring-white/5 md:flex`}
+            } min-h-0 flex-1 flex-col overflow-hidden rounded-[1rem] bg-secondary-bg ring-1 ring-stroke md:flex`}
           >
             <ConversationHeader
               chatMode={chatMode}

--- a/frontend/src/components/chat-workspace.tsx
+++ b/frontend/src/components/chat-workspace.tsx
@@ -50,7 +50,7 @@ export function ChatWorkspace() {
   const router = useRouter();
   const { startCall } = useCall();
   const { currentUser, refreshCurrentUser, setCurrentUser } = useCurrentUserProfile();
-  const { selectedGuild, selectGuild } = useGuilds();
+  const { guilds, hasLoadedGuilds, selectedGuild, selectGuild } = useGuilds();
   const [chatMode, setChatMode] = useState<ChatMode>('guild');
   const [isHydrated, setIsHydrated] = useState(false);
   const [draftsByConversation, setDraftsByConversation] = useState<Record<string, string>>({});
@@ -127,6 +127,20 @@ export function ChatWorkspace() {
     setIsHydrated(true);
     void refreshCurrentUser();
   }, [refreshCurrentUser]);
+
+  // A user with no guilds has nothing to show in guild mode (the sidebar
+  // renders a placeholder guild); fall back to the DM view once the guild
+  // list has actually loaded. Not persisted: it's a fallback, not a
+  // preference.
+  useEffect(() => {
+    if (!isHydrated || !hasLoadedGuilds) {
+      return;
+    }
+
+    if (guilds.length === 0 && chatMode === 'guild') {
+      setChatMode('dm');
+    }
+  }, [isHydrated, hasLoadedGuilds, guilds.length, chatMode]);
 
   useEffect(() => {
     // Friends come straight from GET /users/{id}/friends; the DM list itself

--- a/frontend/src/components/chat/conversation-header.tsx
+++ b/frontend/src/components/chat/conversation-header.tsx
@@ -28,7 +28,7 @@ export function ConversationHeader({
   onStartVideoCall
 }: ConversationHeaderProps) {
   return (
-    <div className="flex h-[4.9rem] shrink-0 items-center justify-between border-b border-white/8 px-5 sm:px-7">
+    <div className="flex h-[4.9rem] shrink-0 items-center justify-between border-b border-stroke px-5 sm:px-7">
       <div className="flex items-center gap-3">
         <button
           type="button"

--- a/frontend/src/components/chat/message-composer.tsx
+++ b/frontend/src/components/chat/message-composer.tsx
@@ -49,10 +49,10 @@ export function MessageComposer({
   onShowMobileSidebar
 }: MessageComposerProps) {
   return (
-    <div className="shrink-0 border-t border-white/8 px-4 py-4 sm:px-5">
+    <div className="shrink-0 border-t border-stroke px-4 py-4 sm:px-5">
       <input ref={fileInputRef} type="file" multiple onChange={onFilesSelected} className="hidden" />
       {replyTarget ? (
-        <div className="mb-3 flex items-center justify-between gap-3 rounded-md border border-white/10 bg-panel px-3 py-2 text-xs text-white/60">
+        <div className="mb-3 flex items-center justify-between gap-3 rounded-md border border-stroke bg-panel px-3 py-2 text-xs text-white/60">
           <span className="flex min-w-0 items-center gap-1.5">
             <CornerUpLeft className="h-3.5 w-3.5 shrink-0" strokeWidth={2} />
             <span className="truncate">
@@ -78,7 +78,7 @@ export function MessageComposer({
               className={`flex h-8 items-center gap-2 rounded-full border px-3 text-xs ${
                 attachment.status === 'error'
                   ? 'border-pink/40 text-pink'
-                  : 'border-white/10 text-white/70'
+                  : 'border-stroke text-white/70'
               }`}
             >
               <span className="max-w-[10rem] truncate">{attachment.filename}</span>
@@ -97,7 +97,7 @@ export function MessageComposer({
         </div>
       ) : null}
       {isEmojiOpen ? (
-        <div className="mb-3 rounded-xl border border-white/10 bg-panel p-3">
+        <div className="mb-3 rounded-xl border border-stroke bg-panel p-3">
           <div className="grid grid-cols-6 gap-2">
             {emojiOptions.map((emoji) => (
               <button

--- a/frontend/src/components/dm-list.tsx
+++ b/frontend/src/components/dm-list.tsx
@@ -151,7 +151,7 @@ export function DmList({
     <div
       className={`${
         mobilePane === 'channels' ? 'flex' : 'hidden'
-      } min-h-0 flex-1 flex-col overflow-hidden rounded-[1rem] bg-secondary-bg ring-1 ring-white/5 md:flex md:max-w-[25rem]`}
+      } min-h-0 flex-1 flex-col overflow-hidden rounded-[1rem] bg-secondary-bg ring-1 ring-stroke md:flex md:max-w-[25rem]`}
     >
       <div className="shrink-0 px-4 pb-4 pt-4 sm:px-6">
         <div className="flex items-center justify-between gap-4">
@@ -330,7 +330,7 @@ export function DmList({
         </div>
       )}
 
-      <div className="shrink-0 border-t border-white/8 px-4 py-4">
+      <div className="shrink-0 border-t border-stroke px-4 py-4">
         <div className="flex items-center justify-between gap-3">
           <div className="flex min-w-0 items-center gap-3">
             <AvatarWithStatus

--- a/frontend/src/components/friends-list.tsx
+++ b/frontend/src/components/friends-list.tsx
@@ -470,7 +470,7 @@ export function FriendsList({
                                   <button
                                     type="button"
                                     onClick={() => void handleDecline(user.friendshipId!)}
-                                    className="flex h-8 items-center gap-1.5 rounded-md border border-white/10 bg-frame px-3 text-xs font-semibold text-white/80 transition hover:text-white"
+                                    className="flex h-8 items-center gap-1.5 rounded-md border border-stroke bg-frame px-3 text-xs font-semibold text-white/80 transition hover:text-white"
                                   >
                                     <XButtonIcon />
                                     Cancel
@@ -500,7 +500,7 @@ export function FriendsList({
                                     <button
                                       type="button"
                                       onClick={() => void handleDecline(user.friendshipId!)}
-                                      className="flex h-8 items-center gap-1.5 rounded-md border border-white/10 bg-frame px-3 text-xs font-semibold text-white/80 transition hover:text-white"
+                                      className="flex h-8 items-center gap-1.5 rounded-md border border-stroke bg-frame px-3 text-xs font-semibold text-white/80 transition hover:text-white"
                                     >
                                       <UserX className="h-3.5 w-3.5" strokeWidth={2} />
                                       Decline
@@ -520,13 +520,13 @@ export function FriendsList({
                               <button
                                 type="button"
                                 onClick={() => void handleUnblock(user.id)}
-                                className="flex h-8 items-center gap-1.5 rounded-md border border-white/10 bg-frame px-3 text-xs font-semibold text-white/80 transition hover:text-white"
+                                className="flex h-8 items-center gap-1.5 rounded-md border border-stroke bg-frame px-3 text-xs font-semibold text-white/80 transition hover:text-white"
                               >
                                 <Check className="h-3.5 w-3.5" strokeWidth={2} />
                                 Unblock
                               </button>
                             ) : isBlockedByThem ? (
-                              <span className="rounded-md border border-white/10 bg-frame px-3 py-2 text-xs font-semibold text-white/45">
+                              <span className="rounded-md border border-stroke bg-frame px-3 py-2 text-xs font-semibold text-white/45">
                                 No action available
                               </span>
                             ) : (
@@ -576,7 +576,7 @@ export function FriendsList({
                         {friend.note}
                       </span>
                     </span>
-                    <span className="rounded-md border border-white/10 bg-panel px-2.5 py-1 text-[0.68rem] font-semibold uppercase tracking-[0.14em] text-white/35">
+                    <span className="rounded-md border border-stroke bg-panel px-2.5 py-1 text-[0.68rem] font-semibold uppercase tracking-[0.14em] text-white/35">
                       {toUserStatusLabel(friend.status === 'idle' ? 'idle' : friend.status === 'online' ? 'online' : 'offline')}
                     </span>
                   </button>
@@ -587,7 +587,7 @@ export function FriendsList({
         )}
       </div>
 
-      <div className="shrink-0 border-t border-white/8 px-4 py-4">
+      <div className="shrink-0 border-t border-stroke px-4 py-4">
         <form
           onSubmit={(event) => {
             event.preventDefault();
@@ -677,7 +677,7 @@ function RequestRow({
             <button
               type="button"
               onClick={onDecline}
-              className="flex h-8 items-center gap-1.5 rounded-md border border-white/10 bg-frame px-3 text-xs font-semibold text-white/80 transition hover:text-white"
+              className="flex h-8 items-center gap-1.5 rounded-md border border-stroke bg-frame px-3 text-xs font-semibold text-white/80 transition hover:text-white"
             >
               <UserX className="h-3.5 w-3.5" strokeWidth={2} />
               {outgoing ? 'Cancel' : 'Decline'}

--- a/frontend/src/components/guild-member-list.tsx
+++ b/frontend/src/components/guild-member-list.tsx
@@ -48,7 +48,7 @@ function formatJoinedAt(joinedAt: string) {
 }
 
 export function toProfileMember(member: HydratedGuildMember): GuildMember {
-  // roles come sorted by position descending, so [0] is the highest role
+  // roles come sorted by display priority, so [0] is the highest role
   const topRole = member.roles[0] ?? null;
 
   return {

--- a/frontend/src/components/guild-member-list.tsx
+++ b/frontend/src/components/guild-member-list.tsx
@@ -13,7 +13,10 @@ import { hashToIndex } from '../shared/lib/hash';
 export type GuildMember = {
   id: string;
   name: string;
-  role: 'Owner' | 'Admin' | 'Member';
+  /** 'Owner', 'Member', or the member's highest guild role name. */
+  role: string;
+  /** The highest role's color, used to tint the role token. */
+  roleColor?: string | null;
   status: DirectMessage['status'];
   accent: ChatMessageData['accent'];
   activity: string;
@@ -45,10 +48,14 @@ function formatJoinedAt(joinedAt: string) {
 }
 
 export function toProfileMember(member: HydratedGuildMember): GuildMember {
+  // roles come sorted by position descending, so [0] is the highest role
+  const topRole = member.roles[0] ?? null;
+
   return {
     id: member.userId,
     name: member.displayName,
-    role: member.isOwner ? 'Owner' : member.roles.length > 0 ? 'Admin' : 'Member',
+    role: member.isOwner ? 'Owner' : (topRole?.name ?? 'Member'),
+    roleColor: member.isOwner ? null : (topRole?.color ?? null),
     status: toSidebarStatus(member.status),
     accent: getAccentForId(member.userId),
     activity: member.joinedAt ? `Joined ${formatJoinedAt(member.joinedAt)}` : 'Member',
@@ -63,8 +70,15 @@ function RoleIcon({ member }: { member: HydratedGuildMember }) {
     return <Crown className="h-3.5 w-3.5 shrink-0 text-yellow" strokeWidth={1.9} />;
   }
 
+  const topRoleColor = member.roles[0]?.color;
   if (member.roles.length > 0) {
-    return <Shield className="h-3.5 w-3.5 shrink-0 text-aqua" strokeWidth={1.9} />;
+    return (
+      <Shield
+        className="h-3.5 w-3.5 shrink-0 text-aqua"
+        strokeWidth={1.9}
+        style={topRoleColor ? { color: topRoleColor } : undefined}
+      />
+    );
   }
 
   return null;

--- a/frontend/src/components/guild-member-list.tsx
+++ b/frontend/src/components/guild-member-list.tsx
@@ -131,9 +131,11 @@ export type MemberGroup = {
   members: HydratedGuildMember[];
 };
 
-// Sections members under their top role (most permissions first, matching the
-// display priority of the roles themselves); role-less members go last under
-// "Members". With grouping off, everyone merges into one alphabetical list.
+// The guild owner is pinned first in a dedicated "Owner" section no matter
+// what roles they hold. Everyone else sections under their top role (most
+// permissions first, matching the display priority of the roles themselves);
+// role-less members go last under "Members". With grouping off, everyone
+// merges into one alphabetical list.
 export function buildMemberGroups(
   members: HydratedGuildMember[],
   groupByRole: boolean
@@ -145,12 +147,17 @@ export function buildMemberGroups(
       : [];
   }
 
+  const owners = members.filter((member) => member.isOwner);
   const groupsByRole = new Map<
     string,
     { role: GuildRoleDto | null; members: HydratedGuildMember[] }
   >();
 
   for (const member of members) {
+    if (member.isOwner) {
+      continue;
+    }
+
     const topRole = member.roles[0] ?? null;
     const key = topRole?.id ?? 'members';
     const group = groupsByRole.get(key) ?? { role: topRole, members: [] };
@@ -158,7 +165,7 @@ export function buildMemberGroups(
     groupsByRole.set(key, group);
   }
 
-  return [...groupsByRole.values()]
+  const roleGroups = [...groupsByRole.values()]
     .sort((a, b) => {
       if (!a.role || !b.role) {
         return a.role ? -1 : b.role ? 1 : 0;
@@ -179,6 +186,10 @@ export function buildMemberGroups(
       roleColor: group.role?.color ?? null,
       members: group.members
     }));
+
+  return owners.length > 0
+    ? [{ id: 'owner', title: 'Owner', roleColor: null, members: owners }, ...roleGroups]
+    : roleGroups;
 }
 
 type GuildMemberListProps = {

--- a/frontend/src/components/guild-member-list.tsx
+++ b/frontend/src/components/guild-member-list.tsx
@@ -205,6 +205,7 @@ export function GuildMemberList({ onOpenProfile }: GuildMemberListProps) {
   const groupByRole = useGroupMembersByRole();
 
   const memberGroups = buildMemberGroups(members, groupByRole);
+  const onlineCount = members.filter((member) => member.status !== 'offline').length;
 
   return (
     <aside className="hidden min-h-0 w-[18rem] shrink-0 flex-col overflow-hidden rounded-[1rem] bg-secondary-bg ring-1 ring-stroke xl:flex">
@@ -212,7 +213,7 @@ export function GuildMemberList({ onOpenProfile }: GuildMemberListProps) {
         <div>
           <h2 className="text-[1.05rem] font-bold tracking-[-0.03em] text-white">Members</h2>
           <p className="font-category mt-1 text-[0.7rem] uppercase tracking-[0.14em] text-white/35">
-            {members.length} online and offline
+            {onlineCount} online · {members.length - onlineCount} offline
           </p>
         </div>
       </div>

--- a/frontend/src/components/guild-member-list.tsx
+++ b/frontend/src/components/guild-member-list.tsx
@@ -5,9 +5,12 @@ import { AvatarWithStatus } from './avatar-with-status';
 import type { ChatMessageData } from './chat-message';
 import type { DirectMessage } from './dm-list';
 import { guildMembers } from './mocks/guild-member-mocks';
+import type { GuildRoleDto } from '../shared/api/guild';
 import type { UserStatus } from '../shared/api/user';
 import { useGuilds } from '../shared/guilds/guild-store';
 import { useGuildMembers, type HydratedGuildMember } from '../shared/guilds/use-guild-members';
+import { countPermissionBits, rolePermissionBits } from '../shared/guilds/role-permissions';
+import { useGroupMembersByRole } from '../shared/hooks/use-group-members-by-role';
 import { hashToIndex } from '../shared/lib/hash';
 
 export type GuildMember = {
@@ -121,6 +124,63 @@ function MemberRow({
   );
 }
 
+export type MemberGroup = {
+  id: string;
+  title: string;
+  roleColor: string | null;
+  members: HydratedGuildMember[];
+};
+
+// Sections members under their top role (most permissions first, matching the
+// display priority of the roles themselves); role-less members go last under
+// "Members". With grouping off, everyone merges into one alphabetical list.
+export function buildMemberGroups(
+  members: HydratedGuildMember[],
+  groupByRole: boolean
+): MemberGroup[] {
+  if (!groupByRole) {
+    const merged = [...members].sort((a, b) => a.displayName.localeCompare(b.displayName));
+    return merged.length > 0
+      ? [{ id: 'all', title: 'Members', roleColor: null, members: merged }]
+      : [];
+  }
+
+  const groupsByRole = new Map<
+    string,
+    { role: GuildRoleDto | null; members: HydratedGuildMember[] }
+  >();
+
+  for (const member of members) {
+    const topRole = member.roles[0] ?? null;
+    const key = topRole?.id ?? 'members';
+    const group = groupsByRole.get(key) ?? { role: topRole, members: [] };
+    group.members.push(member);
+    groupsByRole.set(key, group);
+  }
+
+  return [...groupsByRole.values()]
+    .sort((a, b) => {
+      if (!a.role || !b.role) {
+        return a.role ? -1 : b.role ? 1 : 0;
+      }
+
+      const byPermissionCount =
+        countPermissionBits(rolePermissionBits(b.role)) -
+        countPermissionBits(rolePermissionBits(a.role));
+      if (byPermissionCount !== 0) {
+        return byPermissionCount;
+      }
+
+      return a.role.name.localeCompare(b.role.name);
+    })
+    .map((group) => ({
+      id: group.role?.id ?? 'members',
+      title: group.role?.name ?? 'Members',
+      roleColor: group.role?.color ?? null,
+      members: group.members
+    }));
+}
+
 type GuildMemberListProps = {
   onOpenProfile: (member: GuildMember) => void;
 };
@@ -131,13 +191,9 @@ export function GuildMemberList({ onOpenProfile }: GuildMemberListProps) {
     selectedGuild?.id ?? null,
     selectedGuild?.owner_id ?? null
   );
+  const groupByRole = useGroupMembersByRole();
 
-  const staff = members.filter((member) => member.isOwner || member.roles.length > 0);
-  const regulars = members.filter((member) => !member.isOwner && member.roles.length === 0);
-  const memberGroups = [
-    { id: 'staff', title: 'Staff', members: staff },
-    { id: 'members', title: 'Members', members: regulars }
-  ].filter((group) => group.members.length > 0);
+  const memberGroups = buildMemberGroups(members, groupByRole);
 
   return (
     <aside className="hidden min-h-0 w-[18rem] shrink-0 flex-col overflow-hidden rounded-[1rem] bg-secondary-bg ring-1 ring-stroke xl:flex">
@@ -167,9 +223,17 @@ export function GuildMemberList({ onOpenProfile }: GuildMemberListProps) {
           <div className="space-y-6">
             {memberGroups.map((group) => (
               <section key={group.id}>
-                <p className="font-category px-1 text-[0.72rem] uppercase tracking-[0.16em] text-category">
-                  {group.title} - {group.members.length}
-                </p>
+                {groupByRole ? (
+                  <p className="font-category flex items-center gap-1.5 px-1 text-[0.72rem] uppercase tracking-[0.16em] text-category">
+                    {group.roleColor ? (
+                      <span
+                        className="h-2 w-2 shrink-0 rounded-full"
+                        style={{ backgroundColor: group.roleColor }}
+                      />
+                    ) : null}
+                    {group.title} - {group.members.length}
+                  </p>
+                ) : null}
                 <div className="mt-2 space-y-1">
                   {group.members.map((member) => (
                     <MemberRow key={member.userId} member={member} onOpenProfile={onOpenProfile} />

--- a/frontend/src/components/guild-member-list.tsx
+++ b/frontend/src/components/guild-member-list.tsx
@@ -140,8 +140,8 @@ export function GuildMemberList({ onOpenProfile }: GuildMemberListProps) {
   ].filter((group) => group.members.length > 0);
 
   return (
-    <aside className="hidden min-h-0 w-[18rem] shrink-0 flex-col overflow-hidden rounded-[1rem] bg-secondary-bg ring-1 ring-white/5 xl:flex">
-      <div className="flex h-[4.9rem] shrink-0 items-center justify-between border-b border-white/8 px-5">
+    <aside className="hidden min-h-0 w-[18rem] shrink-0 flex-col overflow-hidden rounded-[1rem] bg-secondary-bg ring-1 ring-stroke xl:flex">
+      <div className="flex h-[4.9rem] shrink-0 items-center justify-between border-b border-stroke px-5">
         <div>
           <h2 className="text-[1.05rem] font-bold tracking-[-0.03em] text-white">Members</h2>
           <p className="font-category mt-1 text-[0.7rem] uppercase tracking-[0.14em] text-white/35">

--- a/frontend/src/components/guild-sidebar.tsx
+++ b/frontend/src/components/guild-sidebar.tsx
@@ -43,12 +43,12 @@ export function GuildSidebar({ activeMode, onOpenDms, onOpenGuild }: GuildSideba
   return (
     <aside
       ref={sidebarRef}
-      className="relative hidden min-h-0 w-[7.25rem] flex-col rounded-[1rem] bg-secondary-bg px-5 py-6 ring-1 ring-white/5 md:flex"
+      className="relative hidden min-h-0 w-[7.25rem] flex-col rounded-[1rem] bg-secondary-bg px-5 py-6 ring-1 ring-stroke md:flex"
     >
       <Link href="/" aria-label="Home" className="mx-auto block w-fit text-white">
         <FortyTwoIcon className="h-8 w-8" />
       </Link>
-      <div className="mx-1 mt-5 border-t border-white/10" />
+      <div className="mx-1 mt-5 border-t border-stroke" />
       <div
         className="mt-6 flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto"
         onScroll={() => setTooltip(null)}
@@ -67,7 +67,7 @@ export function GuildSidebar({ activeMode, onOpenDms, onOpenGuild }: GuildSideba
         >
           <MessageCircle className="h-8 w-8" strokeWidth={1.7} />
         </button>
-        <div className="mx-1 border-t border-white/10" />
+        <div className="mx-1 border-t border-stroke" />
         {isLoading && guilds.length === 0 ? (
           <div className="h-[4.9rem] shrink-0 animate-pulse rounded-xl border border-frame bg-panel" />
         ) : null}
@@ -111,7 +111,7 @@ export function GuildSidebar({ activeMode, onOpenDms, onOpenGuild }: GuildSideba
       </div>
       {tooltip ? (
         <div
-          className="pointer-events-none absolute left-[calc(100%+0.4rem)] z-50 -translate-y-1/2 whitespace-nowrap rounded-md border border-white/10 bg-panel px-4 py-2.5 text-base font-semibold text-white shadow-xl shadow-black/30"
+          className="pointer-events-none absolute left-[calc(100%+0.4rem)] z-50 -translate-y-1/2 whitespace-nowrap rounded-md border border-stroke bg-panel px-4 py-2.5 text-base font-semibold text-white shadow-xl shadow-black/30"
           style={{ top: tooltip.top }}
         >
           {tooltip.name}

--- a/frontend/src/components/guild-sidebar.tsx
+++ b/frontend/src/components/guild-sidebar.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import type { MouseEvent } from 'react';
 import Link from 'next/link';
 import { MessageCircle, Plus } from 'lucide-react';
@@ -15,11 +15,44 @@ type GuildSidebarProps = {
   onOpenGuild: () => void;
 };
 
+// glow bars shown at the edges where the guild list is cropped, hinting that
+// scrolling reveals more; a couple px of slack so they hide at the extremes
+const SCROLL_EDGE_SLACK_PX = 4;
+
 export function GuildSidebar({ activeMode, onOpenDms, onOpenGuild }: GuildSidebarProps) {
   const sidebarRef = useRef<HTMLElement>(null);
+  const scrollRef = useRef<HTMLDivElement>(null);
   const { guilds, isLoading, error, selectedGuildId, selectGuild } = useGuilds();
   const [tooltip, setTooltip] = useState<{ name: string; top: number } | null>(null);
   const [isAddGuildOpen, setIsAddGuildOpen] = useState(false);
+  const [croppedEdges, setCroppedEdges] = useState({ top: false, bottom: false });
+
+  const updateCroppedEdges = useCallback(() => {
+    const list = scrollRef.current;
+    if (!list) {
+      return;
+    }
+
+    const top = list.scrollTop > SCROLL_EDGE_SLACK_PX;
+    const bottom = list.scrollTop + list.clientHeight < list.scrollHeight - SCROLL_EDGE_SLACK_PX;
+    setCroppedEdges((previous) =>
+      previous.top === top && previous.bottom === bottom ? previous : { top, bottom }
+    );
+  }, []);
+
+  useEffect(() => {
+    updateCroppedEdges();
+
+    const list = scrollRef.current;
+    if (!list || typeof ResizeObserver === 'undefined') {
+      return;
+    }
+
+    const observer = new ResizeObserver(updateCroppedEdges);
+    observer.observe(list);
+    return () => observer.disconnect();
+    // re-measure when the list content changes, not just on resize
+  }, [updateCroppedEdges, guilds.length, isLoading]);
 
   function handleSelectGuild(guildId: string) {
     selectGuild(guildId);
@@ -49,65 +82,83 @@ export function GuildSidebar({ activeMode, onOpenDms, onOpenGuild }: GuildSideba
         <FortyTwoIcon className="h-8 w-8" />
       </Link>
       <div className="mx-1 mt-5 border-t border-stroke" />
-      <div
-        className="mt-6 flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto"
-        onScroll={() => setTooltip(null)}
-      >
-        <button
-          type="button"
-          onClick={onOpenDms}
-          onMouseEnter={(event) => handleShowLabel('Direct Messages', event)}
-          onMouseLeave={() => setTooltip(null)}
-          className={`flex h-[4.9rem] shrink-0 items-center justify-center rounded-xl border transition ${
-            activeMode === 'dm'
-              ? 'border-aqua bg-panel text-aqua shadow-[0_0_0_1px_rgba(120,220,232,0.2)]'
-              : 'border-frame bg-panel text-[#8b8b8f] hover:text-white'
-          }`}
-          aria-label="Direct messages"
+      <div className="relative mt-6 flex min-h-0 flex-1 flex-col">
+        <div
+          ref={scrollRef}
+          className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto"
+          onScroll={() => {
+            setTooltip(null);
+            updateCroppedEdges();
+          }}
         >
-          <MessageCircle className="h-8 w-8" strokeWidth={1.7} />
-        </button>
-        <div className="mx-1 border-t border-stroke" />
-        {isLoading && guilds.length === 0 ? (
-          <div className="h-[4.9rem] shrink-0 animate-pulse rounded-xl border border-frame bg-panel" />
-        ) : null}
-        {error && guilds.length === 0 ? (
-          <p className="px-1 text-center text-xs text-pink/80" title={error}>
-            Guilds unavailable
-          </p>
-        ) : null}
-        {guilds.map((guild) => (
           <button
-            key={guild.id}
             type="button"
-            onClick={() => handleSelectGuild(guild.id)}
-            onMouseEnter={(event) => handleShowLabel(guild.name, event)}
+            onClick={onOpenDms}
+            onMouseEnter={(event) => handleShowLabel('Direct Messages', event)}
             onMouseLeave={() => setTooltip(null)}
-            className={`h-[4.9rem] shrink-0 overflow-hidden rounded-xl border transition ${
-              guild.id === selectedGuildId && activeMode === 'guild'
-                ? 'border-aqua shadow-[0_0_0_1px_rgba(120,220,232,0.2)]'
-                : 'border-frame'
+            className={`flex h-[4.9rem] shrink-0 items-center justify-center rounded-xl border transition ${
+              activeMode === 'dm'
+                ? 'border-aqua bg-panel text-aqua shadow-[0_0_0_1px_rgba(120,220,232,0.2)]'
+                : 'border-frame bg-panel text-[#8b8b8f] hover:text-white'
             }`}
-            aria-label={guild.name}
+            aria-label="Direct messages"
           >
-            <GuildIcon
-              guildId={guild.id}
-              name={guild.name}
-              iconUrl={guild.icon_url}
-              className="h-full w-full text-2xl"
-            />
+            <MessageCircle className="h-8 w-8" strokeWidth={1.7} />
           </button>
-        ))}
-        <button
-          type="button"
-          onClick={() => setIsAddGuildOpen(true)}
-          onMouseEnter={(event) => handleShowLabel('Add a guild', event)}
-          onMouseLeave={() => setTooltip(null)}
-          className="flex h-[4.9rem] shrink-0 items-center justify-center rounded-xl bg-panel text-[#535353] transition hover:text-white"
-          aria-label="Add guild"
-        >
-          <Plus className="h-8 w-8" strokeWidth={1.5} />
-        </button>
+          <div className="mx-1 border-t border-stroke" />
+          {isLoading && guilds.length === 0 ? (
+            <div className="h-[4.9rem] shrink-0 animate-pulse rounded-xl border border-frame bg-panel" />
+          ) : null}
+          {error && guilds.length === 0 ? (
+            <p className="px-1 text-center text-xs text-pink/80" title={error}>
+              Guilds unavailable
+            </p>
+          ) : null}
+          {guilds.map((guild) => (
+            <button
+              key={guild.id}
+              type="button"
+              onClick={() => handleSelectGuild(guild.id)}
+              onMouseEnter={(event) => handleShowLabel(guild.name, event)}
+              onMouseLeave={() => setTooltip(null)}
+              className={`h-[4.9rem] shrink-0 overflow-hidden rounded-xl border transition ${
+                guild.id === selectedGuildId && activeMode === 'guild'
+                  ? 'border-aqua shadow-[0_0_0_1px_rgba(120,220,232,0.2)]'
+                  : 'border-frame'
+              }`}
+              aria-label={guild.name}
+            >
+              <GuildIcon
+                guildId={guild.id}
+                name={guild.name}
+                iconUrl={guild.icon_url}
+                className="h-full w-full text-2xl"
+              />
+            </button>
+          ))}
+          <button
+            type="button"
+            onClick={() => setIsAddGuildOpen(true)}
+            onMouseEnter={(event) => handleShowLabel('Add a guild', event)}
+            onMouseLeave={() => setTooltip(null)}
+            className="flex h-[4.9rem] shrink-0 items-center justify-center rounded-xl bg-panel text-[#535353] transition hover:text-white"
+            aria-label="Add guild"
+          >
+            <Plus className="h-8 w-8" strokeWidth={1.5} />
+          </button>
+        </div>
+        <div
+          aria-hidden
+          className={`pointer-events-none absolute inset-x-1 top-0 h-[3px] rounded-full bg-aqua/45 shadow-[0_0_10px_2px_rgba(120,220,232,0.35)] transition-opacity duration-300 ${
+            croppedEdges.top ? 'opacity-100' : 'opacity-0'
+          }`}
+        />
+        <div
+          aria-hidden
+          className={`pointer-events-none absolute inset-x-1 bottom-0 h-[3px] rounded-full bg-aqua/45 shadow-[0_0_10px_2px_rgba(120,220,232,0.35)] transition-opacity duration-300 ${
+            croppedEdges.bottom ? 'opacity-100' : 'opacity-0'
+          }`}
+        />
       </div>
       {tooltip ? (
         <div

--- a/frontend/src/components/guild-sidebar.tsx
+++ b/frontend/src/components/guild-sidebar.tsx
@@ -82,10 +82,10 @@ export function GuildSidebar({ activeMode, onOpenDms, onOpenGuild }: GuildSideba
         <FortyTwoIcon className="h-8 w-8" />
       </Link>
       <div className="mx-1 mt-5 border-t border-stroke" />
-      <div className="relative mt-6 flex min-h-0 flex-1 flex-col">
+      <div className="relative flex min-h-0 flex-1 flex-col">
         <div
           ref={scrollRef}
-          className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto"
+          className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto pt-4"
           onScroll={() => {
             setTooltip(null);
             updateCroppedEdges();
@@ -149,13 +149,13 @@ export function GuildSidebar({ activeMode, onOpenDms, onOpenGuild }: GuildSideba
         </div>
         <div
           aria-hidden
-          className={`pointer-events-none absolute inset-x-1 top-0 h-[3px] rounded-full bg-aqua/45 shadow-[0_0_10px_2px_rgba(120,220,232,0.35)] transition-opacity duration-300 ${
+          className={`pointer-events-none absolute inset-x-0 top-0 h-px rounded-full bg-aqua shadow-[0_0_9px_2px_rgba(120,220,232,0.45)] transition-opacity duration-300 ${
             croppedEdges.top ? 'opacity-100' : 'opacity-0'
           }`}
         />
         <div
           aria-hidden
-          className={`pointer-events-none absolute inset-x-1 bottom-0 h-[3px] rounded-full bg-aqua/45 shadow-[0_0_10px_2px_rgba(120,220,232,0.35)] transition-opacity duration-300 ${
+          className={`pointer-events-none absolute inset-x-0 bottom-0 h-px rounded-full bg-aqua shadow-[0_0_9px_2px_rgba(120,220,232,0.45)] transition-opacity duration-300 ${
             croppedEdges.bottom ? 'opacity-100' : 'opacity-0'
           }`}
         />

--- a/frontend/src/components/guild/add-guild-modal.tsx
+++ b/frontend/src/components/guild/add-guild-modal.tsx
@@ -22,8 +22,8 @@ export function AddGuildModal({ onClose }: AddGuildModalProps) {
         onClick={onClose}
         aria-label="Close add guild"
       />
-      <section className="relative w-full max-w-[24rem] overflow-hidden rounded-[1rem] bg-secondary-bg shadow-2xl shadow-black/50 ring-1 ring-white/10">
-        <div className="flex h-[4.75rem] items-center justify-between border-b border-white/8 px-5">
+      <section className="relative w-full max-w-[24rem] overflow-hidden rounded-[1rem] bg-secondary-bg shadow-2xl shadow-black/50 ring-1 ring-stroke">
+        <div className="flex h-[4.75rem] items-center justify-between border-b border-stroke px-5">
           <div className="flex min-w-0 items-center gap-3">
             <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-md bg-aqua/10 text-aqua">
               <Plus className="h-5 w-5" strokeWidth={1.9} />

--- a/frontend/src/components/guild/guild-bans-panel.tsx
+++ b/frontend/src/components/guild/guild-bans-panel.tsx
@@ -104,7 +104,7 @@ export function GuildBansPanel({ guildId }: GuildBansPanelProps) {
     <div className="grid gap-5">
       <form
         onSubmit={handleBan}
-        className="grid gap-3 rounded-md border border-white/8 bg-panel p-4"
+        className="grid gap-3 rounded-md border border-stroke bg-panel p-4"
       >
         <h3 className="flex items-center gap-2 text-base font-bold text-white">
           <Gavel className="h-4 w-4 text-pink" strokeWidth={1.9} />
@@ -145,7 +145,7 @@ export function GuildBansPanel({ guildId }: GuildBansPanelProps) {
           {bans.map((ban) => (
             <li
               key={ban.user_id}
-              className="flex items-center gap-3 rounded-md border border-white/8 bg-panel px-3 py-2.5"
+              className="flex items-center gap-3 rounded-md border border-stroke bg-panel px-3 py-2.5"
             >
               <div className="min-w-0 flex-1">
                 <p className="truncate text-[0.95rem] font-bold text-white">
@@ -159,7 +159,7 @@ export function GuildBansPanel({ guildId }: GuildBansPanelProps) {
               <button
                 type="button"
                 onClick={() => void handleUnban(ban.user_id)}
-                className="h-8 shrink-0 rounded-md border border-white/10 px-3 text-xs font-bold text-white/60 transition hover:border-aqua/40 hover:text-aqua"
+                className="h-8 shrink-0 rounded-md border border-stroke px-3 text-xs font-bold text-white/60 transition hover:border-aqua/40 hover:text-aqua"
               >
                 Unban
               </button>

--- a/frontend/src/components/guild/guild-categories-panel.tsx
+++ b/frontend/src/components/guild/guild-categories-panel.tsx
@@ -121,7 +121,7 @@ export function GuildCategoriesPanel({ guildId }: GuildCategoriesPanelProps) {
     <div className="grid gap-5">
       <form
         onSubmit={handleCreate}
-        className="grid gap-3 rounded-md border border-white/8 bg-panel p-4"
+        className="grid gap-3 rounded-md border border-stroke bg-panel p-4"
       >
         <h3 className="flex items-center gap-2 text-base font-bold text-white">
           <FolderPlus className="h-4 w-4 text-aqua" strokeWidth={1.9} />
@@ -156,7 +156,7 @@ export function GuildCategoriesPanel({ guildId }: GuildCategoriesPanelProps) {
           {categories.map((category) => (
             <li
               key={category.id}
-              className="flex items-center gap-3 rounded-md border border-white/8 bg-panel px-3 py-2.5"
+              className="flex items-center gap-3 rounded-md border border-stroke bg-panel px-3 py-2.5"
             >
               {editingId === category.id ? (
                 <>

--- a/frontend/src/components/guild/guild-channels-panel.tsx
+++ b/frontend/src/components/guild/guild-channels-panel.tsx
@@ -188,7 +188,7 @@ export function GuildChannelsPanel({ guildId, onChannelsChanged }: GuildChannels
     <div className="grid gap-5">
       <form
         onSubmit={handleCreate}
-        className="grid gap-3 rounded-md border border-white/8 bg-panel p-4"
+        className="grid gap-3 rounded-md border border-stroke bg-panel p-4"
       >
         <h3 className="flex items-center gap-2 text-base font-bold text-white">
           <Hash className="h-4 w-4 text-aqua" strokeWidth={1.9} />
@@ -231,7 +231,7 @@ export function GuildChannelsPanel({ guildId, onChannelsChanged }: GuildChannels
           {channels.map((channel) => (
             <li
               key={channel.id}
-              className="grid gap-3 rounded-md border border-white/8 bg-panel px-3 py-2.5"
+              className="grid gap-3 rounded-md border border-stroke bg-panel px-3 py-2.5"
             >
               {editingId === channel.id && editDraft ? (
                 <div className="grid gap-3">

--- a/frontend/src/components/guild/guild-invites-panel.tsx
+++ b/frontend/src/components/guild/guild-invites-panel.tsx
@@ -158,7 +158,7 @@ export function GuildInvitesPanel({ guildId }: GuildInvitesPanelProps) {
     <div className="grid gap-5">
       <form
         onSubmit={handleCreate}
-        className="grid gap-3 rounded-md border border-white/8 bg-panel p-4"
+        className="grid gap-3 rounded-md border border-stroke bg-panel p-4"
       >
         <h3 className="flex items-center gap-2 text-base font-bold text-white">
           <Link2 className="h-4 w-4 text-aqua" strokeWidth={1.9} />
@@ -223,7 +223,7 @@ export function GuildInvitesPanel({ guildId }: GuildInvitesPanelProps) {
           {invites.map((invite) => (
             <li
               key={invite.code}
-              className="flex items-center gap-3 rounded-md border border-white/8 bg-panel px-3 py-2.5"
+              className="flex items-center gap-3 rounded-md border border-stroke bg-panel px-3 py-2.5"
             >
               <div className="min-w-0 flex-1">
                 <p className="mono-detail flex items-center gap-1.5 truncate text-[0.95rem] font-bold text-white">
@@ -250,7 +250,7 @@ export function GuildInvitesPanel({ guildId }: GuildInvitesPanelProps) {
               <button
                 type="button"
                 onClick={() => void handleRevoke(invite.code)}
-                className="h-8 shrink-0 rounded-md border border-white/10 px-3 text-xs font-bold text-white/60 transition hover:border-pink/40 hover:text-pink"
+                className="h-8 shrink-0 rounded-md border border-stroke px-3 text-xs font-bold text-white/60 transition hover:border-pink/40 hover:text-pink"
               >
                 Revoke
               </button>
@@ -261,7 +261,7 @@ export function GuildInvitesPanel({ guildId }: GuildInvitesPanelProps) {
 
       <form
         onSubmit={handlePreview}
-        className="grid gap-3 rounded-md border border-white/8 bg-panel p-4"
+        className="grid gap-3 rounded-md border border-stroke bg-panel p-4"
       >
         <h3 className="flex items-center gap-2 text-base font-bold text-white">
           <Search className="h-4 w-4 text-lavender" strokeWidth={1.9} />
@@ -277,14 +277,14 @@ export function GuildInvitesPanel({ guildId }: GuildInvitesPanelProps) {
           <button
             type="submit"
             disabled={isPreviewing}
-            className="h-11 shrink-0 rounded-md border border-white/10 px-5 text-sm font-bold text-white/70 transition hover:border-aqua/40 hover:text-aqua disabled:cursor-not-allowed disabled:opacity-50"
+            className="h-11 shrink-0 rounded-md border border-stroke px-5 text-sm font-bold text-white/70 transition hover:border-aqua/40 hover:text-aqua disabled:cursor-not-allowed disabled:opacity-50"
           >
             {isPreviewing ? 'Looking up...' : 'Preview'}
           </button>
         </div>
         {previewError ? <FormError message={previewError} /> : null}
         {preview ? (
-          <div className="flex items-center gap-3 rounded-md border border-white/10 bg-frame/50 px-3 py-2.5">
+          <div className="flex items-center gap-3 rounded-md border border-stroke bg-frame/50 px-3 py-2.5">
             <GuildIcon
               guildId={preview.guild.id}
               name={preview.guild.name}

--- a/frontend/src/components/guild/guild-members-panel.tsx
+++ b/frontend/src/components/guild/guild-members-panel.tsx
@@ -1,14 +1,26 @@
 'use client';
 
-import { useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import Image from 'next/image';
-import { Check, Crown, Gavel, Pencil, UserX, X } from 'lucide-react';
-import { banGuildMember, kickGuildMember, updateGuildMemberNickname } from '../../shared/api/guild';
+import { Check, Crown, Gavel, Pencil, Shield, UserX, X } from 'lucide-react';
+import {
+  banGuildMember,
+  kickGuildMember,
+  updateGuildMemberNickname,
+  type GuildRoleDto
+} from '../../shared/api/guild';
 import { useGuilds } from '../../shared/guilds/guild-store';
 import { useGuildMembers, type HydratedGuildMember } from '../../shared/guilds/use-guild-members';
+import {
+  canManageMemberRoles,
+  effectivePermissions,
+  memberRank,
+  type RoleCaller
+} from '../../shared/guilds/role-permissions';
 import { formatDate } from './guild-overview';
 import { getGuildAccentClasses } from './guild-icon';
 import { FormError } from './guild-forms';
+import { MemberRoleChips, MemberRolesPopover } from './member-roles-popover';
 
 const iconButtonClasses =
   'flex h-8 w-8 items-center justify-center rounded-md text-[#8b8b8f] transition hover:bg-frame hover:text-white';
@@ -41,14 +53,18 @@ function MemberAvatar({ member }: { member: HydratedGuildMember }) {
 type MemberRowProps = {
   guildId: string;
   member: HydratedGuildMember;
+  roles: GuildRoleDto[];
+  caller: RoleCaller | null;
   onChanged: () => void;
   onError: (message: string) => void;
 };
 
-function MemberRow({ guildId, member, onChanged, onError }: MemberRowProps) {
+function MemberRow({ guildId, member, roles, caller, onChanged, onError }: MemberRowProps) {
   const [isEditingNickname, setIsEditingNickname] = useState(false);
+  const [isRolesOpen, setIsRolesOpen] = useState(false);
   const [nicknameDraft, setNicknameDraft] = useState(member.nickname ?? '');
   const [isBusy, setIsBusy] = useState(false);
+  const rolesContainerRef = useRef<HTMLDivElement>(null);
 
   async function run(action: () => Promise<unknown>, fallbackMessage: string) {
     try {
@@ -145,16 +161,39 @@ function MemberRow({ guildId, member, onChanged, onError }: MemberRowProps) {
                   ? `@${member.username}`
                   : 'Member'}
               {member.nickname ? ` · nickname: ${member.nickname}` : ''}
-              {member.roles.length > 0
-                ? ` · ${member.roles.map((role) => role.name).join(', ')}`
-                : ''}
               {` · joined ${formatDate(member.joinedAt)}`}
             </p>
+            <MemberRoleChips roles={member.roles} />
           </>
         )}
       </div>
       {!isEditingNickname ? (
         <div className="flex shrink-0 items-center gap-1">
+          {caller ? (
+            <div className="relative" ref={rolesContainerRef}>
+              <button
+                type="button"
+                onClick={() => setIsRolesOpen((open) => !open)}
+                disabled={isBusy}
+                className={iconButtonClasses}
+                aria-label={`Manage roles of ${member.displayName}`}
+                title="Manage roles"
+              >
+                <Shield className="h-4 w-4 text-aqua" strokeWidth={1.9} />
+              </button>
+              {isRolesOpen ? (
+                <MemberRolesPopover
+                  guildId={guildId}
+                  member={member}
+                  roles={roles}
+                  caller={caller}
+                  containerRef={rolesContainerRef}
+                  onChanged={onChanged}
+                  onClose={() => setIsRolesOpen(false)}
+                />
+              ) : null}
+            </div>
+          ) : null}
           <button
             type="button"
             onClick={() => {
@@ -203,12 +242,32 @@ type GuildMembersPanelProps = {
 };
 
 export function GuildMembersPanel({ guildId }: GuildMembersPanelProps) {
-  const { selectedGuild } = useGuilds();
-  const { members, isLoading, error, refresh } = useGuildMembers(
+  const { selectedGuild, currentUserId } = useGuilds();
+  const { members, roles, isLoading, error, refresh } = useGuildMembers(
     guildId,
     selectedGuild?.id === guildId ? selectedGuild.owner_id : null
   );
   const [actionError, setActionError] = useState('');
+
+  // Gate the role controls to callers the server would authorize; the caller
+  // missing from the loaded members (pagination edge) safely hides them.
+  const caller = useMemo<RoleCaller | null>(() => {
+    const callerMember = members.find((member) => member.userId === currentUserId);
+    if (!callerMember) {
+      return null;
+    }
+
+    const permissions = effectivePermissions(callerMember.roles, roles, callerMember.isOwner);
+    if (!canManageMemberRoles(permissions, callerMember.isOwner)) {
+      return null;
+    }
+
+    return {
+      rank: memberRank(callerMember.roles, callerMember.isOwner),
+      permissions,
+      isOwner: callerMember.isOwner
+    };
+  }, [members, roles, currentUserId]);
 
   return (
     <div className="grid gap-3">
@@ -223,6 +282,8 @@ export function GuildMembersPanel({ guildId }: GuildMembersPanelProps) {
               key={member.userId}
               guildId={guildId}
               member={member}
+              roles={roles}
+              caller={caller}
               onChanged={() => {
                 setActionError('');
                 void refresh();

--- a/frontend/src/components/guild/guild-members-panel.tsx
+++ b/frontend/src/components/guild/guild-members-panel.tsx
@@ -108,7 +108,7 @@ function MemberRow({ guildId, member, roles, caller, onChanged, onError }: Membe
   }
 
   return (
-    <li className="flex items-center gap-3 rounded-md border border-white/8 bg-panel px-3 py-2.5">
+    <li className="flex items-center gap-3 rounded-md border border-stroke bg-panel px-3 py-2.5">
       <MemberAvatar member={member} />
       <div className="min-w-0 flex-1">
         {isEditingNickname ? (

--- a/frontend/src/components/guild/guild-overview.tsx
+++ b/frontend/src/components/guild/guild-overview.tsx
@@ -69,7 +69,7 @@ export function GuildOverview({ guildId }: GuildOverviewProps) {
   }
 
   return (
-    <div className="overflow-hidden rounded-[1rem] border border-white/8 bg-panel">
+    <div className="overflow-hidden rounded-[1rem] border border-stroke bg-panel">
       <div
         className="h-28 bg-[linear-gradient(135deg,#232329_0%,#2b3141_38%,#24545b_68%,#78dce8_100%)] bg-cover bg-center"
         style={guild.banner_url ? { backgroundImage: `url(${guild.banner_url})` } : undefined}

--- a/frontend/src/components/guild/guild-roles-panel.tsx
+++ b/frontend/src/components/guild/guild-roles-panel.tsx
@@ -92,7 +92,7 @@ function RoleEditor({
             type="color"
             value={draft.color}
             onChange={(event) => onChange({ ...draft, color: event.target.value })}
-            className="h-10 w-14 cursor-pointer rounded-md border border-white/10 bg-input-bg p-1"
+            className="h-10 w-14 cursor-pointer rounded-md border border-stroke bg-input-bg p-1"
           />
         </label>
       </div>
@@ -149,7 +149,7 @@ function RoleEditor({
           <button
             type="button"
             onClick={onCancel}
-            className="h-10 rounded-md border border-white/10 px-5 text-sm font-bold text-white/60 transition hover:text-white"
+            className="h-10 rounded-md border border-stroke px-5 text-sm font-bold text-white/60 transition hover:text-white"
           >
             Cancel
           </button>
@@ -265,7 +265,7 @@ export function GuildRolesPanel({ guildId }: GuildRolesPanelProps) {
 
   return (
     <div className="grid gap-5">
-      <div className="grid gap-3 rounded-md border border-white/8 bg-panel p-4">
+      <div className="grid gap-3 rounded-md border border-stroke bg-panel p-4">
         <h3 className="flex items-center gap-2 text-base font-bold text-white">
           <ShieldPlus className="h-4 w-4 text-aqua" strokeWidth={1.9} />
           Create a role
@@ -286,7 +286,7 @@ export function GuildRolesPanel({ guildId }: GuildRolesPanelProps) {
       ) : (
         <ul className="grid gap-2">
           {roles.map((role) => (
-            <li key={role.id} className="rounded-md border border-white/8 bg-panel px-3 py-2.5">
+            <li key={role.id} className="rounded-md border border-stroke bg-panel px-3 py-2.5">
               {editingRoleId === role.id ? (
                 <RoleEditor
                   draft={editDraft}
@@ -324,7 +324,7 @@ export function GuildRolesPanel({ guildId }: GuildRolesPanelProps) {
                       setEditDraft(draftFromRole(role));
                       setEditingRoleId(role.id);
                     }}
-                    className="h-8 shrink-0 rounded-md border border-white/10 px-3 text-xs font-bold text-white/60 transition hover:border-aqua/40 hover:text-aqua"
+                    className="h-8 shrink-0 rounded-md border border-stroke px-3 text-xs font-bold text-white/60 transition hover:border-aqua/40 hover:text-aqua"
                   >
                     Edit
                   </button>

--- a/frontend/src/components/guild/guild-settings-modal.tsx
+++ b/frontend/src/components/guild/guild-settings-modal.tsx
@@ -118,7 +118,7 @@ export function GuildSettingsModal({ guildId, onClose, onChannelsChanged }: Guil
         return <GuildSettingsPanel guildId={guildId} />;
       case 'create':
         return (
-          <div className="rounded-[1rem] border border-white/8 bg-panel p-5">
+          <div className="rounded-[1rem] border border-stroke bg-panel p-5">
             <h3 className="text-xl font-bold tracking-[-0.03em] text-white">Create a guild</h3>
             <p className="mt-1 text-sm text-white/45">
               Start a new guild without leaving the chat workspace.
@@ -130,7 +130,7 @@ export function GuildSettingsModal({ guildId, onClose, onChannelsChanged }: Guil
         );
       case 'join':
         return (
-          <div className="rounded-[1rem] border border-white/8 bg-panel p-5">
+          <div className="rounded-[1rem] border border-stroke bg-panel p-5">
             <h3 className="text-xl font-bold tracking-[-0.03em] text-white">Join a guild</h3>
             <p className="mt-1 text-sm text-white/45">
               Use an invite code to join an existing guild.
@@ -151,8 +151,8 @@ export function GuildSettingsModal({ guildId, onClose, onChannelsChanged }: Guil
         onClick={onClose}
         aria-label="Close guild manager"
       />
-      <section className="relative w-full max-w-[86rem] overflow-hidden rounded-[1rem] bg-secondary-bg shadow-2xl shadow-black/50 ring-1 ring-white/10">
-        <div className="flex h-[4.75rem] items-center justify-between border-b border-white/8 px-5">
+      <section className="relative w-full max-w-[86rem] overflow-hidden rounded-[1rem] bg-secondary-bg shadow-2xl shadow-black/50 ring-1 ring-stroke">
+        <div className="flex h-[4.75rem] items-center justify-between border-b border-stroke px-5">
           <div className="flex min-w-0 items-center gap-3">
             <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-md bg-aqua/10 text-aqua">
               <Settings className="h-5 w-5" strokeWidth={1.9} />
@@ -177,8 +177,8 @@ export function GuildSettingsModal({ guildId, onClose, onChannelsChanged }: Guil
         </div>
 
         <div className="grid max-h-[calc(100vh-7rem)] min-h-0 lg:grid-cols-[18rem_minmax(0,1fr)]">
-          <aside className="border-b border-white/8 p-5 lg:min-h-0 lg:border-b-0 lg:border-r">
-            <div className="rounded-[1rem] border border-white/8 bg-panel p-4">
+          <aside className="border-b border-stroke p-5 lg:min-h-0 lg:border-b-0 lg:border-r">
+            <div className="rounded-[1rem] border border-stroke bg-panel p-4">
               <div className="flex items-center gap-3">
                 <GuildIcon
                   guildId={guildId}

--- a/frontend/src/components/guild/guild-settings-panel.tsx
+++ b/frontend/src/components/guild/guild-settings-panel.tsx
@@ -117,7 +117,7 @@ export function GuildSettingsPanel({ guildId }: GuildSettingsPanelProps) {
     <div className="grid gap-5">
       <form
         onSubmit={handleSave}
-        className="grid gap-3 rounded-md border border-white/8 bg-panel p-4"
+        className="grid gap-3 rounded-md border border-stroke bg-panel p-4"
       >
         <h3 className="text-base font-bold text-white">Guild settings</h3>
         <label className="grid gap-2">

--- a/frontend/src/components/guild/member-roles-popover.tsx
+++ b/frontend/src/components/guild/member-roles-popover.tsx
@@ -22,7 +22,7 @@ export function MemberRoleChips({ roles }: { roles: GuildRoleDto[] }) {
       {roles.map((role) => (
         <span
           key={role.id}
-          className="inline-flex items-center gap-1.5 rounded-full border border-white/10 bg-frame px-2 py-0.5 text-[0.7rem] font-semibold text-white/70"
+          className="inline-flex items-center gap-1.5 rounded-full border border-stroke bg-frame px-2 py-0.5 text-[0.7rem] font-semibold text-white/70"
         >
           <span
             className="h-2 w-2 shrink-0 rounded-full"
@@ -100,7 +100,7 @@ export function MemberRolesPopover({
   }
 
   return (
-    <div className="absolute right-0 top-9 z-20 w-64 rounded-md border border-white/8 bg-panel p-2 shadow-lg">
+    <div className="absolute right-0 top-9 z-20 w-64 rounded-md border border-stroke bg-panel p-2 shadow-lg">
       <div className="mb-1 flex items-center justify-between">
         <p className="px-1 text-xs font-bold uppercase tracking-wide text-white/40">Roles</p>
         <button

--- a/frontend/src/components/guild/member-roles-popover.tsx
+++ b/frontend/src/components/guild/member-roles-popover.tsx
@@ -1,0 +1,157 @@
+'use client';
+
+import { useEffect, useState, type RefObject } from 'react';
+import { X } from 'lucide-react';
+import {
+  assignGuildMemberRole,
+  unassignGuildMemberRole,
+  type GuildRoleDto
+} from '../../shared/api/guild';
+import { canToggleRole, type RoleCaller } from '../../shared/guilds/role-permissions';
+import type { HydratedGuildMember } from '../../shared/guilds/use-guild-members';
+import { useCloseOnEscape } from '../../shared/hooks/use-close-on-escape';
+import { FormError } from './guild-forms';
+
+export function MemberRoleChips({ roles }: { roles: GuildRoleDto[] }) {
+  if (roles.length === 0) {
+    return null;
+  }
+
+  return (
+    <span className="mt-1 flex flex-wrap gap-1">
+      {roles.map((role) => (
+        <span
+          key={role.id}
+          className="inline-flex items-center gap-1.5 rounded-full border border-white/10 bg-frame px-2 py-0.5 text-[0.7rem] font-semibold text-white/70"
+        >
+          <span
+            className="h-2 w-2 shrink-0 rounded-full"
+            style={{ backgroundColor: role.color || '#8b8b8f' }}
+          />
+          {role.name}
+        </span>
+      ))}
+    </span>
+  );
+}
+
+type MemberRolesPopoverProps = {
+  guildId: string;
+  member: HydratedGuildMember;
+  roles: GuildRoleDto[];
+  caller: RoleCaller;
+  /** Wrapper holding the trigger button and this popover; clicks outside it close the popover. */
+  containerRef: RefObject<HTMLElement | null>;
+  onChanged: () => void;
+  onClose: () => void;
+};
+
+export function MemberRolesPopover({
+  guildId,
+  member,
+  roles,
+  caller,
+  containerRef,
+  onChanged,
+  onClose
+}: MemberRolesPopoverProps) {
+  const [pendingRoleIds, setPendingRoleIds] = useState<Set<string>>(new Set());
+  const [error, setError] = useState('');
+
+  useCloseOnEscape(onClose);
+
+  useEffect(() => {
+    function handleMouseDown(event: MouseEvent) {
+      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
+        onClose();
+      }
+    }
+
+    document.addEventListener('mousedown', handleMouseDown);
+    return () => document.removeEventListener('mousedown', handleMouseDown);
+  }, [containerRef, onClose]);
+
+  const assignableRoles = roles
+    .filter((role) => !role.is_default)
+    .sort((a, b) => b.position - a.position);
+  const assignedRoleIds = new Set(member.roles.map((role) => role.id));
+
+  async function handleToggle(role: GuildRoleDto, isAssigned: boolean) {
+    setError('');
+    setPendingRoleIds((prev) => new Set(prev).add(role.id));
+
+    try {
+      if (isAssigned) {
+        await unassignGuildMemberRole(guildId, member.userId, role.id);
+      } else {
+        await assignGuildMemberRole(guildId, member.userId, role.id);
+      }
+
+      onChanged();
+    } catch (toggleError) {
+      setError(toggleError instanceof Error ? toggleError.message : 'Failed to update roles.');
+    } finally {
+      setPendingRoleIds((prev) => {
+        const next = new Set(prev);
+        next.delete(role.id);
+        return next;
+      });
+    }
+  }
+
+  return (
+    <div className="absolute right-0 top-9 z-20 w-64 rounded-md border border-white/8 bg-panel p-2 shadow-lg">
+      <div className="mb-1 flex items-center justify-between">
+        <p className="px-1 text-xs font-bold uppercase tracking-wide text-white/40">Roles</p>
+        <button
+          type="button"
+          onClick={onClose}
+          className="flex h-6 w-6 items-center justify-center rounded-md text-[#8b8b8f] transition hover:bg-frame hover:text-white"
+          aria-label="Close role list"
+        >
+          <X className="h-3.5 w-3.5" strokeWidth={2} />
+        </button>
+      </div>
+      {error ? <FormError message={error} /> : null}
+      {assignableRoles.length === 0 ? (
+        <p className="px-1 pb-1 text-sm text-white/35">
+          No roles yet. Create one in the Roles tab.
+        </p>
+      ) : (
+        <ul className="grid max-h-64 gap-0.5 overflow-y-auto">
+          {assignableRoles.map((role) => {
+            const isAssigned = assignedRoleIds.has(role.id);
+            const isPending = pendingRoleIds.has(role.id);
+            const check = canToggleRole(role, isAssigned, caller);
+
+            return (
+              <li key={role.id}>
+                <label
+                  title={check.reason ?? undefined}
+                  className={`flex items-center gap-2 rounded-md px-1.5 py-1 text-sm text-white/60 ${
+                    check.allowed
+                      ? 'cursor-pointer hover:bg-frame'
+                      : 'cursor-not-allowed opacity-50'
+                  }`}
+                >
+                  <input
+                    type="checkbox"
+                    checked={isAssigned}
+                    disabled={!check.allowed || isPending}
+                    onChange={() => void handleToggle(role, isAssigned)}
+                    className="h-4 w-4 accent-[#78dce8]"
+                  />
+                  <span
+                    className="h-2.5 w-2.5 shrink-0 rounded-full"
+                    style={{ backgroundColor: role.color || '#8b8b8f' }}
+                  />
+                  <span className="min-w-0 flex-1 truncate">{role.name}</span>
+                </label>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/legal-page.tsx
+++ b/frontend/src/components/legal-page.tsx
@@ -26,7 +26,7 @@ export function LegalPage({ eyebrow, title, lastUpdated, children }: LegalPagePr
           </h1>
           <p className="mt-3 text-sm text-white/45">Last updated: {lastUpdated}</p>
         </header>
-        <article className="legal-prose mt-10 rounded-[2rem] border border-white/8 bg-secondary-bg/90 p-8 shadow-2xl shadow-black/40 backdrop-blur md:p-12">
+        <article className="legal-prose mt-10 rounded-[2rem] border border-stroke bg-secondary-bg/90 p-8 shadow-2xl shadow-black/40 backdrop-blur md:p-12">
           {children}
         </article>
       </div>

--- a/frontend/src/components/logout-button.tsx
+++ b/frontend/src/components/logout-button.tsx
@@ -22,7 +22,7 @@ export function LogoutButton() {
     <button
       type="button"
       onClick={handleLogout}
-      className="inline-flex items-center gap-2 rounded-full border border-white/15 bg-panel px-5 py-2 text-sm font-bold text-white transition hover:border-pink/50 hover:text-pink"
+      className="inline-flex items-center gap-2 rounded-full border border-stroke bg-panel px-5 py-2 text-sm font-bold text-white transition hover:border-pink/50 hover:text-pink"
     >
       <LogOut className="h-4 w-4" strokeWidth={2} />
       Log out

--- a/frontend/src/components/notification-card.tsx
+++ b/frontend/src/components/notification-card.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import {
   AtSign,
   Bell,
@@ -21,6 +21,7 @@ import type {
   NotificationPreferenceDto,
   NotificationScopeType
 } from '../shared/api/notification';
+import { getUsersByIds } from '../shared/api/user';
 import {
   getNotificationMuteScopes,
   isScopeMuted,
@@ -87,18 +88,24 @@ function getToneClasses(tone: NotificationTone) {
   }
 }
 
-function describeNotification(notification: NotificationDto): NotificationView {
+// actorName is the resolved display name behind actor_id (the message author,
+// requester, inviter, or caller); null while unresolved, so every branch keeps
+// an actor-less fallback.
+export function describeNotification(
+  notification: NotificationDto,
+  actorName: string | null
+): NotificationView {
   switch (notification.type) {
     case 'mention':
       return {
-        title: 'New mention',
+        title: actorName ? `Mention from ${actorName}` : 'New mention',
         detail: notification.payload.preview,
         tone: 'aqua',
         Icon: AtSign
       };
     case 'dm':
       return {
-        title: 'Private message',
+        title: actorName ? `Private message from ${actorName}` : 'Private message',
         detail: notification.payload.preview,
         tone: 'aqua',
         Icon: MessageCircle
@@ -106,14 +113,18 @@ function describeNotification(notification: NotificationDto): NotificationView {
     case 'friend_request':
       return {
         title: 'Friend request',
-        detail: 'Someone wants to add you as a friend.',
+        detail: actorName
+          ? `${actorName} wants to add you as a friend.`
+          : 'Someone wants to add you as a friend.',
         tone: 'pink',
         Icon: UserPlus
       };
     case 'guild_invite':
       return {
         title: 'Guild invite',
-        detail: `You have been invited to ${notification.payload.guild_name}.`,
+        detail: actorName
+          ? `${actorName} invited you to ${notification.payload.guild_name}.`
+          : `You have been invited to ${notification.payload.guild_name}.`,
         tone: 'yellow',
         Icon: Mail
       };
@@ -124,16 +135,15 @@ function describeNotification(notification: NotificationDto): NotificationView {
         tone: 'yellow',
         Icon: Sparkles
       };
-    case 'incoming_call':
+    case 'incoming_call': {
+      const kind = notification.payload.call_type === 'video' ? 'video' : 'audio';
       return {
         title: 'Incoming call',
-        detail:
-          notification.payload.call_type === 'video'
-            ? 'Incoming video call.'
-            : 'Incoming audio call.',
+        detail: actorName ? `Incoming ${kind} call from ${actorName}.` : `Incoming ${kind} call.`,
         tone: 'pink',
         Icon: Phone
       };
+    }
   }
 }
 
@@ -190,6 +200,7 @@ function getScopeLabel(scopeType: NotificationScopeType) {
 
 type NotificationRowProps = {
   notification: NotificationDto;
+  actorName: string | null;
   preferences: NotificationPreferenceDto[];
   onMarkRead: (notificationId: string) => void;
   onDismiss: (notificationId: string) => void;
@@ -199,13 +210,14 @@ type NotificationRowProps = {
 
 function NotificationRow({
   notification,
+  actorName,
   preferences,
   onMarkRead,
   onDismiss,
   onMute,
   onOpen
 }: NotificationRowProps) {
-  const { title, detail, tone, Icon } = describeNotification(notification);
+  const { title, detail, tone, Icon } = describeNotification(notification, actorName);
   const isDismissed = Boolean(notification.dismissed_at);
   const isClickable = hasNotificationTarget(notification);
   const muteScopes = getNotificationMuteScopes(notification).filter(
@@ -488,6 +500,46 @@ export function NotificationCard({ feed, onClose, onOpenNotification }: Notifica
   } = feed;
   const [view, setView] = useState<'feed' | 'mutes'>('feed');
   const [muteError, setMuteError] = useState('');
+  const [actorNamesById, setActorNamesById] = useState<Map<string, string>>(new Map());
+  // ids already requested (found or not), so deleted actors aren't refetched
+  // on every render; rows fall back to actor-less copy for them
+  const requestedActorIdsRef = useRef<Set<string>>(new Set());
+
+  useEffect(() => {
+    const missingIds = notifications
+      .map((notification) => notification.actor_id)
+      .filter((actorId): actorId is string => Boolean(actorId))
+      .filter((actorId) => !requestedActorIdsRef.current.has(actorId));
+
+    if (missingIds.length === 0) {
+      return;
+    }
+
+    for (const actorId of missingIds) {
+      requestedActorIdsRef.current.add(actorId);
+    }
+
+    // no cancellation on cleanup: the merge below is idempotent, and Strict
+    // Mode's mount/unmount/mount cycle would otherwise discard the response
+    // (the second effect run skips ids the first one already marked requested)
+    getUsersByIds(missingIds)
+      .then((users) => {
+        if (users.length === 0) {
+          return;
+        }
+
+        setActorNamesById((previous) => {
+          const next = new Map(previous);
+          for (const user of users) {
+            next.set(user.id, user.display_name || user.username);
+          }
+          return next;
+        });
+      })
+      .catch(() => {
+        // best effort: rows keep their actor-less wording
+      });
+  }, [notifications]);
 
   async function handleRowMute(scope: NotificationMuteScope) {
     setMuteError('');
@@ -601,6 +653,11 @@ export function NotificationCard({ feed, onClose, onOpenNotification }: Notifica
                 <NotificationRow
                   key={notification.id}
                   notification={notification}
+                  actorName={
+                    notification.actor_id
+                      ? (actorNamesById.get(notification.actor_id) ?? null)
+                      : null
+                  }
                   preferences={preferences}
                   onMarkRead={markRead}
                   onDismiss={dismiss}

--- a/frontend/src/components/notification-card.tsx
+++ b/frontend/src/components/notification-card.tsx
@@ -176,7 +176,7 @@ function FilterChip({ active, label, onClick }: FilterChipProps) {
       className={`font-category h-8 rounded-full border px-3 text-[0.68rem] uppercase tracking-[0.12em] transition ${
         active
           ? 'border-aqua/45 bg-aqua/10 text-aqua'
-          : 'border-white/10 text-white/40 hover:border-white/25 hover:text-white/70'
+          : 'border-stroke text-white/40 hover:border-stroke-strong hover:text-white/70'
       }`}
     >
       {label}
@@ -215,7 +215,7 @@ function NotificationRow({
   return (
     <article
       className={`relative rounded-md border px-3 py-3 ${
-        notification.read ? 'border-white/8' : 'border-aqua/25'
+        notification.read ? 'border-stroke' : 'border-aqua/25'
       } bg-panel ${isDismissed ? 'opacity-55' : ''} ${
         isClickable ? 'transition hover:border-aqua/45' : ''
       }`}
@@ -364,7 +364,7 @@ function MutePanel({ preferences, onMute, onUnmute }: MutePanelProps) {
 
   return (
     <div className="space-y-4">
-      <div className="rounded-md border border-white/8 bg-panel px-3 py-3">
+      <div className="rounded-md border border-stroke bg-panel px-3 py-3">
         <p className="font-category text-[0.68rem] uppercase tracking-[0.14em] text-white/35">
           New mute
         </p>
@@ -378,7 +378,7 @@ function MutePanel({ preferences, onMute, onUnmute }: MutePanelProps) {
               className={`h-8 flex-1 rounded-md border text-xs font-semibold transition ${
                 scopeType === option
                   ? 'border-aqua/45 bg-aqua/10 text-aqua'
-                  : 'border-white/10 text-white/40 hover:text-white/70'
+                  : 'border-stroke text-white/40 hover:text-white/70'
               }`}
               >
               {option === 'guild' ? 'Guild' : 'Channel'}
@@ -401,7 +401,7 @@ function MutePanel({ preferences, onMute, onUnmute }: MutePanelProps) {
               className={`h-7 flex-1 rounded-md border text-[0.68rem] font-semibold transition ${
                 duration === option.value
                   ? 'border-yellow/45 bg-yellow/10 text-yellow'
-                  : 'border-white/10 text-white/40 hover:text-white/70'
+                  : 'border-stroke text-white/40 hover:text-white/70'
               }`}
             >
               {option.label}
@@ -427,13 +427,13 @@ function MutePanel({ preferences, onMute, onUnmute }: MutePanelProps) {
           {preferences.map((preference) => (
             <div
               key={`${preference.scope_type}-${preference.scope_id}`}
-              className="flex items-center gap-3 rounded-md border border-white/8 bg-panel px-3 py-2.5"
+              className="flex items-center gap-3 rounded-md border border-stroke bg-panel px-3 py-2.5"
             >
               <span
                 className={`flex h-8 w-8 shrink-0 items-center justify-center rounded-md border ${
                   preference.muted
                     ? 'border-yellow/30 bg-yellow/10 text-yellow'
-                    : 'border-white/10 bg-frame text-white/35'
+                    : 'border-stroke bg-frame text-white/35'
                 }`}
               >
                 <BellOff className="h-4 w-4" strokeWidth={1.9} />
@@ -454,7 +454,7 @@ function MutePanel({ preferences, onMute, onUnmute }: MutePanelProps) {
                 onClick={() => {
                   void onUnmute(preference.scope_type, preference.scope_id).catch(() => {});
                 }}
-                className="flex h-7 shrink-0 items-center gap-1.5 rounded-md border border-white/10 px-2.5 text-xs font-semibold text-white/50 transition hover:border-aqua/40 hover:text-aqua"
+                className="flex h-7 shrink-0 items-center gap-1.5 rounded-md border border-stroke px-2.5 text-xs font-semibold text-white/50 transition hover:border-aqua/40 hover:text-aqua"
               >
                 <Bell className="h-3.5 w-3.5" strokeWidth={1.9} />
                 Unmute
@@ -508,8 +508,8 @@ export function NotificationCard({ feed, onClose, onOpenNotification }: Notifica
         onClick={onClose}
         aria-label="Close notifications"
       />
-      <section className="relative w-full max-w-[25rem] overflow-hidden rounded-[1rem] bg-secondary-bg shadow-2xl shadow-black/50 ring-1 ring-white/10">
-        <div className="flex h-[4.75rem] items-center justify-between border-b border-white/8 px-5">
+      <section className="relative w-full max-w-[25rem] overflow-hidden rounded-[1rem] bg-secondary-bg shadow-2xl shadow-black/50 ring-1 ring-stroke">
+        <div className="flex h-[4.75rem] items-center justify-between border-b border-stroke px-5">
           <div className="flex min-w-0 items-center gap-3">
             <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-md bg-aqua/10 text-aqua">
               <Bell className="h-5 w-5" strokeWidth={1.9} />
@@ -533,7 +533,7 @@ export function NotificationCard({ feed, onClose, onOpenNotification }: Notifica
           </button>
         </div>
 
-        <div className="flex items-center gap-2 border-b border-white/8 px-5 py-3">
+        <div className="flex items-center gap-2 border-b border-stroke px-5 py-3">
           <FilterChip
             active={filter.unreadOnly}
             label="Unread"
@@ -551,7 +551,7 @@ export function NotificationCard({ feed, onClose, onOpenNotification }: Notifica
             className={`font-category ml-auto flex h-8 items-center gap-1.5 rounded-full border px-3 text-[0.68rem] uppercase tracking-[0.12em] transition ${
               view === 'mutes'
                 ? 'border-yellow/45 bg-yellow/10 text-yellow'
-                : 'border-white/10 text-white/40 hover:border-white/25 hover:text-white/70'
+                : 'border-stroke text-white/40 hover:border-stroke-strong hover:text-white/70'
             }`}
           >
             <BellOff className="h-3.5 w-3.5" strokeWidth={1.9} />
@@ -567,7 +567,7 @@ export function NotificationCard({ feed, onClose, onOpenNotification }: Notifica
               {[0, 1, 2].map((index) => (
                 <div
                   key={index}
-                  className="h-16 animate-pulse rounded-md border border-white/8 bg-panel"
+                  className="h-16 animate-pulse rounded-md border border-stroke bg-panel"
                 />
               ))}
             </div>
@@ -577,7 +577,7 @@ export function NotificationCard({ feed, onClose, onOpenNotification }: Notifica
               <button
                 type="button"
                 onClick={refresh}
-                className="flex h-9 items-center gap-2 rounded-md border border-white/10 bg-frame px-4 text-sm font-semibold text-white/70 transition hover:text-white"
+                className="flex h-9 items-center gap-2 rounded-md border border-stroke bg-frame px-4 text-sm font-semibold text-white/70 transition hover:text-white"
               >
                 <RotateCw className="h-4 w-4" strokeWidth={1.9} />
                 Retry
@@ -615,7 +615,7 @@ export function NotificationCard({ feed, onClose, onOpenNotification }: Notifica
                   type="button"
                   onClick={loadMore}
                   disabled={isLoadingMore}
-                  className="flex h-10 w-full items-center justify-center rounded-md border border-white/10 text-sm font-semibold text-white/50 transition hover:text-white disabled:cursor-not-allowed disabled:opacity-50"
+                  className="flex h-10 w-full items-center justify-center rounded-md border border-stroke text-sm font-semibold text-white/50 transition hover:text-white disabled:cursor-not-allowed disabled:opacity-50"
                 >
                   {isLoadingMore ? 'Loading...' : 'Load more'}
                 </button>
@@ -624,7 +624,7 @@ export function NotificationCard({ feed, onClose, onOpenNotification }: Notifica
           )}
         </div>
 
-        <div className="border-t border-white/8 px-4 py-4">
+        <div className="border-t border-stroke px-4 py-4">
           <button
             type="button"
             onClick={markAllRead}

--- a/frontend/src/components/profile-card.tsx
+++ b/frontend/src/components/profile-card.tsx
@@ -22,7 +22,7 @@ export function ProfileCard({
 
   const card = (
     <section
-      className={`relative w-full overflow-hidden rounded-[1rem] bg-secondary-bg shadow-2xl shadow-black/50 ring-1 ring-white/10 ${
+      className={`relative w-full overflow-hidden rounded-[1rem] bg-secondary-bg shadow-2xl shadow-black/50 ring-1 ring-stroke ${
         variant === 'modal' ? 'max-w-[23rem]' : 'min-h-0 max-w-none'
       }`}
     >
@@ -57,7 +57,7 @@ export function ProfileCard({
             avatarUrl={member.avatarUrl ?? undefined}
           />
           <span
-            className="font-category mb-2 max-w-[11rem] truncate rounded-full border border-white/10 bg-panel px-3 py-1 text-[0.68rem] uppercase tracking-[0.14em] text-white/45"
+            className="font-category mb-2 max-w-[11rem] truncate rounded-full border border-stroke bg-panel px-3 py-1 text-[0.68rem] uppercase tracking-[0.14em] text-white/45"
             style={
               member.roleColor
                 ? {
@@ -80,7 +80,7 @@ export function ProfileCard({
           <p className="mt-1 text-sm text-white/45">{member.activity}</p>
         </div>
 
-        <div className="mt-4 rounded-md border border-white/8 bg-panel px-3 py-3">
+        <div className="mt-4 rounded-md border border-stroke bg-panel px-3 py-3">
           <p className="font-category text-[0.68rem] uppercase tracking-[0.14em] text-white/35">
             Bio
           </p>

--- a/frontend/src/components/profile-card.tsx
+++ b/frontend/src/components/profile-card.tsx
@@ -12,7 +12,12 @@ type ProfileCardProps = {
   onSendMessage?: (member: GuildMember) => void;
 };
 
-export function ProfileCard({ member, variant = 'modal', onClose, onSendMessage }: ProfileCardProps) {
+export function ProfileCard({
+  member,
+  variant = 'modal',
+  onClose,
+  onSendMessage
+}: ProfileCardProps) {
   useCloseOnEscape(onClose);
 
   const card = (
@@ -51,7 +56,19 @@ export function ProfileCard({ member, variant = 'modal', onClose, onSendMessage 
             status={member.status}
             avatarUrl={member.avatarUrl ?? undefined}
           />
-          <span className="font-category mb-2 rounded-full border border-white/10 bg-panel px-3 py-1 text-[0.68rem] uppercase tracking-[0.14em] text-white/45">
+          <span
+            className="font-category mb-2 max-w-[11rem] truncate rounded-full border border-white/10 bg-panel px-3 py-1 text-[0.68rem] uppercase tracking-[0.14em] text-white/45"
+            style={
+              member.roleColor
+                ? {
+                    color: member.roleColor,
+                    borderColor: `${member.roleColor}59`,
+                    backgroundColor: `${member.roleColor}1a`
+                  }
+                : undefined
+            }
+            title={member.role}
+          >
             {member.role}
           </span>
         </div>

--- a/frontend/src/components/profile-editor-panel.tsx
+++ b/frontend/src/components/profile-editor-panel.tsx
@@ -150,7 +150,7 @@ export function ProfileEditorPanel({
     <div className="mt-6 grid gap-4 xl:grid-cols-[minmax(0,1.05fr)_minmax(0,0.95fr)]">
       <div className="grid gap-4">
         <div
-          className="overflow-hidden rounded-[1rem] border border-white/8 bg-panel"
+          className="overflow-hidden rounded-[1rem] border border-stroke bg-panel"
           style={
             currentUser.bannerUrl
               ? {
@@ -218,7 +218,7 @@ export function ProfileEditorPanel({
             type="button"
             onClick={() => void handleRemoveAvatar()}
             disabled={isBusyAvatar || !currentUser.avatarUrl}
-            className="flex h-10 items-center justify-center gap-2 rounded-md border border-white/10 bg-frame text-sm font-semibold text-white/70 transition hover:text-white disabled:cursor-not-allowed disabled:opacity-50"
+            className="flex h-10 items-center justify-center gap-2 rounded-md border border-stroke bg-frame text-sm font-semibold text-white/70 transition hover:text-white disabled:cursor-not-allowed disabled:opacity-50"
           >
             Remove avatar
           </button>
@@ -226,13 +226,13 @@ export function ProfileEditorPanel({
             type="button"
             onClick={() => void handleRemoveBanner()}
             disabled={isBusyBanner || !currentUser.bannerUrl}
-            className="flex h-10 items-center justify-center gap-2 rounded-md border border-white/10 bg-frame text-sm font-semibold text-white/70 transition hover:text-white disabled:cursor-not-allowed disabled:opacity-50"
+            className="flex h-10 items-center justify-center gap-2 rounded-md border border-stroke bg-frame text-sm font-semibold text-white/70 transition hover:text-white disabled:cursor-not-allowed disabled:opacity-50"
           >
             Remove banner
           </button>
         </div>
 
-        <div className="rounded-md border border-white/8 bg-panel px-3 py-2 text-xs text-white/40">
+        <div className="rounded-md border border-stroke bg-panel px-3 py-2 text-xs text-white/40">
           <div className="flex items-center gap-2">
             <ImageIcon className="h-3.5 w-3.5" strokeWidth={1.9} />
             Avatars and banners are stored by the user service. Upload a JPEG, PNG, or WebP file.
@@ -290,7 +290,7 @@ export function ProfileEditorPanel({
             <button
               type="button"
               onClick={onBack}
-              className="flex h-11 items-center justify-center rounded-md border border-white/10 bg-frame text-sm font-semibold text-white/70 transition hover:text-white"
+              className="flex h-11 items-center justify-center rounded-md border border-stroke bg-frame text-sm font-semibold text-white/70 transition hover:text-white"
             >
               Back
             </button>

--- a/frontend/src/components/settings-modal.tsx
+++ b/frontend/src/components/settings-modal.tsx
@@ -2,8 +2,19 @@
 
 import { useEffect, useState, type ReactNode } from 'react';
 import { useRouter } from 'next/navigation';
-import { Image as ImageIcon, LogOut, Mail, Settings, ShieldCheck, Trash2, X } from 'lucide-react';
+import {
+  Image as ImageIcon,
+  LogOut,
+  Mail,
+  Settings,
+  ShieldCheck,
+  SlidersHorizontal,
+  Trash2,
+  X
+} from 'lucide-react';
 import { deleteAccount, getIdentity, updateIdentity, type AuthIdentity } from '../shared/api/auth';
+import { setGroupMembersByRole } from '../shared/lib/preferences';
+import { useGroupMembersByRole } from '../shared/hooks/use-group-members-by-role';
 import { clearSession } from '../shared/lib/session';
 import { describeAccountUpdateError, describeDeleteAccountError } from '../shared/lib/auth-errors';
 import { checkEmail, checkPassword } from '../shared/lib/validators/auth';
@@ -19,7 +30,7 @@ type SettingsModalProps = {
   onDisconnect: () => void;
 };
 
-type Panel = 'profile' | 'credentials' | 'delete';
+type Panel = 'profile' | 'credentials' | 'preferences' | 'delete';
 
 export function SettingsModal({ currentUser, onClose, onDisconnect }: SettingsModalProps) {
   const router = useRouter();
@@ -32,6 +43,7 @@ export function SettingsModal({ currentUser, onClose, onDisconnect }: SettingsMo
   } = useCurrentUserProfile();
   const [identity, setIdentity] = useState<AuthIdentity | null>(null);
   const [panel, setPanel] = useState<Panel>('profile');
+  const groupMembersByRole = useGroupMembersByRole();
 
   useCloseOnEscape(onClose);
 
@@ -141,6 +153,13 @@ export function SettingsModal({ currentUser, onClose, onDisconnect }: SettingsMo
                 disabled={isOAuthOnly}
               />
               <SidebarButton
+                active={panel === 'preferences'}
+                icon={SlidersHorizontal}
+                label="Preferences"
+                description="Display options"
+                onClick={() => setPanel('preferences')}
+              />
+              <SidebarButton
                 active={panel === 'delete'}
                 icon={Trash2}
                 label="Delete account"
@@ -198,6 +217,20 @@ export function SettingsModal({ currentUser, onClose, onDisconnect }: SettingsMo
               </PanelSection>
             ) : null}
 
+            {panel === 'preferences' ? (
+              <PanelSection
+                title="Preferences"
+                description="Tune how the app displays things for you."
+              >
+                <PreferenceToggle
+                  label="Group members by role"
+                  description="Sections the guild member list by each member's top role. Turn off to merge everyone into a single list."
+                  checked={groupMembersByRole}
+                  onChange={setGroupMembersByRole}
+                />
+              </PanelSection>
+            ) : null}
+
             {panel === 'delete' ? (
               <PanelSection
                 title="Delete account"
@@ -250,6 +283,41 @@ function SidebarButton({
       <span className="min-w-0">
         <span className="block text-sm font-semibold">{label}</span>
         <span className="mt-0.5 block text-xs text-white/40">{description}</span>
+      </span>
+    </button>
+  );
+}
+
+type PreferenceToggleProps = {
+  label: string;
+  description: string;
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+};
+
+function PreferenceToggle({ label, description, checked, onChange }: PreferenceToggleProps) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      onClick={() => onChange(!checked)}
+      className="flex w-full items-center justify-between gap-4 rounded-md border border-stroke bg-frame px-4 py-3 text-left transition hover:border-aqua/30"
+    >
+      <span className="min-w-0">
+        <span className="block text-sm font-semibold text-white/85">{label}</span>
+        <span className="mt-0.5 block text-xs leading-5 text-white/40">{description}</span>
+      </span>
+      <span
+        className={`relative h-6 w-11 shrink-0 rounded-full transition ${
+          checked ? 'bg-aqua' : 'bg-input-bg'
+        }`}
+      >
+        <span
+          className={`absolute top-0.5 h-5 w-5 rounded-full transition-all ${
+            checked ? 'left-[1.375rem] bg-primary-bg' : 'left-0.5 bg-white/45'
+          }`}
+        />
       </span>
     </button>
   );

--- a/frontend/src/components/settings-modal.tsx
+++ b/frontend/src/components/settings-modal.tsx
@@ -65,8 +65,8 @@ export function SettingsModal({ currentUser, onClose, onDisconnect }: SettingsMo
         onClick={onClose}
         aria-label="Close settings"
       />
-      <section className="relative w-full max-w-[78rem] overflow-hidden rounded-[1rem] bg-secondary-bg shadow-2xl shadow-black/50 ring-1 ring-white/10">
-        <div className="flex h-[4.75rem] items-center justify-between border-b border-white/8 px-5">
+      <section className="relative w-full max-w-[78rem] overflow-hidden rounded-[1rem] bg-secondary-bg shadow-2xl shadow-black/50 ring-1 ring-stroke">
+        <div className="flex h-[4.75rem] items-center justify-between border-b border-stroke px-5">
           <div className="flex min-w-0 items-center gap-3">
             <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-md bg-aqua/10 text-aqua">
               <Settings className="h-5 w-5" strokeWidth={1.9} />
@@ -91,8 +91,8 @@ export function SettingsModal({ currentUser, onClose, onDisconnect }: SettingsMo
         </div>
 
         <div className="grid max-h-[calc(100vh-7rem)] min-h-0 lg:grid-cols-[20rem_minmax(0,1fr)]">
-          <aside className="border-b border-white/8 p-5 lg:border-b-0 lg:border-r">
-            <div className="rounded-[1rem] border border-white/8 bg-panel p-4">
+          <aside className="border-b border-stroke p-5 lg:border-b-0 lg:border-r">
+            <div className="rounded-[1rem] border border-stroke bg-panel p-4">
               <div className="flex items-center gap-4">
                 <AvatarWithStatus
                   size="lg"
@@ -243,7 +243,7 @@ function SidebarButton({
           ? 'border-aqua/40 bg-aqua/10 text-white'
           : destructive
             ? 'border-pink/20 bg-pink/5 text-white/70 hover:border-pink/35 hover:text-white'
-            : 'border-white/10 bg-frame text-white/75 hover:border-aqua/30 hover:text-white'
+            : 'border-stroke bg-frame text-white/75 hover:border-aqua/30 hover:text-white'
       } disabled:cursor-not-allowed disabled:opacity-40`}
     >
       {Icon ? <Icon className="h-4 w-4 shrink-0" strokeWidth={1.9} /> : null}
@@ -263,7 +263,7 @@ type PanelSectionProps = {
 
 function PanelSection({ title, description, children }: PanelSectionProps) {
   return (
-    <section className="grid gap-4 rounded-[1rem] border border-white/8 bg-panel p-5 lg:p-6">
+    <section className="grid gap-4 rounded-[1rem] border border-stroke bg-panel p-5 lg:p-6">
       <div className="grid gap-1">
         <h3 className="text-[1.35rem] font-bold tracking-[-0.04em] text-white">{title}</h3>
         <p className="text-sm leading-6 text-white/45">{description}</p>
@@ -371,7 +371,7 @@ function CredentialsForm({ currentEmail, onBack }: CredentialsFormProps) {
         <button
           type="button"
           onClick={onBack}
-          className="flex h-11 items-center justify-center rounded-md border border-white/10 bg-frame text-sm font-semibold text-white/70 transition hover:text-white"
+          className="flex h-11 items-center justify-center rounded-md border border-stroke bg-frame text-sm font-semibold text-white/70 transition hover:text-white"
         >
           Back
         </button>
@@ -426,7 +426,7 @@ function DeleteAccountPanel({ onBack, onDeleted }: DeleteAccountPanelProps) {
           type="button"
           onClick={onBack}
           disabled={isSubmitting}
-          className="flex h-11 items-center justify-center rounded-md border border-white/10 bg-frame text-sm font-semibold text-white/70 transition hover:text-white disabled:opacity-50"
+          className="flex h-11 items-center justify-center rounded-md border border-stroke bg-frame text-sm font-semibold text-white/70 transition hover:text-white disabled:opacity-50"
         >
           Cancel
         </button>

--- a/frontend/src/shared/api/guild.ts
+++ b/frontend/src/shared/api/guild.ts
@@ -201,6 +201,18 @@ export function kickGuildMember(guildId: string, userId: string) {
   });
 }
 
+export function assignGuildMemberRole(guildId: string, userId: string, roleId: string) {
+  return apiFetch<void>('guild', `/guilds/${guildId}/members/${userId}/roles/${roleId}`, {
+    method: 'PUT'
+  });
+}
+
+export function unassignGuildMemberRole(guildId: string, userId: string, roleId: string) {
+  return apiFetch<void>('guild', `/guilds/${guildId}/members/${userId}/roles/${roleId}`, {
+    method: 'DELETE'
+  });
+}
+
 export function listGuildBans(guildId: string, query?: { limit?: number; after?: string }) {
   return apiFetch<GuildBanDto[]>('guild', `/guilds/${guildId}/bans`, { query });
 }

--- a/frontend/src/shared/guilds/guild-store.tsx
+++ b/frontend/src/shared/guilds/guild-store.tsx
@@ -21,6 +21,8 @@ export const LAST_GUILD_KEY = 'ft_transcendence_last_guild';
 type GuildStoreValue = {
   guilds: MyGuildDto[];
   isLoading: boolean;
+  /** True once the guild list has been fetched successfully at least once. */
+  hasLoadedGuilds: boolean;
   error: string | null;
   selectedGuildId: string | null;
   selectedGuild: MyGuildDto | null;
@@ -70,6 +72,7 @@ function sortByJoinedAt(guilds: MyGuildDto[]) {
 export function GuildProvider({ children }: { children: ReactNode }) {
   const [guilds, setGuilds] = useState<MyGuildDto[]>([]);
   const [isLoading, setIsLoading] = useState(false);
+  const [hasLoadedGuilds, setHasLoadedGuilds] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [selectedGuildId, setSelectedGuildId] = useState<string | null>(null);
   const [currentUserId, setCurrentUserId] = useState<string | null>(null);
@@ -95,6 +98,7 @@ export function GuildProvider({ children }: { children: ReactNode }) {
 
     try {
       applyGuilds(await listMyGuilds());
+      setHasLoadedGuilds(true);
     } catch (refreshError) {
       setError(refreshError instanceof Error ? refreshError.message : 'Failed to load guilds.');
     } finally {
@@ -177,6 +181,7 @@ export function GuildProvider({ children }: { children: ReactNode }) {
     () => ({
       guilds,
       isLoading,
+      hasLoadedGuilds,
       error,
       selectedGuildId,
       selectedGuild,
@@ -189,6 +194,7 @@ export function GuildProvider({ children }: { children: ReactNode }) {
     [
       guilds,
       isLoading,
+      hasLoadedGuilds,
       error,
       selectedGuildId,
       selectedGuild,

--- a/frontend/src/shared/guilds/role-permissions.ts
+++ b/frontend/src/shared/guilds/role-permissions.ts
@@ -1,0 +1,103 @@
+import type { GuildRoleDto } from '../api/guild';
+
+// Client-side mirror of the guild service's PermissionResolver, used to gate
+// the member-role UI so users don't see actions the server would 403. The
+// server remains the source of truth for every mutation.
+export const PERMISSIONS = {
+  ManageRoles: 64,
+  Administrator: 256
+} as const;
+
+export function rolePermissionBits(role: GuildRoleDto): number {
+  return Number(role.permissions) || 0;
+}
+
+export function hasPermission(mask: number, bits: number): boolean {
+  if ((mask & PERMISSIONS.Administrator) !== 0) {
+    return true;
+  }
+
+  return (mask & bits) === bits;
+}
+
+// Union of the @everyone role (from allRoles) and the member's assigned roles.
+// The owner resolves to Administrator, which grants everything.
+export function effectivePermissions(
+  assignedRoles: GuildRoleDto[],
+  allRoles: GuildRoleDto[],
+  isOwner: boolean
+): number {
+  if (isOwner) {
+    return PERMISSIONS.Administrator;
+  }
+
+  let mask = 0;
+
+  for (const role of allRoles) {
+    if (role.is_default) {
+      mask |= rolePermissionBits(role);
+    }
+  }
+
+  for (const role of assignedRoles) {
+    mask |= rolePermissionBits(role);
+  }
+
+  return mask;
+}
+
+// Highest position among explicitly-assigned non-default roles; the owner
+// outranks everyone and a member with no roles outranks no one.
+export function memberRank(assignedRoles: GuildRoleDto[], isOwner: boolean): number {
+  if (isOwner) {
+    return Infinity;
+  }
+
+  let rank = -Infinity;
+
+  for (const role of assignedRoles) {
+    if (!role.is_default && role.position > rank) {
+      rank = role.position;
+    }
+  }
+
+  return rank;
+}
+
+export function canManageMemberRoles(mask: number, isOwner: boolean): boolean {
+  return isOwner || hasPermission(mask, PERMISSIONS.ManageRoles);
+}
+
+export type RoleCaller = {
+  rank: number;
+  permissions: number;
+  isOwner: boolean;
+};
+
+export type RoleToggleCheck = {
+  allowed: boolean;
+  reason: string | null;
+};
+
+// Mirrors AssignRoleHandler/UnassignRoleHandler: the default role is never
+// togglable, hierarchy applies in both directions, and the "you must already
+// hold every bit the role grants" check applies only when assigning.
+export function canToggleRole(
+  role: GuildRoleDto,
+  isAssigned: boolean,
+  caller: RoleCaller
+): RoleToggleCheck {
+  if (role.is_default) {
+    return { allowed: false, reason: 'The default role cannot be assigned or removed.' };
+  }
+
+  if (caller.rank <= role.position) {
+    return { allowed: false, reason: 'This role sits at or above your highest role.' };
+  }
+
+  if (!isAssigned && !hasPermission(caller.permissions, rolePermissionBits(role))) {
+    return { allowed: false, reason: "This role grants permissions you don't have." };
+  }
+
+  return { allowed: true, reason: null };
+}

--- a/frontend/src/shared/guilds/role-permissions.ts
+++ b/frontend/src/shared/guilds/role-permissions.ts
@@ -20,6 +20,45 @@ export function hasPermission(mask: number, bits: number): boolean {
   return (mask & bits) === bits;
 }
 
+export function countPermissionBits(mask: number): number {
+  let count = 0;
+  let rest = mask;
+
+  while (rest !== 0) {
+    count += rest & 1;
+    rest >>>= 1;
+  }
+
+  return count;
+}
+
+// Display priority of a member's roles: the role granting the most
+// permissions wins; on a tie, the most recently assigned one (the API lists
+// a member's role ids most-recently-assigned first, name-alphabetical when
+// assigned at the same instant); name as a final fallback.
+export function sortRolesByDisplayPriority(
+  roles: GuildRoleDto[],
+  assignmentOrder: string[]
+): GuildRoleDto[] {
+  const recencyIndex = new Map(assignmentOrder.map((roleId, index) => [roleId, index]));
+
+  return [...roles].sort((a, b) => {
+    const byPermissionCount =
+      countPermissionBits(rolePermissionBits(b)) - countPermissionBits(rolePermissionBits(a));
+    if (byPermissionCount !== 0) {
+      return byPermissionCount;
+    }
+
+    const aRecency = recencyIndex.get(a.id) ?? Number.MAX_SAFE_INTEGER;
+    const bRecency = recencyIndex.get(b.id) ?? Number.MAX_SAFE_INTEGER;
+    if (aRecency !== bRecency) {
+      return aRecency - bRecency;
+    }
+
+    return a.name.localeCompare(b.name);
+  });
+}
+
 // Union of the @everyone role (from allRoles) and the member's assigned roles.
 // The owner resolves to Administrator, which grants everything.
 export function effectivePermissions(

--- a/frontend/src/shared/guilds/use-guild-members.ts
+++ b/frontend/src/shared/guilds/use-guild-members.ts
@@ -8,6 +8,7 @@ import {
   type GuildRoleDto
 } from '../api/guild';
 import { getUser, getUsersByIds, type UserStatus, type UserSummaryDto } from '../api/user';
+import { sortRolesByDisplayPriority } from './role-permissions';
 import { subscribeProfileUpdated } from '../lib/profile-events';
 
 const MEMBERS_PAGE_SIZE = 100;
@@ -98,10 +99,12 @@ export function hydrateGuildMembers({
 
   return memberRows.map<HydratedGuildMember>((member) => {
     const user = usersById.get(member.user_id);
-    const memberRoles = member.roles
-      .map((roleId) => rolesById.get(roleId))
-      .filter((role): role is GuildRoleDto => Boolean(role))
-      .sort((a, b) => b.position - a.position);
+    const memberRoles = sortRolesByDisplayPriority(
+      member.roles
+        .map((roleId) => rolesById.get(roleId))
+        .filter((role): role is GuildRoleDto => Boolean(role)),
+      member.roles
+    );
 
     const isDeleted = deletedUserIds.has(member.user_id) && !user;
 

--- a/frontend/src/shared/hooks/use-group-members-by-role.ts
+++ b/frontend/src/shared/hooks/use-group-members-by-role.ts
@@ -1,0 +1,8 @@
+'use client';
+
+import { useSyncExternalStore } from 'react';
+import { getGroupMembersByRole, subscribePreferences } from '../lib/preferences';
+
+export function useGroupMembersByRole() {
+  return useSyncExternalStore(subscribePreferences, getGroupMembersByRole, () => true);
+}

--- a/frontend/src/shared/lib/preferences.ts
+++ b/frontend/src/shared/lib/preferences.ts
@@ -1,0 +1,36 @@
+// Client-side display preferences, persisted in localStorage. Same-tab
+// consumers get change notifications through a window event (the 'storage'
+// event only fires in other tabs).
+
+export const GROUP_MEMBERS_BY_ROLE_KEY = 'ft_transcendence_group_members_by_role';
+const PREFERENCES_CHANGED_EVENT = 'ft_transcendence:preferences-changed';
+
+export function getGroupMembersByRole(): boolean {
+  if (typeof window === 'undefined') {
+    return true;
+  }
+
+  return window.localStorage.getItem(GROUP_MEMBERS_BY_ROLE_KEY) !== 'false';
+}
+
+export function setGroupMembersByRole(enabled: boolean): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  window.localStorage.setItem(GROUP_MEMBERS_BY_ROLE_KEY, String(enabled));
+  window.dispatchEvent(new Event(PREFERENCES_CHANGED_EVENT));
+}
+
+export function subscribePreferences(handler: () => void): () => void {
+  if (typeof window === 'undefined') {
+    return () => {};
+  }
+
+  window.addEventListener(PREFERENCES_CHANGED_EVENT, handler);
+  window.addEventListener('storage', handler);
+  return () => {
+    window.removeEventListener(PREFERENCES_CHANGED_EVENT, handler);
+    window.removeEventListener('storage', handler);
+  };
+}

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -35,6 +35,7 @@ const config: Config = {
         panel: '#121213',
         frame: '#1a1a1c',
         stroke: '#242426',
+        'stroke-strong': '#3a3a3f',
         'grey-link': '#848485',
         muted: '#5b5b5c',
         category: '#545454',

--- a/frontend/tests/guild-member-list.test.tsx
+++ b/frontend/tests/guild-member-list.test.tsx
@@ -1,0 +1,65 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { toProfileMember } from '../src/components/guild-member-list';
+import type { HydratedGuildMember } from '../src/shared/guilds/use-guild-members';
+import type { GuildRoleDto } from '../src/shared/api/guild';
+
+function makeRole(overrides: Partial<GuildRoleDto> = {}): GuildRoleDto {
+  return {
+    id: 'r-1',
+    guild_id: 'g-1',
+    name: 'Role',
+    color: '#78dce8',
+    permissions: '0',
+    position: 1,
+    is_hoisted: false,
+    is_mentionable: false,
+    is_default: false,
+    ...overrides
+  };
+}
+
+function makeMember(overrides: Partial<HydratedGuildMember> = {}): HydratedGuildMember {
+  return {
+    userId: 'u-1',
+    displayName: 'Newcomer',
+    username: 'newcomer',
+    avatarUrl: null,
+    bannerUrl: null,
+    bio: null,
+    nickname: null,
+    status: 'online',
+    roles: [],
+    joinedAt: '2026-07-11T00:00:00Z',
+    isOwner: false,
+    isDeleted: false,
+    ...overrides
+  };
+}
+
+describe('toProfileMember', () => {
+  it('uses the highest role name and color instead of a generic "Admin"', () => {
+    const test = makeRole({ id: 'r-test', name: 'test', color: '#ff6188', position: 7 });
+    const plouf = makeRole({ id: 'r-plouf', name: 'plouf', color: '#a9dc76', position: 2 });
+    const profile = toProfileMember(makeMember({ roles: [test, plouf] }));
+
+    assert.equal(profile.role, 'test');
+    assert.equal(profile.roleColor, '#ff6188');
+  });
+
+  it('labels the owner as Owner without a role color', () => {
+    const profile = toProfileMember(
+      makeMember({ isOwner: true, roles: [makeRole({ name: 'test', color: '#ff6188' })] })
+    );
+
+    assert.equal(profile.role, 'Owner');
+    assert.equal(profile.roleColor, null);
+  });
+
+  it('falls back to Member when no roles are assigned', () => {
+    const profile = toProfileMember(makeMember());
+
+    assert.equal(profile.role, 'Member');
+    assert.equal(profile.roleColor, null);
+  });
+});

--- a/frontend/tests/guild-member-list.test.tsx
+++ b/frontend/tests/guild-member-list.test.tsx
@@ -90,16 +90,34 @@ describe('buildMemberGroups', () => {
     );
   });
 
-  it('puts a role-less owner in the Members group', () => {
-    const groups = buildMemberGroups([owner, tester], true);
+  it('pins the owner in an Owner group at the top', () => {
+    const groups = buildMemberGroups([tester, owner], true);
 
     assert.deepEqual(
       groups.map((group) => group.title),
-      ['test', 'Members']
+      ['Owner', 'test']
     );
     assert.deepEqual(
-      groups[1].members.map((member) => member.displayName),
+      groups[0].members.map((member) => member.displayName),
       ['Owner']
+    );
+  });
+
+  it('keeps the owner on top even when another role grants more permissions', () => {
+    const adminRole = makeRole({ id: 'r-admin', name: 'Administrator', permissions: '256' });
+    const richOwner = makeMember({
+      userId: 'u-owner',
+      displayName: 'Owner',
+      isOwner: true,
+      roles: [adminRole]
+    });
+
+    // "test" has all 12 permission flags; the owner's Administrator role has 1
+    const groups = buildMemberGroups([tester, richOwner], true);
+
+    assert.deepEqual(
+      groups.map((group) => group.title),
+      ['Owner', 'test']
     );
   });
 

--- a/frontend/tests/guild-member-list.test.tsx
+++ b/frontend/tests/guild-member-list.test.tsx
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
-import { toProfileMember } from '../src/components/guild-member-list';
+import { buildMemberGroups, toProfileMember } from '../src/components/guild-member-list';
 import type { HydratedGuildMember } from '../src/shared/guilds/use-guild-members';
 import type { GuildRoleDto } from '../src/shared/api/guild';
 
@@ -61,5 +61,74 @@ describe('toProfileMember', () => {
 
     assert.equal(profile.role, 'Member');
     assert.equal(profile.roleColor, null);
+  });
+});
+
+describe('buildMemberGroups', () => {
+  const test = makeRole({ id: 'r-test', name: 'test', color: '#ff6188', permissions: '4095' });
+  const plouf = makeRole({ id: 'r-plouf', name: 'plouf', color: '#a9dc76', permissions: '0' });
+  const tester = makeMember({ userId: 'u-tester', displayName: 'Tester', roles: [test] });
+  const ploufer = makeMember({ userId: 'u-ploufer', displayName: 'Ploufer', roles: [plouf] });
+  const owner = makeMember({ userId: 'u-owner', displayName: 'Owner', isOwner: true });
+  const nobody = makeMember({ userId: 'u-nobody', displayName: 'Anna' });
+
+  it('groups each member under their top role, ordered by permission count', () => {
+    const groups = buildMemberGroups([nobody, ploufer, tester], true);
+
+    assert.deepEqual(
+      groups.map((group) => group.title),
+      ['test', 'plouf', 'Members']
+    );
+    assert.equal(groups[0].roleColor, '#ff6188');
+    assert.deepEqual(
+      groups[0].members.map((member) => member.displayName),
+      ['Tester']
+    );
+    assert.deepEqual(
+      groups[2].members.map((member) => member.displayName),
+      ['Anna']
+    );
+  });
+
+  it('puts a role-less owner in the Members group', () => {
+    const groups = buildMemberGroups([owner, tester], true);
+
+    assert.deepEqual(
+      groups.map((group) => group.title),
+      ['test', 'Members']
+    );
+    assert.deepEqual(
+      groups[1].members.map((member) => member.displayName),
+      ['Owner']
+    );
+  });
+
+  it('breaks equal permission counts alphabetically', () => {
+    const zeta = makeRole({ id: 'r-z', name: 'zeta', permissions: '1' });
+    const alpha = makeRole({ id: 'r-a', name: 'alpha', permissions: '2' });
+    const groups = buildMemberGroups(
+      [makeMember({ userId: 'u-1', roles: [zeta] }), makeMember({ userId: 'u-2', roles: [alpha] })],
+      true
+    );
+
+    assert.deepEqual(
+      groups.map((group) => group.title),
+      ['alpha', 'zeta']
+    );
+  });
+
+  it('merges everyone into one alphabetical list when grouping is off', () => {
+    const groups = buildMemberGroups([tester, nobody, ploufer], false);
+
+    assert.equal(groups.length, 1);
+    assert.deepEqual(
+      groups[0].members.map((member) => member.displayName),
+      ['Anna', 'Ploufer', 'Tester']
+    );
+  });
+
+  it('returns no groups for an empty member list', () => {
+    assert.deepEqual(buildMemberGroups([], false), []);
+    assert.deepEqual(buildMemberGroups([], true), []);
   });
 });

--- a/frontend/tests/guild-members.test.tsx
+++ b/frontend/tests/guild-members.test.tsx
@@ -72,4 +72,21 @@ describe('hydrateGuildMembers', () => {
     assert.equal(hydrated[0].displayName, 'Member');
     assert.equal(hydrated[0].isDeleted, false);
   });
+
+  it('orders member roles by permission count, not position', () => {
+    const roles: GuildRoleDto[] = [
+      { ...guildRoles[0], id: 'r-high-pos', name: 'plouf', permissions: '0', position: 10 },
+      { ...guildRoles[0], id: 'r-full', name: 'test', permissions: '4095', position: 2 }
+    ];
+    const hydrated = hydrateGuildMembers({
+      memberRows: [{ ...memberRows[0], roles: ['r-high-pos', 'r-full'] }],
+      guildRoles: roles,
+      users: [user]
+    });
+
+    assert.deepEqual(
+      hydrated[0].roles.map((role) => role.name),
+      ['test', 'plouf']
+    );
+  });
 });

--- a/frontend/tests/member-roles-popover.test.tsx
+++ b/frontend/tests/member-roles-popover.test.tsx
@@ -1,0 +1,114 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { createRef } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { MemberRoleChips, MemberRolesPopover } from '../src/components/guild/member-roles-popover';
+import type { GuildRoleDto } from '../src/shared/api/guild';
+import type { HydratedGuildMember } from '../src/shared/guilds/use-guild-members';
+import { PERMISSIONS, type RoleCaller } from '../src/shared/guilds/role-permissions';
+
+function makeRole(overrides: Partial<GuildRoleDto> = {}): GuildRoleDto {
+  return {
+    id: 'r-1',
+    guild_id: 'g-1',
+    name: 'Role',
+    color: '#78dce8',
+    permissions: '0',
+    position: 1,
+    is_hoisted: false,
+    is_mentionable: false,
+    is_default: false,
+    ...overrides
+  };
+}
+
+const everyone = makeRole({ id: 'r-everyone', name: '@everyone', position: 0, is_default: true });
+const moderator = makeRole({ id: 'r-mod', name: 'Moderator', color: '#ff6188', position: 5 });
+const helper = makeRole({ id: 'r-helper', name: 'Helper', color: '#a9dc76', position: 2 });
+const overseer = makeRole({ id: 'r-overseer', name: 'Overseer', position: 9, permissions: '2048' });
+
+function makeMember(roles: GuildRoleDto[]): HydratedGuildMember {
+  return {
+    userId: 'u-1',
+    displayName: 'Newcomer',
+    username: 'newcomer',
+    avatarUrl: null,
+    bannerUrl: null,
+    bio: null,
+    nickname: null,
+    status: 'online',
+    roles,
+    joinedAt: '2026-07-11T00:00:00Z',
+    isOwner: false,
+    isDeleted: false
+  };
+}
+
+const midCaller: RoleCaller = { rank: 6, permissions: PERMISSIONS.ManageRoles, isOwner: false };
+
+function renderPopover(member: HydratedGuildMember, roles: GuildRoleDto[], caller: RoleCaller) {
+  return renderToStaticMarkup(
+    <MemberRolesPopover
+      guildId="g-1"
+      member={member}
+      roles={roles}
+      caller={caller}
+      containerRef={createRef<HTMLDivElement>()}
+      onChanged={() => undefined}
+      onClose={() => undefined}
+    />
+  );
+}
+
+describe('MemberRoleChips', () => {
+  it('renders one chip per role with its color dot', () => {
+    const html = renderToStaticMarkup(<MemberRoleChips roles={[moderator, helper]} />);
+
+    assert.ok(html.includes('Moderator'));
+    assert.ok(html.includes('Helper'));
+    assert.ok(html.includes('background-color:#ff6188'));
+    assert.ok(html.includes('background-color:#a9dc76'));
+  });
+
+  it('renders nothing without roles', () => {
+    assert.equal(renderToStaticMarkup(<MemberRoleChips roles={[]} />), '');
+  });
+});
+
+describe('MemberRolesPopover', () => {
+  it('lists non-default roles sorted by position descending', () => {
+    const html = renderPopover(makeMember([]), [everyone, helper, moderator], midCaller);
+
+    assert.ok(!html.includes('@everyone'));
+    assert.ok(html.indexOf('Moderator') < html.indexOf('Helper'));
+  });
+
+  it('checks the roles the member holds', () => {
+    const html = renderPopover(makeMember([helper]), [helper, moderator], midCaller);
+
+    const checkboxes = html.match(/<input[^>]*type="checkbox"[^>]*>/g) ?? [];
+    assert.equal(checkboxes.length, 2);
+    assert.equal(checkboxes.filter((input) => input.includes('checked')).length, 1);
+  });
+
+  it('disables roles at or above the caller rank with a hierarchy hint', () => {
+    const html = renderPopover(makeMember([]), [overseer], midCaller);
+
+    assert.ok(html.includes('disabled'));
+    assert.ok(html.includes('This role sits at or above your highest role.'));
+  });
+
+  it('disables assigning roles that grant bits the caller lacks', () => {
+    const richRole = makeRole({ id: 'r-rich', name: 'Rich', position: 2, permissions: '2048' });
+    const html = renderPopover(makeMember([]), [richRole], midCaller);
+
+    assert.ok(html.includes('disabled'));
+    assert.ok(html.includes('This role grants permissions you don&#x27;t have.'));
+  });
+
+  it('shows an empty state when only the default role exists', () => {
+    const html = renderPopover(makeMember([]), [everyone], midCaller);
+
+    assert.ok(html.includes('No roles yet. Create one in the Roles tab.'));
+  });
+});

--- a/frontend/tests/notification-card.test.tsx
+++ b/frontend/tests/notification-card.test.tsx
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import { renderToStaticMarkup } from 'react-dom/server';
-import { NotificationCard } from '../src/components/notification-card';
+import { NotificationCard, describeNotification } from '../src/components/notification-card';
 import type { NotificationDto } from '../src/shared/api/notification';
 import type { UseNotificationsResult } from '../src/shared/lib/use-notifications';
 
@@ -70,8 +70,46 @@ describe('NotificationCard', () => {
     assert.equal(html.split('aria-label="Voir la demande d ami"').length - 1, 1);
     // an incoming call has nowhere to deep-link to
     assert.equal(html.split('aria-label="Ouvrir').length - 1, 1);
-    assert.ok(html.includes('Message prive'));
-    assert.ok(html.includes('Demande d ami'));
-    assert.ok(html.includes('Appel entrant'));
+    assert.ok(html.includes('Private message'));
+    assert.ok(html.includes('Friend request'));
+    assert.ok(html.includes('Incoming call'));
+  });
+});
+
+describe('describeNotification', () => {
+  it('names the author when the actor is resolved', () => {
+    assert.equal(describeNotification(dmNotification, 'Testa').title, 'Private message from Testa');
+    assert.equal(
+      describeNotification(friendRequestNotification, 'Testa').detail,
+      'Testa wants to add you as a friend.'
+    );
+    assert.equal(
+      describeNotification(incomingCallNotification, 'Testa').detail,
+      'Incoming audio call from Testa.'
+    );
+    assert.equal(
+      describeNotification(
+        {
+          ...dmNotification,
+          id: '903',
+          type: 'mention',
+          payload: { channel_id: '1', guild_id: '2', preview: 'hey' }
+        },
+        'Testa'
+      ).title,
+      'Mention from Testa'
+    );
+  });
+
+  it('keeps actor-less wording while the author is unresolved', () => {
+    assert.equal(describeNotification(dmNotification, null).title, 'Private message');
+    assert.equal(
+      describeNotification(friendRequestNotification, null).detail,
+      'Someone wants to add you as a friend.'
+    );
+    assert.equal(
+      describeNotification(incomingCallNotification, null).detail,
+      'Incoming audio call.'
+    );
   });
 });

--- a/frontend/tests/profile-card.test.tsx
+++ b/frontend/tests/profile-card.test.tsx
@@ -32,4 +32,25 @@ describe('ProfileCard', () => {
 
     assert.ok(fallbackHtml.includes('No bio set.'));
   });
+
+  it('renders the actual role name tinted with the role color', () => {
+    const html = renderToStaticMarkup(
+      <ProfileCard
+        member={{ ...member, role: 'test', roleColor: '#ff6188' }}
+        onClose={() => undefined}
+      />
+    );
+
+    assert.ok(html.includes('>test</span>'));
+    assert.ok(html.includes('color:#ff6188'));
+    assert.ok(html.includes('border-color:#ff618859'));
+    assert.ok(html.includes('background-color:#ff61881a'));
+  });
+
+  it('keeps the neutral token when no role color is set', () => {
+    const html = renderToStaticMarkup(<ProfileCard member={member} onClose={() => undefined} />);
+
+    assert.ok(html.includes('>Owner</span>'));
+    assert.ok(!html.includes('border-color'));
+  });
 });

--- a/frontend/tests/role-permissions.test.ts
+++ b/frontend/tests/role-permissions.test.ts
@@ -4,9 +4,11 @@ import {
   PERMISSIONS,
   canManageMemberRoles,
   canToggleRole,
+  countPermissionBits,
   effectivePermissions,
   hasPermission,
   memberRank,
+  sortRolesByDisplayPriority,
   type RoleCaller
 } from '../src/shared/guilds/role-permissions';
 import type { GuildRoleDto } from '../src/shared/api/guild';
@@ -87,6 +89,55 @@ describe('canManageMemberRoles', () => {
 
   it('rejects everyone else', () => {
     assert.equal(canManageMemberRoles(515, false), false);
+  });
+});
+
+describe('countPermissionBits', () => {
+  it('counts the permission flags set on a mask', () => {
+    assert.equal(countPermissionBits(0), 0);
+    assert.equal(countPermissionBits(256), 1);
+    assert.equal(countPermissionBits(64 | 16 | 32), 3);
+    assert.equal(countPermissionBits(4095), 12);
+  });
+});
+
+describe('sortRolesByDisplayPriority', () => {
+  it('puts the role with the most permissions first, regardless of position', () => {
+    const full = makeRole({ id: 'r-full', name: 'test', permissions: '4095', position: 1 });
+    const none = makeRole({ id: 'r-none', name: 'plouf', permissions: '0', position: 9 });
+    const some = makeRole({ id: 'r-some', name: 'mid', permissions: '112', position: 5 });
+
+    const sorted = sortRolesByDisplayPriority([none, some, full], []);
+
+    assert.deepEqual(
+      sorted.map((role) => role.name),
+      ['test', 'mid', 'plouf']
+    );
+  });
+
+  it('breaks permission-count ties by assignment recency (API order)', () => {
+    const older = makeRole({ id: 'r-older', name: 'older', permissions: '3' });
+    const newer = makeRole({ id: 'r-newer', name: 'newer', permissions: '5' });
+
+    // the API lists role ids most-recently-assigned first
+    const sorted = sortRolesByDisplayPriority([older, newer], ['r-newer', 'r-older']);
+
+    assert.deepEqual(
+      sorted.map((role) => role.name),
+      ['newer', 'older']
+    );
+  });
+
+  it('falls back to alphabetical order when count and recency do not separate', () => {
+    const zeta = makeRole({ id: 'r-z', name: 'zeta', permissions: '1' });
+    const alpha = makeRole({ id: 'r-a', name: 'alpha', permissions: '2' });
+
+    const sorted = sortRolesByDisplayPriority([zeta, alpha], []);
+
+    assert.deepEqual(
+      sorted.map((role) => role.name),
+      ['alpha', 'zeta']
+    );
   });
 });
 

--- a/frontend/tests/role-permissions.test.ts
+++ b/frontend/tests/role-permissions.test.ts
@@ -1,0 +1,145 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  PERMISSIONS,
+  canManageMemberRoles,
+  canToggleRole,
+  effectivePermissions,
+  hasPermission,
+  memberRank,
+  type RoleCaller
+} from '../src/shared/guilds/role-permissions';
+import type { GuildRoleDto } from '../src/shared/api/guild';
+
+function makeRole(overrides: Partial<GuildRoleDto> = {}): GuildRoleDto {
+  return {
+    id: 'r-1',
+    guild_id: 'g-1',
+    name: 'Role',
+    color: '#78dce8',
+    permissions: '0',
+    position: 1,
+    is_hoisted: false,
+    is_mentionable: false,
+    is_default: false,
+    ...overrides
+  };
+}
+
+const everyone = makeRole({
+  id: 'r-everyone',
+  name: '@everyone',
+  permissions: '515',
+  position: 0,
+  is_default: true
+});
+const moderator = makeRole({ id: 'r-mod', name: 'Moderator', permissions: '112', position: 5 });
+const admin = makeRole({ id: 'r-admin', name: 'Administrator', permissions: '256', position: 10 });
+
+describe('memberRank', () => {
+  it('gives the owner the highest possible rank', () => {
+    assert.equal(memberRank([admin], true), Infinity);
+    assert.equal(memberRank([], true), Infinity);
+  });
+
+  it('gives a member with no roles the lowest possible rank', () => {
+    assert.equal(memberRank([], false), -Infinity);
+  });
+
+  it('ignores the default role and picks the highest position', () => {
+    assert.equal(memberRank([everyone, moderator], false), 5);
+    assert.equal(memberRank([everyone], false), -Infinity);
+    assert.equal(memberRank([moderator, admin], false), 10);
+  });
+});
+
+describe('effectivePermissions', () => {
+  it('unions the default role with assigned roles', () => {
+    assert.equal(effectivePermissions([moderator], [everyone, moderator, admin], false), 515 | 112);
+  });
+
+  it('includes only the default role when nothing is assigned', () => {
+    assert.equal(effectivePermissions([], [everyone, moderator, admin], false), 515);
+  });
+
+  it('resolves the owner to Administrator', () => {
+    assert.equal(effectivePermissions([], [everyone], true), PERMISSIONS.Administrator);
+  });
+});
+
+describe('hasPermission', () => {
+  it('lets the Administrator bit grant everything', () => {
+    assert.equal(hasPermission(PERMISSIONS.Administrator, 2048), true);
+  });
+
+  it('requires every requested bit otherwise', () => {
+    assert.equal(hasPermission(64 | 16, 64), true);
+    assert.equal(hasPermission(64 | 16, 64 | 32), false);
+  });
+});
+
+describe('canManageMemberRoles', () => {
+  it('allows the owner, Administrator and ManageRoles holders', () => {
+    assert.equal(canManageMemberRoles(0, true), true);
+    assert.equal(canManageMemberRoles(PERMISSIONS.Administrator, false), true);
+    assert.equal(canManageMemberRoles(PERMISSIONS.ManageRoles, false), true);
+  });
+
+  it('rejects everyone else', () => {
+    assert.equal(canManageMemberRoles(515, false), false);
+  });
+});
+
+describe('canToggleRole', () => {
+  const midCaller: RoleCaller = {
+    rank: 5,
+    permissions: 515 | 112 | PERMISSIONS.ManageRoles,
+    isOwner: false
+  };
+  const owner: RoleCaller = {
+    rank: Infinity,
+    permissions: PERMISSIONS.Administrator,
+    isOwner: true
+  };
+
+  it('never allows toggling the default role', () => {
+    assert.equal(canToggleRole(everyone, false, owner).allowed, false);
+    assert.equal(canToggleRole(everyone, true, owner).allowed, false);
+  });
+
+  it('blocks roles at or above the caller rank in both directions', () => {
+    const sameRank = makeRole({ position: 5 });
+    assert.equal(canToggleRole(sameRank, false, midCaller).allowed, false);
+    assert.equal(canToggleRole(sameRank, true, midCaller).allowed, false);
+    assert.match(canToggleRole(sameRank, false, midCaller).reason ?? '', /at or above/);
+  });
+
+  it('allows a lower role the caller can fully grant', () => {
+    const lower = makeRole({ position: 2, permissions: '112' });
+    assert.deepEqual(canToggleRole(lower, false, midCaller), { allowed: true, reason: null });
+  });
+
+  it('blocks assigning a role granting bits the caller lacks but allows unassigning it', () => {
+    const banRole = makeRole({ position: 2, permissions: '2048' });
+    assert.equal(canToggleRole(banRole, false, midCaller).allowed, false);
+    assert.match(canToggleRole(banRole, false, midCaller).reason ?? '', /grants permissions/);
+    assert.equal(canToggleRole(banRole, true, midCaller).allowed, true);
+  });
+
+  it('lets Administrator bypass the grant check but not the hierarchy', () => {
+    const adminCaller: RoleCaller = {
+      rank: 5,
+      permissions: PERMISSIONS.Administrator,
+      isOwner: false
+    };
+    const lowRich = makeRole({ position: 2, permissions: '4095' });
+    const highRole = makeRole({ position: 10, permissions: '0' });
+    assert.equal(canToggleRole(lowRich, false, adminCaller).allowed, true);
+    assert.equal(canToggleRole(highRole, false, adminCaller).allowed, false);
+  });
+
+  it('allows the owner to toggle any non-default role', () => {
+    assert.equal(canToggleRole(admin, false, owner).allowed, true);
+    assert.equal(canToggleRole(moderator, true, owner).allowed, true);
+  });
+});

--- a/services/guild/src/Guild.Persistence/Repositories/GuildRepository.cs
+++ b/services/guild/src/Guild.Persistence/Repositories/GuildRepository.cs
@@ -69,11 +69,20 @@ internal sealed class GuildRepository(GuildDbContext context) : IGuildRepository
 		// change committing between the two selects can leave a member listed with
 		// stale RoleIds. acceptable eventual consistency for a paginated list; a
 		// fresh page reflects the change.
+		// role ids are emitted most-recently-assigned first (name breaks exact
+		// AssignedAt ties) so clients can use the order as assignment recency.
 		var userIds = members.Select(m => m.UserId).ToList();
 		var assignments = await context.MemberRoles
 			.AsNoTracking()
 			.Where(mr => mr.GuildId == guildId && userIds.Contains(mr.UserId))
-			.Select(mr => new { mr.UserId, mr.RoleId })
+			.Join(
+				context.Roles,
+				mr => new { mr.GuildId, RoleId = mr.RoleId },
+				r => new { r.GuildId, RoleId = r.Id },
+				(mr, r) => new { mr.UserId, mr.RoleId, mr.AssignedAt, r.Name })
+			.OrderByDescending(a => a.AssignedAt)
+			.ThenBy(a => a.Name)
+			.Select(a => new { a.UserId, a.RoleId })
 			.ToListAsync(cancellationToken);
 
 		var rolesByUser = assignments


### PR DESCRIPTION
Wires the existing backend member-role endpoints into the frontend and cleans up the member list, notifications, and guild rail along the way.

### Features
- **Member role assignment** — assign/remove roles from the Members panel via a per-member popover, with colored role chips and client-side gating mirroring the server rules (ManageRoles/hierarchy/grant checks)
- **Role-based member list** — sections per role (color-dotted headers) instead of a generic "Staff", owner pinned in an `Owner` section on top, plus a Settings → Preferences toggle to merge everyone into one flat list
- **Role display priority** — a member's top role is the one with the most permissions, then most recently given, then alphabetical (backend now emits role ids in assignment order)
- **Notification authors** — notifications name their source ("Private message from X", "X invited you to …") by resolving the `actor_id` the backend already sent
- **Guild rail overflow hint** — a thin aqua glow line marks the cropped edge of the guild list (bottom, top, or both depending on scroll)

---

### Fixes
- Landing on a broken placeholder guild view when logging in with no guilds → opens the DM view instead
- Profile card showing a hardcoded "Admin" token → shows the real top role name in its color
- Member list header "N online and offline" → real split, for example "2 online · 1 offline"
- Uneven spacing around the DM icon in the guild rail

---

### Chores
- All white-alpha borders/separators unified on the palette's `stroke` grey token