### PR TITLE
Fix: hostname agnostic urls

### DIFF
--- a/frontend/src/components/settings-modal.tsx
+++ b/frontend/src/components/settings-modal.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState, type ReactNode } from 'react';
 import { useRouter } from 'next/navigation';
 import {
+  Download,
   Image as ImageIcon,
   LogOut,
   Mail,
@@ -13,6 +14,8 @@ import {
   X
 } from 'lucide-react';
 import { deleteAccount, getIdentity, updateIdentity, type AuthIdentity } from '../shared/api/auth';
+import { getDataExportStatus, requestDataExport } from '../shared/api/user';
+import { downloadAuthedAttachment } from '../shared/lib/attachments';
 import { setGroupMembersByRole } from '../shared/lib/preferences';
 import { useGroupMembersByRole } from '../shared/hooks/use-group-members-by-role';
 import { clearSession } from '../shared/lib/session';
@@ -44,6 +47,8 @@ export function SettingsModal({ currentUser, onClose, onDisconnect }: SettingsMo
   const [identity, setIdentity] = useState<AuthIdentity | null>(null);
   const [panel, setPanel] = useState<Panel>('profile');
   const groupMembersByRole = useGroupMembersByRole();
+  const [exporting, setExporting] = useState(false);
+  const [exportError, setExportError] = useState<string | null>(null);
 
   useCloseOnEscape(onClose);
 
@@ -67,6 +72,28 @@ export function SettingsModal({ currentUser, onClose, onDisconnect }: SettingsMo
     clearSession();
     router.push('/auth/login');
     router.refresh();
+  }
+
+  async function handleDownloadData() {
+    setExporting(true);
+    setExportError(null);
+    try {
+      const created = await requestDataExport();
+      let status = created;
+      for (let i = 0; i < 30 && status.status === 'pending'; i += 1) {
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+        status = await getDataExportStatus(created.export_id);
+      }
+      if (status.status === 'ready' && status.download_url) {
+        await downloadAuthedAttachment(status.download_url, 'data-export.json');
+      } else {
+        setExportError('Could not prepare your export. Please try again.');
+      }
+    } catch {
+      setExportError('Could not prepare your export. Please try again.');
+    } finally {
+      setExporting(false);
+    }
   }
 
   return (
@@ -167,6 +194,16 @@ export function SettingsModal({ currentUser, onClose, onDisconnect }: SettingsMo
                 onClick={() => setPanel('delete')}
                 destructive
               />
+              <SidebarButton
+                icon={Download}
+                label={exporting ? 'Preparing export…' : 'Download my data'}
+                description="Export everything we store about you (GDPR)"
+                onClick={handleDownloadData}
+                disabled={exporting}
+              />
+              {exportError ? (
+                <p className="px-1 text-xs leading-5 text-pink">{exportError}</p>
+              ) : null}
               {isOAuthOnly ? (
                 <p className="px-1 text-xs leading-5 text-white/35">
                   This account signs in with an OAuth provider, so there is no password to change

--- a/frontend/src/shared/api/user.ts
+++ b/frontend/src/shared/api/user.ts
@@ -203,3 +203,21 @@ export function removeBanner(userId: string) {
     method: 'DELETE'
   });
 }
+
+export type DataExportStatusResponse = {
+  export_id: string;
+  status: 'pending' | 'ready' | 'failed';
+  download_url?: string;
+  expires_at?: string;
+  error?: string;
+};
+
+export function requestDataExport() {
+  return apiFetch<DataExportStatusResponse>('user', '/users/me/data-export', {
+    method: 'POST'
+  });
+}
+
+export function getDataExportStatus(exportId: string) {
+  return apiFetch<DataExportStatusResponse>('user', `/users/me/data-export/${exportId}`);
+}

--- a/frontend/src/shared/call/ice.ts
+++ b/frontend/src/shared/call/ice.ts
@@ -19,10 +19,20 @@ export function getIceServers(): RTCIceServer[] {
     return [];
   }
 
-  // strip any turn:/turns:/stun: scheme so we can derive both from the bare host
-  const host = url.replace(/^(turns?|stun):/i, '');
+  // strip any turn:/turns:/stun: scheme, then split host:port
+  const hostPort = url.replace(/^(turns?|stun):/i, '');
   const isSecure = /^turns:/i.test(url);
   const turnScheme = isSecure ? 'turns' : 'turn';
+
+  // coturn is co-located with the app, so target it on whatever host the browser
+  // used to reach the app (localhost, a hostname, the evaluator's IP) rather than
+  // the build-time host baked into NEXT_PUBLIC_TURN_URL - only the port/scheme are
+  // taken from config. SSR (no window) keeps the configured host.
+  const lastColon = hostPort.lastIndexOf(':');
+  const configuredHost = lastColon > -1 ? hostPort.slice(0, lastColon) : hostPort;
+  const port = lastColon > -1 ? hostPort.slice(lastColon + 1) : '';
+  const runtimeHost = typeof window !== 'undefined' ? window.location.hostname : configuredHost;
+  const host = port ? `${runtimeHost}:${port}` : runtimeHost;
 
   const servers: RTCIceServer[] = [{ urls: `stun:${host}` }];
 

--- a/services/chat/src/Chat.Infrastructure/Storage/AttachmentUrlFactory.cs
+++ b/services/chat/src/Chat.Infrastructure/Storage/AttachmentUrlFactory.cs
@@ -5,15 +5,25 @@ using Microsoft.Extensions.Options;
 namespace Chat.Infrastructure.Storage;
 
 /// <summary>
-/// builds the public, auth-checked download URL for an attachment off the gateway
-/// base API URL, e.g. <c>https://host/api/chat/attachments/{id}/{filename}</c>
+/// builds the public, auth-checked download URL for an attachment as an
+/// origin-relative path, e.g. <c>/api/chat/v1/attachments/{id}/{filename}</c>.
+/// It is intentionally relative (no scheme/host): the frontend fetches attachments
+/// with JS (which enforces CORS), and the app is reached by whatever hostname/IP
+/// the evaluator uses, not necessarily <c>localhost</c>. A relative path always
+/// resolves against the page's own origin, so it stays same-origin (no CORS)
+/// regardless of how the app is accessed.
 /// </summary>
 internal sealed class AttachmentUrlFactory(IOptions<BackendConfigurationOptions> options) : IAttachmentUrlFactory
 {
-	private readonly string _baseApiUrl = options.Value.BaseApiUrl.TrimEnd('/');
+	// take just the path prefix of the configured API base (e.g. "/api"); drop the
+	// scheme + host so the URL is origin-relative.
+	private readonly string _basePath =
+		Uri.TryCreate(options.Value.BaseApiUrl.TrimEnd('/'), UriKind.Absolute, out var uri)
+			? uri.AbsolutePath.TrimEnd('/')
+			: options.Value.BaseApiUrl.TrimEnd('/');
 
 	// the /v1 segment is required: the gateway routes on /api/{service}/v{N}/...,
 	// so a versionless URL (as drawn in the contract) is not reachable
 	public string BuildUrl(long attachmentId, string filename) =>
-		$"{_baseApiUrl}/chat/v1/attachments/{attachmentId}/{Uri.EscapeDataString(filename)}";
+		$"{_basePath}/chat/v1/attachments/{attachmentId}/{Uri.EscapeDataString(filename)}";
 }

--- a/services/user/src/users/data-export.controller.ts
+++ b/services/user/src/users/data-export.controller.ts
@@ -4,6 +4,7 @@ import {
   NotFoundException,
   Param,
   Post,
+  StreamableFile,
   UseGuards,
 } from '@nestjs/common';
 import { CurrentUserId } from '../auth/current-user.decorator';
@@ -35,5 +36,21 @@ export class DataExportController {
     }
 
     return job;
+  }
+
+  @Get('me/data-export/:exportId/download')
+  async downloadExport(
+    @CurrentUserId() userId: string,
+    @Param('exportId', ParseSnowflakePipe) exportId: string,
+  ): Promise<StreamableFile> {
+    const result = await this.dataExport.downloadExport(userId, exportId);
+    if (!result) {
+      throw new NotFoundException('Export not ready');
+    }
+
+    return new StreamableFile(result.body, {
+      type: result.contentType,
+      disposition: `attachment; filename="${result.filename}"`,
+    });
   }
 }

--- a/services/user/src/users/data-export.service.ts
+++ b/services/user/src/users/data-export.service.ts
@@ -1,3 +1,4 @@
+import { Readable } from 'node:stream';
 import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { SnowflakeIdGenerator } from '../common/snowflake-id.generator';
@@ -82,11 +83,34 @@ export class DataExportService {
     return {
       export_id: job.id,
       status: 'ready',
-      download_url: await this.storage.createDownloadUrl(
-        job.object_key,
-        secondsRemaining,
-      ),
+      // origin-relative, JWT-authed streaming endpoint so the in-app download is
+      // same-origin (works from any host). the emailed link stays presigned +
+      // absolute, since an email link can't rely on the app session.
+      download_url: `/api/user/v1/users/me/data-export/${job.id}/download`,
       expires_at: job.expires_at.toISOString(),
+    };
+  }
+
+  // resolves a ready export to a streamable object for the same-origin download
+  // endpoint; enforces ownership (getExportById is scoped to userId).
+  async downloadExport(
+    userId: string,
+    exportId: string,
+  ): Promise<{ body: Readable; contentType: string; filename: string } | null> {
+    const job = await this.repository.getExportById(userId, exportId);
+    if (!job || job.status !== 'ready' || !job.object_key) {
+      return null;
+    }
+
+    const obj = await this.storage.getObjectStream(job.object_key);
+    if (!obj) {
+      return null;
+    }
+
+    return {
+      body: obj.body,
+      contentType: obj.contentType,
+      filename: `data-export-${exportId}.json`,
     };
   }
 

--- a/services/user/src/users/data-export.service.ts
+++ b/services/user/src/users/data-export.service.ts
@@ -228,7 +228,26 @@ export class DataExportService {
   }
 
   private async safeUserExport(userId: string): Promise<DataExportBundle['services']['user']> {
-    return this.users.getInternalDataExport(userId);
+    const data = await this.users.getInternalDataExport(userId);
+    const baseUrl = this.config.getOrThrow('BASE_URL').replace(/\/$/, '');
+    // media URLs are stored origin-relative (so in-app rendering is same-origin),
+    // but a data export is a portable file with no origin to resolve against, so
+    // make them absolute here. already-absolute (legacy) URLs pass through.
+    return {
+      ...data,
+      profile: {
+        ...data.profile,
+        avatar_url: this.toAbsoluteMediaUrl(data.profile.avatar_url, baseUrl),
+        banner_url: this.toAbsoluteMediaUrl(data.profile.banner_url, baseUrl),
+      },
+    };
+  }
+
+  private toAbsoluteMediaUrl(url: string | null, baseUrl: string): string | null {
+    if (!url) {
+      return null;
+    }
+    return url.startsWith('/') ? `${baseUrl}${url}` : url;
   }
 
   private extractEmail(value: AuthExportResponse | undefined): string | null {

--- a/services/user/src/users/data-export.storage.ts
+++ b/services/user/src/users/data-export.storage.ts
@@ -1,3 +1,4 @@
+import { Readable } from 'node:stream';
 import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import {
@@ -52,6 +53,28 @@ export class DataExportStorageService {
         ContentType: 'application/json',
       }),
     );
+  }
+
+  // streams the bundle straight from MinIO over the internal client, so the app
+  // can serve the download itself (same-origin, JWT-authed) instead of handing
+  // the browser an absolute presigned URL. used by the in-app "download my data".
+  async getObjectStream(
+    objectKey: string,
+  ): Promise<{ body: Readable; contentType: string } | null> {
+    try {
+      const res = await this.client.send(
+        new GetObjectCommand({ Bucket: this.bucket, Key: objectKey }),
+      );
+      if (!res.Body) {
+        return null;
+      }
+      return {
+        body: res.Body as Readable,
+        contentType: res.ContentType ?? 'application/json',
+      };
+    } catch {
+      return null;
+    }
   }
 
   async createDownloadUrl(

--- a/services/user/src/users/media/profile-media.storage.ts
+++ b/services/user/src/users/media/profile-media.storage.ts
@@ -17,7 +17,6 @@ export type ProfileMediaKind = 'avatar' | 'banner';
 @Injectable()
 export class ProfileMediaStorageService {
   private readonly client: S3Client;
-  private readonly baseUrl: string;
   private readonly bucket: string;
 
   constructor(private readonly config: ConfigService<ValidatedEnv, true>) {
@@ -30,7 +29,6 @@ export class ProfileMediaStorageService {
         secretAccessKey: this.config.getOrThrow('MINIO_SECRET_KEY'),
       },
     });
-    this.baseUrl = this.config.getOrThrow('BASE_URL').replace(/\/$/, '');
     this.bucket = this.config.getOrThrow('MINIO_USER_BUCKET');
   }
 
@@ -69,7 +67,9 @@ export class ProfileMediaStorageService {
 
   extractKeyFromUrl(url: string, kind: ProfileMediaKind, userId: string): string | null {
     try {
-      const parsed = new URL(url);
+      // a placeholder base lets this parse both legacy absolute URLs and the new
+      // origin-relative ones (/s3/...); the base is ignored for absolute inputs.
+      const parsed = new URL(url, 'http://placeholder');
       const prefix = `/s3/${this.bucket}/${this.buildKeyPrefix(kind, userId)}`;
       if (!parsed.pathname.startsWith(prefix)) {
         return null;
@@ -89,7 +89,9 @@ export class ProfileMediaStorageService {
     return `${kind}s/${userId}/`;
   }
 
+  // origin-relative so the browser loads media from whatever host it opened the
+  // app on (not a hardcoded localhost), keeping avatars/banners same-origin.
   private buildPublicUrl(key: string): string {
-    return `${this.baseUrl}/s3/${this.bucket}/${key}`;
+    return `/s3/${this.bucket}/${key}`;
   }
 }


### PR DESCRIPTION
**fix/hostname-agnostic-urls**

Makes every browser-facing URL work regardless of the host the app is reached on (`localhost`, a hostname like `void-engine.local`, or the evaluator's IP), instead of being hardcoded to `localhost`. Motivated by the eval, where we connect to the app on a non-`localhost` origin: absolute `localhost` URLs either hit CORS (fetched via JS) or point at the wrong machine.

**What was breaking:** the page loads on `<hostname_that_is_not_localhost>:1443`, but attachment URLs were absolute `https://localhost:1443/...`, so `AuthedImage`'s `fetch()` was cross-origin and CORS-blocked. Avatars/banners and the WebRTC TURN host had the same hardcoded-`localhost` fragility.

**Changes (per commit):**
- `fix(chat)` — attachment download URLs are now origin-relative (`/api/chat/v1/attachments/...`), so the browser fetches them same-origin.
- `fix(user)` — avatar/banner URLs are origin-relative (`/s3/...`); the reverse key-parse handles both relative and legacy-absolute URLs so old media still deletes correctly.
- `fix(frontend)` — WebRTC ICE derives the TURN host from `window.location.hostname` at runtime (coturn is co-located), keeping only port/scheme from config.
- `feat(user)` — the GDPR "Download my data" flow now streams same-origin through a JWT-authed endpoint (`GET /users/me/data-export/:id/download`) instead of an absolute presigned URL, and the previously-missing **"Download my data" button** is added to the settings modal (blob-download pattern). The emailed link keeps its presigned absolute URL (email links can't be relative).
- `fix(user)` — media URLs are made absolute **in the data-export bundle** (a portable file has no origin to resolve against), while in-app rendering stays relative.

**Still host-bound by nature (out of scope):** OAuth redirect (provider-registered URI) and the export *email* link (email links must be absolute).

**Verification:** attachment/avatar/banner uploads return relative URLs; the export download endpoint returns 200 authed / 401 unauth; the export bundle carries absolute media URLs; all rebuilt and confirmed live. Frontend `tsc`/eslint clean.
