### PR TITLE
Feat/frontend action modals

### DIFF
--- a/frontend/app/auth/login/page.tsx
+++ b/frontend/app/auth/login/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { LogIn } from 'lucide-react';
 import { AuthCard } from '../../../src/components/auth-card';
@@ -9,6 +9,7 @@ import { establishSession } from '../../../src/shared/lib/session';
 import { describeLoginError } from '../../../src/shared/lib/auth-errors';
 import { useGuilds } from '../../../src/shared/guilds/guild-store';
 import { validateLoginForm, type LoginFormErrors } from '../../../src/shared/lib/validators/auth';
+import { useToast } from '../../../src/shared/ui/toast';
 
 export default function LoginPage() {
   const router = useRouter();
@@ -16,6 +17,17 @@ export default function LoginPage() {
   const [errors, setErrors] = useState<LoginFormErrors>({});
   const [serverError, setServerError] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const { pushToast } = useToast();
+
+  useEffect(() => {
+    if (serverError) {
+      pushToast({
+        title: 'Login failed',
+        description: serverError,
+        tone: 'error'
+      });
+    }
+  }, [serverError, pushToast]);
 
   async function handleSubmit(formData: FormData) {
     const email = String(formData.get('email') ?? '');
@@ -78,11 +90,6 @@ export default function LoginPage() {
           />
           {errors.password ? <p className="text-sm text-pink">{errors.password}</p> : null}
         </div>
-        {serverError ? (
-          <p className="rounded-md border border-pink/25 bg-pink/10 px-3 py-2 text-sm text-pink">
-            {serverError}
-          </p>
-        ) : null}
         <button
           type="submit"
           disabled={isSubmitting}

--- a/frontend/app/auth/register/page.tsx
+++ b/frontend/app/auth/register/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { UserPlus } from 'lucide-react';
 import { AuthCard } from '../../../src/components/auth-card';
@@ -11,12 +11,24 @@ import {
   validateRegisterForm,
   type RegisterFormErrors
 } from '../../../src/shared/lib/validators/auth';
+import { useToast } from '../../../src/shared/ui/toast';
 
 export default function RegisterPage() {
   const router = useRouter();
   const [errors, setErrors] = useState<RegisterFormErrors>({});
   const [serverError, setServerError] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const { pushToast } = useToast();
+
+  useEffect(() => {
+    if (serverError) {
+      pushToast({
+        title: 'Registration failed',
+        description: serverError,
+        tone: 'error'
+      });
+    }
+  }, [serverError, pushToast]);
 
   async function handleSubmit(formData: FormData) {
     const email = String(formData.get('email') ?? '');
@@ -93,11 +105,6 @@ export default function RegisterPage() {
           />
           {errors.confirm ? <p className="text-sm text-pink">{errors.confirm}</p> : null}
         </div>
-        {serverError ? (
-          <p className="rounded-md border border-pink/25 bg-pink/10 px-3 py-2 text-sm text-pink">
-            {serverError}
-          </p>
-        ) : null}
         <button
           type="submit"
           disabled={isSubmitting}

--- a/frontend/app/guilds/page.tsx
+++ b/frontend/app/guilds/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { GuildIcon } from '../../src/components/guild/guild-icon';
 import { GuildBansPanel } from '../../src/components/guild/guild-bans-panel';
@@ -13,6 +13,7 @@ import { GuildOverview } from '../../src/components/guild/guild-overview';
 import { GuildRolesPanel } from '../../src/components/guild/guild-roles-panel';
 import { GuildSettingsPanel } from '../../src/components/guild/guild-settings-panel';
 import { useGuilds } from '../../src/shared/guilds/guild-store';
+import { useToast } from '../../src/shared/ui/toast';
 
 const TABS = [
   { id: 'overview', label: 'Overview' },
@@ -30,6 +31,17 @@ type TabId = (typeof TABS)[number]['id'];
 export default function GuildsPage() {
   const { guilds, isLoading, error, selectedGuildId, selectGuild } = useGuilds();
   const [activeTab, setActiveTab] = useState<TabId>('overview');
+  const { pushToast } = useToast();
+
+  useEffect(() => {
+    if (error) {
+      pushToast({
+        title: 'Guilds',
+        description: error,
+        tone: 'error'
+      });
+    }
+  }, [error, pushToast]);
 
   return (
     <section className="mx-auto flex min-h-screen w-full max-w-5xl flex-col px-6 py-10">
@@ -50,8 +62,8 @@ export default function GuildsPage() {
         </div>
 
         {error && guilds.length === 0 ? (
-          <p className="mt-6 rounded-md border border-pink/25 bg-pink/10 px-4 py-3 text-sm text-pink">
-            {error}
+          <p className="mt-6 rounded-md border border-stroke bg-frame px-4 py-3 text-sm text-white/45">
+            Guilds unavailable.
           </p>
         ) : null}
 

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,37 +1,25 @@
 import type { Metadata } from 'next';
-import { Inter, JetBrains_Mono, Outfit } from 'next/font/google';
+import type { CSSProperties, ReactNode } from 'react';
 import { AppProviders } from '../src/components/app-providers';
 import './globals.css';
-
-const inter = Inter({
-  subsets: ['latin'],
-  variable: '--font-inter',
-  display: 'swap'
-});
-
-const outfit = Outfit({
-  subsets: ['latin'],
-  variable: '--font-outfit',
-  display: 'swap',
-  preload: false
-});
-
-const jetBrainsMono = JetBrains_Mono({
-  subsets: ['latin'],
-  variable: '--font-jetbrains-mono',
-  display: 'swap',
-  preload: false
-});
 
 export const metadata: Metadata = {
   title: 'ft_transcendence',
   description: 'Frontend for ft_transcendence'
 };
 
-export default function RootLayout({ children }: { children: React.ReactNode }) {
+export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en">
-      <body className={`${inter.variable} ${outfit.variable} ${jetBrainsMono.variable}`}>
+      <body
+        style={
+          {
+            '--font-inter': 'system-ui',
+            '--font-outfit': 'system-ui',
+            '--font-jetbrains-mono': 'ui-monospace'
+          } as CSSProperties
+        }
+      >
         <AppProviders>
           <main className="app-shell min-h-screen max-h-screen">{children}</main>
         </AppProviders>

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,8 +1,6 @@
 import type { Metadata } from 'next';
 import { Inter, JetBrains_Mono, Outfit } from 'next/font/google';
-import { GuildProvider } from '../src/shared/guilds/guild-store';
-import { CurrentUserProvider } from '../src/shared/user/user-store';
-import { SessionExpiryRedirect } from '../src/components/session-expiry-redirect';
+import { AppProviders } from '../src/components/app-providers';
 import './globals.css';
 
 const inter = Inter({
@@ -34,12 +32,9 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en">
       <body className={`${inter.variable} ${outfit.variable} ${jetBrainsMono.variable}`}>
-        <CurrentUserProvider>
-          <GuildProvider>
-            <SessionExpiryRedirect />
-            <main className="app-shell min-h-screen max-h-screen">{children}</main>
-          </GuildProvider>
-        </CurrentUserProvider>
+        <AppProviders>
+          <main className="app-shell min-h-screen max-h-screen">{children}</main>
+        </AppProviders>
       </body>
     </html>
   );

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "next build --webpack",
     "start": "next start",
     "lint": "eslint .",
     "typecheck": "tsc --noEmit",

--- a/frontend/src/components/action-modal.tsx
+++ b/frontend/src/components/action-modal.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { AlertTriangle, X } from 'lucide-react';
+import { useCloseOnEscape } from '../shared/hooks/use-close-on-escape';
+
+type ActionModalProps = {
+  title: string;
+  description: ReactNode;
+  confirmLabel: string;
+  cancelLabel?: string;
+  destructive?: boolean;
+  isBusy?: boolean;
+  onClose: () => void;
+  onConfirm: () => void | Promise<void>;
+  children?: ReactNode;
+};
+
+export function ActionModal({
+  title,
+  description,
+  confirmLabel,
+  cancelLabel = 'Cancel',
+  destructive = false,
+  isBusy = false,
+  onClose,
+  onConfirm,
+  children
+}: ActionModalProps) {
+  useCloseOnEscape(onClose);
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/55 px-4 py-6">
+      <button
+        type="button"
+        className="absolute inset-0 cursor-default"
+        onClick={onClose}
+        aria-label="Close dialog"
+      />
+      <section className="relative w-full max-w-[28rem] overflow-hidden rounded-[1rem] bg-secondary-bg shadow-2xl shadow-black/50 ring-1 ring-stroke">
+        <div className="flex h-[4.75rem] items-center justify-between border-b border-stroke px-5">
+          <div className="flex min-w-0 items-center gap-3">
+            <span
+              className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-md ${
+                destructive ? 'bg-pink/10 text-pink' : 'bg-aqua/10 text-aqua'
+              }`}
+            >
+              <AlertTriangle className="h-5 w-5" strokeWidth={1.9} />
+            </span>
+            <div className="min-w-0">
+              <h2 className="truncate text-[1.15rem] font-bold tracking-[-0.03em] text-white">
+                {title}
+              </h2>
+              <p className="font-category text-[0.7rem] uppercase tracking-[0.14em] text-white/35">
+                Confirm action
+              </p>
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="flex h-9 w-9 items-center justify-center rounded-md text-[#8b8b8f] transition hover:bg-frame hover:text-white"
+            aria-label="Close dialog"
+          >
+            <X className="h-4 w-4" strokeWidth={2} />
+          </button>
+        </div>
+
+        <div className="grid gap-4 p-5">
+          <div className="grid gap-3">
+            <div className="text-sm leading-6 text-white/65">{description}</div>
+            {children ? <div className="grid gap-2">{children}</div> : null}
+          </div>
+          <div className="flex flex-wrap justify-end gap-3">
+            <button
+              type="button"
+              onClick={onClose}
+              className="h-10 rounded-md border border-stroke bg-frame px-5 text-sm font-bold text-white/70 transition hover:text-white"
+            >
+              {cancelLabel}
+            </button>
+            <button
+              type="button"
+              onClick={() => void onConfirm()}
+              disabled={isBusy}
+              className={`h-10 rounded-md px-5 text-sm font-bold transition disabled:cursor-not-allowed disabled:opacity-50 ${
+                destructive
+                  ? 'border border-pink/25 bg-pink/10 text-pink hover:border-pink/45 hover:bg-pink/15'
+                  : 'bg-aqua text-primary-bg hover:bg-white'
+              }`}
+            >
+              {isBusy ? 'Working...' : confirmLabel}
+            </button>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/components/app-providers.tsx
+++ b/frontend/src/components/app-providers.tsx
@@ -1,0 +1,21 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { GuildProvider } from '../shared/guilds/guild-store';
+import { CurrentUserProvider } from '../shared/user/user-store';
+import { SessionExpiryRedirect } from './session-expiry-redirect';
+import { ToastProvider } from '../shared/ui/toast';
+
+export function AppProviders({ children }: { children: ReactNode }) {
+  return (
+    <CurrentUserProvider>
+      <GuildProvider>
+        <ToastProvider>
+          <SessionExpiryRedirect />
+          {children}
+        </ToastProvider>
+      </GuildProvider>
+    </CurrentUserProvider>
+  );
+}
+

--- a/frontend/src/components/friends-list.tsx
+++ b/frontend/src/components/friends-list.tsx
@@ -34,6 +34,7 @@ import {
   type FriendshipStateDto,
   type SearchUserDto
 } from '../shared/api/user';
+import { useToast } from '../shared/ui/toast';
 
 export type Friend = {
   id: string;
@@ -122,6 +123,7 @@ export function FriendsList({
   const [discoverLoading, setDiscoverLoading] = useState(false);
   const [actionError, setActionError] = useState('');
   const [actionSuccess, setActionSuccess] = useState('');
+  const { pushToast } = useToast();
 
   const term = search.trim().toLowerCase();
 
@@ -200,6 +202,16 @@ export function FriendsList({
   useEffect(() => {
     void loadPendingRequests();
   }, [loadPendingRequests]);
+
+  useEffect(() => {
+    if (actionError) {
+      pushToast({
+        title: 'Friends',
+        description: actionError,
+        tone: 'error'
+      });
+    }
+  }, [actionError, pushToast]);
 
   useEffect(() => {
     if (activeTab !== 'discover') {
@@ -610,11 +622,6 @@ export function FriendsList({
             <UserPlus className="h-4 w-4" strokeWidth={2} />
           </button>
         </form>
-        {actionError ? (
-          <p className="mt-2 rounded-md border border-pink/25 bg-pink/10 px-3 py-2 text-sm text-pink">
-            {actionError}
-          </p>
-        ) : null}
         {actionSuccess ? (
           <p className="mt-2 rounded-md border border-lime/25 bg-lime/10 px-3 py-2 text-sm text-lime">
             {actionSuccess}

--- a/frontend/src/components/guild-member-list.tsx
+++ b/frontend/src/components/guild-member-list.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useEffect } from 'react';
 import { Crown, Shield } from 'lucide-react';
 import { AvatarWithStatus } from './avatar-with-status';
 import type { ChatMessageData } from './chat-message';
@@ -12,6 +13,7 @@ import { useGuildMembers, type HydratedGuildMember } from '../shared/guilds/use-
 import { countPermissionBits, rolePermissionBits } from '../shared/guilds/role-permissions';
 import { useGroupMembersByRole } from '../shared/hooks/use-group-members-by-role';
 import { hashToIndex } from '../shared/lib/hash';
+import { useToast } from '../shared/ui/toast';
 
 export type GuildMember = {
   id: string;
@@ -203,6 +205,17 @@ export function GuildMemberList({ onOpenProfile }: GuildMemberListProps) {
     selectedGuild?.owner_id ?? null
   );
   const groupByRole = useGroupMembersByRole();
+  const { pushToast } = useToast();
+
+  useEffect(() => {
+    if (error) {
+      pushToast({
+        title: 'Members',
+        description: error,
+        tone: 'error'
+      });
+    }
+  }, [error, pushToast]);
 
   const memberGroups = buildMemberGroups(members, groupByRole);
   const onlineCount = members.filter((member) => member.status !== 'offline').length;
@@ -226,8 +239,8 @@ export function GuildMemberList({ onOpenProfile }: GuildMemberListProps) {
             ))}
           </div>
         ) : error && members.length === 0 ? (
-          <p className="rounded-md border border-pink/25 bg-pink/10 px-3 py-2 text-sm text-pink">
-            {error}
+          <p className="rounded-md border border-stroke bg-frame px-3 py-2 text-sm text-white/45">
+            Members unavailable.
           </p>
         ) : !selectedGuild ? (
           <p className="px-1 text-sm text-white/35">Select a guild to see its members.</p>

--- a/frontend/src/components/guild-sidebar.tsx
+++ b/frontend/src/components/guild-sidebar.tsx
@@ -8,6 +8,7 @@ import { AddGuildModal } from './guild/add-guild-modal';
 import { GuildIcon } from './guild/guild-icon';
 import { FortyTwoIcon } from './icons/brand-icons';
 import { useGuilds } from '../shared/guilds/guild-store';
+import { useToast } from '../shared/ui/toast';
 
 type GuildSidebarProps = {
   activeMode: 'guild' | 'dm';
@@ -26,6 +27,7 @@ export function GuildSidebar({ activeMode, onOpenDms, onOpenGuild }: GuildSideba
   const [tooltip, setTooltip] = useState<{ name: string; top: number } | null>(null);
   const [isAddGuildOpen, setIsAddGuildOpen] = useState(false);
   const [croppedEdges, setCroppedEdges] = useState({ top: false, bottom: false });
+  const { pushToast } = useToast();
 
   const updateCroppedEdges = useCallback(() => {
     const list = scrollRef.current;
@@ -39,6 +41,16 @@ export function GuildSidebar({ activeMode, onOpenDms, onOpenGuild }: GuildSideba
       previous.top === top && previous.bottom === bottom ? previous : { top, bottom }
     );
   }, []);
+
+  useEffect(() => {
+    if (error) {
+      pushToast({
+        title: 'Guild list',
+        description: error,
+        tone: 'error'
+      });
+    }
+  }, [error, pushToast]);
 
   useEffect(() => {
     updateCroppedEdges();
@@ -110,7 +122,7 @@ export function GuildSidebar({ activeMode, onOpenDms, onOpenGuild }: GuildSideba
             <div className="h-[4.9rem] shrink-0 animate-pulse rounded-xl border border-frame bg-panel" />
           ) : null}
           {error && guilds.length === 0 ? (
-            <p className="px-1 text-center text-xs text-pink/80" title={error}>
+            <p className="px-1 text-center text-xs text-white/45" title={error}>
               Guilds unavailable
             </p>
           ) : null}

--- a/frontend/src/components/guild/guild-bans-panel.tsx
+++ b/frontend/src/components/guild/guild-bans-panel.tsx
@@ -10,6 +10,7 @@ import {
   type GuildBanDto
 } from '../../shared/api/guild';
 import { getUsersByIds, type UserSummaryDto } from '../../shared/api/user';
+import { ActionModal } from '../action-modal';
 import { formatDate } from './guild-overview';
 import { FormError } from './guild-forms';
 
@@ -28,6 +29,8 @@ export function GuildBansPanel({ guildId }: GuildBansPanelProps) {
   const [banUserId, setBanUserId] = useState('');
   const [banReason, setBanReason] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [unbanTarget, setUnbanTarget] = useState<string | null>(null);
+  const [isUnbanning, setIsUnbanning] = useState(false);
 
   const load = useCallback(async () => {
     setIsLoading(true);
@@ -86,17 +89,25 @@ export function GuildBansPanel({ guildId }: GuildBansPanelProps) {
   }
 
   async function handleUnban(userId: string) {
-    if (!window.confirm(`Unban ${describeUser(userId)}?`)) {
+    setUnbanTarget(userId);
+  }
+
+  async function confirmUnban() {
+    if (!unbanTarget) {
       return;
     }
 
     setError('');
 
     try {
-      await unbanGuildMember(guildId, userId);
+      setIsUnbanning(true);
+      await unbanGuildMember(guildId, unbanTarget);
       await load();
+      setUnbanTarget(null);
     } catch (unbanError) {
       setError(unbanError instanceof Error ? unbanError.message : 'Failed to unban user.');
+    } finally {
+      setIsUnbanning(false);
     }
   }
 
@@ -167,6 +178,17 @@ export function GuildBansPanel({ guildId }: GuildBansPanelProps) {
           ))}
         </ul>
       )}
+
+      {unbanTarget ? (
+        <ActionModal
+          title={`Unban ${describeUser(unbanTarget)}?`}
+          description="This will restore the user's access to the guild immediately."
+          confirmLabel="Unban user"
+          isBusy={isUnbanning}
+          onClose={() => setUnbanTarget(null)}
+          onConfirm={confirmUnban}
+        />
+      ) : null}
     </div>
   );
 }

--- a/frontend/src/components/guild/guild-bans-panel.tsx
+++ b/frontend/src/components/guild/guild-bans-panel.tsx
@@ -12,7 +12,7 @@ import {
 import { getUsersByIds, type UserSummaryDto } from '../../shared/api/user';
 import { ActionModal } from '../action-modal';
 import { formatDate } from './guild-overview';
-import { FormError } from './guild-forms';
+import { useToast } from '../../shared/ui/toast';
 
 const inputClasses =
   'h-11 w-full rounded-md border border-transparent bg-input-bg px-4 text-base text-white outline-none transition placeholder:text-input-placeholder focus:border-aqua/35';
@@ -31,6 +31,7 @@ export function GuildBansPanel({ guildId }: GuildBansPanelProps) {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [unbanTarget, setUnbanTarget] = useState<string | null>(null);
   const [isUnbanning, setIsUnbanning] = useState(false);
+  const { pushToast } = useToast();
 
   const load = useCallback(async () => {
     setIsLoading(true);
@@ -55,6 +56,16 @@ export function GuildBansPanel({ guildId }: GuildBansPanelProps) {
   useEffect(() => {
     void load();
   }, [load]);
+
+  useEffect(() => {
+    if (error) {
+      pushToast({
+        title: 'Bans',
+        description: error,
+        tone: 'error'
+      });
+    }
+  }, [error, pushToast]);
 
   function describeUser(userId: string | null) {
     if (!userId) {
@@ -144,8 +155,6 @@ export function GuildBansPanel({ guildId }: GuildBansPanelProps) {
           {isSubmitting ? 'Banning...' : 'Ban user'}
         </button>
       </form>
-
-      {error ? <FormError message={error} /> : null}
 
       {isLoading ? (
         <div className="h-24 animate-pulse rounded-md bg-panel" />

--- a/frontend/src/components/guild/guild-categories-panel.tsx
+++ b/frontend/src/components/guild/guild-categories-panel.tsx
@@ -11,7 +11,7 @@ import {
   type GuildCategoryDto
 } from '../../shared/api/guild';
 import { ActionModal } from '../action-modal';
-import { FormError } from './guild-forms';
+import { useToast } from '../../shared/ui/toast';
 
 const inputClasses =
   'h-10 w-full rounded-md border border-transparent bg-input-bg px-3 text-sm text-white outline-none transition placeholder:text-input-placeholder focus:border-aqua/35';
@@ -33,6 +33,7 @@ export function GuildCategoriesPanel({ guildId }: GuildCategoriesPanelProps) {
   const [editPosition, setEditPosition] = useState('');
   const [isBusy, setIsBusy] = useState(false);
   const [deleteTarget, setDeleteTarget] = useState<GuildCategoryDto | null>(null);
+  const { pushToast } = useToast();
 
   const load = useCallback(async () => {
     setIsLoading(true);
@@ -51,6 +52,16 @@ export function GuildCategoriesPanel({ guildId }: GuildCategoriesPanelProps) {
   useEffect(() => {
     void load();
   }, [load]);
+
+  useEffect(() => {
+    if (error) {
+      pushToast({
+        title: 'Categories',
+        description: error,
+        tone: 'error'
+      });
+    }
+  }, [error, pushToast]);
 
   async function handleCreate(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -151,8 +162,6 @@ export function GuildCategoriesPanel({ guildId }: GuildCategoriesPanelProps) {
           </button>
         </div>
       </form>
-
-      {error ? <FormError message={error} /> : null}
 
       {isLoading ? (
         <div className="h-24 animate-pulse rounded-md bg-panel" />

--- a/frontend/src/components/guild/guild-categories-panel.tsx
+++ b/frontend/src/components/guild/guild-categories-panel.tsx
@@ -10,6 +10,7 @@ import {
   updateGuildCategory,
   type GuildCategoryDto
 } from '../../shared/api/guild';
+import { ActionModal } from '../action-modal';
 import { FormError } from './guild-forms';
 
 const inputClasses =
@@ -31,6 +32,7 @@ export function GuildCategoriesPanel({ guildId }: GuildCategoriesPanelProps) {
   const [editName, setEditName] = useState('');
   const [editPosition, setEditPosition] = useState('');
   const [isBusy, setIsBusy] = useState(false);
+  const [deleteTarget, setDeleteTarget] = useState<GuildCategoryDto | null>(null);
 
   const load = useCallback(async () => {
     setIsLoading(true);
@@ -100,7 +102,11 @@ export function GuildCategoriesPanel({ guildId }: GuildCategoriesPanelProps) {
   }
 
   async function handleDelete(category: GuildCategoryDto) {
-    if (!window.confirm(`Delete category "${category.name}"? Its channels become uncategorised.`)) {
+    setDeleteTarget(category);
+  }
+
+  async function confirmDeleteCategory() {
+    if (!deleteTarget) {
       return;
     }
 
@@ -108,8 +114,9 @@ export function GuildCategoriesPanel({ guildId }: GuildCategoriesPanelProps) {
 
     try {
       setIsBusy(true);
-      await deleteGuildCategory(guildId, category.id);
+      await deleteGuildCategory(guildId, deleteTarget.id);
       await load();
+      setDeleteTarget(null);
     } catch (deleteError) {
       setError(deleteError instanceof Error ? deleteError.message : 'Failed to delete category.');
     } finally {
@@ -225,6 +232,18 @@ export function GuildCategoriesPanel({ guildId }: GuildCategoriesPanelProps) {
           ))}
         </ul>
       )}
+
+      {deleteTarget ? (
+        <ActionModal
+          title={`Delete category "${deleteTarget.name}"?`}
+          description="The category will be removed and its channels will become uncategorised."
+          confirmLabel="Delete category"
+          destructive
+          isBusy={isBusy}
+          onClose={() => setDeleteTarget(null)}
+          onConfirm={confirmDeleteCategory}
+        />
+      ) : null}
     </div>
   );
 }

--- a/frontend/src/components/guild/guild-channels-panel.tsx
+++ b/frontend/src/components/guild/guild-channels-panel.tsx
@@ -12,6 +12,7 @@ import {
   type GuildCategoryDto,
   type GuildChannelDto
 } from '../../shared/api/guild';
+import { ActionModal } from '../action-modal';
 import { FormError } from './guild-forms';
 
 const inputClasses =
@@ -56,6 +57,7 @@ export function GuildChannelsPanel({ guildId, onChannelsChanged }: GuildChannels
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editDraft, setEditDraft] = useState<EditDraft | null>(null);
   const [isBusy, setIsBusy] = useState(false);
+  const [deleteTarget, setDeleteTarget] = useState<GuildChannelDto | null>(null);
 
   const load = useCallback(async () => {
     setIsLoading(true);
@@ -166,7 +168,11 @@ export function GuildChannelsPanel({ guildId, onChannelsChanged }: GuildChannels
   }
 
   async function handleDelete(channel: GuildChannelDto) {
-    if (!window.confirm(`Delete channel "${channel.name}"? This cannot be undone.`)) {
+    setDeleteTarget(channel);
+  }
+
+  async function confirmDeleteChannel() {
+    if (!deleteTarget) {
       return;
     }
 
@@ -174,9 +180,10 @@ export function GuildChannelsPanel({ guildId, onChannelsChanged }: GuildChannels
 
     try {
       setIsBusy(true);
-      await deleteGuildChannel(guildId, channel.id);
+      await deleteGuildChannel(guildId, deleteTarget.id);
       await load();
       onChannelsChanged?.();
+      setDeleteTarget(null);
     } catch (deleteError) {
       setError(deleteError instanceof Error ? deleteError.message : 'Failed to delete channel.');
     } finally {
@@ -360,6 +367,18 @@ export function GuildChannelsPanel({ guildId, onChannelsChanged }: GuildChannels
           ))}
         </ul>
       )}
+
+      {deleteTarget ? (
+        <ActionModal
+          title={`Delete channel "${deleteTarget.name}"?`}
+          description="This cannot be undone. Any messages in the channel will remain linked to the deleted channel."
+          confirmLabel="Delete channel"
+          destructive
+          isBusy={isBusy}
+          onClose={() => setDeleteTarget(null)}
+          onConfirm={confirmDeleteChannel}
+        />
+      ) : null}
     </div>
   );
 }

--- a/frontend/src/components/guild/guild-channels-panel.tsx
+++ b/frontend/src/components/guild/guild-channels-panel.tsx
@@ -13,7 +13,7 @@ import {
   type GuildChannelDto
 } from '../../shared/api/guild';
 import { ActionModal } from '../action-modal';
-import { FormError } from './guild-forms';
+import { useToast } from '../../shared/ui/toast';
 
 const inputClasses =
   'h-10 w-full rounded-md border border-transparent bg-input-bg px-3 text-sm text-white outline-none transition placeholder:text-input-placeholder focus:border-aqua/35';
@@ -58,6 +58,7 @@ export function GuildChannelsPanel({ guildId, onChannelsChanged }: GuildChannels
   const [editDraft, setEditDraft] = useState<EditDraft | null>(null);
   const [isBusy, setIsBusy] = useState(false);
   const [deleteTarget, setDeleteTarget] = useState<GuildChannelDto | null>(null);
+  const { pushToast } = useToast();
 
   const load = useCallback(async () => {
     setIsLoading(true);
@@ -80,6 +81,16 @@ export function GuildChannelsPanel({ guildId, onChannelsChanged }: GuildChannels
   useEffect(() => {
     void load();
   }, [load]);
+
+  useEffect(() => {
+    if (error) {
+      pushToast({
+        title: 'Channels',
+        description: error,
+        tone: 'error'
+      });
+    }
+  }, [error, pushToast]);
 
   async function handleCreate(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -226,8 +237,6 @@ export function GuildChannelsPanel({ guildId, onChannelsChanged }: GuildChannels
           </button>
         </div>
       </form>
-
-      {error ? <FormError message={error} /> : null}
 
       {isLoading ? (
         <div className="h-24 animate-pulse rounded-md bg-panel" />

--- a/frontend/src/components/guild/guild-forms.tsx
+++ b/frontend/src/components/guild/guild-forms.tsx
@@ -1,24 +1,17 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { FormEvent } from 'react';
 import { Plus } from 'lucide-react';
 import type { GuildDto } from '../../shared/api/guild';
 import { useGuilds } from '../../shared/guilds/guild-store';
+import { useToast } from '../../shared/ui/toast';
 
 const inputClasses =
   'h-11 w-full rounded-md border border-transparent bg-input-bg px-4 text-base text-white outline-none transition placeholder:text-input-placeholder focus:border-aqua/35';
 
 const submitClasses =
   'flex h-11 items-center justify-center gap-2 rounded-md bg-aqua px-5 text-sm font-bold text-primary-bg transition hover:bg-white disabled:cursor-not-allowed disabled:bg-frame disabled:text-white/25';
-
-export function FormError({ message }: { message: string }) {
-  return (
-    <p className="rounded-md border border-pink/25 bg-pink/10 px-3 py-2 text-sm text-pink">
-      {message}
-    </p>
-  );
-}
 
 type GuildCreateFormProps = {
   onCreated?: (guild: GuildDto) => void;
@@ -31,6 +24,17 @@ export function GuildCreateForm({ onCreated }: GuildCreateFormProps) {
   const [iconUrl, setIconUrl] = useState('');
   const [error, setError] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const { pushToast } = useToast();
+
+  useEffect(() => {
+    if (error) {
+      pushToast({
+        title: 'Could not create guild',
+        description: error,
+        tone: 'error'
+      });
+    }
+  }, [error, pushToast]);
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -90,7 +94,6 @@ export function GuildCreateForm({ onCreated }: GuildCreateFormProps) {
           className={inputClasses}
         />
       </label>
-      {error ? <FormError message={error} /> : null}
       <button type="submit" disabled={isSubmitting} className={submitClasses}>
         <Plus className="h-4 w-4" strokeWidth={2} />
         {isSubmitting ? 'Creating...' : 'Create guild'}
@@ -108,6 +111,17 @@ export function GuildJoinForm({ onJoined }: GuildJoinFormProps) {
   const [code, setCode] = useState('');
   const [error, setError] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const { pushToast } = useToast();
+
+  useEffect(() => {
+    if (error) {
+      pushToast({
+        title: 'Could not join guild',
+        description: error,
+        tone: 'error'
+      });
+    }
+  }, [error, pushToast]);
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -142,7 +156,6 @@ export function GuildJoinForm({ onJoined }: GuildJoinFormProps) {
           className={inputClasses}
         />
       </label>
-      {error ? <FormError message={error} /> : null}
       <button type="submit" disabled={isSubmitting} className={submitClasses}>
         {isSubmitting ? 'Joining...' : 'Join guild'}
       </button>

--- a/frontend/src/components/guild/guild-invites-panel.tsx
+++ b/frontend/src/components/guild/guild-invites-panel.tsx
@@ -16,7 +16,7 @@ import { getUsersByIds, type UserSummaryDto } from '../../shared/api/user';
 import { ActionModal } from '../action-modal';
 import { formatDate } from './guild-overview';
 import { GuildIcon } from './guild-icon';
-import { FormError } from './guild-forms';
+import { useToast } from '../../shared/ui/toast';
 
 const inputClasses =
   'h-11 w-full rounded-md border border-transparent bg-input-bg px-4 text-base text-white outline-none transition placeholder:text-input-placeholder focus:border-aqua/35';
@@ -42,6 +42,7 @@ export function GuildInvitesPanel({ guildId }: GuildInvitesPanelProps) {
   const [copiedCode, setCopiedCode] = useState('');
   const [revokeTarget, setRevokeTarget] = useState<string | null>(null);
   const [isRevoking, setIsRevoking] = useState(false);
+  const { pushToast } = useToast();
 
   async function handleCopyCode(code: string) {
     try {
@@ -80,6 +81,26 @@ export function GuildInvitesPanel({ guildId }: GuildInvitesPanelProps) {
   useEffect(() => {
     void load();
   }, [load]);
+
+  useEffect(() => {
+    if (error) {
+      pushToast({
+        title: 'Invites',
+        description: error,
+        tone: 'error'
+      });
+    }
+  }, [error, pushToast]);
+
+  useEffect(() => {
+    if (previewError) {
+      pushToast({
+        title: 'Invite preview',
+        description: previewError,
+        tone: 'error'
+      });
+    }
+  }, [previewError, pushToast]);
 
   async function handleCreate(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -219,8 +240,6 @@ export function GuildInvitesPanel({ guildId }: GuildInvitesPanelProps) {
         </div>
       </form>
 
-      {error ? <FormError message={error} /> : null}
-
       {isLoading ? (
         <div className="h-24 animate-pulse rounded-md bg-panel" />
       ) : !canViewInvites ? (
@@ -305,7 +324,6 @@ export function GuildInvitesPanel({ guildId }: GuildInvitesPanelProps) {
             {isPreviewing ? 'Looking up...' : 'Preview'}
           </button>
         </div>
-        {previewError ? <FormError message={previewError} /> : null}
         {preview ? (
           <div className="flex items-center gap-3 rounded-md border border-stroke bg-frame/50 px-3 py-2.5">
             <GuildIcon

--- a/frontend/src/components/guild/guild-invites-panel.tsx
+++ b/frontend/src/components/guild/guild-invites-panel.tsx
@@ -13,6 +13,7 @@ import {
 } from '../../shared/api/guild';
 import { ApiError } from '../../shared/api/client';
 import { getUsersByIds, type UserSummaryDto } from '../../shared/api/user';
+import { ActionModal } from '../action-modal';
 import { formatDate } from './guild-overview';
 import { GuildIcon } from './guild-icon';
 import { FormError } from './guild-forms';
@@ -39,6 +40,8 @@ export function GuildInvitesPanel({ guildId }: GuildInvitesPanelProps) {
   const [previewError, setPreviewError] = useState('');
   const [isPreviewing, setIsPreviewing] = useState(false);
   const [copiedCode, setCopiedCode] = useState('');
+  const [revokeTarget, setRevokeTarget] = useState<string | null>(null);
+  const [isRevoking, setIsRevoking] = useState(false);
 
   async function handleCopyCode(code: string) {
     try {
@@ -112,17 +115,25 @@ export function GuildInvitesPanel({ guildId }: GuildInvitesPanelProps) {
   }
 
   async function handleRevoke(code: string) {
-    if (!window.confirm(`Revoke invite ${code}? It becomes unusable immediately.`)) {
+    setRevokeTarget(code);
+  }
+
+  async function confirmRevokeInvite() {
+    if (!revokeTarget) {
       return;
     }
 
     setError('');
 
     try {
-      await revokeGuildInvite(guildId, code);
+      setIsRevoking(true);
+      await revokeGuildInvite(guildId, revokeTarget);
       await load();
+      setRevokeTarget(null);
     } catch (revokeError) {
       setError(revokeError instanceof Error ? revokeError.message : 'Failed to revoke invite.');
+    } finally {
+      setIsRevoking(false);
     }
   }
 
@@ -258,6 +269,18 @@ export function GuildInvitesPanel({ guildId }: GuildInvitesPanelProps) {
           ))}
         </ul>
       )}
+
+      {revokeTarget ? (
+        <ActionModal
+          title={`Revoke invite ${revokeTarget}?`}
+          description="This invite will stop working immediately."
+          confirmLabel="Revoke invite"
+          destructive
+          isBusy={isRevoking}
+          onClose={() => setRevokeTarget(null)}
+          onConfirm={confirmRevokeInvite}
+        />
+      ) : null}
 
       <form
         onSubmit={handlePreview}

--- a/frontend/src/components/guild/guild-members-panel.tsx
+++ b/frontend/src/components/guild/guild-members-panel.tsx
@@ -17,6 +17,7 @@ import {
   memberRank,
   type RoleCaller
 } from '../../shared/guilds/role-permissions';
+import { ActionModal } from '../action-modal';
 import { formatDate } from './guild-overview';
 import { getGuildAccentClasses } from './guild-icon';
 import { FormError } from './guild-forms';
@@ -57,9 +58,20 @@ type MemberRowProps = {
   caller: RoleCaller | null;
   onChanged: () => void;
   onError: (message: string) => void;
+  onRequestKick: (member: HydratedGuildMember) => void;
+  onRequestBan: (member: HydratedGuildMember) => void;
 };
 
-function MemberRow({ guildId, member, roles, caller, onChanged, onError }: MemberRowProps) {
+function MemberRow({
+  guildId,
+  member,
+  roles,
+  caller,
+  onChanged,
+  onError,
+  onRequestKick,
+  onRequestBan
+}: MemberRowProps) {
   const [isEditingNickname, setIsEditingNickname] = useState(false);
   const [isRolesOpen, setIsRolesOpen] = useState(false);
   const [nicknameDraft, setNicknameDraft] = useState(member.nickname ?? '');
@@ -85,26 +97,6 @@ function MemberRow({ guildId, member, roles, caller, onChanged, onError }: Membe
       'Failed to update nickname.'
     );
     setIsEditingNickname(false);
-  }
-
-  function handleKick() {
-    if (!window.confirm(`Kick ${member.displayName} from the guild?`)) {
-      return;
-    }
-
-    void run(() => kickGuildMember(guildId, member.userId), 'Failed to kick member.');
-  }
-
-  function handleBan() {
-    const reason = window.prompt(`Ban ${member.displayName}? Optional reason:`);
-    if (reason === null) {
-      return;
-    }
-
-    void run(
-      () => banGuildMember(guildId, member.userId, reason.trim() || undefined),
-      'Failed to ban member.'
-    );
   }
 
   return (
@@ -211,7 +203,7 @@ function MemberRow({ guildId, member, roles, caller, onChanged, onError }: Membe
             <>
               <button
                 type="button"
-                onClick={handleKick}
+                onClick={() => onRequestKick(member)}
                 disabled={isBusy}
                 className={iconButtonClasses}
                 aria-label={`Kick ${member.displayName}`}
@@ -221,7 +213,7 @@ function MemberRow({ guildId, member, roles, caller, onChanged, onError }: Membe
               </button>
               <button
                 type="button"
-                onClick={handleBan}
+                onClick={() => onRequestBan(member)}
                 disabled={isBusy}
                 className={iconButtonClasses}
                 aria-label={`Ban ${member.displayName}`}
@@ -248,6 +240,10 @@ export function GuildMembersPanel({ guildId }: GuildMembersPanelProps) {
     selectedGuild?.id === guildId ? selectedGuild.owner_id : null
   );
   const [actionError, setActionError] = useState('');
+  const [kickTarget, setKickTarget] = useState<HydratedGuildMember | null>(null);
+  const [banTarget, setBanTarget] = useState<HydratedGuildMember | null>(null);
+  const [banReason, setBanReason] = useState('');
+  const [isActionBusy, setIsActionBusy] = useState(false);
 
   // Gate the role controls to callers the server would authorize; the caller
   // missing from the loaded members (pagination edge) safely hides them.
@@ -269,6 +265,45 @@ export function GuildMembersPanel({ guildId }: GuildMembersPanelProps) {
     };
   }, [members, roles, currentUserId]);
 
+  async function confirmKickMember() {
+    if (!kickTarget) {
+      return;
+    }
+
+    setActionError('');
+
+    try {
+      setIsActionBusy(true);
+      await kickGuildMember(guildId, kickTarget.userId);
+      void refresh();
+      setKickTarget(null);
+    } catch (kickError) {
+      setActionError(kickError instanceof Error ? kickError.message : 'Failed to kick member.');
+    } finally {
+      setIsActionBusy(false);
+    }
+  }
+
+  async function confirmBanMember() {
+    if (!banTarget) {
+      return;
+    }
+
+    setActionError('');
+
+    try {
+      setIsActionBusy(true);
+      await banGuildMember(guildId, banTarget.userId, banReason.trim() || undefined);
+      void refresh();
+      setBanTarget(null);
+      setBanReason('');
+    } catch (banError) {
+      setActionError(banError instanceof Error ? banError.message : 'Failed to ban member.');
+    } finally {
+      setIsActionBusy(false);
+    }
+  }
+
   return (
     <div className="grid gap-3">
       {actionError ? <FormError message={actionError} /> : null}
@@ -289,10 +324,54 @@ export function GuildMembersPanel({ guildId }: GuildMembersPanelProps) {
                 void refresh();
               }}
               onError={setActionError}
+              onRequestKick={setKickTarget}
+              onRequestBan={(target) => {
+                setBanTarget(target);
+                setBanReason('');
+              }}
             />
           ))}
         </ul>
       )}
+
+      {kickTarget ? (
+        <ActionModal
+          title={`Kick ${kickTarget.displayName}?`}
+          description="This will remove the member from the guild."
+          confirmLabel="Kick member"
+          destructive
+          isBusy={isActionBusy}
+          onClose={() => setKickTarget(null)}
+          onConfirm={confirmKickMember}
+        />
+      ) : null}
+
+      {banTarget ? (
+        <ActionModal
+          title={`Ban ${banTarget.displayName}?`}
+          description="This will remove the member from the guild and block them from rejoining until unbanned."
+          confirmLabel="Ban member"
+          destructive
+          isBusy={isActionBusy}
+          onClose={() => {
+            setBanTarget(null);
+            setBanReason('');
+          }}
+          onConfirm={confirmBanMember}
+        >
+          <label className="grid gap-2">
+            <span className="text-sm font-semibold text-white/70">Reason (optional)</span>
+            <textarea
+              value={banReason}
+              onChange={(event) => setBanReason(event.target.value)}
+              rows={4}
+              maxLength={512}
+              placeholder="Optional moderation note"
+              className="min-h-[7rem] w-full rounded-md border border-transparent bg-input-bg px-4 py-3 text-base text-white outline-none transition placeholder:text-input-placeholder focus:border-aqua/35"
+            />
+          </label>
+        </ActionModal>
+      ) : null}
     </div>
   );
 }

--- a/frontend/src/components/guild/guild-members-panel.tsx
+++ b/frontend/src/components/guild/guild-members-panel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import Image from 'next/image';
 import { Check, Crown, Gavel, Pencil, Shield, UserX, X } from 'lucide-react';
 import {

--- a/frontend/src/components/guild/guild-members-panel.tsx
+++ b/frontend/src/components/guild/guild-members-panel.tsx
@@ -20,8 +20,8 @@ import {
 import { ActionModal } from '../action-modal';
 import { formatDate } from './guild-overview';
 import { getGuildAccentClasses } from './guild-icon';
-import { FormError } from './guild-forms';
 import { MemberRoleChips, MemberRolesPopover } from './member-roles-popover';
+import { useToast } from '../../shared/ui/toast';
 
 const iconButtonClasses =
   'flex h-8 w-8 items-center justify-center rounded-md text-[#8b8b8f] transition hover:bg-frame hover:text-white';
@@ -244,6 +244,7 @@ export function GuildMembersPanel({ guildId }: GuildMembersPanelProps) {
   const [banTarget, setBanTarget] = useState<HydratedGuildMember | null>(null);
   const [banReason, setBanReason] = useState('');
   const [isActionBusy, setIsActionBusy] = useState(false);
+  const { pushToast } = useToast();
 
   // Gate the role controls to callers the server would authorize; the caller
   // missing from the loaded members (pagination edge) safely hides them.
@@ -264,6 +265,26 @@ export function GuildMembersPanel({ guildId }: GuildMembersPanelProps) {
       isOwner: callerMember.isOwner
     };
   }, [members, roles, currentUserId]);
+
+  useEffect(() => {
+    if (actionError) {
+      pushToast({
+        title: 'Members',
+        description: actionError,
+        tone: 'error'
+      });
+    }
+  }, [actionError, pushToast]);
+
+  useEffect(() => {
+    if (error) {
+      pushToast({
+        title: 'Members',
+        description: error,
+        tone: 'error'
+      });
+    }
+  }, [error, pushToast]);
 
   async function confirmKickMember() {
     if (!kickTarget) {
@@ -306,8 +327,6 @@ export function GuildMembersPanel({ guildId }: GuildMembersPanelProps) {
 
   return (
     <div className="grid gap-3">
-      {actionError ? <FormError message={actionError} /> : null}
-      {error ? <FormError message={error} /> : null}
       {isLoading && members.length === 0 ? (
         <div className="h-32 animate-pulse rounded-md bg-panel" />
       ) : (

--- a/frontend/src/components/guild/guild-overview.tsx
+++ b/frontend/src/components/guild/guild-overview.tsx
@@ -5,6 +5,7 @@ import { Crown, Users } from 'lucide-react';
 import { getGuild, type GuildDto } from '../../shared/api/guild';
 import { useGuilds } from '../../shared/guilds/guild-store';
 import { GuildIcon } from './guild-icon';
+import { useToast } from '../../shared/ui/toast';
 
 export function formatDate(value: string | null | undefined) {
   if (!value) {
@@ -26,6 +27,7 @@ export function GuildOverview({ guildId }: GuildOverviewProps) {
   const [guild, setGuild] = useState<GuildDto | null>(null);
   const [error, setError] = useState('');
   const [isLoading, setIsLoading] = useState(true);
+  const { pushToast } = useToast();
 
   useEffect(() => {
     let isCancelled = false;
@@ -56,13 +58,23 @@ export function GuildOverview({ guildId }: GuildOverviewProps) {
     };
   }, [guildId]);
 
+  useEffect(() => {
+    if (error) {
+      pushToast({
+        title: 'Guild overview',
+        description: error,
+        tone: 'error'
+      });
+    }
+  }, [error, pushToast]);
+
   if (isLoading) {
     return <div className="h-48 animate-pulse rounded-[1rem] bg-panel" />;
   }
 
   if (error || !guild) {
     return (
-      <p className="rounded-md border border-pink/25 bg-pink/10 px-4 py-3 text-sm text-pink">
+      <p className="rounded-md border border-stroke bg-frame px-4 py-3 text-sm text-white/45">
         {error || 'Guild not found.'}
       </p>
     );

--- a/frontend/src/components/guild/guild-roles-panel.tsx
+++ b/frontend/src/components/guild/guild-roles-panel.tsx
@@ -10,7 +10,7 @@ import {
   type GuildRoleDto
 } from '../../shared/api/guild';
 import { ActionModal } from '../action-modal';
-import { FormError } from './guild-forms';
+import { useToast } from '../../shared/ui/toast';
 
 const inputClasses =
   'h-10 w-full rounded-md border border-transparent bg-input-bg px-3 text-sm text-white outline-none transition placeholder:text-input-placeholder focus:border-aqua/35';
@@ -173,6 +173,7 @@ export function GuildRolesPanel({ guildId }: GuildRolesPanelProps) {
   const [editDraft, setEditDraft] = useState<RoleDraft>(emptyDraft);
   const [isBusy, setIsBusy] = useState(false);
   const [deleteTarget, setDeleteTarget] = useState<GuildRoleDto | null>(null);
+  const { pushToast } = useToast();
 
   const load = useCallback(async () => {
     setIsLoading(true);
@@ -191,6 +192,16 @@ export function GuildRolesPanel({ guildId }: GuildRolesPanelProps) {
   useEffect(() => {
     void load();
   }, [load]);
+
+  useEffect(() => {
+    if (error) {
+      pushToast({
+        title: 'Roles',
+        description: error,
+        tone: 'error'
+      });
+    }
+  }, [error, pushToast]);
 
   async function handleCreate() {
     setError('');
@@ -285,8 +296,6 @@ export function GuildRolesPanel({ guildId }: GuildRolesPanelProps) {
           isBusy={isBusy}
         />
       </div>
-
-      {error ? <FormError message={error} /> : null}
 
       {isLoading ? (
         <div className="h-24 animate-pulse rounded-md bg-panel" />

--- a/frontend/src/components/guild/guild-roles-panel.tsx
+++ b/frontend/src/components/guild/guild-roles-panel.tsx
@@ -9,6 +9,7 @@ import {
   updateGuildRole,
   type GuildRoleDto
 } from '../../shared/api/guild';
+import { ActionModal } from '../action-modal';
 import { FormError } from './guild-forms';
 
 const inputClasses =
@@ -171,6 +172,7 @@ export function GuildRolesPanel({ guildId }: GuildRolesPanelProps) {
   const [editingRoleId, setEditingRoleId] = useState<string | null>(null);
   const [editDraft, setEditDraft] = useState<RoleDraft>(emptyDraft);
   const [isBusy, setIsBusy] = useState(false);
+  const [deleteTarget, setDeleteTarget] = useState<GuildRoleDto | null>(null);
 
   const load = useCallback(async () => {
     setIsLoading(true);
@@ -246,7 +248,11 @@ export function GuildRolesPanel({ guildId }: GuildRolesPanelProps) {
   }
 
   async function handleDelete(role: GuildRoleDto) {
-    if (!window.confirm(`Delete role "${role.name}"?`)) {
+    setDeleteTarget(role);
+  }
+
+  async function confirmDeleteRole() {
+    if (!deleteTarget) {
       return;
     }
 
@@ -254,8 +260,9 @@ export function GuildRolesPanel({ guildId }: GuildRolesPanelProps) {
 
     try {
       setIsBusy(true);
-      await deleteGuildRole(guildId, role.id);
+      await deleteGuildRole(guildId, deleteTarget.id);
       await load();
+      setDeleteTarget(null);
     } catch (deleteError) {
       setError(deleteError instanceof Error ? deleteError.message : 'Failed to delete role.');
     } finally {
@@ -345,6 +352,18 @@ export function GuildRolesPanel({ guildId }: GuildRolesPanelProps) {
           ))}
         </ul>
       )}
+
+      {deleteTarget ? (
+        <ActionModal
+          title={`Delete role "${deleteTarget.name}"?`}
+          description="This will remove the role from the guild and from every member who has it."
+          confirmLabel="Delete role"
+          destructive
+          isBusy={isBusy}
+          onClose={() => setDeleteTarget(null)}
+          onConfirm={confirmDeleteRole}
+        />
+      ) : null}
     </div>
   );
 }

--- a/frontend/src/components/guild/guild-settings-panel.tsx
+++ b/frontend/src/components/guild/guild-settings-panel.tsx
@@ -6,6 +6,7 @@ import { AlertTriangle, Save } from 'lucide-react';
 import { deleteGuild, getGuild, updateGuild, type GuildDto } from '../../shared/api/guild';
 import { useGuilds } from '../../shared/guilds/guild-store';
 import { FormError } from './guild-forms';
+import { ActionModal } from '../action-modal';
 
 const inputClasses =
   'h-11 w-full rounded-md border border-transparent bg-input-bg px-4 text-base text-white outline-none transition placeholder:text-input-placeholder focus:border-aqua/35';
@@ -27,6 +28,7 @@ export function GuildSettingsPanel({ guildId }: GuildSettingsPanelProps) {
   const [deleteConfirm, setDeleteConfirm] = useState('');
   const [deleteError, setDeleteError] = useState('');
   const [isDeleting, setIsDeleting] = useState(false);
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
 
   useEffect(() => {
     let isCancelled = false;
@@ -96,14 +98,21 @@ export function GuildSettingsPanel({ guildId }: GuildSettingsPanelProps) {
       return;
     }
 
-    if (!window.confirm(`Delete "${guild.name}" permanently? This cannot be undone.`)) {
+    setIsDeleteModalOpen(true);
+  }
+
+  async function confirmDeleteGuild() {
+    if (!guild) {
       return;
     }
+
+    setDeleteError('');
 
     try {
       setIsDeleting(true);
       await deleteGuild(guildId);
       await refreshGuilds();
+      setIsDeleteModalOpen(false);
     } catch (removeError) {
       setDeleteError(
         removeError instanceof Error ? removeError.message : 'Failed to delete guild.'
@@ -204,6 +213,23 @@ export function GuildSettingsPanel({ guildId }: GuildSettingsPanelProps) {
           </div>
           {deleteError ? <FormError message={deleteError} /> : null}
         </form>
+      ) : null}
+
+      {isDeleteModalOpen && guild ? (
+        <ActionModal
+          title={`Delete "${guild.name}"?`}
+          description={
+            <>
+              This will permanently delete the guild and remove all of its data. This cannot be
+              undone.
+            </>
+          }
+          confirmLabel="Delete guild"
+          destructive
+          isBusy={isDeleting}
+          onClose={() => setIsDeleteModalOpen(false)}
+          onConfirm={confirmDeleteGuild}
+        />
       ) : null}
     </div>
   );

--- a/frontend/src/components/guild/guild-settings-panel.tsx
+++ b/frontend/src/components/guild/guild-settings-panel.tsx
@@ -5,8 +5,8 @@ import type { FormEvent } from 'react';
 import { AlertTriangle, Save } from 'lucide-react';
 import { deleteGuild, getGuild, updateGuild, type GuildDto } from '../../shared/api/guild';
 import { useGuilds } from '../../shared/guilds/guild-store';
-import { FormError } from './guild-forms';
 import { ActionModal } from '../action-modal';
+import { useToast } from '../../shared/ui/toast';
 
 const inputClasses =
   'h-11 w-full rounded-md border border-transparent bg-input-bg px-4 text-base text-white outline-none transition placeholder:text-input-placeholder focus:border-aqua/35';
@@ -29,6 +29,7 @@ export function GuildSettingsPanel({ guildId }: GuildSettingsPanelProps) {
   const [deleteError, setDeleteError] = useState('');
   const [isDeleting, setIsDeleting] = useState(false);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+  const { pushToast } = useToast();
 
   useEffect(() => {
     let isCancelled = false;
@@ -55,6 +56,26 @@ export function GuildSettingsPanel({ guildId }: GuildSettingsPanelProps) {
       isCancelled = true;
     };
   }, [guildId]);
+
+  useEffect(() => {
+    if (error) {
+      pushToast({
+        title: 'Guild settings',
+        description: error,
+        tone: 'error'
+      });
+    }
+  }, [error, pushToast]);
+
+  useEffect(() => {
+    if (deleteError) {
+      pushToast({
+        title: 'Guild deletion',
+        description: deleteError,
+        tone: 'error'
+      });
+    }
+  }, [deleteError, pushToast]);
 
   // The server enforces ownership; without a resolved current user we still
   // show the section so the fake-session dev flow can exercise it.
@@ -167,7 +188,6 @@ export function GuildSettingsPanel({ guildId }: GuildSettingsPanelProps) {
             />
           </label>
         </div>
-        {error ? <FormError message={error} /> : null}
         {savedMessage ? (
           <p className="rounded-md border border-lime/30 bg-lime/10 px-3 py-2 text-sm text-lime">
             {savedMessage}
@@ -211,7 +231,6 @@ export function GuildSettingsPanel({ guildId }: GuildSettingsPanelProps) {
               {isDeleting ? 'Deleting...' : 'Delete guild'}
             </button>
           </div>
-          {deleteError ? <FormError message={deleteError} /> : null}
         </form>
       ) : null}
 

--- a/frontend/src/components/guild/member-roles-popover.tsx
+++ b/frontend/src/components/guild/member-roles-popover.tsx
@@ -10,7 +10,7 @@ import {
 import { canToggleRole, type RoleCaller } from '../../shared/guilds/role-permissions';
 import type { HydratedGuildMember } from '../../shared/guilds/use-guild-members';
 import { useCloseOnEscape } from '../../shared/hooks/use-close-on-escape';
-import { FormError } from './guild-forms';
+import { useToast } from '../../shared/ui/toast';
 
 export function MemberRoleChips({ roles }: { roles: GuildRoleDto[] }) {
   if (roles.length === 0) {
@@ -57,6 +57,7 @@ export function MemberRolesPopover({
 }: MemberRolesPopoverProps) {
   const [pendingRoleIds, setPendingRoleIds] = useState<Set<string>>(new Set());
   const [error, setError] = useState('');
+  const { pushToast } = useToast();
 
   useCloseOnEscape(onClose);
 
@@ -70,6 +71,16 @@ export function MemberRolesPopover({
     document.addEventListener('mousedown', handleMouseDown);
     return () => document.removeEventListener('mousedown', handleMouseDown);
   }, [containerRef, onClose]);
+
+  useEffect(() => {
+    if (error) {
+      pushToast({
+        title: 'Member roles',
+        description: error,
+        tone: 'error'
+      });
+    }
+  }, [error, pushToast]);
 
   const assignableRoles = roles
     .filter((role) => !role.is_default)
@@ -112,7 +123,6 @@ export function MemberRolesPopover({
           <X className="h-3.5 w-3.5" strokeWidth={2} />
         </button>
       </div>
-      {error ? <FormError message={error} /> : null}
       {assignableRoles.length === 0 ? (
         <p className="px-1 pb-1 text-sm text-white/35">
           No roles yet. Create one in the Roles tab.

--- a/frontend/src/components/notification-card.tsx
+++ b/frontend/src/components/notification-card.tsx
@@ -29,6 +29,7 @@ import {
   type UseNotificationsResult
 } from '../shared/lib/use-notifications';
 import { useCloseOnEscape } from '../shared/hooks/use-close-on-escape';
+import { useToast } from '../shared/ui/toast';
 
 type NotificationTone = 'aqua' | 'yellow' | 'pink';
 
@@ -354,6 +355,17 @@ function MutePanel({ preferences, onMute, onUnmute }: MutePanelProps) {
   const [duration, setDuration] = useState<MuteDuration>('forever');
   const [formError, setFormError] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const { pushToast } = useToast();
+
+  useEffect(() => {
+    if (formError) {
+      pushToast({
+        title: 'Notification mutes',
+        description: formError,
+        tone: 'error'
+      });
+    }
+  }, [formError, pushToast]);
 
   async function handleAddMute() {
     const trimmedId = scopeId.trim();
@@ -420,7 +432,6 @@ function MutePanel({ preferences, onMute, onUnmute }: MutePanelProps) {
             </button>
           ))}
         </div>
-        {formError ? <p className="mt-2 text-xs text-pink">{formError}</p> : null}
         <button
           type="button"
           onClick={handleAddMute}
@@ -501,6 +512,7 @@ export function NotificationCard({ feed, onClose, onOpenNotification }: Notifica
   const [view, setView] = useState<'feed' | 'mutes'>('feed');
   const [muteError, setMuteError] = useState('');
   const [actorNamesById, setActorNamesById] = useState<Map<string, string>>(new Map());
+  const { pushToast } = useToast();
   // ids already requested (found or not), so deleted actors aren't refetched
   // on every render; rows fall back to actor-less copy for them
   const requestedActorIdsRef = useRef<Set<string>>(new Set());
@@ -540,6 +552,26 @@ export function NotificationCard({ feed, onClose, onOpenNotification }: Notifica
         // best effort: rows keep their actor-less wording
       });
   }, [notifications]);
+
+  useEffect(() => {
+    if (error) {
+      pushToast({
+        title: 'Notifications',
+        description: error,
+        tone: 'error'
+      });
+    }
+  }, [error, pushToast]);
+
+  useEffect(() => {
+    if (muteError) {
+      pushToast({
+        title: 'Notification mutes',
+        description: muteError,
+        tone: 'error'
+      });
+    }
+  }, [muteError, pushToast]);
 
   async function handleRowMute(scope: NotificationMuteScope) {
     setMuteError('');
@@ -625,7 +657,7 @@ export function NotificationCard({ feed, onClose, onOpenNotification }: Notifica
             </div>
           ) : error ? (
             <div className="flex flex-col items-center gap-3 py-8 text-center">
-              <p className="text-sm text-white/45">{error}</p>
+              <p className="text-sm text-white/45">Notifications unavailable.</p>
               <button
                 type="button"
                 onClick={refresh}
@@ -644,11 +676,6 @@ export function NotificationCard({ feed, onClose, onOpenNotification }: Notifica
             </div>
           ) : (
             <div className="space-y-2">
-              {muteError ? (
-                <p className="rounded-md border border-pink/25 bg-pink/10 px-3 py-2 text-sm text-pink">
-                  {muteError}
-                </p>
-              ) : null}
               {notifications.map((notification) => (
                 <NotificationRow
                   key={notification.id}

--- a/frontend/src/components/profile-editor-panel.tsx
+++ b/frontend/src/components/profile-editor-panel.tsx
@@ -11,6 +11,7 @@ import {
   validateProfileImageFile,
   validateProfileUpdateInput
 } from '../shared/lib/validators/profile';
+import { useToast } from '../shared/ui/toast';
 
 type ProfileEditorPanelProps = {
   currentUser: CurrentUserProfile;
@@ -45,12 +46,23 @@ export function ProfileEditorPanel({
   const [isBusyBanner, setIsBusyBanner] = useState(false);
   const avatarInputRef = useRef<HTMLInputElement>(null);
   const bannerInputRef = useRef<HTMLInputElement>(null);
+  const { pushToast } = useToast();
 
   useEffect(() => {
     setDisplayName(currentUser.displayName);
     setBio(currentUser.bio ?? '');
     setStatus(currentUser.status);
   }, [currentUser]);
+
+  useEffect(() => {
+    if (error) {
+      pushToast({
+        title: 'Profile',
+        description: error,
+        tone: 'error'
+      });
+    }
+  }, [error, pushToast]);
 
   async function handleSave() {
     setError('');
@@ -305,11 +317,6 @@ export function ProfileEditorPanel({
           </button>
         </div>
 
-        {error ? (
-          <p className="rounded-md border border-pink/25 bg-pink/10 px-3 py-2 text-sm text-pink">
-            {error}
-          </p>
-        ) : null}
         {success ? (
           <p className="rounded-md border border-lime/25 bg-lime/10 px-3 py-2 text-sm text-lime">
             {success}

--- a/frontend/src/components/settings-modal.tsx
+++ b/frontend/src/components/settings-modal.tsx
@@ -23,6 +23,7 @@ import { toSidebarStatus, type CurrentUserProfile } from '../shared/mappers/user
 import { AvatarWithStatus } from './avatar-with-status';
 import { ProfileEditorPanel } from './profile-editor-panel';
 import { useCurrentUserProfile } from '../shared/user/user-store';
+import { useToast } from '../shared/ui/toast';
 
 type SettingsModalProps = {
   currentUser: CurrentUserProfile | null;
@@ -350,6 +351,17 @@ function CredentialsForm({ currentEmail, onBack }: CredentialsFormProps) {
   const [error, setError] = useState('');
   const [success, setSuccess] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const { pushToast } = useToast();
+
+  useEffect(() => {
+    if (error) {
+      pushToast({
+        title: 'Credentials',
+        description: error,
+        tone: 'error'
+      });
+    }
+  }, [error, pushToast]);
 
   async function handleSubmit(formData: FormData) {
     const email = String(formData.get('email') ?? '').trim();
@@ -424,11 +436,6 @@ function CredentialsForm({ currentEmail, onBack }: CredentialsFormProps) {
         autoComplete="current-password"
       />
 
-      {error ? (
-        <p className="rounded-md border border-pink/25 bg-pink/10 px-3 py-2 text-sm text-pink">
-          {error}
-        </p>
-      ) : null}
       {success ? (
         <p className="rounded-md border border-lime/25 bg-lime/10 px-3 py-2 text-sm text-lime">
           {success}
@@ -463,6 +470,17 @@ type DeleteAccountPanelProps = {
 function DeleteAccountPanel({ onBack, onDeleted }: DeleteAccountPanelProps) {
   const [error, setError] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const { pushToast } = useToast();
+
+  useEffect(() => {
+    if (error) {
+      pushToast({
+        title: 'Delete account',
+        description: error,
+        tone: 'error'
+      });
+    }
+  }, [error, pushToast]);
 
   async function handleDelete() {
     setError('');
@@ -482,12 +500,6 @@ function DeleteAccountPanel({ onBack, onDeleted }: DeleteAccountPanelProps) {
         This permanently deletes your account and frees your email for re-registration. This cannot
         be undone.
       </p>
-
-      {error ? (
-        <p className="rounded-md border border-pink/25 bg-pink/10 px-3 py-2 text-sm text-pink">
-          {error}
-        </p>
-      ) : null}
 
       <div className="grid grid-cols-2 gap-2.5">
         <button

--- a/frontend/src/shared/ui/toast.tsx
+++ b/frontend/src/shared/ui/toast.tsx
@@ -1,0 +1,138 @@
+'use client';
+
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
+import { CheckCircle2, Info, TriangleAlert, X } from 'lucide-react';
+
+type ToastTone = 'error' | 'success' | 'info';
+
+type ToastInput = {
+  title: string;
+  description: string;
+  tone?: ToastTone;
+  durationMs?: number;
+};
+
+type ToastItem = ToastInput & {
+  id: string;
+};
+
+type ToastContextValue = {
+  pushToast: (toast: ToastInput) => string;
+};
+
+const ToastContext = createContext<ToastContextValue | null>(null);
+
+function getToastClasses(tone: ToastTone) {
+  switch (tone) {
+    case 'success':
+      return {
+        shell: 'border-lime/25 bg-[rgba(14,18,16,0.96)] text-lime',
+        accent: 'bg-lime/80',
+        icon: CheckCircle2
+      };
+    case 'info':
+      return {
+        shell: 'border-aqua/25 bg-[rgba(10,15,18,0.96)] text-aqua',
+        accent: 'bg-aqua/80',
+        icon: Info
+      };
+    default:
+      return {
+        shell: 'border-pink/25 bg-[rgba(18,10,14,0.96)] text-pink',
+        accent: 'bg-pink/80',
+        icon: TriangleAlert
+      };
+  }
+}
+
+export function ToastProvider({ children }: { children: React.ReactNode }) {
+  const [toasts, setToasts] = useState<ToastItem[]>([]);
+  const timersRef = useRef<Map<string, number>>(new Map());
+  const idRef = useRef(0);
+
+  const dismissToast = useCallback((id: string) => {
+    const timer = timersRef.current.get(id);
+    if (timer !== undefined) {
+      window.clearTimeout(timer);
+      timersRef.current.delete(id);
+    }
+    setToasts((current) => current.filter((toast) => toast.id !== id));
+  }, []);
+
+  const pushToast = useCallback(
+    ({ durationMs = 5000, tone = 'error', ...toast }: ToastInput) => {
+      const id = `toast-${++idRef.current}`;
+      setToasts((current) => [...current, { id, tone, durationMs, ...toast }]);
+
+      const timer = window.setTimeout(() => {
+        dismissToast(id);
+      }, durationMs);
+      timersRef.current.set(id, timer);
+
+      return id;
+    },
+    [dismissToast]
+  );
+
+  useEffect(() => {
+    return () => {
+      for (const timer of timersRef.current.values()) {
+        window.clearTimeout(timer);
+      }
+      timersRef.current.clear();
+    };
+  }, []);
+
+  const value = useMemo(() => ({ pushToast }), [pushToast]);
+
+  return (
+    <ToastContext.Provider value={value}>
+      {children}
+      <div
+        className="pointer-events-none fixed right-4 top-4 z-[80] grid w-[min(24rem,calc(100vw-2rem))] gap-3"
+        aria-label="Notifications"
+        aria-live="polite"
+      >
+        {toasts.map((toast) => {
+          const { shell, accent, icon: Icon } = getToastClasses(toast.tone);
+          return (
+            <article
+              key={toast.id}
+              role={toast.tone === 'error' ? 'alert' : 'status'}
+              className={`pointer-events-auto overflow-hidden rounded-[1rem] border shadow-2xl shadow-black/40 ${shell}`}
+            >
+              <div className={`h-1 ${accent}`} />
+              <div className="flex items-start gap-3 px-4 py-3">
+                <span className={`mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-white/5`}>
+                  <Icon className="h-4 w-4" strokeWidth={2} />
+                </span>
+                <div className="min-w-0 flex-1">
+                  <p className="text-sm font-bold tracking-[-0.02em] text-white">{toast.title}</p>
+                  <p className="mt-1 text-sm leading-6 text-white/65">{toast.description}</p>
+                </div>
+                <button
+                  type="button"
+                  onClick={() => dismissToast(toast.id)}
+                  className="mt-0.5 flex h-8 w-8 items-center justify-center rounded-md text-white/35 transition hover:bg-white/5 hover:text-white"
+                  aria-label="Dismiss notification"
+                >
+                  <X className="h-4 w-4" strokeWidth={2} />
+                </button>
+              </div>
+            </article>
+          );
+        })}
+      </div>
+    </ToastContext.Provider>
+  );
+}
+
+export function useToast() {
+  const context = useContext(ToastContext);
+  if (!context) {
+    return {
+      pushToast: () => 'toast-0'
+    };
+  }
+  return context;
+}

--- a/frontend/src/shared/ui/toast.tsx
+++ b/frontend/src/shared/ui/toast.tsx
@@ -1,6 +1,14 @@
 'use client';
 
-import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState
+} from 'react';
 import { CheckCircle2, Info, TriangleAlert, X } from 'lucide-react';
 
 type ToastTone = 'error' | 'success' | 'info';
@@ -22,8 +30,8 @@ type ToastContextValue = {
 
 const ToastContext = createContext<ToastContextValue | null>(null);
 
-function getToastClasses(tone: ToastTone) {
-  switch (tone) {
+function getToastClasses(tone?: ToastTone) {
+  switch (tone ?? 'error') {
     case 'success':
       return {
         shell: 'border-lime/25 bg-[rgba(14,18,16,0.96)] text-lime',
@@ -62,7 +70,8 @@ export function ToastProvider({ children }: { children: React.ReactNode }) {
   const pushToast = useCallback(
     ({ durationMs = 5000, tone = 'error', ...toast }: ToastInput) => {
       const id = `toast-${++idRef.current}`;
-      setToasts((current) => [...current, { id, tone, durationMs, ...toast }]);
+      const resolvedTone: ToastTone = tone ?? 'error';
+      setToasts((current) => [...current, { id, tone: resolvedTone, durationMs, ...toast }]);
 
       const timer = window.setTimeout(() => {
         dismissToast(id);


### PR DESCRIPTION
## Summary

- Remplace les `window.alert`, `confirm` et `prompt` du front par des modales réutilisables.
- Ajoute une modale d'action générique pour les opérations destructives.
- Introduit un système global de toasts pour les erreurs et retours non bloquants.
- Harmonise plusieurs écrans du frontend pour éviter les messages d’erreur inline trop agressifs.

## Changes

- Modale générique: `ActionModal`
- Provider global: `ToastProvider`
- Migration des confirmations dans:
  - guild members
  - guild bans
  - guild roles
  - guild categories
  - guild channels
  - guild invites
  - guild settings
- Remplacement des erreurs inline les plus visibles par des toasts dans:
  - auth login/register
  - profile editor
  - friends list
  - notifications
  - guild pages

## Validation

- `node frontend/scripts/run-tests.mjs`