### PR TITLE
Fix: realtime propagation

### DIFF
--- a/docs/contracts/guild.md
+++ b/docs/contracts/guild.md
@@ -1040,7 +1040,7 @@ Same shape as `GET /guilds/{id}/channels`. A channel is included when the user's
 | `guild.member_joined` | `{ guild_id, guild_name, user_id }` | User joins a guild |
 | `guild.member_left` | `{ guild_id, user_id }` | User leaves, is kicked, or banned |
 | `guild.invite_created` | `{ guild_id, guild_name, invited_by_user_id, invited_user_id? }` | Invite created; `invited_user_id` present only for targeted invites |
-| `guild.deleted` | `{ guild_id }` | Guild deleted by its owner. Downstream services cascade their own cleanup by `guild_id` (Chat channels/messages, Notification rows, membership references). |
+| `guild.deleted` | `{ guild_id, channel_ids }` | Guild deleted by its owner. `channel_ids` lists the guild's channels at deletion time so Chat (which cannot read Guild's DB) can purge each channel's message history. Chat also broadcasts `GuildDeleted` over SignalR so members' clients drop the guild live. Other downstream services cascade their own cleanup by `guild_id` (Notification rows, membership references). |
 | `guild.owner_transferred` | `{ guild_id, old_owner_id, new_owner_id }` | Ownership transferred to another member. At least Notification reacts (notify old and/or new owner). |
 | `channel.access_revoked` | `{ channel_id, user_id }` | A member lost `READ_MESSAGES` on a channel via a role or overwrite change (role permission update, role assignment or unassignment, role deletion, or a channel-overwrite put/delete). One event per (channel, member) whose effective read flipped from allowed to denied. Chat consumes it to evict the member's live SignalR subscription (`EvictFromChannelAsync`). |
 

--- a/docs/contracts/notification.md
+++ b/docs/contracts/notification.md
@@ -275,6 +275,7 @@ This is the internal-perspective twin of `GET /notifications/preferences`: every
 | `call.incoming` | Always | `type: incoming_call` for `callee_id` - prompts them to open the app |
 | `friend.request_sent` | Always | `type: friend_request` for `addressee_id` |
 | `friend.accepted` | Always | `type: friend_accept` for `requester_id` - tells them their request was accepted |
+| `friend.removed` | Always | no stored notification; pushes a transient `friends_changed` SSE signal to both `requester_id` and `addressee_id` so their friends lists re-fetch |
 | `guild.invite_created` | `invited_user_id` is present | `type: guild_invite` for `invited_user_id` |
 | `guild.member_joined` | Always | `type: guild_welcome` for the joining user |
 | `user.deleted` | Always | Delete every notification row where `user_id` or `actor_id` matches the deleted user, and drop the user's `notification_preferences` rows. Also sends the `account_deleted` confirmation email (see [Email delivery](#email-delivery)). |

--- a/docs/contracts/notification.md
+++ b/docs/contracts/notification.md
@@ -63,6 +63,7 @@ Fetch notifications for the authenticated user. Dismissed notifications are excl
 | `mention` | `author_id` of the message | `message_id` | `{ channel_id, guild_id, preview }` |
 | `dm` | `sender_id` | `message_id` | `{ conversation_id, preview }` |
 | `friend_request` | `requester_id` | friendship row id | `{}` |
+| `friend_accept` | `addressee_id` (who accepted) | friendship row id | `{}` |
 | `guild_invite` | `invited_by_user_id` | `guild_id` | `{ guild_name }` |
 | `guild_welcome` | NULL (system event) | `guild_id` | `{ guild_name }` |
 | `incoming_call` | `caller_id` | NULL (call is ephemeral) | `{ call_type: "audio" \| "video" }` |
@@ -273,6 +274,7 @@ This is the internal-perspective twin of `GET /notifications/preferences`: every
 | `chat.dm_sent` | Always | `type: dm` for `recipient_id` |
 | `call.incoming` | Always | `type: incoming_call` for `callee_id` - prompts them to open the app |
 | `friend.request_sent` | Always | `type: friend_request` for `addressee_id` |
+| `friend.accepted` | Always | `type: friend_accept` for `requester_id` - tells them their request was accepted |
 | `guild.invite_created` | `invited_user_id` is present | `type: guild_invite` for `invited_user_id` |
 | `guild.member_joined` | Always | `type: guild_welcome` for the joining user |
 | `user.deleted` | Always | Delete every notification row where `user_id` or `actor_id` matches the deleted user, and drop the user's `notification_preferences` rows. Also sends the `account_deleted` confirmation email (see [Email delivery](#email-delivery)). |

--- a/docs/contracts/user.md
+++ b/docs/contracts/user.md
@@ -619,6 +619,7 @@ The user's User-owned data for a GDPR self-serve export: profile, friends, and t
 |-------|---------|---------|
 | `friend.request_sent` | `{ friendship_id, requester_id, addressee_id }` | Friend request sent |
 | `friend.accepted` | `{ friendship_id, requester_id, addressee_id }` | A pending friend request was accepted by the addressee. Consumed by Notification (`friend_accept` notification to the requester), which pushes it over SSE so the requester's friends list refreshes. |
+| `friend.removed` | `{ requester_id, addressee_id }` | An **accepted** friendship was deleted (unfriend). Consumed by Notification, which pushes a transient `friends_changed` SSE signal (no stored notification) to both parties so their friends lists re-fetch. Not published for declining/cancelling a pending request. |
 | `data.export_ready` | `{ user_id, email, download_url, expires_at }` | An async data-export job finished and the bundle is stored. Consumed by Notification to email the presigned download link. `email` is the recipient address (owned by Auth; the aggregator already holds it from Auth's export leg); `download_url` is a presigned MinIO GET URL; `expires_at` is its expiry. |
 
 ## RabbitMQ Events Consumed

--- a/docs/contracts/user.md
+++ b/docs/contracts/user.md
@@ -246,6 +246,7 @@ List a user's friends.
 [
   {
     "id": "<snowflake>",
+    "friendship_id": "<snowflake>",
     "username": "tstephan",
     "display_name": "SkyDogzz",
     "avatar_url": "https://...",
@@ -254,6 +255,8 @@ List a user's friends.
   }
 ]
 ```
+
+`friendship_id` is the `friendships` row id, so the UI can `DELETE /friends/{id}` to unfriend without a separate lookup.
 
 ---
 

--- a/docs/contracts/user.md
+++ b/docs/contracts/user.md
@@ -615,6 +615,7 @@ The user's User-owned data for a GDPR self-serve export: profile, friends, and t
 | Event | Payload | Trigger |
 |-------|---------|---------|
 | `friend.request_sent` | `{ friendship_id, requester_id, addressee_id }` | Friend request sent |
+| `friend.accepted` | `{ friendship_id, requester_id, addressee_id }` | A pending friend request was accepted by the addressee. Consumed by Notification (`friend_accept` notification to the requester), which pushes it over SSE so the requester's friends list refreshes. |
 | `data.export_ready` | `{ user_id, email, download_url, expires_at }` | An async data-export job finished and the bundle is stored. Consumed by Notification to email the presigned download link. `email` is the recipient address (owned by Auth; the aggregator already holds it from Auth's export leg); `download_url` is a presigned MinIO GET URL; `expires_at` is its expiry. |
 
 ## RabbitMQ Events Consumed

--- a/frontend/src/components/chat-workspace.tsx
+++ b/frontend/src/components/chat-workspace.tsx
@@ -25,7 +25,7 @@ import { useNotifications } from '../shared/lib/use-notifications';
 import { clearSession, getUserId } from '../shared/lib/session';
 import { logout } from '../shared/api/auth';
 import { markChannelRead, markDirectMessageRead } from '../shared/api/chat';
-import { stopChatHub } from '../shared/api/chat-hub';
+import { onChatHubEvent, stopChatHub } from '../shared/api/chat-hub';
 import { useCurrentUserId } from '../shared/hooks/use-current-user-id';
 import { useGuildWorkspace } from '../shared/hooks/use-guild-workspace';
 import { useDmWorkspace } from '../shared/hooks/use-dm-workspace';
@@ -167,6 +167,25 @@ export function ChatWorkspace() {
       cancelled = true;
     };
   }, [currentUserId]);
+
+  // live presence: patch a friend's status dot when they go online/offline,
+  // instead of only reflecting the status fetched at load.
+  useEffect(() => {
+    return onChatHubEvent('UserPresence', (event) => {
+      const status = event.status === 'dnd' ? 'idle' : event.status;
+      setFriends((current) => {
+        let changed = false;
+        const next = current.map((friend) => {
+          if (friend.id !== event.user_id || friend.status === status) {
+            return friend;
+          }
+          changed = true;
+          return { ...friend, status };
+        });
+        return changed ? next : current;
+      });
+    });
+  }, []);
 
   const activeDmDetails =
     chatMode === 'dm' && dmWorkspace.activeDm

--- a/frontend/src/components/chat-workspace.tsx
+++ b/frontend/src/components/chat-workspace.tsx
@@ -26,13 +26,13 @@ import { clearSession, getUserId } from '../shared/lib/session';
 import { logout } from '../shared/api/auth';
 import { markChannelRead, markDirectMessageRead } from '../shared/api/chat';
 import { onChatHubEvent, stopChatHub } from '../shared/api/chat-hub';
-import { subscribeFriendsChanged } from '../shared/lib/friends-events';
+import { dispatchFriendsChanged, subscribeFriendsChanged } from '../shared/lib/friends-events';
 import { useCurrentUserId } from '../shared/hooks/use-current-user-id';
 import { useGuildWorkspace } from '../shared/hooks/use-guild-workspace';
 import { useDmWorkspace } from '../shared/hooks/use-dm-workspace';
 import { useConversationHistory } from '../shared/hooks/use-conversation-history';
 import { useScrollPreservation } from '../shared/hooks/use-scroll-preservation';
-import { getUsersByIds, listFriends, type UserSummaryDto } from '../shared/api/user';
+import { deleteFriendship, getUsersByIds, listFriends, type UserSummaryDto } from '../shared/api/user';
 import { toFriend } from '../shared/api/hydrate';
 import { useCall } from '../shared/call/call-context';
 import { IncomingCallOverlay } from './call/incoming-call-overlay';
@@ -458,6 +458,23 @@ export function ChatWorkspace() {
     setMobilePane('messages');
     window.sessionStorage.setItem(LAST_CHAT_MODE_KEY, 'dm');
     setProfileMember(null);
+  }
+
+  async function handleUnfriend(member: GuildMember) {
+    const friend = friends.find((entry) => entry.id === member.id);
+    if (!friend) {
+      return;
+    }
+
+    setProfileMember(null);
+    // optimistic: drop them locally, then confirm with the server and re-sync.
+    setFriends((current) => current.filter((entry) => entry.id !== member.id));
+    try {
+      await deleteFriendship(friend.friendshipId);
+    } catch {
+      // best effort: a failed delete reconciles on the next friends re-fetch
+    }
+    dispatchFriendsChanged();
   }
 
   function handleToggleMicMute() {
@@ -944,6 +961,11 @@ export function ChatWorkspace() {
               member={profileMember}
               onClose={handleCloseAuthorProfile}
               onSendMessage={handleSendMessageToProfile}
+              onUnfriend={
+                friends.some((entry) => entry.id === profileMember.id)
+                  ? handleUnfriend
+                  : undefined
+              }
             />
           ) : null}
 

--- a/frontend/src/components/chat-workspace.tsx
+++ b/frontend/src/components/chat-workspace.tsx
@@ -26,6 +26,7 @@ import { clearSession, getUserId } from '../shared/lib/session';
 import { logout } from '../shared/api/auth';
 import { markChannelRead, markDirectMessageRead } from '../shared/api/chat';
 import { onChatHubEvent, stopChatHub } from '../shared/api/chat-hub';
+import { subscribeFriendsChanged } from '../shared/lib/friends-events';
 import { useCurrentUserId } from '../shared/hooks/use-current-user-id';
 import { useGuildWorkspace } from '../shared/hooks/use-guild-workspace';
 import { useDmWorkspace } from '../shared/hooks/use-dm-workspace';
@@ -59,6 +60,7 @@ export function ChatWorkspace() {
   const [editingDraft, setEditingDraft] = useState('');
   const [mobilePane, setMobilePane] = useState<'channels' | 'messages'>('messages');
   const [friends, setFriends] = useState<Friend[]>([]);
+  const [friendsReloadKey, setFriendsReloadKey] = useState(0);
   const [profileMember, setProfileMember] = useState<GuildMember | null>(null);
   const [isNotificationCardOpen, setIsNotificationCardOpen] = useState(false);
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
@@ -166,7 +168,16 @@ export function ChatWorkspace() {
     return () => {
       cancelled = true;
     };
-  }, [currentUserId]);
+  }, [currentUserId, friendsReloadKey]);
+
+  // re-fetch the friends list when the friend graph changed elsewhere (a
+  // pending request we sent was accepted, delivered as a friend_accept
+  // notification over SSE).
+  useEffect(() => {
+    return subscribeFriendsChanged(() => {
+      setFriendsReloadKey((key) => key + 1);
+    });
+  }, []);
 
   // live presence: patch a friend's status dot when they go online/offline,
   // instead of only reflecting the status fetched at load.
@@ -632,6 +643,9 @@ export function ChatWorkspace() {
     } else if (notification.type === 'friend_request') {
       handleOpenDms();
       setIsFriendRequestsFocusPending(true);
+      setMobilePane('channels');
+    } else if (notification.type === 'friend_accept') {
+      handleOpenDms();
       setMobilePane('channels');
     } else if (notification.type === 'guild_invite') {
       // no "invites addressed to me" endpoint exists, so the closest target

--- a/frontend/src/components/friends-list.tsx
+++ b/frontend/src/components/friends-list.tsx
@@ -35,9 +35,11 @@ import {
   type SearchUserDto
 } from '../shared/api/user';
 import { useToast } from '../shared/ui/toast';
+import { dispatchFriendsChanged } from '../shared/lib/friends-events';
 
 export type Friend = {
   id: string;
+  friendshipId: string;
   name: string;
   status: DirectMessage['status'];
   accent: ChatMessageData['accent'];
@@ -264,6 +266,10 @@ export function FriendsList({
     try {
       await updateFriendship(friendshipId, 'accepted');
       setActionSuccess('Friend request accepted.');
+      // reload our friends list (the accepter's side): refreshEverything only
+      // reloads requests + discovery, so the new friend would otherwise not
+      // appear until a manual refresh.
+      dispatchFriendsChanged();
       await refreshEverything();
     } catch (acceptError) {
       setActionError(acceptError instanceof Error ? acceptError.message : 'Failed to accept.');

--- a/frontend/src/components/notification-card.tsx
+++ b/frontend/src/components/notification-card.tsx
@@ -56,6 +56,7 @@ function hasNotificationTarget(notification: NotificationDto): boolean {
       return Boolean(notification.actor_id);
     case 'mention':
     case 'friend_request':
+    case 'friend_accept':
     case 'guild_invite':
       return true;
     case 'guild_welcome':
@@ -117,6 +118,15 @@ export function describeNotification(
         detail: actorName
           ? `${actorName} wants to add you as a friend.`
           : 'Someone wants to add you as a friend.',
+        tone: 'pink',
+        Icon: UserPlus
+      };
+    case 'friend_accept':
+      return {
+        title: 'Friend request accepted',
+        detail: actorName
+          ? `${actorName} accepted your friend request.`
+          : 'Your friend request was accepted.',
         tone: 'pink',
         Icon: UserPlus
       };

--- a/frontend/src/components/profile-card.tsx
+++ b/frontend/src/components/profile-card.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { MessageCircle, Shield, Trophy, X } from 'lucide-react';
+import { MessageCircle, Shield, Trophy, UserMinus, X } from 'lucide-react';
 import { AvatarWithStatus } from './avatar-with-status';
 import type { GuildMember } from './guild-member-list';
 import { useCloseOnEscape } from '../shared/hooks/use-close-on-escape';
@@ -10,13 +10,15 @@ type ProfileCardProps = {
   variant?: 'modal' | 'side';
   onClose: () => void;
   onSendMessage?: (member: GuildMember) => void;
+  onUnfriend?: (member: GuildMember) => void;
 };
 
 export function ProfileCard({
   member,
   variant = 'modal',
   onClose,
-  onSendMessage
+  onSendMessage,
+  onUnfriend
 }: ProfileCardProps) {
   useCloseOnEscape(onClose);
 
@@ -97,6 +99,17 @@ export function ProfileCard({
           >
             <MessageCircle className="h-4 w-4" strokeWidth={2} />
             Send message
+          </button>
+        ) : null}
+
+        {onUnfriend ? (
+          <button
+            type="button"
+            onClick={() => onUnfriend(member)}
+            className="mt-3 flex h-11 w-full items-center justify-center gap-2 rounded-md border border-pink/40 bg-pink/10 text-sm font-bold text-pink transition hover:bg-pink/20"
+          >
+            <UserMinus className="h-4 w-4" strokeWidth={2} />
+            Unfriend
           </button>
         ) : null}
       </div>

--- a/frontend/src/shared/api/chat-hub.ts
+++ b/frontend/src/shared/api/chat-hub.ts
@@ -3,7 +3,7 @@ import { API_BASE_URL } from '../config/env';
 import { getAccessToken, invalidateSession } from '../lib/session';
 import { refreshAccessToken } from './client';
 import type { SendChannelMessageResponse, SendDirectMessageResponse } from './chat';
-import type { GuildChannelDto } from './guild';
+import type { GuildCategoryDto, GuildChannelDto } from './guild';
 
 export type MessageEditedEvent = {
   id: string;
@@ -75,6 +75,11 @@ export type ChannelDeletedEvent = {
   channel_id: string;
 };
 
+export type CategoryDeletedEvent = {
+  guild_id: string;
+  category_id: string;
+};
+
 export type GuildMemberEvent = {
   guild_id: string;
   user_id: string;
@@ -104,6 +109,9 @@ export type ChatHubEvents = {
   ChannelCreated: (event: GuildChannelDto) => void;
   ChannelUpdated: (event: GuildChannelDto) => void;
   ChannelDeleted: (event: ChannelDeletedEvent) => void;
+  CategoryCreated: (event: GuildCategoryDto) => void;
+  CategoryUpdated: (event: GuildCategoryDto) => void;
+  CategoryDeleted: (event: CategoryDeletedEvent) => void;
   MemberJoined: (event: GuildMemberEvent) => void;
   MemberLeft: (event: GuildMemberEvent) => void;
   Error: (event: ChatHubErrorEvent) => void;

--- a/frontend/src/shared/api/chat-hub.ts
+++ b/frontend/src/shared/api/chat-hub.ts
@@ -86,6 +86,11 @@ export type CategoryDeletedEvent = {
   category_id: string;
 };
 
+export type ChannelAccessGrantedEvent = {
+  guild_id: string;
+  channel_id: string;
+};
+
 export type GuildMemberEvent = {
   guild_id: string;
   user_id: string;
@@ -119,6 +124,7 @@ export type ChatHubEvents = {
   CategoryCreated: (event: GuildCategoryDto) => void;
   CategoryUpdated: (event: GuildCategoryDto) => void;
   CategoryDeleted: (event: CategoryDeletedEvent) => void;
+  ChannelAccessGranted: (event: ChannelAccessGrantedEvent) => void;
   MemberJoined: (event: GuildMemberEvent) => void;
   MemberLeft: (event: GuildMemberEvent) => void;
   MemberUpdated: (event: GuildMemberEvent) => void;

--- a/frontend/src/shared/api/chat-hub.ts
+++ b/frontend/src/shared/api/chat-hub.ts
@@ -100,6 +100,7 @@ export type ChatHubEvents = {
   UserPresence: (event: UserPresenceEvent) => void;
   GuildJoined: (event: GuildJoinedEvent) => void;
   GuildLeft: (event: GuildLeftEvent) => void;
+  GuildDeleted: (guildId: string) => void;
   ChannelCreated: (event: GuildChannelDto) => void;
   ChannelUpdated: (event: GuildChannelDto) => void;
   ChannelDeleted: (event: ChannelDeletedEvent) => void;

--- a/frontend/src/shared/api/chat-hub.ts
+++ b/frontend/src/shared/api/chat-hub.ts
@@ -3,6 +3,7 @@ import { API_BASE_URL } from '../config/env';
 import { getAccessToken, invalidateSession } from '../lib/session';
 import { refreshAccessToken } from './client';
 import type { SendChannelMessageResponse, SendDirectMessageResponse } from './chat';
+import type { GuildChannelDto } from './guild';
 
 export type MessageEditedEvent = {
   id: string;
@@ -69,6 +70,16 @@ export type GuildLeftEvent = {
   guild_id: string;
 };
 
+export type ChannelDeletedEvent = {
+  guild_id: string;
+  channel_id: string;
+};
+
+export type GuildMemberEvent = {
+  guild_id: string;
+  user_id: string;
+};
+
 export type ChatHubErrorEvent = {
   code: string;
   message: string;
@@ -89,6 +100,11 @@ export type ChatHubEvents = {
   UserPresence: (event: UserPresenceEvent) => void;
   GuildJoined: (event: GuildJoinedEvent) => void;
   GuildLeft: (event: GuildLeftEvent) => void;
+  ChannelCreated: (event: GuildChannelDto) => void;
+  ChannelUpdated: (event: GuildChannelDto) => void;
+  ChannelDeleted: (event: ChannelDeletedEvent) => void;
+  MemberJoined: (event: GuildMemberEvent) => void;
+  MemberLeft: (event: GuildMemberEvent) => void;
   Error: (event: ChatHubErrorEvent) => void;
 };
 

--- a/frontend/src/shared/api/chat-hub.ts
+++ b/frontend/src/shared/api/chat-hub.ts
@@ -121,6 +121,8 @@ export type ChatHubEvents = {
   CategoryDeleted: (event: CategoryDeletedEvent) => void;
   MemberJoined: (event: GuildMemberEvent) => void;
   MemberLeft: (event: GuildMemberEvent) => void;
+  MemberUpdated: (event: GuildMemberEvent) => void;
+  RolesChanged: (guildId: string) => void;
   Error: (event: ChatHubErrorEvent) => void;
 };
 

--- a/frontend/src/shared/api/chat-hub.ts
+++ b/frontend/src/shared/api/chat-hub.ts
@@ -70,6 +70,12 @@ export type GuildLeftEvent = {
   guild_id: string;
 };
 
+export type GuildUpdatedEvent = {
+  guild_id: string;
+  name: string;
+  icon_url?: string | null;
+};
+
 export type ChannelDeletedEvent = {
   guild_id: string;
   channel_id: string;
@@ -106,6 +112,7 @@ export type ChatHubEvents = {
   GuildJoined: (event: GuildJoinedEvent) => void;
   GuildLeft: (event: GuildLeftEvent) => void;
   GuildDeleted: (guildId: string) => void;
+  GuildUpdated: (event: GuildUpdatedEvent) => void;
   ChannelCreated: (event: GuildChannelDto) => void;
   ChannelUpdated: (event: GuildChannelDto) => void;
   ChannelDeleted: (event: ChannelDeletedEvent) => void;

--- a/frontend/src/shared/api/hydrate.ts
+++ b/frontend/src/shared/api/hydrate.ts
@@ -61,6 +61,7 @@ export function toDirectMessage(
 export function toFriend(friend: FriendDto): Friend {
   return {
     id: friend.id,
+    friendshipId: friend.friendship_id,
     name: friend.display_name || friend.username,
     status: toSidebarStatus(friend.status),
     accent: accentForId(friend.id),

--- a/frontend/src/shared/api/notification.ts
+++ b/frontend/src/shared/api/notification.ts
@@ -5,6 +5,7 @@ export type NotificationType =
   | 'mention'
   | 'dm'
   | 'friend_request'
+  | 'friend_accept'
   | 'guild_invite'
   | 'guild_welcome'
   | 'incoming_call';
@@ -13,6 +14,7 @@ export type NotificationPayloadMap = {
   mention: { channel_id: string; guild_id: string; preview: string };
   dm: { conversation_id: string; preview: string };
   friend_request: Record<string, never>;
+  friend_accept: Record<string, never>;
   guild_invite: { guild_name: string };
   guild_welcome: { guild_name: string };
   incoming_call: { call_type: 'audio' | 'video' };

--- a/frontend/src/shared/api/user.ts
+++ b/frontend/src/shared/api/user.ts
@@ -29,6 +29,7 @@ export type UpdateUserProfilePayload = {
 
 export type FriendDto = {
   id: string;
+  friendship_id: string;
   username: string;
   display_name: string;
   avatar_url?: string | null;

--- a/frontend/src/shared/guilds/use-guild-members.ts
+++ b/frontend/src/shared/guilds/use-guild-members.ts
@@ -198,5 +198,22 @@ export function useGuildMembers(guildId: string | null, ownerId?: string | null)
     };
   }, [guildId, load]);
 
+  // live presence: update a member's status dot without re-fetching the roster.
+  useEffect(() => {
+    return onChatHubEvent('UserPresence', (event) => {
+      setMembers((current) => {
+        let changed = false;
+        const next = current.map((member) => {
+          if (member.userId !== event.user_id || member.status === event.status) {
+            return member;
+          }
+          changed = true;
+          return { ...member, status: event.status };
+        });
+        return changed ? next : current;
+      });
+    });
+  }, []);
+
   return { members, roles, isLoading, error, refresh: load };
 }

--- a/frontend/src/shared/guilds/use-guild-members.ts
+++ b/frontend/src/shared/guilds/use-guild-members.ts
@@ -191,10 +191,21 @@ export function useGuildMembers(guildId: string | null, ownerId?: string | null)
 
     const unsubscribeJoined = onChatHubEvent('MemberJoined', reloadIfThisGuild);
     const unsubscribeLeft = onChatHubEvent('MemberLeft', reloadIfThisGuild);
+    // nickname / role assignment change for a member, and role set changes
+    // (create/update/delete/reorder), both re-hydrate the roster so displayed
+    // nicknames, role colours and role membership stay current.
+    const unsubscribeMemberUpdated = onChatHubEvent('MemberUpdated', reloadIfThisGuild);
+    const unsubscribeRolesChanged = onChatHubEvent('RolesChanged', (changedGuildId) => {
+      if (changedGuildId === guildId) {
+        void load();
+      }
+    });
 
     return () => {
       unsubscribeJoined();
       unsubscribeLeft();
+      unsubscribeMemberUpdated();
+      unsubscribeRolesChanged();
     };
   }, [guildId, load]);
 

--- a/frontend/src/shared/guilds/use-guild-members.ts
+++ b/frontend/src/shared/guilds/use-guild-members.ts
@@ -10,6 +10,7 @@ import {
 import { getUser, getUsersByIds, type UserStatus, type UserSummaryDto } from '../api/user';
 import { sortRolesByDisplayPriority } from './role-permissions';
 import { subscribeProfileUpdated } from '../lib/profile-events';
+import { onChatHubEvent } from '../api/chat-hub';
 
 const MEMBERS_PAGE_SIZE = 100;
 const MEMBERS_MAX_PAGES = 10;
@@ -173,6 +174,29 @@ export function useGuildMembers(guildId: string | null, ownerId?: string | null)
       void load();
     });
   }, [load]);
+
+  // roster changes for this guild (someone joined or left, including the
+  // current user's own just-committed join) re-hydrate the member list so it
+  // reflects membership without a manual refresh.
+  useEffect(() => {
+    if (!guildId) {
+      return;
+    }
+
+    const reloadIfThisGuild = (event: { guild_id: string }) => {
+      if (event.guild_id === guildId) {
+        void load();
+      }
+    };
+
+    const unsubscribeJoined = onChatHubEvent('MemberJoined', reloadIfThisGuild);
+    const unsubscribeLeft = onChatHubEvent('MemberLeft', reloadIfThisGuild);
+
+    return () => {
+      unsubscribeJoined();
+      unsubscribeLeft();
+    };
+  }, [guildId, load]);
 
   return { members, roles, isLoading, error, refresh: load };
 }

--- a/frontend/src/shared/hooks/use-guild-workspace.ts
+++ b/frontend/src/shared/hooks/use-guild-workspace.ts
@@ -109,10 +109,17 @@ export function useGuildWorkspace(): GuildWorkspace {
       void refreshGuilds();
     });
 
+    // name/icon change: refresh the guild list so the sidebar + header pick up
+    // the new values.
+    const unsubscribeUpdated = onChatHubEvent('GuildUpdated', () => {
+      void refreshGuilds();
+    });
+
     return () => {
       unsubscribeJoined();
       unsubscribeLeft();
       unsubscribeDeleted();
+      unsubscribeUpdated();
     };
   }, [refreshGuilds]);
 

--- a/frontend/src/shared/hooks/use-guild-workspace.ts
+++ b/frontend/src/shared/hooks/use-guild-workspace.ts
@@ -102,9 +102,17 @@ export function useGuildWorkspace(): GuildWorkspace {
       void refreshGuilds();
     });
 
+    // a deleted guild is dropped from listMyGuilds, so refreshing the list also
+    // reconciles the selection (applyGuilds falls back to another guild/none)
+    // and clears the now-gone guild's channels.
+    const unsubscribeDeleted = onChatHubEvent('GuildDeleted', () => {
+      void refreshGuilds();
+    });
+
     return () => {
       unsubscribeJoined();
       unsubscribeLeft();
+      unsubscribeDeleted();
     };
   }, [refreshGuilds]);
 

--- a/frontend/src/shared/hooks/use-guild-workspace.ts
+++ b/frontend/src/shared/hooks/use-guild-workspace.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { hasChannel, type ChannelCategory, type TextChannel } from '../../components/channel-list';
 import {
   listGuildCategories,
@@ -64,17 +64,38 @@ export type GuildWorkspace = {
 // /guilds management pages, not just chat.
 export function useGuildWorkspace(): GuildWorkspace {
   const { selectedGuildId, refreshGuilds, currentUserId } = useGuilds();
-  const [channelCategories, setChannelCategories] = useState<ChannelCategory[]>([]);
-  const [channels, setChannels] = useState<TextChannel[]>([]);
+  // raw server DTOs are kept so real-time channel events can be spliced in
+  // without a refetch; the sidebar-shaped views below are derived from them.
+  const [rawChannels, setRawChannels] = useState<GuildChannelDto[]>([]);
+  const [rawCategories, setRawCategories] = useState<GuildCategoryDto[]>([]);
   const [activeChannel, setActiveChannel] = useState<string | null>(null);
   const [channelReadStates, setChannelReadStates] = useState<Record<string, ChannelReadState>>({});
   const activeChannelRef = useRef<string | null>(null);
   activeChannelRef.current = activeChannel;
+  const selectedGuildIdRef = useRef<string | null>(selectedGuildId);
+  selectedGuildIdRef.current = selectedGuildId;
   const [channelsRefreshKey, setChannelsRefreshKey] = useState(0);
 
+  const channelCategories = useMemo(
+    () => buildChannelCategories(rawChannels, rawCategories),
+    [rawChannels, rawCategories]
+  );
+  const channels = useMemo<TextChannel[]>(
+    () => rawChannels.map((channel) => ({ id: channel.id, name: channel.name })),
+    [rawChannels]
+  );
+  // stable identity of the channel set: the join/leave-all effect keys off this
+  // so a rename (same ids) doesn't tear down and re-join every SignalR group.
+  const channelIdsKey = useMemo(() => channels.map((channel) => channel.id).join(','), [channels]);
+
   useEffect(() => {
-    const unsubscribeJoined = onChatHubEvent('GuildJoined', () => {
+    const unsubscribeJoined = onChatHubEvent('GuildJoined', (event) => {
       void refreshGuilds();
+      // if the just-joined guild is the one on screen, its channel load may have
+      // raced the membership commit and 403'd; re-load now that we are a member.
+      if (event.guild_id === selectedGuildIdRef.current) {
+        setChannelsRefreshKey((key) => key + 1);
+      }
     });
 
     const unsubscribeLeft = onChatHubEvent('GuildLeft', () => {
@@ -89,8 +110,8 @@ export function useGuildWorkspace(): GuildWorkspace {
 
   useEffect(() => {
     if (!selectedGuildId) {
-      setChannelCategories([]);
-      setChannels([]);
+      setRawChannels([]);
+      setRawCategories([]);
       return;
     }
 
@@ -106,26 +127,12 @@ export function useGuildWorkspace(): GuildWorkspace {
           return;
         }
 
-        const flatChannels: TextChannel[] = channelDtos.map((channel) => ({
-          id: channel.id,
-          name: channel.name
-        }));
-        setChannelCategories(buildChannelCategories(channelDtos, categoryDtos));
-        setChannels(flatChannels);
-
-        setActiveChannel((current) => {
-          if (current && hasChannel(current, flatChannels)) {
-            return current;
-          }
-          const storedChannelId = window.sessionStorage.getItem(LAST_CHAT_CHANNEL_KEY);
-          return storedChannelId && hasChannel(storedChannelId, flatChannels)
-            ? storedChannelId
-            : (flatChannels[0]?.id ?? null);
-        });
+        setRawChannels(channelDtos);
+        setRawCategories(categoryDtos);
       } catch {
         if (!cancelled) {
-          setChannelCategories([]);
-          setChannels([]);
+          setRawChannels([]);
+          setRawCategories([]);
         }
       }
     }
@@ -136,6 +143,56 @@ export function useGuildWorkspace(): GuildWorkspace {
       cancelled = true;
     };
   }, [selectedGuildId, channelsRefreshKey]);
+
+  // keep the active channel valid as the channel set changes (initial load, a
+  // live create/delete). when the open channel is removed, fall back to the
+  // last-used or first available channel.
+  useEffect(() => {
+    setActiveChannel((current) => {
+      if (current && hasChannel(current, channels)) {
+        return current;
+      }
+      const storedChannelId = window.sessionStorage.getItem(LAST_CHAT_CHANNEL_KEY);
+      return storedChannelId && hasChannel(storedChannelId, channels)
+        ? storedChannelId
+        : (channels[0]?.id ?? null);
+    });
+  }, [channels]);
+
+  // splice live channel lifecycle events into the raw set. Guild targets these
+  // only at members who may read the channel, so anything that arrives is
+  // something the current user is allowed to see.
+  useEffect(() => {
+    const upsert = (channel: GuildChannelDto) => {
+      if (channel.guild_id !== selectedGuildIdRef.current) {
+        return;
+      }
+      setRawChannels((current) => {
+        const index = current.findIndex((existing) => existing.id === channel.id);
+        if (index === -1) {
+          return [...current, channel];
+        }
+        const next = [...current];
+        next[index] = channel;
+        return next;
+      });
+    };
+
+    const unsubscribeCreated = onChatHubEvent('ChannelCreated', upsert);
+    const unsubscribeUpdated = onChatHubEvent('ChannelUpdated', upsert);
+    const unsubscribeDeleted = onChatHubEvent('ChannelDeleted', (event) => {
+      if (event.guild_id !== selectedGuildIdRef.current) {
+        return;
+      }
+      setRawChannels((current) => current.filter((channel) => channel.id !== event.channel_id));
+    });
+
+    return () => {
+      unsubscribeCreated();
+      unsubscribeUpdated();
+      unsubscribeDeleted();
+    };
+  }, []);
 
   useEffect(() => {
     let cancelled = false;
@@ -165,13 +222,14 @@ export function useGuildWorkspace(): GuildWorkspace {
   }, []);
 
   // join every channel of the active guild (not just the one being viewed),
-  // so unread badges for other channels update live too.
+  // so unread badges for other channels update live too. keyed off the stable
+  // id set so a live rename (same ids) does not re-join everything.
   useEffect(() => {
-    if (channels.length === 0) {
+    if (!channelIdsKey) {
       return;
     }
 
-    const channelIds = channels.map((channel) => channel.id);
+    const channelIds = channelIdsKey.split(',');
 
     function joinAll() {
       for (const channelId of channelIds) {
@@ -191,7 +249,7 @@ export function useGuildWorkspace(): GuildWorkspace {
         leaveChatChannel(channelId).catch(() => {});
       }
     };
-  }, [channels]);
+  }, [channelIdsKey]);
 
   useEffect(() => {
     const unsubscribeReadState = onChatHubEvent('ReadStateUpdated', (event) => {

--- a/frontend/src/shared/hooks/use-guild-workspace.ts
+++ b/frontend/src/shared/hooks/use-guild-workspace.ts
@@ -115,11 +115,20 @@ export function useGuildWorkspace(): GuildWorkspace {
       void refreshGuilds();
     });
 
+    // gained read access to a channel (role/overwrite change): re-load the
+    // selected guild's channels so the newly-visible channel appears.
+    const unsubscribeAccessGranted = onChatHubEvent('ChannelAccessGranted', (event) => {
+      if (event.guild_id === selectedGuildIdRef.current) {
+        setChannelsRefreshKey((key) => key + 1);
+      }
+    });
+
     return () => {
       unsubscribeJoined();
       unsubscribeLeft();
       unsubscribeDeleted();
       unsubscribeUpdated();
+      unsubscribeAccessGranted();
     };
   }, [refreshGuilds]);
 

--- a/frontend/src/shared/hooks/use-guild-workspace.ts
+++ b/frontend/src/shared/hooks/use-guild-workspace.ts
@@ -195,10 +195,37 @@ export function useGuildWorkspace(): GuildWorkspace {
       setRawChannels((current) => current.filter((channel) => channel.id !== event.channel_id));
     });
 
+    const upsertCategory = (category: GuildCategoryDto) => {
+      if (category.guild_id !== selectedGuildIdRef.current) {
+        return;
+      }
+      setRawCategories((current) => {
+        const index = current.findIndex((existing) => existing.id === category.id);
+        if (index === -1) {
+          return [...current, category];
+        }
+        const next = [...current];
+        next[index] = category;
+        return next;
+      });
+    };
+
+    const unsubscribeCategoryCreated = onChatHubEvent('CategoryCreated', upsertCategory);
+    const unsubscribeCategoryUpdated = onChatHubEvent('CategoryUpdated', upsertCategory);
+    const unsubscribeCategoryDeleted = onChatHubEvent('CategoryDeleted', (event) => {
+      if (event.guild_id !== selectedGuildIdRef.current) {
+        return;
+      }
+      setRawCategories((current) => current.filter((category) => category.id !== event.category_id));
+    });
+
     return () => {
       unsubscribeCreated();
       unsubscribeUpdated();
       unsubscribeDeleted();
+      unsubscribeCategoryCreated();
+      unsubscribeCategoryUpdated();
+      unsubscribeCategoryDeleted();
     };
   }, []);
 

--- a/frontend/src/shared/lib/friends-events.ts
+++ b/frontend/src/shared/lib/friends-events.ts
@@ -1,0 +1,24 @@
+const FRIENDS_CHANGED_EVENT = 'ft-transcendence:friends-changed';
+
+// fired when the current user's friend graph changed elsewhere (e.g. a pending
+// request they sent was accepted, surfaced via a friend_accept notification),
+// so the friends list can re-fetch without a manual refresh.
+export function dispatchFriendsChanged(): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  window.dispatchEvent(new CustomEvent(FRIENDS_CHANGED_EVENT));
+}
+
+export function subscribeFriendsChanged(handler: () => void): () => void {
+  if (typeof window === 'undefined') {
+    return () => undefined;
+  }
+
+  window.addEventListener(FRIENDS_CHANGED_EVENT, handler);
+
+  return () => {
+    window.removeEventListener(FRIENDS_CHANGED_EVENT, handler);
+  };
+}

--- a/frontend/src/shared/lib/use-notifications.ts
+++ b/frontend/src/shared/lib/use-notifications.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { ApiError } from '../api/client';
+import { dispatchFriendsChanged } from './friends-events';
 import {
   buildNotificationEventsUrl,
   deleteNotificationPreference,
@@ -230,6 +231,12 @@ export function useNotifications() {
           ? current
           : [notification, ...current]
       );
+
+      // a friend request we sent was accepted: our friend graph changed, so
+      // nudge the friends list to re-fetch.
+      if (notification.type === 'friend_accept') {
+        dispatchFriendsChanged();
+      }
     }
 
     function scheduleReconnect() {

--- a/frontend/src/shared/lib/use-notifications.ts
+++ b/frontend/src/shared/lib/use-notifications.ts
@@ -212,6 +212,14 @@ export function useNotifications() {
         return;
       }
 
+      // transient "friends changed" signal (e.g. we were unfriended): not a
+      // persisted notification, so re-fetch the friends list and stop before the
+      // list/badge bookkeeping.
+      if ((notification.type as string) === 'friends_changed') {
+        dispatchFriendsChanged();
+        return;
+      }
+
       // belt and braces: the server already skips muted inserts, but a mute
       // set in this tab may not have reached it before the push
       if (isSuppressedByMute(notification, preferencesRef.current)) {

--- a/frontend/src/shared/mappers/user.ts
+++ b/frontend/src/shared/mappers/user.ts
@@ -82,12 +82,3 @@ export function toUserStatusLabel(status: UserStatus): string {
   }
 }
 
-export function toFriend(friend: { id: string; username: string; display_name: string; status: UserStatus; friendship_status: 'accepted' | 'pending' | 'blocked'; }): Friend {
-  return {
-    id: friend.id,
-    name: friend.display_name || friend.username,
-    status: toSidebarStatus(friend.status),
-    accent: accentForUserId(friend.id),
-    note: friend.friendship_status === 'pending' ? 'Pending request' : ''
-  };
-}

--- a/services/chat/src/Chat.Application/Abstractions/IGuildClient.cs
+++ b/services/chat/src/Chat.Application/Abstractions/IGuildClient.cs
@@ -4,6 +4,13 @@ public interface IGuildClient
 {
 	Task<ChannelMembership?> GetMembershipAsync(long channelId, long userId, CancellationToken ct);
 	Task<IReadOnlyList<long>> GetVisibleChannelIdsAsync(long userId, CancellationToken ct);
+
+	/// <summary>
+	/// every guild the user is a member of. used on hub connect to subscribe the
+	/// connection to each <c>guild:{id}</c> group so guild-scoped broadcasts reach
+	/// all members.
+	/// </summary>
+	Task<IReadOnlyList<long>> GetUserGuildIdsAsync(long userId, CancellationToken ct);
 }
 
 public sealed record ChannelMembership(bool IsMember, long GuildId, long Permissions);

--- a/services/chat/src/Chat.Application/Abstractions/IUserBroadcaster.cs
+++ b/services/chat/src/Chat.Application/Abstractions/IUserBroadcaster.cs
@@ -68,6 +68,13 @@ public interface IUserBroadcaster
 	Task BroadcastCategoryDeletedAsync(long guildId, long categoryId, CancellationToken ct);
 
 	/// <summary>
+	/// signals the guild:{guildId} group that its role set changed / a single
+	/// member's roles or nickname changed, so clients re-fetch the affected view.
+	/// </summary>
+	Task BroadcastRolesChangedAsync(long guildId, CancellationToken ct);
+	Task BroadcastMemberUpdatedAsync(long guildId, long userId, CancellationToken ct);
+
+	/// <summary>
 	/// force-terminates every active connection of <paramref name="userId"/> at
 	/// the transport level, regardless of client cooperation. used for
 	/// user.logged_out/user.deleted so a stale or malicious client can't keep

--- a/services/chat/src/Chat.Application/Abstractions/IUserBroadcaster.cs
+++ b/services/chat/src/Chat.Application/Abstractions/IUserBroadcaster.cs
@@ -75,6 +75,13 @@ public interface IUserBroadcaster
 	Task BroadcastMemberUpdatedAsync(long guildId, long userId, CancellationToken ct);
 
 	/// <summary>
+	/// tells a single user they gained read access to a channel so their client
+	/// refreshes the guild's channel list and the newly-visible channel appears.
+	/// mirror of the channel.access_revoked eviction.
+	/// </summary>
+	Task BroadcastChannelAccessGrantedAsync(long userId, long guildId, long channelId, CancellationToken ct);
+
+	/// <summary>
 	/// force-terminates every active connection of <paramref name="userId"/> at
 	/// the transport level, regardless of client cooperation. used for
 	/// user.logged_out/user.deleted so a stale or malicious client can't keep

--- a/services/chat/src/Chat.Application/Abstractions/IUserBroadcaster.cs
+++ b/services/chat/src/Chat.Application/Abstractions/IUserBroadcaster.cs
@@ -31,6 +31,22 @@ public interface IUserBroadcaster
 	Task BroadcastDmReadStateUpdatedAsync(long userId, DmReadStateResponse response, CancellationToken ct);
 
 	/// <summary>
+	/// pushes a channel create/update to exactly the members who may read it
+	/// (<paramref name="userIds"/>), so private channels never surface to members
+	/// without read access.
+	/// </summary>
+	Task BroadcastChannelCreatedAsync(IReadOnlyList<long> userIds, GuildChannelDto channel, CancellationToken ct);
+	Task BroadcastChannelUpdatedAsync(IReadOnlyList<long> userIds, GuildChannelDto channel, CancellationToken ct);
+	Task BroadcastChannelDeletedAsync(IReadOnlyList<long> userIds, long guildId, long channelId, CancellationToken ct);
+
+	/// <summary>
+	/// notifies the guild:{guildId} group that a member joined / left, so every
+	/// current member's roster updates live.
+	/// </summary>
+	Task BroadcastMemberJoinedAsync(long guildId, long userId, CancellationToken ct);
+	Task BroadcastMemberLeftAsync(long guildId, long userId, CancellationToken ct);
+
+	/// <summary>
 	/// force-terminates every active connection of <paramref name="userId"/> at
 	/// the transport level, regardless of client cooperation. used for
 	/// user.logged_out/user.deleted so a stale or malicious client can't keep

--- a/services/chat/src/Chat.Application/Abstractions/IUserBroadcaster.cs
+++ b/services/chat/src/Chat.Application/Abstractions/IUserBroadcaster.cs
@@ -14,6 +14,13 @@ public interface IUserBroadcaster
 	Task BroadcastGuildLeftAsync(long userId, long guildId, CancellationToken ct);
 
 	/// <summary>
+	/// tells every member of the guild:{guildId} group the guild was deleted so
+	/// their client removes it live instead of showing a stale guild until
+	/// refresh.
+	/// </summary>
+	Task BroadcastGuildDeletedAsync(long guildId, CancellationToken ct);
+
+	/// <summary>
 	/// subscribes every open connection of <paramref name="userId"/> to the
 	/// <c>guild:{guildId}</c> group so they receive that guild's real-time
 	/// broadcasts. called when the user joins a guild while already connected

--- a/services/chat/src/Chat.Application/Abstractions/IUserBroadcaster.cs
+++ b/services/chat/src/Chat.Application/Abstractions/IUserBroadcaster.cs
@@ -54,6 +54,14 @@ public interface IUserBroadcaster
 	Task BroadcastMemberLeftAsync(long guildId, long userId, CancellationToken ct);
 
 	/// <summary>
+	/// category lifecycle to the guild:{guildId} group. categories carry no
+	/// per-member read restriction, so every member receives them.
+	/// </summary>
+	Task BroadcastCategoryCreatedAsync(long guildId, GuildCategoryDto category, CancellationToken ct);
+	Task BroadcastCategoryUpdatedAsync(long guildId, GuildCategoryDto category, CancellationToken ct);
+	Task BroadcastCategoryDeletedAsync(long guildId, long categoryId, CancellationToken ct);
+
+	/// <summary>
 	/// force-terminates every active connection of <paramref name="userId"/> at
 	/// the transport level, regardless of client cooperation. used for
 	/// user.logged_out/user.deleted so a stale or malicious client can't keep

--- a/services/chat/src/Chat.Application/Abstractions/IUserBroadcaster.cs
+++ b/services/chat/src/Chat.Application/Abstractions/IUserBroadcaster.cs
@@ -21,6 +21,12 @@ public interface IUserBroadcaster
 	Task BroadcastGuildDeletedAsync(long guildId, CancellationToken ct);
 
 	/// <summary>
+	/// tells the guild:{guildId} group the guild's name/icon changed so members'
+	/// sidebar + header update live.
+	/// </summary>
+	Task BroadcastGuildUpdatedAsync(long guildId, string name, string? iconUrl, CancellationToken ct);
+
+	/// <summary>
 	/// subscribes every open connection of <paramref name="userId"/> to the
 	/// <c>guild:{guildId}</c> group so they receive that guild's real-time
 	/// broadcasts. called when the user joins a guild while already connected

--- a/services/chat/src/Chat.Application/Abstractions/IUserBroadcaster.cs
+++ b/services/chat/src/Chat.Application/Abstractions/IUserBroadcaster.cs
@@ -13,6 +13,20 @@ public interface IUserBroadcaster
 	Task BroadcastGuildJoinedAsync(long userId, long guildId, string guildName, CancellationToken ct);
 	Task BroadcastGuildLeftAsync(long userId, long guildId, CancellationToken ct);
 
+	/// <summary>
+	/// subscribes every open connection of <paramref name="userId"/> to the
+	/// <c>guild:{guildId}</c> group so they receive that guild's real-time
+	/// broadcasts. called when the user joins a guild while already connected
+	/// (connect-time subscription is handled by the hub itself).
+	/// </summary>
+	Task AddUserToGuildGroupAsync(long userId, long guildId, CancellationToken ct);
+
+	/// <summary>
+	/// removes every open connection of <paramref name="userId"/> from the
+	/// <c>guild:{guildId}</c> group when they leave / are kicked from the guild.
+	/// </summary>
+	Task RemoveUserFromGuildGroupAsync(long userId, long guildId, CancellationToken ct);
+
 	Task BroadcastChannelReadStateUpdatedAsync(long userId, ChannelReadStateResponse response, CancellationToken ct);
 	Task BroadcastDmReadStateUpdatedAsync(long userId, DmReadStateResponse response, CancellationToken ct);
 

--- a/services/chat/src/Chat.Application/Abstractions/IUserClient.cs
+++ b/services/chat/src/Chat.Application/Abstractions/IUserClient.cs
@@ -3,6 +3,13 @@ namespace Chat.Application.Abstractions;
 public interface IUserClient
 {
 	Task<UsersRelationship?> GetUsersRelationship(long callerId, long recipientId, CancellationToken ct);
+
+	/// <summary>
+	/// accepted-friend ids of <paramref name="userId"/> (excluding blocks). used
+	/// to fan presence/social/profile changes out to friends who may not share a
+	/// guild with the user.
+	/// </summary>
+	Task<IReadOnlyList<long>> GetFriendIdsAsync(long userId, CancellationToken ct);
 }
 
 public sealed record UsersRelationship(string Status, DateTimeOffset? Since);

--- a/services/chat/src/Chat.Application/Abstractions/Persistence/IMessageRepository.cs
+++ b/services/chat/src/Chat.Application/Abstractions/Persistence/IMessageRepository.cs
@@ -41,6 +41,13 @@ public interface IMessageRepository
 
 	Task DeleteConversationAsync(long userId, CancellationToken ct);
 
+	/// <summary>
+	/// hard-deletes every message in <paramref name="channelId"/> (a single-
+	/// partition delete). called when the owning guild is deleted so its
+	/// channels' history does not outlive the guild.
+	/// </summary>
+	Task DeleteChannelMessagesAsync(long channelId, CancellationToken ct);
+
 	/// <summary>every DM thread for this user, from their own user_conversations partition</summary>
 	Task<IReadOnlyList<DmConversation>> GetConversationsAsync(long userId, CancellationToken ct);
 

--- a/services/chat/src/Chat.Application/Features/Channels/Common/GuildCategoryDto.cs
+++ b/services/chat/src/Chat.Application/Features/Channels/Common/GuildCategoryDto.cs
@@ -1,0 +1,12 @@
+namespace Chat.Application.Features.Channels.Common;
+
+/// <summary>
+/// client-facing shape of a channel category, pushed over SignalR to the guild
+/// group when a category is created / updated / deleted. snowflake ids are
+/// quoted strings.
+/// </summary>
+public sealed record GuildCategoryDto(
+	string Id,
+	string GuildId,
+	string Name,
+	int Position);

--- a/services/chat/src/Chat.Application/Features/Channels/Common/GuildChannelDto.cs
+++ b/services/chat/src/Chat.Application/Features/Channels/Common/GuildChannelDto.cs
@@ -1,0 +1,18 @@
+namespace Chat.Application.Features.Channels.Common;
+
+/// <summary>
+/// client-facing shape of a guild channel, pushed over SignalR when a channel
+/// is created / updated / deleted so subscribers update their sidebar without a
+/// refetch. mirrors Guild's channel wire shape; snowflake ids are quoted
+/// strings.
+/// </summary>
+public sealed record GuildChannelDto(
+	string Id,
+	string GuildId,
+	string? CategoryId,
+	string Name,
+	string? Topic,
+	string Type,
+	int Position,
+	bool IsNsfw,
+	int SlowmodeSeconds);

--- a/services/chat/src/Chat.Infrastructure/DependencyInjection.cs
+++ b/services/chat/src/Chat.Infrastructure/DependencyInjection.cs
@@ -59,6 +59,7 @@ public static class DependencyInjection
 			x.AddConsumer<GuildRolesChangedConsumer>();
 			x.AddConsumer<GuildMemberUpdatedConsumer>();
 			x.AddConsumer<ChannelAccessRevokedConsumer>();
+			x.AddConsumer<ChannelAccessGrantedConsumer>();
 			x.AddConsumer<GuildChannelCreatedConsumer>();
 			x.AddConsumer<GuildChannelUpdatedConsumer>();
 			x.AddConsumer<GuildChannelDeletedConsumer>();
@@ -105,6 +106,7 @@ public static class DependencyInjection
 				cfg.Message<GuildRolesChanged>(m => m.SetEntityName("guild.roles_changed"));
 				cfg.Message<GuildMemberUpdated>(m => m.SetEntityName("guild.member_updated"));
 				cfg.Message<ChannelAccessRevoked>(m => m.SetEntityName("channel.access_revoked"));
+				cfg.Message<ChannelAccessGranted>(m => m.SetEntityName("channel.access_granted"));
 				cfg.Message<GuildChannelCreated>(m => m.SetEntityName("channel.created"));
 				cfg.Message<GuildChannelUpdated>(m => m.SetEntityName("channel.updated"));
 				cfg.Message<GuildChannelDeleted>(m => m.SetEntityName("channel.deleted"));

--- a/services/chat/src/Chat.Infrastructure/DependencyInjection.cs
+++ b/services/chat/src/Chat.Infrastructure/DependencyInjection.cs
@@ -55,6 +55,7 @@ public static class DependencyInjection
 			x.AddConsumer<GuildMemberJoinedConsumer>();
 			x.AddConsumer<GuildMemberLeftConsumer>();
 			x.AddConsumer<GuildDeletedConsumer>();
+			x.AddConsumer<GuildUpdatedConsumer>();
 			x.AddConsumer<ChannelAccessRevokedConsumer>();
 			x.AddConsumer<GuildChannelCreatedConsumer>();
 			x.AddConsumer<GuildChannelUpdatedConsumer>();
@@ -98,6 +99,7 @@ public static class DependencyInjection
 				cfg.Message<GuildMemberJoined>(m => m.SetEntityName("guild.member_joined"));
 				cfg.Message<GuildMemberLeft>(m => m.SetEntityName("guild.member_left"));
 				cfg.Message<GuildDeleted>(m => m.SetEntityName("guild.deleted"));
+				cfg.Message<GuildUpdated>(m => m.SetEntityName("guild.updated"));
 				cfg.Message<ChannelAccessRevoked>(m => m.SetEntityName("channel.access_revoked"));
 				cfg.Message<GuildChannelCreated>(m => m.SetEntityName("channel.created"));
 				cfg.Message<GuildChannelUpdated>(m => m.SetEntityName("channel.updated"));

--- a/services/chat/src/Chat.Infrastructure/DependencyInjection.cs
+++ b/services/chat/src/Chat.Infrastructure/DependencyInjection.cs
@@ -54,6 +54,7 @@ public static class DependencyInjection
 		{
 			x.AddConsumer<GuildMemberJoinedConsumer>();
 			x.AddConsumer<GuildMemberLeftConsumer>();
+			x.AddConsumer<GuildDeletedConsumer>();
 			x.AddConsumer<ChannelAccessRevokedConsumer>();
 			x.AddConsumer<GuildChannelCreatedConsumer>();
 			x.AddConsumer<GuildChannelUpdatedConsumer>();
@@ -93,6 +94,7 @@ public static class DependencyInjection
 				cfg.Message<UserOffline>(m => m.SetEntityName("user.offline"));
 				cfg.Message<GuildMemberJoined>(m => m.SetEntityName("guild.member_joined"));
 				cfg.Message<GuildMemberLeft>(m => m.SetEntityName("guild.member_left"));
+				cfg.Message<GuildDeleted>(m => m.SetEntityName("guild.deleted"));
 				cfg.Message<ChannelAccessRevoked>(m => m.SetEntityName("channel.access_revoked"));
 				cfg.Message<GuildChannelCreated>(m => m.SetEntityName("channel.created"));
 				cfg.Message<GuildChannelUpdated>(m => m.SetEntityName("channel.updated"));

--- a/services/chat/src/Chat.Infrastructure/DependencyInjection.cs
+++ b/services/chat/src/Chat.Infrastructure/DependencyInjection.cs
@@ -59,6 +59,9 @@ public static class DependencyInjection
 			x.AddConsumer<GuildChannelCreatedConsumer>();
 			x.AddConsumer<GuildChannelUpdatedConsumer>();
 			x.AddConsumer<GuildChannelDeletedConsumer>();
+			x.AddConsumer<GuildCategoryCreatedConsumer>();
+			x.AddConsumer<GuildCategoryUpdatedConsumer>();
+			x.AddConsumer<GuildCategoryDeletedConsumer>();
 			x.AddConsumer<UserLoggedOutConsumer>();
 			x.AddConsumer<UserDeletedConsumer>();
 
@@ -99,6 +102,9 @@ public static class DependencyInjection
 				cfg.Message<GuildChannelCreated>(m => m.SetEntityName("channel.created"));
 				cfg.Message<GuildChannelUpdated>(m => m.SetEntityName("channel.updated"));
 				cfg.Message<GuildChannelDeleted>(m => m.SetEntityName("channel.deleted"));
+				cfg.Message<GuildCategoryCreated>(m => m.SetEntityName("category.created"));
+				cfg.Message<GuildCategoryUpdated>(m => m.SetEntityName("category.updated"));
+				cfg.Message<GuildCategoryDeleted>(m => m.SetEntityName("category.deleted"));
 				cfg.Message<UserLoggedOut>(m => m.SetEntityName("user.logged_out"));
 
 				cfg.ConfigureEndpoints(ctx);

--- a/services/chat/src/Chat.Infrastructure/DependencyInjection.cs
+++ b/services/chat/src/Chat.Infrastructure/DependencyInjection.cs
@@ -56,6 +56,8 @@ public static class DependencyInjection
 			x.AddConsumer<GuildMemberLeftConsumer>();
 			x.AddConsumer<GuildDeletedConsumer>();
 			x.AddConsumer<GuildUpdatedConsumer>();
+			x.AddConsumer<GuildRolesChangedConsumer>();
+			x.AddConsumer<GuildMemberUpdatedConsumer>();
 			x.AddConsumer<ChannelAccessRevokedConsumer>();
 			x.AddConsumer<GuildChannelCreatedConsumer>();
 			x.AddConsumer<GuildChannelUpdatedConsumer>();
@@ -100,6 +102,8 @@ public static class DependencyInjection
 				cfg.Message<GuildMemberLeft>(m => m.SetEntityName("guild.member_left"));
 				cfg.Message<GuildDeleted>(m => m.SetEntityName("guild.deleted"));
 				cfg.Message<GuildUpdated>(m => m.SetEntityName("guild.updated"));
+				cfg.Message<GuildRolesChanged>(m => m.SetEntityName("guild.roles_changed"));
+				cfg.Message<GuildMemberUpdated>(m => m.SetEntityName("guild.member_updated"));
 				cfg.Message<ChannelAccessRevoked>(m => m.SetEntityName("channel.access_revoked"));
 				cfg.Message<GuildChannelCreated>(m => m.SetEntityName("channel.created"));
 				cfg.Message<GuildChannelUpdated>(m => m.SetEntityName("channel.updated"));

--- a/services/chat/src/Chat.Infrastructure/DependencyInjection.cs
+++ b/services/chat/src/Chat.Infrastructure/DependencyInjection.cs
@@ -55,6 +55,9 @@ public static class DependencyInjection
 			x.AddConsumer<GuildMemberJoinedConsumer>();
 			x.AddConsumer<GuildMemberLeftConsumer>();
 			x.AddConsumer<ChannelAccessRevokedConsumer>();
+			x.AddConsumer<GuildChannelCreatedConsumer>();
+			x.AddConsumer<GuildChannelUpdatedConsumer>();
+			x.AddConsumer<GuildChannelDeletedConsumer>();
 			x.AddConsumer<UserLoggedOutConsumer>();
 			x.AddConsumer<UserDeletedConsumer>();
 
@@ -91,6 +94,9 @@ public static class DependencyInjection
 				cfg.Message<GuildMemberJoined>(m => m.SetEntityName("guild.member_joined"));
 				cfg.Message<GuildMemberLeft>(m => m.SetEntityName("guild.member_left"));
 				cfg.Message<ChannelAccessRevoked>(m => m.SetEntityName("channel.access_revoked"));
+				cfg.Message<GuildChannelCreated>(m => m.SetEntityName("channel.created"));
+				cfg.Message<GuildChannelUpdated>(m => m.SetEntityName("channel.updated"));
+				cfg.Message<GuildChannelDeleted>(m => m.SetEntityName("channel.deleted"));
 				cfg.Message<UserLoggedOut>(m => m.SetEntityName("user.logged_out"));
 
 				cfg.ConfigureEndpoints(ctx);

--- a/services/chat/src/Chat.Infrastructure/Http/GuildClient.cs
+++ b/services/chat/src/Chat.Infrastructure/Http/GuildClient.cs
@@ -33,5 +33,11 @@ internal sealed class GuildClient(HttpClient http) : IGuildClient
 		return channels?.Select(c => long.Parse(c.Id)).ToList() ?? [];
 	}
 
+	public async Task<IReadOnlyList<long>> GetUserGuildIdsAsync(long userId, CancellationToken ct)
+	{
+		var ids = await http.GetFromJsonAsync<List<string>>($"users/{userId}/guilds", JsonOptions, ct);
+		return ids?.Select(long.Parse).ToList() ?? [];
+	}
+
 	private sealed record ChannelSummary(string Id);
 }

--- a/services/chat/src/Chat.Infrastructure/Http/UserClient.cs
+++ b/services/chat/src/Chat.Infrastructure/Http/UserClient.cs
@@ -26,4 +26,10 @@ internal sealed class UserClient(HttpClient http) : IUserClient
 			return null;
 		}
 	}
+
+	public async Task<IReadOnlyList<long>> GetFriendIdsAsync(long userId, CancellationToken ct)
+	{
+		var ids = await http.GetFromJsonAsync<List<string>>($"users/{userId}/friend-ids", JsonOptions, ct);
+		return ids?.Select(long.Parse).ToList() ?? [];
+	}
 }

--- a/services/chat/src/Chat.Infrastructure/Messaging/Consumers/ChannelConsumers.cs
+++ b/services/chat/src/Chat.Infrastructure/Messaging/Consumers/ChannelConsumers.cs
@@ -63,3 +63,47 @@ public sealed class GuildChannelDeletedConsumer(
 			msg.GuildId, msg.ChannelId, msg.EligibleUserIds.Count);
 	}
 }
+
+// category lifecycle -> guild group (no per-member read restriction on categories).
+
+public sealed class GuildCategoryCreatedConsumer(
+	IUserBroadcaster broadcaster,
+	ILogger<GuildCategoryCreatedConsumer> logger)
+	: IConsumer<GuildCategoryCreated>
+{
+	public async Task Consume(ConsumeContext<GuildCategoryCreated> context)
+	{
+		var msg = context.Message;
+		await broadcaster.BroadcastCategoryCreatedAsync(msg.GuildId, ToDto(msg.Category), context.CancellationToken);
+		logger.LogDebug("category.created consumed: guild_id={GuildId} category_id={CategoryId}", msg.GuildId, msg.Category.Id);
+	}
+
+	internal static GuildCategoryDto ToDto(CategoryPayload c) => new(c.Id, c.GuildId, c.Name, c.Position);
+}
+
+public sealed class GuildCategoryUpdatedConsumer(
+	IUserBroadcaster broadcaster,
+	ILogger<GuildCategoryUpdatedConsumer> logger)
+	: IConsumer<GuildCategoryUpdated>
+{
+	public async Task Consume(ConsumeContext<GuildCategoryUpdated> context)
+	{
+		var msg = context.Message;
+		await broadcaster.BroadcastCategoryUpdatedAsync(
+			msg.GuildId, GuildCategoryCreatedConsumer.ToDto(msg.Category), context.CancellationToken);
+		logger.LogDebug("category.updated consumed: guild_id={GuildId} category_id={CategoryId}", msg.GuildId, msg.Category.Id);
+	}
+}
+
+public sealed class GuildCategoryDeletedConsumer(
+	IUserBroadcaster broadcaster,
+	ILogger<GuildCategoryDeletedConsumer> logger)
+	: IConsumer<GuildCategoryDeleted>
+{
+	public async Task Consume(ConsumeContext<GuildCategoryDeleted> context)
+	{
+		var msg = context.Message;
+		await broadcaster.BroadcastCategoryDeletedAsync(msg.GuildId, msg.CategoryId, context.CancellationToken);
+		logger.LogDebug("category.deleted consumed: guild_id={GuildId} category_id={CategoryId}", msg.GuildId, msg.CategoryId);
+	}
+}

--- a/services/chat/src/Chat.Infrastructure/Messaging/Consumers/ChannelConsumers.cs
+++ b/services/chat/src/Chat.Infrastructure/Messaging/Consumers/ChannelConsumers.cs
@@ -1,0 +1,65 @@
+using Chat.Application.Abstractions;
+using Chat.Application.Features.Channels.Common;
+using Chat.Infrastructure.Messaging.Contracts;
+using MassTransit;
+using Microsoft.Extensions.Logging;
+
+namespace Chat.Infrastructure.Messaging.Consumers;
+
+// guild channel was created/updated/deleted. Guild resolves the members who may
+// read the channel (EligibleUserIds) so we push the change only to them, keeping
+// private channels invisible to members without read access.
+
+public sealed class GuildChannelCreatedConsumer(
+	IUserBroadcaster broadcaster,
+	ILogger<GuildChannelCreatedConsumer> logger)
+	: IConsumer<GuildChannelCreated>
+{
+	public async Task Consume(ConsumeContext<GuildChannelCreated> context)
+	{
+		var msg = context.Message;
+		await broadcaster.BroadcastChannelCreatedAsync(
+			msg.EligibleUserIds, ToDto(msg.Channel), context.CancellationToken);
+
+		logger.LogDebug(
+			"channel.created consumed: guild_id={GuildId} channel_id={ChannelId} eligible={Eligible}",
+			msg.GuildId, msg.Channel.Id, msg.EligibleUserIds.Count);
+	}
+
+	internal static GuildChannelDto ToDto(ChannelPayload c) => new(
+		c.Id, c.GuildId, c.CategoryId, c.Name, c.Topic, c.Type, c.Position, c.IsNsfw, c.SlowmodeSeconds);
+}
+
+public sealed class GuildChannelUpdatedConsumer(
+	IUserBroadcaster broadcaster,
+	ILogger<GuildChannelUpdatedConsumer> logger)
+	: IConsumer<GuildChannelUpdated>
+{
+	public async Task Consume(ConsumeContext<GuildChannelUpdated> context)
+	{
+		var msg = context.Message;
+		await broadcaster.BroadcastChannelUpdatedAsync(
+			msg.EligibleUserIds, GuildChannelCreatedConsumer.ToDto(msg.Channel), context.CancellationToken);
+
+		logger.LogDebug(
+			"channel.updated consumed: guild_id={GuildId} channel_id={ChannelId} eligible={Eligible}",
+			msg.GuildId, msg.Channel.Id, msg.EligibleUserIds.Count);
+	}
+}
+
+public sealed class GuildChannelDeletedConsumer(
+	IUserBroadcaster broadcaster,
+	ILogger<GuildChannelDeletedConsumer> logger)
+	: IConsumer<GuildChannelDeleted>
+{
+	public async Task Consume(ConsumeContext<GuildChannelDeleted> context)
+	{
+		var msg = context.Message;
+		await broadcaster.BroadcastChannelDeletedAsync(
+			msg.EligibleUserIds, msg.GuildId, msg.ChannelId, context.CancellationToken);
+
+		logger.LogDebug(
+			"channel.deleted consumed: guild_id={GuildId} channel_id={ChannelId} eligible={Eligible}",
+			msg.GuildId, msg.ChannelId, msg.EligibleUserIds.Count);
+	}
+}

--- a/services/chat/src/Chat.Infrastructure/Messaging/Consumers/MembershipConsumers.cs
+++ b/services/chat/src/Chat.Infrastructure/Messaging/Consumers/MembershipConsumers.cs
@@ -20,6 +20,10 @@ public sealed class GuildMemberJoinedConsumer(
 		// without reconnecting. connect-time subscription is handled by the hub.
 		await broadcaster.AddUserToGuildGroupAsync(msg.UserId, msg.GuildId, context.CancellationToken);
 
+		// tell the rest of the guild's members (the guild group) that the roster
+		// gained a member, so their member list updates without a refresh.
+		await broadcaster.BroadcastMemberJoinedAsync(msg.GuildId, msg.UserId, context.CancellationToken);
+
 		await broadcaster.BroadcastGuildJoinedAsync(
 			userId: msg.UserId,
 			guildId: msg.GuildId,
@@ -49,8 +53,11 @@ public sealed class GuildMemberLeftConsumer(
 			guildId: msg.GuildId,
 			ct: context.CancellationToken);
 
-		// drop the member from the guild group so they stop receiving that guild's
-		// structure/presence broadcasts server-side, even if the client lingers.
+		// tell the remaining members the roster shrank (while the leaver is still
+		// in the group is fine; they also get GuildLeft below), then drop the
+		// leaver from the guild group so they stop receiving its broadcasts
+		// server-side even if the client lingers.
+		await broadcaster.BroadcastMemberLeftAsync(msg.GuildId, msg.UserId, context.CancellationToken);
 		await broadcaster.RemoveUserFromGuildGroupAsync(msg.UserId, msg.GuildId, context.CancellationToken);
 
 		await broadcaster.BroadcastGuildLeftAsync(

--- a/services/chat/src/Chat.Infrastructure/Messaging/Consumers/MembershipConsumers.cs
+++ b/services/chat/src/Chat.Infrastructure/Messaging/Consumers/MembershipConsumers.cs
@@ -15,6 +15,11 @@ public sealed class GuildMemberJoinedConsumer(
 	{
 		var msg = context.Message;
 
+		// subscribe the (already-connected) member's connections to the guild
+		// group so they start receiving that guild's structure/presence broadcasts
+		// without reconnecting. connect-time subscription is handled by the hub.
+		await broadcaster.AddUserToGuildGroupAsync(msg.UserId, msg.GuildId, context.CancellationToken);
+
 		await broadcaster.BroadcastGuildJoinedAsync(
 			userId: msg.UserId,
 			guildId: msg.GuildId,
@@ -43,6 +48,10 @@ public sealed class GuildMemberLeftConsumer(
 			userId: msg.UserId,
 			guildId: msg.GuildId,
 			ct: context.CancellationToken);
+
+		// drop the member from the guild group so they stop receiving that guild's
+		// structure/presence broadcasts server-side, even if the client lingers.
+		await broadcaster.RemoveUserFromGuildGroupAsync(msg.UserId, msg.GuildId, context.CancellationToken);
 
 		await broadcaster.BroadcastGuildLeftAsync(
 			userId: msg.UserId,

--- a/services/chat/src/Chat.Infrastructure/Messaging/Consumers/MembershipConsumers.cs
+++ b/services/chat/src/Chat.Infrastructure/Messaging/Consumers/MembershipConsumers.cs
@@ -73,6 +73,7 @@ public sealed class GuildMemberLeftConsumer(
 
 public sealed class GuildDeletedConsumer(
 	IUserBroadcaster broadcaster,
+	IMessageRepository messages,
 	ILogger<GuildDeletedConsumer> logger)
 	: IConsumer<GuildDeleted>
 {
@@ -80,12 +81,19 @@ public sealed class GuildDeletedConsumer(
 	{
 		var msg = context.Message;
 
+		// purge each deleted channel's message history so it does not outlive the
+		// guild. the ids come on the event because Chat cannot read Guild's DB.
+		foreach (var channelId in msg.ChannelIds)
+			await messages.DeleteChannelMessagesAsync(channelId, context.CancellationToken);
+
 		// notify every connected member (the guild group) that the guild is gone
 		// so their client drops it live. server-side group membership becomes
 		// stale but harmless: no further broadcasts target a deleted guild.
 		await broadcaster.BroadcastGuildDeletedAsync(msg.GuildId, context.CancellationToken);
 
-		logger.LogDebug("guild.deleted consumed: guild_id={GuildId}", msg.GuildId);
+		logger.LogDebug(
+			"guild.deleted consumed: guild_id={GuildId} purged_channels={PurgedChannels}",
+			msg.GuildId, msg.ChannelIds.Count);
 	}
 }
 

--- a/services/chat/src/Chat.Infrastructure/Messaging/Consumers/MembershipConsumers.cs
+++ b/services/chat/src/Chat.Infrastructure/Messaging/Consumers/MembershipConsumers.cs
@@ -110,6 +110,32 @@ public sealed class GuildUpdatedConsumer(
 	}
 }
 
+public sealed class GuildRolesChangedConsumer(
+	IUserBroadcaster broadcaster,
+	ILogger<GuildRolesChangedConsumer> logger)
+	: IConsumer<GuildRolesChanged>
+{
+	public async Task Consume(ConsumeContext<GuildRolesChanged> context)
+	{
+		var msg = context.Message;
+		await broadcaster.BroadcastRolesChangedAsync(msg.GuildId, context.CancellationToken);
+		logger.LogDebug("guild.roles_changed consumed: guild_id={GuildId}", msg.GuildId);
+	}
+}
+
+public sealed class GuildMemberUpdatedConsumer(
+	IUserBroadcaster broadcaster,
+	ILogger<GuildMemberUpdatedConsumer> logger)
+	: IConsumer<GuildMemberUpdated>
+{
+	public async Task Consume(ConsumeContext<GuildMemberUpdated> context)
+	{
+		var msg = context.Message;
+		await broadcaster.BroadcastMemberUpdatedAsync(msg.GuildId, msg.UserId, context.CancellationToken);
+		logger.LogDebug("guild.member_updated consumed: guild_id={GuildId} user_id={UserId}", msg.GuildId, msg.UserId);
+	}
+}
+
 public sealed class ChannelAccessRevokedConsumer(
 	IUserBroadcaster broadcaster,
 	ILogger<ChannelAccessRevokedConsumer> logger)

--- a/services/chat/src/Chat.Infrastructure/Messaging/Consumers/MembershipConsumers.cs
+++ b/services/chat/src/Chat.Infrastructure/Messaging/Consumers/MembershipConsumers.cs
@@ -71,6 +71,24 @@ public sealed class GuildMemberLeftConsumer(
 	}
 }
 
+public sealed class GuildDeletedConsumer(
+	IUserBroadcaster broadcaster,
+	ILogger<GuildDeletedConsumer> logger)
+	: IConsumer<GuildDeleted>
+{
+	public async Task Consume(ConsumeContext<GuildDeleted> context)
+	{
+		var msg = context.Message;
+
+		// notify every connected member (the guild group) that the guild is gone
+		// so their client drops it live. server-side group membership becomes
+		// stale but harmless: no further broadcasts target a deleted guild.
+		await broadcaster.BroadcastGuildDeletedAsync(msg.GuildId, context.CancellationToken);
+
+		logger.LogDebug("guild.deleted consumed: guild_id={GuildId}", msg.GuildId);
+	}
+}
+
 public sealed class ChannelAccessRevokedConsumer(
 	IUserBroadcaster broadcaster,
 	ILogger<ChannelAccessRevokedConsumer> logger)

--- a/services/chat/src/Chat.Infrastructure/Messaging/Consumers/MembershipConsumers.cs
+++ b/services/chat/src/Chat.Infrastructure/Messaging/Consumers/MembershipConsumers.cs
@@ -97,6 +97,19 @@ public sealed class GuildDeletedConsumer(
 	}
 }
 
+public sealed class GuildUpdatedConsumer(
+	IUserBroadcaster broadcaster,
+	ILogger<GuildUpdatedConsumer> logger)
+	: IConsumer<GuildUpdated>
+{
+	public async Task Consume(ConsumeContext<GuildUpdated> context)
+	{
+		var msg = context.Message;
+		await broadcaster.BroadcastGuildUpdatedAsync(msg.GuildId, msg.Name, msg.IconUrl, context.CancellationToken);
+		logger.LogDebug("guild.updated consumed: guild_id={GuildId}", msg.GuildId);
+	}
+}
+
 public sealed class ChannelAccessRevokedConsumer(
 	IUserBroadcaster broadcaster,
 	ILogger<ChannelAccessRevokedConsumer> logger)

--- a/services/chat/src/Chat.Infrastructure/Messaging/Consumers/MembershipConsumers.cs
+++ b/services/chat/src/Chat.Infrastructure/Messaging/Consumers/MembershipConsumers.cs
@@ -160,6 +160,28 @@ public sealed class ChannelAccessRevokedConsumer(
 	}
 }
 
+public sealed class ChannelAccessGrantedConsumer(
+	IUserBroadcaster broadcaster,
+	ILogger<ChannelAccessGrantedConsumer> logger)
+	: IConsumer<ChannelAccessGranted>
+{
+	public async Task Consume(ConsumeContext<ChannelAccessGranted> context)
+	{
+		var msg = context.Message;
+
+		// read access to a channel was granted (role/overwrite change) without the
+		// member joining the guild. tell their client to refresh the guild's
+		// channel list so the newly-visible channel appears; the client then joins
+		// the channel group itself on next load.
+		await broadcaster.BroadcastChannelAccessGrantedAsync(
+			msg.UserId, msg.GuildId, msg.ChannelId, context.CancellationToken);
+
+		logger.LogDebug(
+			"channel.access_granted consumed: channel_id={ChannelId} guild_id={GuildId} user_id={UserId}",
+			msg.ChannelId, msg.GuildId, msg.UserId);
+	}
+}
+
 public sealed class UserLoggedOutConsumer(
 	IUserBroadcaster broadcaster,
 	ILogger<UserLoggedOutConsumer> logger): IConsumer<UserLoggedOut>

--- a/services/chat/src/Chat.Infrastructure/Messaging/Contracts/InboundEvents.cs
+++ b/services/chat/src/Chat.Infrastructure/Messaging/Contracts/InboundEvents.cs
@@ -43,6 +43,17 @@ public sealed record ChannelPayload(
 	bool IsNsfw,
 	int SlowmodeSeconds);
 
+[MessageUrn("Guild.Application.Contracts:GuildCategoryCreated")]
+public sealed record GuildCategoryCreated(long GuildId, CategoryPayload Category);
+
+[MessageUrn("Guild.Application.Contracts:GuildCategoryUpdated")]
+public sealed record GuildCategoryUpdated(long GuildId, CategoryPayload Category);
+
+[MessageUrn("Guild.Application.Contracts:GuildCategoryDeleted")]
+public sealed record GuildCategoryDeleted(long GuildId, long CategoryId);
+
+public sealed record CategoryPayload(string Id, string GuildId, string Name, int Position);
+
 [MessageUrn("Auth.Application.Contracts:UserLoggedOut")]
 public sealed record UserLoggedOut(long UserId);
 

--- a/services/chat/src/Chat.Infrastructure/Messaging/Contracts/InboundEvents.cs
+++ b/services/chat/src/Chat.Infrastructure/Messaging/Contracts/InboundEvents.cs
@@ -18,6 +18,9 @@ public sealed record GuildMemberLeft(long GuildId, long UserId);
 [MessageUrn("Guild.Application.Contracts:GuildDeleted")]
 public sealed record GuildDeleted(long GuildId, IReadOnlyList<long> ChannelIds);
 
+[MessageUrn("Guild.Application.Contracts:GuildUpdated")]
+public sealed record GuildUpdated(long GuildId, string Name, string? IconUrl);
+
 [MessageUrn("Guild.Application.Contracts:ChannelAccessRevoked")]
 public sealed record ChannelAccessRevoked(long ChannelId, long UserId);
 

--- a/services/chat/src/Chat.Infrastructure/Messaging/Contracts/InboundEvents.cs
+++ b/services/chat/src/Chat.Infrastructure/Messaging/Contracts/InboundEvents.cs
@@ -16,7 +16,7 @@ public sealed record GuildMemberJoined(long GuildId, string GuildName, long User
 public sealed record GuildMemberLeft(long GuildId, long UserId);
 
 [MessageUrn("Guild.Application.Contracts:GuildDeleted")]
-public sealed record GuildDeleted(long GuildId);
+public sealed record GuildDeleted(long GuildId, IReadOnlyList<long> ChannelIds);
 
 [MessageUrn("Guild.Application.Contracts:ChannelAccessRevoked")]
 public sealed record ChannelAccessRevoked(long ChannelId, long UserId);

--- a/services/chat/src/Chat.Infrastructure/Messaging/Contracts/InboundEvents.cs
+++ b/services/chat/src/Chat.Infrastructure/Messaging/Contracts/InboundEvents.cs
@@ -15,6 +15,9 @@ public sealed record GuildMemberJoined(long GuildId, string GuildName, long User
 [MessageUrn("Guild.Application.Contracts:GuildMemberLeft")]
 public sealed record GuildMemberLeft(long GuildId, long UserId);
 
+[MessageUrn("Guild.Application.Contracts:GuildDeleted")]
+public sealed record GuildDeleted(long GuildId);
+
 [MessageUrn("Guild.Application.Contracts:ChannelAccessRevoked")]
 public sealed record ChannelAccessRevoked(long ChannelId, long UserId);
 

--- a/services/chat/src/Chat.Infrastructure/Messaging/Contracts/InboundEvents.cs
+++ b/services/chat/src/Chat.Infrastructure/Messaging/Contracts/InboundEvents.cs
@@ -21,6 +21,12 @@ public sealed record GuildDeleted(long GuildId, IReadOnlyList<long> ChannelIds);
 [MessageUrn("Guild.Application.Contracts:GuildUpdated")]
 public sealed record GuildUpdated(long GuildId, string Name, string? IconUrl);
 
+[MessageUrn("Guild.Application.Contracts:GuildRolesChanged")]
+public sealed record GuildRolesChanged(long GuildId);
+
+[MessageUrn("Guild.Application.Contracts:GuildMemberUpdated")]
+public sealed record GuildMemberUpdated(long GuildId, long UserId);
+
 [MessageUrn("Guild.Application.Contracts:ChannelAccessRevoked")]
 public sealed record ChannelAccessRevoked(long ChannelId, long UserId);
 

--- a/services/chat/src/Chat.Infrastructure/Messaging/Contracts/InboundEvents.cs
+++ b/services/chat/src/Chat.Infrastructure/Messaging/Contracts/InboundEvents.cs
@@ -30,6 +30,9 @@ public sealed record GuildMemberUpdated(long GuildId, long UserId);
 [MessageUrn("Guild.Application.Contracts:ChannelAccessRevoked")]
 public sealed record ChannelAccessRevoked(long ChannelId, long UserId);
 
+[MessageUrn("Guild.Application.Contracts:ChannelAccessGranted")]
+public sealed record ChannelAccessGranted(long ChannelId, long GuildId, long UserId);
+
 [MessageUrn("Guild.Application.Contracts:GuildChannelCreated")]
 public sealed record GuildChannelCreated(long GuildId, ChannelPayload Channel, IReadOnlyList<long> EligibleUserIds);
 

--- a/services/chat/src/Chat.Infrastructure/Messaging/Contracts/InboundEvents.cs
+++ b/services/chat/src/Chat.Infrastructure/Messaging/Contracts/InboundEvents.cs
@@ -18,6 +18,28 @@ public sealed record GuildMemberLeft(long GuildId, long UserId);
 [MessageUrn("Guild.Application.Contracts:ChannelAccessRevoked")]
 public sealed record ChannelAccessRevoked(long ChannelId, long UserId);
 
+[MessageUrn("Guild.Application.Contracts:GuildChannelCreated")]
+public sealed record GuildChannelCreated(long GuildId, ChannelPayload Channel, IReadOnlyList<long> EligibleUserIds);
+
+[MessageUrn("Guild.Application.Contracts:GuildChannelUpdated")]
+public sealed record GuildChannelUpdated(long GuildId, ChannelPayload Channel, IReadOnlyList<long> EligibleUserIds);
+
+[MessageUrn("Guild.Application.Contracts:GuildChannelDeleted")]
+public sealed record GuildChannelDeleted(long GuildId, long ChannelId, IReadOnlyList<long> EligibleUserIds);
+
+// mirrors Guild's ChannelPayload wire shape (snake_case, snowflake ids as
+// quoted strings). property names must match the publisher exactly.
+public sealed record ChannelPayload(
+	string Id,
+	string GuildId,
+	string? CategoryId,
+	string Name,
+	string? Topic,
+	string Type,
+	int Position,
+	bool IsNsfw,
+	int SlowmodeSeconds);
+
 [MessageUrn("Auth.Application.Contracts:UserLoggedOut")]
 public sealed record UserLoggedOut(long UserId);
 

--- a/services/chat/src/Chat.Persistence/Repositories/MessageRepository.cs
+++ b/services/chat/src/Chat.Persistence/Repositories/MessageRepository.cs
@@ -252,6 +252,12 @@ internal sealed class MessageRepository(ISession session, MessageStatements stat
 		await session.ExecuteAsync(stmt.Bind(userId));
 	}
 
+	public async Task DeleteChannelMessagesAsync(long channelId, CancellationToken ct)
+	{
+		var stmt = await statements.DeleteChannelMessages.Value;
+		await session.ExecuteAsync(stmt.Bind(channelId));
+	}
+
 	public async Task<IReadOnlyList<DmConversation>> GetConversationsAsync(long userId, CancellationToken ct)
 	{
 		var stmt = await statements.SelectConversationsByUser.Value;

--- a/services/chat/src/Chat.Persistence/Repositories/MessageStatements.cs
+++ b/services/chat/src/Chat.Persistence/Repositories/MessageStatements.cs
@@ -44,6 +44,12 @@ internal sealed class MessageStatements(ISession session)
 		"UPDATE messages SET is_deleted = true " +
 		"WHERE channel_id = ? AND created_at = ? AND id = ?"));
 
+	// partition delete: messages are partitioned by channel_id, so removing a
+	// whole channel's history is a single-partition delete. used when a guild
+	// (and thus its channels) is deleted.
+	public Lazy<Task<PreparedStatement>> DeleteChannelMessages { get; } = new(() => session.PrepareAsync(
+		"DELETE FROM messages WHERE channel_id = ?"));
+
 	public Lazy<Task<PreparedStatement>> SelectChannelMessage { get; } = new(() => session.PrepareAsync(
 		"SELECT channel_id, created_at, id, author_id, content, edited_at, is_deleted, reply_to_id " +
 		"FROM messages WHERE channel_id = ? AND created_at = ? AND id = ?"));

--- a/services/chat/src/Chat.Presentation/Hubs/ChatHub.cs
+++ b/services/chat/src/Chat.Presentation/Hubs/ChatHub.cs
@@ -28,6 +28,23 @@ public sealed class ChatHub(
 	{
 		if (connectionTracker.TrackConnected(Context.GetUserId(), Context.ConnectionId, Context))
 			await eventBus.PublishAsync(new UserOnline(Context.GetUserId()), CancellationToken.None);
+
+		// subscribe this connection to the guild:{id} group of every guild the
+		// user belongs to, so guild-scoped broadcasts (channel/member/role
+		// changes, presence) reach them. a Guild outage must not reject the
+		// connection: log-and-continue, the client still gets DMs + channel
+		// broadcasts it explicitly joins.
+		try
+		{
+			var guildIds = await guildClient.GetUserGuildIdsAsync(Context.GetUserId(), Context.ConnectionAborted);
+			foreach (var guildId in guildIds)
+				await Groups.AddToGroupAsync(Context.ConnectionId, $"guild:{guildId}", Context.ConnectionAborted);
+		}
+		catch (Exception ex) when (ex is not OperationCanceledException)
+		{
+			// swallow: guild-group membership is best-effort real-time sugar
+		}
+
 		await base.OnConnectedAsync();
 	}
 

--- a/services/chat/src/Chat.Presentation/Hubs/ChatHub.cs
+++ b/services/chat/src/Chat.Presentation/Hubs/ChatHub.cs
@@ -26,7 +26,8 @@ public sealed class ChatHub(
 
 	public override async Task OnConnectedAsync()
 	{
-		if (connectionTracker.TrackConnected(Context.GetUserId(), Context.ConnectionId, Context))
+		var isFirstConnection = connectionTracker.TrackConnected(Context.GetUserId(), Context.ConnectionId, Context);
+		if (isFirstConnection)
 			await eventBus.PublishAsync(new UserOnline(Context.GetUserId()), CancellationToken.None);
 
 		// subscribe this connection to the guild:{id} group of every guild the
@@ -39,10 +40,15 @@ public sealed class ChatHub(
 			var guildIds = await guildClient.GetUserGuildIdsAsync(Context.GetUserId(), Context.ConnectionAborted);
 			foreach (var guildId in guildIds)
 				await Groups.AddToGroupAsync(Context.ConnectionId, $"guild:{guildId}", Context.ConnectionAborted);
+
+			// only the first connection flips the user to online; extra tabs are
+			// already covered. tell co-guild-members and friends live.
+			if (isFirstConnection)
+				await BroadcastPresenceAsync(Context.GetUserId(), "online", guildIds, Context.ConnectionAborted);
 		}
 		catch (Exception ex) when (ex is not OperationCanceledException)
 		{
-			// swallow: guild-group membership is best-effort real-time sugar
+			// swallow: guild-group membership + presence are best-effort real-time sugar
 		}
 
 		await base.OnConnectedAsync();
@@ -51,8 +57,39 @@ public sealed class ChatHub(
 	public override async Task OnDisconnectedAsync(Exception? exception)
 	{
 		if (connectionTracker.TrackDisconnected(Context.GetUserId(), Context.ConnectionId))
+		{
 			await eventBus.PublishAsync(new UserOffline(Context.GetUserId()), CancellationToken.None);
+
+			// last connection closed: the user is now offline for everyone who can
+			// see them. best-effort, must not throw out of the disconnect path.
+			try
+			{
+				var guildIds = await guildClient.GetUserGuildIdsAsync(Context.GetUserId(), CancellationToken.None);
+				await BroadcastPresenceAsync(Context.GetUserId(), "offline", guildIds, CancellationToken.None);
+			}
+			catch
+			{
+				// swallow: presence is best-effort
+			}
+		}
+
 		await base.OnDisconnectedAsync(exception);
+	}
+
+	// fans a presence change out to everyone who may see the user: every guild
+	// group they belong to (co-members) plus their friends (who may share no
+	// guild). a friend who is also a co-member receives it twice; the client
+	// handler is idempotent so that is harmless.
+	private async Task BroadcastPresenceAsync(long userId, string status, IReadOnlyList<long> guildIds, CancellationToken ct)
+	{
+		var evt = new UserPresenceEvent(userId.ToString(), status);
+
+		foreach (var guildId in guildIds)
+			await Clients.Group($"guild:{guildId}").UserPresence(evt);
+
+		var friendIds = await userClient.GetFriendIdsAsync(userId, ct);
+		if (friendIds.Count > 0)
+			await Clients.Users(friendIds.Select(id => id.ToString()).ToList()).UserPresence(evt);
 	}
 
 	public async Task JoinChannel(long channelId)

--- a/services/chat/src/Chat.Presentation/Hubs/IChatClient.cs
+++ b/services/chat/src/Chat.Presentation/Hubs/IChatClient.cs
@@ -33,8 +33,11 @@ public interface IChatClient
 	Task MemberJoined(GuildMemberEvent evt);
 	Task MemberLeft(GuildMemberEvent evt);
 
+	Task UserPresence(UserPresenceEvent evt);
+
 	Task Error(string code, string message);
 }
 
 public sealed record ChannelDeletedEvent(string GuildId, string ChannelId);
 public sealed record GuildMemberEvent(string GuildId, string UserId);
+public sealed record UserPresenceEvent(string UserId, string Status);

--- a/services/chat/src/Chat.Presentation/Hubs/IChatClient.cs
+++ b/services/chat/src/Chat.Presentation/Hubs/IChatClient.cs
@@ -37,6 +37,9 @@ public interface IChatClient
 
 	Task MemberJoined(GuildMemberEvent evt);
 	Task MemberLeft(GuildMemberEvent evt);
+	Task MemberUpdated(GuildMemberEvent evt);
+
+	Task RolesChanged(string guildId);
 
 	Task UserPresence(UserPresenceEvent evt);
 

--- a/services/chat/src/Chat.Presentation/Hubs/IChatClient.cs
+++ b/services/chat/src/Chat.Presentation/Hubs/IChatClient.cs
@@ -24,5 +24,16 @@ public interface IChatClient
 
 	Task GuildJoined(string guildId, string guildName);
 	Task GuildLeft(string guildId);
+
+	Task ChannelCreated(GuildChannelDto channel);
+	Task ChannelUpdated(GuildChannelDto channel);
+	Task ChannelDeleted(ChannelDeletedEvent evt);
+
+	Task MemberJoined(GuildMemberEvent evt);
+	Task MemberLeft(GuildMemberEvent evt);
+
 	Task Error(string code, string message);
 }
+
+public sealed record ChannelDeletedEvent(string GuildId, string ChannelId);
+public sealed record GuildMemberEvent(string GuildId, string UserId);

--- a/services/chat/src/Chat.Presentation/Hubs/IChatClient.cs
+++ b/services/chat/src/Chat.Presentation/Hubs/IChatClient.cs
@@ -24,6 +24,7 @@ public interface IChatClient
 
 	Task GuildJoined(string guildId, string guildName);
 	Task GuildLeft(string guildId);
+	Task GuildDeleted(string guildId);
 
 	Task ChannelCreated(GuildChannelDto channel);
 	Task ChannelUpdated(GuildChannelDto channel);

--- a/services/chat/src/Chat.Presentation/Hubs/IChatClient.cs
+++ b/services/chat/src/Chat.Presentation/Hubs/IChatClient.cs
@@ -40,6 +40,7 @@ public interface IChatClient
 	Task MemberUpdated(GuildMemberEvent evt);
 
 	Task RolesChanged(string guildId);
+	Task ChannelAccessGranted(ChannelAccessGrantedEvent evt);
 
 	Task UserPresence(UserPresenceEvent evt);
 
@@ -51,3 +52,4 @@ public sealed record CategoryDeletedEvent(string GuildId, string CategoryId);
 public sealed record GuildMemberEvent(string GuildId, string UserId);
 public sealed record UserPresenceEvent(string UserId, string Status);
 public sealed record GuildUpdatedEvent(string GuildId, string Name, string? IconUrl);
+public sealed record ChannelAccessGrantedEvent(string GuildId, string ChannelId);

--- a/services/chat/src/Chat.Presentation/Hubs/IChatClient.cs
+++ b/services/chat/src/Chat.Presentation/Hubs/IChatClient.cs
@@ -25,6 +25,7 @@ public interface IChatClient
 	Task GuildJoined(string guildId, string guildName);
 	Task GuildLeft(string guildId);
 	Task GuildDeleted(string guildId);
+	Task GuildUpdated(GuildUpdatedEvent evt);
 
 	Task ChannelCreated(GuildChannelDto channel);
 	Task ChannelUpdated(GuildChannelDto channel);
@@ -46,3 +47,4 @@ public sealed record ChannelDeletedEvent(string GuildId, string ChannelId);
 public sealed record CategoryDeletedEvent(string GuildId, string CategoryId);
 public sealed record GuildMemberEvent(string GuildId, string UserId);
 public sealed record UserPresenceEvent(string UserId, string Status);
+public sealed record GuildUpdatedEvent(string GuildId, string Name, string? IconUrl);

--- a/services/chat/src/Chat.Presentation/Hubs/IChatClient.cs
+++ b/services/chat/src/Chat.Presentation/Hubs/IChatClient.cs
@@ -30,6 +30,10 @@ public interface IChatClient
 	Task ChannelUpdated(GuildChannelDto channel);
 	Task ChannelDeleted(ChannelDeletedEvent evt);
 
+	Task CategoryCreated(GuildCategoryDto category);
+	Task CategoryUpdated(GuildCategoryDto category);
+	Task CategoryDeleted(CategoryDeletedEvent evt);
+
 	Task MemberJoined(GuildMemberEvent evt);
 	Task MemberLeft(GuildMemberEvent evt);
 
@@ -39,5 +43,6 @@ public interface IChatClient
 }
 
 public sealed record ChannelDeletedEvent(string GuildId, string ChannelId);
+public sealed record CategoryDeletedEvent(string GuildId, string CategoryId);
 public sealed record GuildMemberEvent(string GuildId, string UserId);
 public sealed record UserPresenceEvent(string UserId, string Status);

--- a/services/chat/src/Chat.Presentation/Hubs/SignalRUserBroadcaster.cs
+++ b/services/chat/src/Chat.Presentation/Hubs/SignalRUserBroadcaster.cs
@@ -23,6 +23,18 @@ internal sealed class SignalRUserBroadcaster(
 	public Task BroadcastGuildLeftAsync(long userId, long guildId, CancellationToken ct) =>
 		hub.Clients.User(userId.ToString()).GuildLeft(guildId.ToString());
 
+	public async Task AddUserToGuildGroupAsync(long userId, long guildId, CancellationToken ct)
+	{
+		foreach (var connectionId in tracker.ConnectionIds(userId))
+			await hub.Groups.AddToGroupAsync(connectionId, $"guild:{guildId}", ct);
+	}
+
+	public async Task RemoveUserFromGuildGroupAsync(long userId, long guildId, CancellationToken ct)
+	{
+		foreach (var connectionId in tracker.ConnectionIds(userId))
+			await hub.Groups.RemoveFromGroupAsync(connectionId, $"guild:{guildId}", ct);
+	}
+
 	public Task<int> DisconnectUserAsync(long userId, CancellationToken ct)
 	{
 		var contexts = tracker.UserContexts(userId);

--- a/services/chat/src/Chat.Presentation/Hubs/SignalRUserBroadcaster.cs
+++ b/services/chat/src/Chat.Presentation/Hubs/SignalRUserBroadcaster.cs
@@ -23,6 +23,9 @@ internal sealed class SignalRUserBroadcaster(
 	public Task BroadcastGuildLeftAsync(long userId, long guildId, CancellationToken ct) =>
 		hub.Clients.User(userId.ToString()).GuildLeft(guildId.ToString());
 
+	public Task BroadcastGuildDeletedAsync(long guildId, CancellationToken ct) =>
+		hub.Clients.Group($"guild:{guildId}").GuildDeleted(guildId.ToString());
+
 	public async Task AddUserToGuildGroupAsync(long userId, long guildId, CancellationToken ct)
 	{
 		foreach (var connectionId in tracker.ConnectionIds(userId))

--- a/services/chat/src/Chat.Presentation/Hubs/SignalRUserBroadcaster.cs
+++ b/services/chat/src/Chat.Presentation/Hubs/SignalRUserBroadcaster.cs
@@ -81,6 +81,12 @@ internal sealed class SignalRUserBroadcaster(
 	public Task BroadcastCategoryDeletedAsync(long guildId, long categoryId, CancellationToken ct) =>
 		hub.Clients.Group($"guild:{guildId}").CategoryDeleted(new CategoryDeletedEvent(guildId.ToString(), categoryId.ToString()));
 
+	public Task BroadcastRolesChangedAsync(long guildId, CancellationToken ct) =>
+		hub.Clients.Group($"guild:{guildId}").RolesChanged(guildId.ToString());
+
+	public Task BroadcastMemberUpdatedAsync(long guildId, long userId, CancellationToken ct) =>
+		hub.Clients.Group($"guild:{guildId}").MemberUpdated(new GuildMemberEvent(guildId.ToString(), userId.ToString()));
+
 	public async Task<int> EvictFromGuildChannelsAsync(long userId, long guildId, CancellationToken ct)
 	{
 		var subscriptions = tracker.ConnectionsInGuild(userId, guildId);

--- a/services/chat/src/Chat.Presentation/Hubs/SignalRUserBroadcaster.cs
+++ b/services/chat/src/Chat.Presentation/Hubs/SignalRUserBroadcaster.cs
@@ -87,6 +87,9 @@ internal sealed class SignalRUserBroadcaster(
 	public Task BroadcastMemberUpdatedAsync(long guildId, long userId, CancellationToken ct) =>
 		hub.Clients.Group($"guild:{guildId}").MemberUpdated(new GuildMemberEvent(guildId.ToString(), userId.ToString()));
 
+	public Task BroadcastChannelAccessGrantedAsync(long userId, long guildId, long channelId, CancellationToken ct) =>
+		hub.Clients.User(userId.ToString()).ChannelAccessGranted(new ChannelAccessGrantedEvent(guildId.ToString(), channelId.ToString()));
+
 	public async Task<int> EvictFromGuildChannelsAsync(long userId, long guildId, CancellationToken ct)
 	{
 		var subscriptions = tracker.ConnectionsInGuild(userId, guildId);

--- a/services/chat/src/Chat.Presentation/Hubs/SignalRUserBroadcaster.cs
+++ b/services/chat/src/Chat.Presentation/Hubs/SignalRUserBroadcaster.cs
@@ -26,6 +26,9 @@ internal sealed class SignalRUserBroadcaster(
 	public Task BroadcastGuildDeletedAsync(long guildId, CancellationToken ct) =>
 		hub.Clients.Group($"guild:{guildId}").GuildDeleted(guildId.ToString());
 
+	public Task BroadcastGuildUpdatedAsync(long guildId, string name, string? iconUrl, CancellationToken ct) =>
+		hub.Clients.Group($"guild:{guildId}").GuildUpdated(new GuildUpdatedEvent(guildId.ToString(), name, iconUrl));
+
 	public async Task AddUserToGuildGroupAsync(long userId, long guildId, CancellationToken ct)
 	{
 		foreach (var connectionId in tracker.ConnectionIds(userId))

--- a/services/chat/src/Chat.Presentation/Hubs/SignalRUserBroadcaster.cs
+++ b/services/chat/src/Chat.Presentation/Hubs/SignalRUserBroadcaster.cs
@@ -50,6 +50,22 @@ internal sealed class SignalRUserBroadcaster(
 	public Task BroadcastDmReadStateUpdatedAsync(long userId, DmReadStateResponse response, CancellationToken ct) =>
 		hub.Clients.User(userId.ToString()).DmReadStateUpdated(response);
 
+	public Task BroadcastChannelCreatedAsync(IReadOnlyList<long> userIds, GuildChannelDto channel, CancellationToken ct) =>
+		hub.Clients.Users(userIds.Select(id => id.ToString()).ToList()).ChannelCreated(channel);
+
+	public Task BroadcastChannelUpdatedAsync(IReadOnlyList<long> userIds, GuildChannelDto channel, CancellationToken ct) =>
+		hub.Clients.Users(userIds.Select(id => id.ToString()).ToList()).ChannelUpdated(channel);
+
+	public Task BroadcastChannelDeletedAsync(IReadOnlyList<long> userIds, long guildId, long channelId, CancellationToken ct) =>
+		hub.Clients.Users(userIds.Select(id => id.ToString()).ToList())
+			.ChannelDeleted(new ChannelDeletedEvent(guildId.ToString(), channelId.ToString()));
+
+	public Task BroadcastMemberJoinedAsync(long guildId, long userId, CancellationToken ct) =>
+		hub.Clients.Group($"guild:{guildId}").MemberJoined(new GuildMemberEvent(guildId.ToString(), userId.ToString()));
+
+	public Task BroadcastMemberLeftAsync(long guildId, long userId, CancellationToken ct) =>
+		hub.Clients.Group($"guild:{guildId}").MemberLeft(new GuildMemberEvent(guildId.ToString(), userId.ToString()));
+
 	public async Task<int> EvictFromGuildChannelsAsync(long userId, long guildId, CancellationToken ct)
 	{
 		var subscriptions = tracker.ConnectionsInGuild(userId, guildId);

--- a/services/chat/src/Chat.Presentation/Hubs/SignalRUserBroadcaster.cs
+++ b/services/chat/src/Chat.Presentation/Hubs/SignalRUserBroadcaster.cs
@@ -69,6 +69,15 @@ internal sealed class SignalRUserBroadcaster(
 	public Task BroadcastMemberLeftAsync(long guildId, long userId, CancellationToken ct) =>
 		hub.Clients.Group($"guild:{guildId}").MemberLeft(new GuildMemberEvent(guildId.ToString(), userId.ToString()));
 
+	public Task BroadcastCategoryCreatedAsync(long guildId, GuildCategoryDto category, CancellationToken ct) =>
+		hub.Clients.Group($"guild:{guildId}").CategoryCreated(category);
+
+	public Task BroadcastCategoryUpdatedAsync(long guildId, GuildCategoryDto category, CancellationToken ct) =>
+		hub.Clients.Group($"guild:{guildId}").CategoryUpdated(category);
+
+	public Task BroadcastCategoryDeletedAsync(long guildId, long categoryId, CancellationToken ct) =>
+		hub.Clients.Group($"guild:{guildId}").CategoryDeleted(new CategoryDeletedEvent(guildId.ToString(), categoryId.ToString()));
+
 	public async Task<int> EvictFromGuildChannelsAsync(long userId, long guildId, CancellationToken ct)
 	{
 		var subscriptions = tracker.ConnectionsInGuild(userId, guildId);

--- a/services/chat/src/Chat.Presentation/Hubs/UserConnectionTracker.cs
+++ b/services/chat/src/Chat.Presentation/Hubs/UserConnectionTracker.cs
@@ -121,6 +121,19 @@ public sealed class UserConnectionTracker
 		return matches;
 	}
 
+	// snapshot of every open connection id for the user. used to add/remove all
+	// of a user's connections to a guild:{id} group when they join/leave a guild
+	// while already connected (guild-group membership is derived from guild
+	// membership, so it needs no per-connection bookkeeping of its own).
+	public IReadOnlyList<string> ConnectionIds(long userId)
+	{
+		if (!_users.TryGetValue(userId, out var state))
+			return [];
+
+		lock (state)
+			return state.Connections.Keys.ToList();
+	}
+
 	public IReadOnlyList<string> ConnectionsInChannel(long userId, long channelId)
 	{
 		if (!_users.TryGetValue(userId, out var state))

--- a/services/chat/tests/Chat.UnitTests/Fakes/FakeGuildClient.cs
+++ b/services/chat/tests/Chat.UnitTests/Fakes/FakeGuildClient.cs
@@ -19,4 +19,9 @@ public sealed class FakeGuildClient : IGuildClient
 
 	public Task<IReadOnlyList<long>> GetVisibleChannelIdsAsync(long userId, CancellationToken ct)
 		=> Task.FromResult<IReadOnlyList<long>>(VisibleChannelIds);
+
+	public List<long> UserGuildIds { get; set; } = [];
+
+	public Task<IReadOnlyList<long>> GetUserGuildIdsAsync(long userId, CancellationToken ct)
+		=> Task.FromResult<IReadOnlyList<long>>(UserGuildIds);
 }

--- a/services/chat/tests/Chat.UnitTests/Fakes/FakeMessageRepository.cs
+++ b/services/chat/tests/Chat.UnitTests/Fakes/FakeMessageRepository.cs
@@ -129,6 +129,15 @@ public sealed class FakeMessageRepository : IMessageRepository
 		return Task.CompletedTask;
 	}
 
+	private readonly List<long> _deletedChannelMessagesFor = [];
+	public IReadOnlyList<long> DeletedChannelMessagesFor => _deletedChannelMessagesFor;
+
+	public Task DeleteChannelMessagesAsync(long channelId, CancellationToken ct)
+	{
+		_deletedChannelMessagesFor.Add(channelId);
+		return Task.CompletedTask;
+	}
+
 	public Task<IReadOnlyList<DmConversation>> GetConversationsAsync(long userId, CancellationToken ct)
 	{
 		var result = _conversationSummaries

--- a/services/chat/tests/Chat.UnitTests/Fakes/FakeUserBroadcaster.cs
+++ b/services/chat/tests/Chat.UnitTests/Fakes/FakeUserBroadcaster.cs
@@ -165,6 +165,15 @@ public sealed class FakeUserBroadcaster : IUserBroadcaster
 		return Task.CompletedTask;
 	}
 
+	private readonly List<(long UserId, long GuildId, long ChannelId)> _channelAccessGrantedCalls = [];
+	public IReadOnlyList<(long UserId, long GuildId, long ChannelId)> ChannelAccessGrantedCalls => _channelAccessGrantedCalls;
+
+	public Task BroadcastChannelAccessGrantedAsync(long userId, long guildId, long channelId, CancellationToken ct)
+	{
+		_channelAccessGrantedCalls.Add((userId, guildId, channelId));
+		return Task.CompletedTask;
+	}
+
 	// EvictedCount is returned from both evict methods so consumer tests can
 	// exercise whatever the caller does with the purged-subscription count.
 	public int EvictedCount { get; set; }

--- a/services/chat/tests/Chat.UnitTests/Fakes/FakeUserBroadcaster.cs
+++ b/services/chat/tests/Chat.UnitTests/Fakes/FakeUserBroadcaster.cs
@@ -113,6 +113,32 @@ public sealed class FakeUserBroadcaster : IUserBroadcaster
 		return Task.CompletedTask;
 	}
 
+	private readonly List<(long GuildId, GuildCategoryDto Category)> _categoryCreatedCalls = [];
+	private readonly List<(long GuildId, GuildCategoryDto Category)> _categoryUpdatedCalls = [];
+	private readonly List<(long GuildId, long CategoryId)> _categoryDeletedCalls = [];
+
+	public IReadOnlyList<(long GuildId, GuildCategoryDto Category)> CategoryCreatedCalls => _categoryCreatedCalls;
+	public IReadOnlyList<(long GuildId, GuildCategoryDto Category)> CategoryUpdatedCalls => _categoryUpdatedCalls;
+	public IReadOnlyList<(long GuildId, long CategoryId)> CategoryDeletedCalls => _categoryDeletedCalls;
+
+	public Task BroadcastCategoryCreatedAsync(long guildId, GuildCategoryDto category, CancellationToken ct)
+	{
+		_categoryCreatedCalls.Add((guildId, category));
+		return Task.CompletedTask;
+	}
+
+	public Task BroadcastCategoryUpdatedAsync(long guildId, GuildCategoryDto category, CancellationToken ct)
+	{
+		_categoryUpdatedCalls.Add((guildId, category));
+		return Task.CompletedTask;
+	}
+
+	public Task BroadcastCategoryDeletedAsync(long guildId, long categoryId, CancellationToken ct)
+	{
+		_categoryDeletedCalls.Add((guildId, categoryId));
+		return Task.CompletedTask;
+	}
+
 	// EvictedCount is returned from both evict methods so consumer tests can
 	// exercise whatever the caller does with the purged-subscription count.
 	public int EvictedCount { get; set; }

--- a/services/chat/tests/Chat.UnitTests/Fakes/FakeUserBroadcaster.cs
+++ b/services/chat/tests/Chat.UnitTests/Fakes/FakeUserBroadcaster.cs
@@ -47,6 +47,15 @@ public sealed class FakeUserBroadcaster : IUserBroadcaster
 		return Task.CompletedTask;
 	}
 
+	private readonly List<(long GuildId, string Name, string? IconUrl)> _guildUpdatedCalls = [];
+	public IReadOnlyList<(long GuildId, string Name, string? IconUrl)> GuildUpdatedCalls => _guildUpdatedCalls;
+
+	public Task BroadcastGuildUpdatedAsync(long guildId, string name, string? iconUrl, CancellationToken ct)
+	{
+		_guildUpdatedCalls.Add((guildId, name, iconUrl));
+		return Task.CompletedTask;
+	}
+
 	public Task AddUserToGuildGroupAsync(long userId, long guildId, CancellationToken ct)
 	{
 		_addGuildGroupCalls.Add((userId, guildId));

--- a/services/chat/tests/Chat.UnitTests/Fakes/FakeUserBroadcaster.cs
+++ b/services/chat/tests/Chat.UnitTests/Fakes/FakeUserBroadcaster.cs
@@ -8,6 +8,8 @@ public sealed class FakeUserBroadcaster : IUserBroadcaster
 {
 	private readonly List<(long UserId, long GuildId, string GuildName)> _joinCalls = [];
 	private readonly List<(long UserId, long GuildId)> _leftCalls = [];
+	private readonly List<(long UserId, long GuildId)> _addGuildGroupCalls = [];
+	private readonly List<(long UserId, long GuildId)> _removeGuildGroupCalls = [];
 	private readonly List<(long UserId, long GuildId)> _evictGuildCalls = [];
 	private readonly List<(long UserId, long ChannelId)> _evictChannelCalls = [];
 	private readonly List<long> _disconnectCalls = [];
@@ -16,6 +18,8 @@ public sealed class FakeUserBroadcaster : IUserBroadcaster
 
 	public IReadOnlyList<(long UserId, long GuildId, string GuildName)> JoinCalls => _joinCalls;
 	public IReadOnlyList<(long UserId, long GuildId)> LeftCalls => _leftCalls;
+	public IReadOnlyList<(long UserId, long GuildId)> AddGuildGroupCalls => _addGuildGroupCalls;
+	public IReadOnlyList<(long UserId, long GuildId)> RemoveGuildGroupCalls => _removeGuildGroupCalls;
 	public IReadOnlyList<(long UserId, long GuildId)> EvictGuildCalls => _evictGuildCalls;
 	public IReadOnlyList<(long UserId, long ChannelId)> EvictChannelCalls => _evictChannelCalls;
 	public IReadOnlyList<long> DisconnectCalls => _disconnectCalls;
@@ -31,6 +35,18 @@ public sealed class FakeUserBroadcaster : IUserBroadcaster
 	public Task BroadcastGuildLeftAsync(long userId, long guildId, CancellationToken ct)
 	{
 		_leftCalls.Add((userId, guildId));
+		return Task.CompletedTask;
+	}
+
+	public Task AddUserToGuildGroupAsync(long userId, long guildId, CancellationToken ct)
+	{
+		_addGuildGroupCalls.Add((userId, guildId));
+		return Task.CompletedTask;
+	}
+
+	public Task RemoveUserFromGuildGroupAsync(long userId, long guildId, CancellationToken ct)
+	{
+		_removeGuildGroupCalls.Add((userId, guildId));
 		return Task.CompletedTask;
 	}
 

--- a/services/chat/tests/Chat.UnitTests/Fakes/FakeUserBroadcaster.cs
+++ b/services/chat/tests/Chat.UnitTests/Fakes/FakeUserBroadcaster.cs
@@ -62,6 +62,48 @@ public sealed class FakeUserBroadcaster : IUserBroadcaster
 		return Task.CompletedTask;
 	}
 
+	private readonly List<(IReadOnlyList<long> UserIds, GuildChannelDto Channel)> _channelCreatedCalls = [];
+	private readonly List<(IReadOnlyList<long> UserIds, GuildChannelDto Channel)> _channelUpdatedCalls = [];
+	private readonly List<(IReadOnlyList<long> UserIds, long GuildId, long ChannelId)> _channelDeletedCalls = [];
+	private readonly List<(long GuildId, long UserId)> _memberJoinedCalls = [];
+	private readonly List<(long GuildId, long UserId)> _memberLeftCalls = [];
+
+	public IReadOnlyList<(IReadOnlyList<long> UserIds, GuildChannelDto Channel)> ChannelCreatedCalls => _channelCreatedCalls;
+	public IReadOnlyList<(IReadOnlyList<long> UserIds, GuildChannelDto Channel)> ChannelUpdatedCalls => _channelUpdatedCalls;
+	public IReadOnlyList<(IReadOnlyList<long> UserIds, long GuildId, long ChannelId)> ChannelDeletedCalls => _channelDeletedCalls;
+	public IReadOnlyList<(long GuildId, long UserId)> MemberJoinedCalls => _memberJoinedCalls;
+	public IReadOnlyList<(long GuildId, long UserId)> MemberLeftCalls => _memberLeftCalls;
+
+	public Task BroadcastChannelCreatedAsync(IReadOnlyList<long> userIds, GuildChannelDto channel, CancellationToken ct)
+	{
+		_channelCreatedCalls.Add((userIds, channel));
+		return Task.CompletedTask;
+	}
+
+	public Task BroadcastChannelUpdatedAsync(IReadOnlyList<long> userIds, GuildChannelDto channel, CancellationToken ct)
+	{
+		_channelUpdatedCalls.Add((userIds, channel));
+		return Task.CompletedTask;
+	}
+
+	public Task BroadcastChannelDeletedAsync(IReadOnlyList<long> userIds, long guildId, long channelId, CancellationToken ct)
+	{
+		_channelDeletedCalls.Add((userIds, guildId, channelId));
+		return Task.CompletedTask;
+	}
+
+	public Task BroadcastMemberJoinedAsync(long guildId, long userId, CancellationToken ct)
+	{
+		_memberJoinedCalls.Add((guildId, userId));
+		return Task.CompletedTask;
+	}
+
+	public Task BroadcastMemberLeftAsync(long guildId, long userId, CancellationToken ct)
+	{
+		_memberLeftCalls.Add((guildId, userId));
+		return Task.CompletedTask;
+	}
+
 	// EvictedCount is returned from both evict methods so consumer tests can
 	// exercise whatever the caller does with the purged-subscription count.
 	public int EvictedCount { get; set; }

--- a/services/chat/tests/Chat.UnitTests/Fakes/FakeUserBroadcaster.cs
+++ b/services/chat/tests/Chat.UnitTests/Fakes/FakeUserBroadcaster.cs
@@ -148,6 +148,23 @@ public sealed class FakeUserBroadcaster : IUserBroadcaster
 		return Task.CompletedTask;
 	}
 
+	private readonly List<long> _rolesChangedCalls = [];
+	private readonly List<(long GuildId, long UserId)> _memberUpdatedCalls = [];
+	public IReadOnlyList<long> RolesChangedCalls => _rolesChangedCalls;
+	public IReadOnlyList<(long GuildId, long UserId)> MemberUpdatedCalls => _memberUpdatedCalls;
+
+	public Task BroadcastRolesChangedAsync(long guildId, CancellationToken ct)
+	{
+		_rolesChangedCalls.Add(guildId);
+		return Task.CompletedTask;
+	}
+
+	public Task BroadcastMemberUpdatedAsync(long guildId, long userId, CancellationToken ct)
+	{
+		_memberUpdatedCalls.Add((guildId, userId));
+		return Task.CompletedTask;
+	}
+
 	// EvictedCount is returned from both evict methods so consumer tests can
 	// exercise whatever the caller does with the purged-subscription count.
 	public int EvictedCount { get; set; }

--- a/services/chat/tests/Chat.UnitTests/Fakes/FakeUserBroadcaster.cs
+++ b/services/chat/tests/Chat.UnitTests/Fakes/FakeUserBroadcaster.cs
@@ -38,6 +38,15 @@ public sealed class FakeUserBroadcaster : IUserBroadcaster
 		return Task.CompletedTask;
 	}
 
+	private readonly List<long> _guildDeletedCalls = [];
+	public IReadOnlyList<long> GuildDeletedCalls => _guildDeletedCalls;
+
+	public Task BroadcastGuildDeletedAsync(long guildId, CancellationToken ct)
+	{
+		_guildDeletedCalls.Add(guildId);
+		return Task.CompletedTask;
+	}
+
 	public Task AddUserToGuildGroupAsync(long userId, long guildId, CancellationToken ct)
 	{
 		_addGuildGroupCalls.Add((userId, guildId));

--- a/services/chat/tests/Chat.UnitTests/Fakes/FakeUserClient.cs
+++ b/services/chat/tests/Chat.UnitTests/Fakes/FakeUserClient.cs
@@ -13,4 +13,9 @@ public sealed class FakeUserClient : IUserClient
 
 	public Task<UsersRelationship?> GetUsersRelationship(long callerId, long recipientId, CancellationToken ct)
 		=> Task.FromResult(_map.TryGetValue((callerId, recipientId), out var rel) ? rel : null);
+
+	public List<long> FriendIds { get; set; } = [];
+
+	public Task<IReadOnlyList<long>> GetFriendIdsAsync(long userId, CancellationToken ct)
+		=> Task.FromResult<IReadOnlyList<long>>(FriendIds);
 }

--- a/services/chat/tests/Chat.UnitTests/Infrastructure/ChannelConsumersTests.cs
+++ b/services/chat/tests/Chat.UnitTests/Infrastructure/ChannelConsumersTests.cs
@@ -67,4 +67,27 @@ public sealed class ChannelConsumersTests
 		Assert.Equal(100L, call.GuildId);
 		Assert.Equal(500L, call.ChannelId);
 	}
+
+	[Fact]
+	public async Task CategoryCreated_BroadcastsToGuild()
+	{
+		var broadcaster = new FakeUserBroadcaster();
+		await using var provider = new ServiceCollection()
+			.AddSingleton<IUserBroadcaster>(broadcaster)
+			.AddMassTransitTestHarness(x => x.AddConsumer<GuildCategoryCreatedConsumer>())
+			.BuildServiceProvider(true);
+
+		var harness = provider.GetRequiredService<ITestHarness>();
+		await harness.Start();
+
+		await harness.Bus.Publish(new GuildCategoryCreated(
+			GuildId: 100, Category: new CategoryPayload("30", "100", "General", 0)));
+
+		Assert.True(await harness.Consumed.Any<GuildCategoryCreated>());
+
+		var call = Assert.Single(broadcaster.CategoryCreatedCalls);
+		Assert.Equal(100L, call.GuildId);
+		Assert.Equal("30", call.Category.Id);
+		Assert.Equal("General", call.Category.Name);
+	}
 }

--- a/services/chat/tests/Chat.UnitTests/Infrastructure/ChannelConsumersTests.cs
+++ b/services/chat/tests/Chat.UnitTests/Infrastructure/ChannelConsumersTests.cs
@@ -1,0 +1,70 @@
+using Chat.Application.Abstractions;
+using Chat.Infrastructure.Messaging.Consumers;
+using Chat.Infrastructure.Messaging.Contracts;
+using Chat.UnitTests.Fakes;
+using MassTransit;
+using MassTransit.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Chat.UnitTests.Infrastructure;
+
+public sealed class ChannelConsumersTests
+{
+	private static ChannelPayload SamplePayload() => new(
+		Id: "500",
+		GuildId: "100",
+		CategoryId: null,
+		Name: "general",
+		Topic: null,
+		Type: "text",
+		Position: 0,
+		IsNsfw: false,
+		SlowmodeSeconds: 0);
+
+	[Fact]
+	public async Task ChannelCreated_BroadcastsChannelToEligibleUsers()
+	{
+		var broadcaster = new FakeUserBroadcaster();
+		await using var provider = new ServiceCollection()
+			.AddSingleton<IUserBroadcaster>(broadcaster)
+			.AddMassTransitTestHarness(x => x.AddConsumer<GuildChannelCreatedConsumer>())
+			.BuildServiceProvider(true);
+
+		var harness = provider.GetRequiredService<ITestHarness>();
+		await harness.Start();
+
+		await harness.Bus.Publish(new GuildChannelCreated(
+			GuildId: 100, Channel: SamplePayload(), EligibleUserIds: [1, 2]));
+
+		Assert.True(await harness.Consumed.Any<GuildChannelCreated>());
+
+		var call = Assert.Single(broadcaster.ChannelCreatedCalls);
+		Assert.Equal(new long[] { 1, 2 }, call.UserIds);
+		Assert.Equal("500", call.Channel.Id);
+		Assert.Equal("general", call.Channel.Name);
+	}
+
+	[Fact]
+	public async Task ChannelDeleted_BroadcastsIdsToEligibleUsers()
+	{
+		var broadcaster = new FakeUserBroadcaster();
+		await using var provider = new ServiceCollection()
+			.AddSingleton<IUserBroadcaster>(broadcaster)
+			.AddMassTransitTestHarness(x => x.AddConsumer<GuildChannelDeletedConsumer>())
+			.BuildServiceProvider(true);
+
+		var harness = provider.GetRequiredService<ITestHarness>();
+		await harness.Start();
+
+		await harness.Bus.Publish(new GuildChannelDeleted(
+			GuildId: 100, ChannelId: 500, EligibleUserIds: [7]));
+
+		Assert.True(await harness.Consumed.Any<GuildChannelDeleted>());
+
+		var call = Assert.Single(broadcaster.ChannelDeletedCalls);
+		Assert.Equal(new long[] { 7 }, call.UserIds);
+		Assert.Equal(100L, call.GuildId);
+		Assert.Equal(500L, call.ChannelId);
+	}
+}

--- a/services/chat/tests/Chat.UnitTests/Infrastructure/GuildMemberJoinedConsumerTests.cs
+++ b/services/chat/tests/Chat.UnitTests/Infrastructure/GuildMemberJoinedConsumerTests.cs
@@ -113,3 +113,28 @@ public sealed class ChannelAccessRevokedConsumerTests
 		Assert.Equal(500L, ChannelId);
 	}
 }
+
+public sealed class ChannelAccessGrantedConsumerTests
+{
+	[Fact]
+	public async Task Consume_NotifiesUserOfGrantedChannel()
+	{
+		var broadcaster = new FakeUserBroadcaster();
+		await using var provider = new ServiceCollection()
+			.AddSingleton<IUserBroadcaster>(broadcaster)
+			.AddMassTransitTestHarness(x => x.AddConsumer<ChannelAccessGrantedConsumer>())
+			.BuildServiceProvider(true);
+
+		var harness = provider.GetRequiredService<ITestHarness>();
+		await harness.Start();
+
+		await harness.Bus.Publish(new ChannelAccessGranted(ChannelId: 500, GuildId: 100, UserId: 42));
+
+		Assert.True(await harness.Consumed.Any<ChannelAccessGranted>());
+
+		var call = Assert.Single(broadcaster.ChannelAccessGrantedCalls);
+		Assert.Equal(42L, call.UserId);
+		Assert.Equal(100L, call.GuildId);
+		Assert.Equal(500L, call.ChannelId);
+	}
+}

--- a/services/chat/tests/Chat.UnitTests/Infrastructure/GuildMemberJoinedConsumerTests.cs
+++ b/services/chat/tests/Chat.UnitTests/Infrastructure/GuildMemberJoinedConsumerTests.cs
@@ -63,6 +63,29 @@ public sealed class GuildMemberLeftConsumerTests
 	}
 }
 
+public sealed class GuildDeletedConsumerTests
+{
+	[Fact]
+	public async Task Consume_BroadcastsGuildDeletedToGroup()
+	{
+		var broadcaster = new FakeUserBroadcaster();
+		await using var provider = new ServiceCollection()
+			.AddSingleton<IUserBroadcaster>(broadcaster)
+			.AddMassTransitTestHarness(x => x.AddConsumer<GuildDeletedConsumer>())
+			.BuildServiceProvider(true);
+
+		var harness = provider.GetRequiredService<ITestHarness>();
+		await harness.Start();
+
+		await harness.Bus.Publish(new GuildDeleted(GuildId: 100));
+
+		Assert.True(await harness.Consumed.Any<GuildDeleted>());
+
+		var guildId = Assert.Single(broadcaster.GuildDeletedCalls);
+		Assert.Equal(100L, guildId);
+	}
+}
+
 public sealed class ChannelAccessRevokedConsumerTests
 {
 	[Fact]

--- a/services/chat/tests/Chat.UnitTests/Infrastructure/GuildMemberJoinedConsumerTests.cs
+++ b/services/chat/tests/Chat.UnitTests/Infrastructure/GuildMemberJoinedConsumerTests.cs
@@ -1,4 +1,5 @@
 using Chat.Application.Abstractions;
+using Chat.Application.Abstractions.Persistence;
 using Chat.Infrastructure.Messaging.Consumers;
 using Chat.Infrastructure.Messaging.Contracts;
 using Chat.UnitTests.Fakes;
@@ -66,21 +67,24 @@ public sealed class GuildMemberLeftConsumerTests
 public sealed class GuildDeletedConsumerTests
 {
 	[Fact]
-	public async Task Consume_BroadcastsGuildDeletedToGroup()
+	public async Task Consume_PurgesChannelMessages_AndBroadcastsGuildDeleted()
 	{
 		var broadcaster = new FakeUserBroadcaster();
+		var messages = new FakeMessageRepository();
 		await using var provider = new ServiceCollection()
 			.AddSingleton<IUserBroadcaster>(broadcaster)
+			.AddSingleton<IMessageRepository>(messages)
 			.AddMassTransitTestHarness(x => x.AddConsumer<GuildDeletedConsumer>())
 			.BuildServiceProvider(true);
 
 		var harness = provider.GetRequiredService<ITestHarness>();
 		await harness.Start();
 
-		await harness.Bus.Publish(new GuildDeleted(GuildId: 100));
+		await harness.Bus.Publish(new GuildDeleted(GuildId: 100, ChannelIds: [10, 20]));
 
 		Assert.True(await harness.Consumed.Any<GuildDeleted>());
 
+		Assert.Equal(new long[] { 10, 20 }, messages.DeletedChannelMessagesFor);
 		var guildId = Assert.Single(broadcaster.GuildDeletedCalls);
 		Assert.Equal(100L, guildId);
 	}

--- a/services/guild/src/Guild.Application/Authorization/ChannelAccess.cs
+++ b/services/guild/src/Guild.Application/Authorization/ChannelAccess.cs
@@ -7,9 +7,11 @@ using GuildEntity = Guild.Domain.Guild.Guild;
 namespace Guild.Application.Authorization;
 
 // read-access captured before a mutation, diffed against the after-state by
-// PublishRevocationsAsync to emit revocations.
+// PublishAccessChangesAsync to emit revocations and grants. Candidates is the
+// full (channel, user) set considered; Before is the subset readable pre-change.
 internal readonly record struct ChannelReadSnapshot(
 	HashSet<(long ChannelId, long UserId)> Before,
+	IReadOnlyList<(long ChannelId, long UserId)> Candidates,
 	IReadOnlyDictionary<long, IReadOnlyList<ChannelPermissionOverwrite>> Overwrites);
 
 internal static class ChannelAccess
@@ -42,16 +44,16 @@ internal static class ChannelAccess
 		Capture(guild, Pairs([channelId], affectedUserIds), Group(channelId, channelOverwrites));
 
 	// role mutations: overwrites are unchanged, so the snapshot's set is the after-state.
-	public static Task PublishRevocationsAsync(
+	public static Task PublishAccessChangesAsync(
 		IEventBus eventBus, GuildEntity guild, ChannelReadSnapshot snapshot, CancellationToken cancellationToken) =>
-		PublishRevocationsAsync(eventBus, guild, snapshot, snapshot.Overwrites, cancellationToken);
+		PublishAccessChangesAsync(eventBus, guild, snapshot, snapshot.Overwrites, cancellationToken);
 
 	// overwrite mutations: one channel's overwrites changed.
-	public static Task PublishRevocationsAsync(
+	public static Task PublishAccessChangesAsync(
 		IEventBus eventBus, GuildEntity guild, ChannelReadSnapshot snapshot,
 		long channelId, IReadOnlyList<ChannelPermissionOverwrite> afterChannelOverwrites,
 		CancellationToken cancellationToken) =>
-		PublishRevocationsAsync(eventBus, guild, snapshot, Group(channelId, afterChannelOverwrites), cancellationToken);
+		PublishAccessChangesAsync(eventBus, guild, snapshot, Group(channelId, afterChannelOverwrites), cancellationToken);
 
 	// members whose effective permissions include ReadMessages for the channel,
 	// given its current overwrites. feeds the eligible-user set on channel
@@ -84,25 +86,34 @@ internal static class ChannelAccess
 			: guild.MemberRoles.Where(mr => mr.RoleId == targetId).Select(mr => mr.UserId);
 	}
 
-	private static async Task PublishRevocationsAsync(
+	private static async Task PublishAccessChangesAsync(
 		IEventBus eventBus, GuildEntity guild, ChannelReadSnapshot snapshot,
 		IReadOnlyDictionary<long, IReadOnlyList<ChannelPermissionOverwrite>> afterOverwrites,
 		CancellationToken cancellationToken)
 	{
-		// a revocation can only come from a pair that could read before; re-resolve
-		// each once and publish the moment it has flipped to denied.
-		foreach (var (channelId, userId) in snapshot.Before)
+		// re-resolve each candidate once and publish only on a transition: a pair
+		// readable before but not after is a revocation; not before but after is a
+		// grant (the member gains a newly-visible channel).
+		foreach (var (channelId, userId) in snapshot.Candidates)
 		{
-			if (!CanRead(guild, channelId, userId, afterOverwrites))
+			var wasReadable = snapshot.Before.Contains((channelId, userId));
+			var isReadable = CanRead(guild, channelId, userId, afterOverwrites);
+
+			if (wasReadable && !isReadable)
 				await eventBus.PublishAsync(new ChannelAccessRevoked(channelId, userId), cancellationToken);
+			else if (!wasReadable && isReadable)
+				await eventBus.PublishAsync(new ChannelAccessGranted(channelId, guild.Id, userId), cancellationToken);
 		}
 	}
 
 	private static ChannelReadSnapshot Capture(
 		GuildEntity guild,
 		IEnumerable<(long ChannelId, long UserId)> candidates,
-		IReadOnlyDictionary<long, IReadOnlyList<ChannelPermissionOverwrite>> overwrites) =>
-		new(ReadableIn(guild, candidates, overwrites), overwrites);
+		IReadOnlyDictionary<long, IReadOnlyList<ChannelPermissionOverwrite>> overwrites)
+	{
+		var candidateList = candidates.ToList();
+		return new(ReadableIn(guild, candidateList, overwrites), candidateList, overwrites);
+	}
 
 	private static HashSet<(long ChannelId, long UserId)> ReadableIn(
 		GuildEntity guild,

--- a/services/guild/src/Guild.Application/Authorization/ChannelAccess.cs
+++ b/services/guild/src/Guild.Application/Authorization/ChannelAccess.cs
@@ -53,6 +53,22 @@ internal static class ChannelAccess
 		CancellationToken cancellationToken) =>
 		PublishRevocationsAsync(eventBus, guild, snapshot, Group(channelId, afterChannelOverwrites), cancellationToken);
 
+	// members whose effective permissions include ReadMessages for the channel,
+	// given its current overwrites. feeds the eligible-user set on channel
+	// lifecycle events so Chat can target only members who may see the channel.
+	public static IReadOnlyList<long> ReadersOf(
+		GuildEntity guild, long channelId, IReadOnlyList<ChannelPermissionOverwrite> channelOverwrites)
+	{
+		var byChannel = Group(channelId, channelOverwrites);
+		var readers = new List<long>();
+		foreach (var member in guild.Members)
+		{
+			if (CanRead(guild, channelId, member.UserId, byChannel))
+				readers.Add(member.UserId);
+		}
+		return readers;
+	}
+
 	public static IEnumerable<long> MembersAffectedBy(
 		GuildEntity guild, OverwriteTargetType targetType, long targetId)
 	{

--- a/services/guild/src/Guild.Application/Contracts/Events.cs
+++ b/services/guild/src/Guild.Application/Contracts/Events.cs
@@ -17,6 +17,10 @@ public sealed record GuildUpdated(long GuildId, string Name, string? IconUrl);
 public sealed record GuildRolesChanged(long GuildId);
 public sealed record GuildMemberUpdated(long GuildId, long UserId);
 public sealed record ChannelAccessRevoked(long ChannelId, long UserId);
+// mirror of ChannelAccessRevoked: a member gained read access to a channel (via
+// a role/overwrite change) without joining the guild. carries GuildId so Chat
+// can tell the member's client which guild's channel list to refresh.
+public sealed record ChannelAccessGranted(long ChannelId, long GuildId, long UserId);
 
 // channel-lifecycle events consumed by Chat to push real-time structure updates.
 // EligibleUserIds are the members whose effective permissions include

--- a/services/guild/src/Guild.Application/Contracts/Events.cs
+++ b/services/guild/src/Guild.Application/Contracts/Events.cs
@@ -5,7 +5,9 @@ namespace Guild.Application.Contracts;
 public sealed record GuildMemberJoined(long GuildId, string GuildName, long UserId);
 public sealed record GuildMemberLeft(long GuildId, long UserId);
 public sealed record GuildInviteCreated(long GuildId, string GuildName, long InvitedByUserId, long? InvitedUserId);
-public sealed record GuildDeleted(long GuildId);
+// ChannelIds lists the guild's channels at deletion time so Chat (which cannot
+// read Guild's DB) can purge each channel's message history.
+public sealed record GuildDeleted(long GuildId, IReadOnlyList<long> ChannelIds);
 public sealed record GuildOwnerTransferred(long GuildId, long OldOwnerId, long NewOwnerId);
 public sealed record ChannelAccessRevoked(long ChannelId, long UserId);
 

--- a/services/guild/src/Guild.Application/Contracts/Events.cs
+++ b/services/guild/src/Guild.Application/Contracts/Events.cs
@@ -1,3 +1,5 @@
+using Guild.Domain.Guild;
+
 namespace Guild.Application.Contracts;
 
 public sealed record GuildMemberJoined(long GuildId, string GuildName, long UserId);
@@ -6,3 +8,34 @@ public sealed record GuildInviteCreated(long GuildId, string GuildName, long Inv
 public sealed record GuildDeleted(long GuildId);
 public sealed record GuildOwnerTransferred(long GuildId, long OldOwnerId, long NewOwnerId);
 public sealed record ChannelAccessRevoked(long ChannelId, long UserId);
+
+// channel-lifecycle events consumed by Chat to push real-time structure updates.
+// EligibleUserIds are the members whose effective permissions include
+// ReadMessages for the channel: Chat targets only them so private (overwrite-
+// restricted) channels never leak to members who cannot read them.
+public sealed record GuildChannelCreated(long GuildId, ChannelPayload Channel, IReadOnlyList<long> EligibleUserIds);
+public sealed record GuildChannelUpdated(long GuildId, ChannelPayload Channel, IReadOnlyList<long> EligibleUserIds);
+public sealed record GuildChannelDeleted(long GuildId, long ChannelId, IReadOnlyList<long> EligibleUserIds);
+
+public sealed record ChannelPayload(
+	string Id,
+	string GuildId,
+	string? CategoryId,
+	string Name,
+	string? Topic,
+	string Type,
+	int Position,
+	bool IsNsfw,
+	int SlowmodeSeconds)
+{
+	public static ChannelPayload From(Channel c) => new(
+		Id: c.Id.ToString(),
+		GuildId: c.GuildId.ToString(),
+		CategoryId: c.CategoryId?.ToString(),
+		Name: c.Name,
+		Topic: c.Topic,
+		Type: c.Type.ToString().ToLowerInvariant(),
+		Position: c.Position,
+		IsNsfw: c.IsNsfw,
+		SlowmodeSeconds: c.SlowmodeSeconds);
+}

--- a/services/guild/src/Guild.Application/Contracts/Events.cs
+++ b/services/guild/src/Guild.Application/Contracts/Events.cs
@@ -10,6 +10,12 @@ public sealed record GuildInviteCreated(long GuildId, string GuildName, long Inv
 public sealed record GuildDeleted(long GuildId, IReadOnlyList<long> ChannelIds);
 public sealed record GuildOwnerTransferred(long GuildId, long OldOwnerId, long NewOwnerId);
 public sealed record GuildUpdated(long GuildId, string Name, string? IconUrl);
+
+// coalesced structure events: the frontend re-fetches the affected guild's roles
+// / roster rather than patching bitmasks and hierarchy, so a single "something
+// changed" signal per family is enough.
+public sealed record GuildRolesChanged(long GuildId);
+public sealed record GuildMemberUpdated(long GuildId, long UserId);
 public sealed record ChannelAccessRevoked(long ChannelId, long UserId);
 
 // channel-lifecycle events consumed by Chat to push real-time structure updates.

--- a/services/guild/src/Guild.Application/Contracts/Events.cs
+++ b/services/guild/src/Guild.Application/Contracts/Events.cs
@@ -41,3 +41,18 @@ public sealed record ChannelPayload(
 		IsNsfw: c.IsNsfw,
 		SlowmodeSeconds: c.SlowmodeSeconds);
 }
+
+// category-lifecycle events consumed by Chat. categories carry no per-member
+// read restriction, so Chat broadcasts them to the whole guild group.
+public sealed record GuildCategoryCreated(long GuildId, CategoryPayload Category);
+public sealed record GuildCategoryUpdated(long GuildId, CategoryPayload Category);
+public sealed record GuildCategoryDeleted(long GuildId, long CategoryId);
+
+public sealed record CategoryPayload(string Id, string GuildId, string Name, int Position)
+{
+	public static CategoryPayload From(ChannelCategory c) => new(
+		Id: c.Id.ToString(),
+		GuildId: c.GuildId.ToString(),
+		Name: c.Name,
+		Position: c.Position);
+}

--- a/services/guild/src/Guild.Application/Contracts/Events.cs
+++ b/services/guild/src/Guild.Application/Contracts/Events.cs
@@ -9,6 +9,7 @@ public sealed record GuildInviteCreated(long GuildId, string GuildName, long Inv
 // read Guild's DB) can purge each channel's message history.
 public sealed record GuildDeleted(long GuildId, IReadOnlyList<long> ChannelIds);
 public sealed record GuildOwnerTransferred(long GuildId, long OldOwnerId, long NewOwnerId);
+public sealed record GuildUpdated(long GuildId, string Name, string? IconUrl);
 public sealed record ChannelAccessRevoked(long ChannelId, long UserId);
 
 // channel-lifecycle events consumed by Chat to push real-time structure updates.

--- a/services/guild/src/Guild.Application/Features/Categories/CreateCategory/CreateCategoryHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Categories/CreateCategory/CreateCategoryHandler.cs
@@ -3,6 +3,7 @@ using Guild.Application.Abstractions.Messaging;
 using Guild.Application.Abstractions.Persistence;
 using Guild.Application.Abstractions.Security;
 using Guild.Application.Authorization;
+using Guild.Application.Contracts;
 using Guild.Application.Features.Categories.Common;
 using Guild.Domain.Guild;
 using Guild.Domain.Results;
@@ -12,6 +13,7 @@ namespace Guild.Application.Features.Categories.CreateCategory;
 internal sealed class CreateCategoryHandler(
 	IGuildRepository guilds,
 	IChannelCategoryRepository categories,
+	IEventBus eventBus,
 	IIdGenerator ids,
 	IClock clock,
 	ICurrentUser currentUser,
@@ -50,6 +52,11 @@ internal sealed class CreateCategoryHandler(
 			return categoryResult.Error;
 
 		categories.Add(categoryResult.Value);
+
+		await eventBus.PublishAsync(
+			new GuildCategoryCreated(command.GuildId, CategoryPayload.From(categoryResult.Value)),
+			cancellationToken);
+
 		await unitOfWork.SaveChangesAsync(cancellationToken);
 
 		return CategoryResponse.From(categoryResult.Value);

--- a/services/guild/src/Guild.Application/Features/Categories/DeleteCategory/DeleteCategoryHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Categories/DeleteCategory/DeleteCategoryHandler.cs
@@ -1,7 +1,9 @@
+using Guild.Application.Abstractions;
 using Guild.Application.Abstractions.Messaging;
 using Guild.Application.Abstractions.Persistence;
 using Guild.Application.Abstractions.Security;
 using Guild.Application.Authorization;
+using Guild.Application.Contracts;
 using Guild.Domain.Guild;
 using Guild.Domain.Results;
 
@@ -10,6 +12,7 @@ namespace Guild.Application.Features.Categories.DeleteCategory;
 internal sealed class DeleteCategoryHandler(
 	IGuildRepository guilds,
 	IChannelCategoryRepository categories,
+	IEventBus eventBus,
 	ICurrentUser currentUser,
 	IUnitOfWork unitOfWork)
 	: ICommandHandler<DeleteCategoryCommand, Result>
@@ -29,6 +32,11 @@ internal sealed class DeleteCategoryHandler(
 			return GuildFailures.CategoryNotFound;
 
 		categories.Remove(category);
+
+		await eventBus.PublishAsync(
+			new GuildCategoryDeleted(command.GuildId, command.CategoryId),
+			cancellationToken);
+
 		await unitOfWork.SaveChangesAsync(cancellationToken);
 
 		return Result.Ok();

--- a/services/guild/src/Guild.Application/Features/Categories/UpdateCategory/UpdateCategoryHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Categories/UpdateCategory/UpdateCategoryHandler.cs
@@ -3,6 +3,7 @@ using Guild.Application.Abstractions.Messaging;
 using Guild.Application.Abstractions.Persistence;
 using Guild.Application.Abstractions.Security;
 using Guild.Application.Authorization;
+using Guild.Application.Contracts;
 using Guild.Application.Features.Categories.Common;
 using Guild.Domain.Guild;
 using Guild.Domain.Results;
@@ -12,6 +13,7 @@ namespace Guild.Application.Features.Categories.UpdateCategory;
 internal sealed class UpdateCategoryHandler(
 	IGuildRepository guilds,
 	IChannelCategoryRepository categories,
+	IEventBus eventBus,
 	IClock clock,
 	ICurrentUser currentUser,
 	IUnitOfWork unitOfWork)
@@ -48,6 +50,11 @@ internal sealed class UpdateCategoryHandler(
 		}
 
 		categories.Update(category);
+
+		await eventBus.PublishAsync(
+			new GuildCategoryUpdated(command.GuildId, CategoryPayload.From(category)),
+			cancellationToken);
+
 		await unitOfWork.SaveChangesAsync(cancellationToken);
 
 		return CategoryResponse.From(category);

--- a/services/guild/src/Guild.Application/Features/Channels/CreateChannel/CreateChannelHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Channels/CreateChannel/CreateChannelHandler.cs
@@ -3,6 +3,7 @@ using Guild.Application.Abstractions.Messaging;
 using Guild.Application.Abstractions.Persistence;
 using Guild.Application.Abstractions.Security;
 using Guild.Application.Authorization;
+using Guild.Application.Contracts;
 using Guild.Application.Features.Channels.Common;
 using Guild.Domain.Guild;
 using Guild.Domain.Results;
@@ -13,6 +14,7 @@ internal sealed class CreateChannelHandler(
 	IGuildRepository guilds,
 	IChannelRepository channels,
 	IChannelCategoryRepository categories,
+	IEventBus eventBus,
 	IIdGenerator ids,
 	IClock clock,
 	ICurrentUser currentUser,
@@ -67,6 +69,15 @@ internal sealed class CreateChannelHandler(
 			return channelResult.Error;
 
 		channels.Add(channelResult.Value);
+
+		// a freshly-created channel has no overwrites yet, so eligibility is the
+		// base-permission ReadMessages set. publish before SaveChanges so the
+		// outbox binds the event to the same transaction as the insert.
+		var eligible = ChannelAccess.ReadersOf(guild, channelResult.Value.Id, []);
+		await eventBus.PublishAsync(
+			new GuildChannelCreated(command.GuildId, ChannelPayload.From(channelResult.Value), eligible),
+			cancellationToken);
+
 		await unitOfWork.SaveChangesAsync(cancellationToken);
 
 		return ChannelResponse.From(channelResult.Value);

--- a/services/guild/src/Guild.Application/Features/Channels/DeleteChannel/DeleteChannelHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Channels/DeleteChannel/DeleteChannelHandler.cs
@@ -1,7 +1,9 @@
+using Guild.Application.Abstractions;
 using Guild.Application.Abstractions.Messaging;
 using Guild.Application.Abstractions.Persistence;
 using Guild.Application.Abstractions.Security;
 using Guild.Application.Authorization;
+using Guild.Application.Contracts;
 using Guild.Domain.Guild;
 using Guild.Domain.Results;
 
@@ -10,6 +12,8 @@ namespace Guild.Application.Features.Channels.DeleteChannel;
 internal sealed class DeleteChannelHandler(
 	IGuildRepository guilds,
 	IChannelRepository channels,
+	IChannelPermissionOverwriteRepository overwrites,
+	IEventBus eventBus,
 	ICurrentUser currentUser,
 	IUnitOfWork unitOfWork)
 	: ICommandHandler<DeleteChannelCommand, Result>
@@ -28,7 +32,17 @@ internal sealed class DeleteChannelHandler(
 		if (channel is null || channel.GuildId != command.GuildId)
 			return GuildFailures.ChannelNotFound;
 
+		// resolve who could see the channel *before* removing it, so Chat can tell
+		// exactly those members to drop it from their sidebar.
+		var channelOverwrites = await overwrites.GetForChannelAsync(channel.Id, cancellationToken);
+		var eligible = ChannelAccess.ReadersOf(guild, channel.Id, channelOverwrites);
+
 		channels.Remove(channel);
+
+		await eventBus.PublishAsync(
+			new GuildChannelDeleted(command.GuildId, channel.Id, eligible),
+			cancellationToken);
+
 		await unitOfWork.SaveChangesAsync(cancellationToken);
 
 		return Result.Ok();

--- a/services/guild/src/Guild.Application/Features/Channels/Permissions/DeleteOverwrite/DeleteOverwriteHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Channels/Permissions/DeleteOverwrite/DeleteOverwriteHandler.cs
@@ -46,7 +46,7 @@ internal sealed class DeleteOverwriteHandler(
 		overwrites.Remove(match);
 
 		var after = channelOverwrites.Where(o => o.Id != match.Id).ToList();
-		await ChannelAccess.PublishRevocationsAsync(eventBus, guild, snapshot, channel.Id, after, cancellationToken);
+		await ChannelAccess.PublishAccessChangesAsync(eventBus, guild, snapshot, channel.Id, after, cancellationToken);
 
 		await unitOfWork.SaveChangesAsync(cancellationToken);
 

--- a/services/guild/src/Guild.Application/Features/Channels/Permissions/PutOverwrite/PutOverwriteHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Channels/Permissions/PutOverwrite/PutOverwriteHandler.cs
@@ -88,7 +88,7 @@ internal sealed class PutOverwriteHandler(
 			after = [.. channelOverwrites, createResult.Value];
 		}
 
-		await ChannelAccess.PublishRevocationsAsync(eventBus, guild, snapshot, channel.Id, after, cancellationToken);
+		await ChannelAccess.PublishAccessChangesAsync(eventBus, guild, snapshot, channel.Id, after, cancellationToken);
 
 		await unitOfWork.SaveChangesAsync(cancellationToken);
 

--- a/services/guild/src/Guild.Application/Features/Channels/UpdateChannel/UpdateChannelHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Channels/UpdateChannel/UpdateChannelHandler.cs
@@ -3,6 +3,7 @@ using Guild.Application.Abstractions.Messaging;
 using Guild.Application.Abstractions.Persistence;
 using Guild.Application.Abstractions.Security;
 using Guild.Application.Authorization;
+using Guild.Application.Contracts;
 using Guild.Application.Features.Channels.Common;
 using Guild.Domain.Guild;
 using Guild.Domain.Results;
@@ -13,6 +14,8 @@ internal sealed class UpdateChannelHandler(
 	IGuildRepository guilds,
 	IChannelRepository channels,
 	IChannelCategoryRepository categories,
+	IChannelPermissionOverwriteRepository overwrites,
+	IEventBus eventBus,
 	IClock clock,
 	ICurrentUser currentUser,
 	IUnitOfWork unitOfWork)
@@ -70,6 +73,16 @@ internal sealed class UpdateChannelHandler(
 		}
 
 		channels.Update(channel);
+
+		// eligibility can shift when a rename/move is combined with existing
+		// overwrites, so re-resolve against the channel's current overwrites and
+		// let Chat reconcile the visible set for each targeted member.
+		var channelOverwrites = await overwrites.GetForChannelAsync(channel.Id, cancellationToken);
+		var eligible = ChannelAccess.ReadersOf(guild, channel.Id, channelOverwrites);
+		await eventBus.PublishAsync(
+			new GuildChannelUpdated(command.GuildId, ChannelPayload.From(channel), eligible),
+			cancellationToken);
+
 		await unitOfWork.SaveChangesAsync(cancellationToken);
 
 		return ChannelResponse.From(channel);

--- a/services/guild/src/Guild.Application/Features/Guilds/DeleteGuild/DeleteGuildHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Guilds/DeleteGuild/DeleteGuildHandler.cs
@@ -9,6 +9,7 @@ namespace Guild.Application.Features.Guilds.DeleteGuild;
 
 internal sealed class DeleteGuildHandler(
 	IGuildRepository repository,
+	IChannelRepository channels,
 	IEventBus eventBus,
 	ICurrentUser currentUser,
 	IUnitOfWork unitOfWork)
@@ -25,10 +26,15 @@ internal sealed class DeleteGuildHandler(
 		if (guild.OwnerId != currentUser.Id)
 			return GuildFailures.NotTheOwner;
 
+		// capture the channel ids before the cascade removes them, so Chat can
+		// purge each channel's message history it stores in ScyllaDB.
+		var guildChannels = await channels.GetByGuildAsync(command.GuildId, cancellationToken);
+		var channelIds = guildChannels.Select(c => c.Id).ToList();
+
 		repository.Remove(guild);
 
 		// publish before SaveChanges so the outbox binds it to the same transaction
-		await eventBus.PublishAsync(new GuildDeleted(guild.Id), cancellationToken);
+		await eventBus.PublishAsync(new GuildDeleted(guild.Id, channelIds), cancellationToken);
 
 		await unitOfWork.SaveChangesAsync(cancellationToken);
 

--- a/services/guild/src/Guild.Application/Features/Guilds/UpdateGuild/UpdateGuildHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Guilds/UpdateGuild/UpdateGuildHandler.cs
@@ -3,6 +3,7 @@ using Guild.Application.Abstractions.Messaging;
 using Guild.Application.Abstractions.Persistence;
 using Guild.Application.Abstractions.Security;
 using Guild.Application.Authorization;
+using Guild.Application.Contracts;
 using Guild.Application.Features.Guilds.Common;
 using Guild.Domain.Guild;
 using Guild.Domain.Results;
@@ -11,6 +12,7 @@ namespace Guild.Application.Features.Guilds.UpdateGuild;
 
 internal sealed class UpdateGuildHandler(
 	IGuildRepository repository,
+	IEventBus eventBus,
 	IClock clock,
 	ICurrentUser currentUser,
 	IUnitOfWork unitOfWork)
@@ -35,6 +37,10 @@ internal sealed class UpdateGuildHandler(
 
 		if (updateResult.IsFailure)
 			return updateResult.Error;
+
+		await eventBus.PublishAsync(
+			new GuildUpdated(guild.Id, guild.Name, guild.IconUrl),
+			cancellationToken);
 
 		await unitOfWork.SaveChangesAsync(cancellationToken);
 

--- a/services/guild/src/Guild.Application/Features/Guilds/UserGuildIds/GetUserGuildIdsHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Guilds/UserGuildIds/GetUserGuildIdsHandler.cs
@@ -1,0 +1,23 @@
+using Guild.Application.Abstractions.Messaging;
+using Guild.Application.Abstractions.Persistence;
+using Guild.Domain.Results;
+
+namespace Guild.Application.Features.Guilds.UserGuildIds;
+
+/// <summary>
+/// internal lookup used by the Chat Service on hub connect to subscribe a
+/// connection to the <c>guild:{id}</c> SignalR group of every guild the user
+/// belongs to, so guild-scoped real-time broadcasts (channel/member/role
+/// changes, presence) reach all members without a per-guild round trip.
+/// </summary>
+internal sealed class GetUserGuildIdsHandler(IGuildRepository guilds)
+	: IQueryHandler<GetUserGuildIdsQuery, Result<IReadOnlyList<long>>>
+{
+	public async Task<Result<IReadOnlyList<long>>> HandleAsync(
+		GetUserGuildIdsQuery query,
+		CancellationToken cancellationToken = default)
+	{
+		var guildIds = await guilds.ListGuildIdsForMemberAsync(query.UserId, cancellationToken);
+		return Result.Ok(guildIds);
+	}
+}

--- a/services/guild/src/Guild.Application/Features/Guilds/UserGuildIds/GetUserGuildIdsQuery.cs
+++ b/services/guild/src/Guild.Application/Features/Guilds/UserGuildIds/GetUserGuildIdsQuery.cs
@@ -1,0 +1,6 @@
+using Guild.Application.Abstractions.Messaging;
+using Guild.Domain.Results;
+
+namespace Guild.Application.Features.Guilds.UserGuildIds;
+
+public sealed record GetUserGuildIdsQuery(long UserId) : IQuery<Result<IReadOnlyList<long>>>;

--- a/services/guild/src/Guild.Application/Features/Membership/AssignRole/AssignRoleHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Membership/AssignRole/AssignRoleHandler.cs
@@ -49,7 +49,7 @@ internal sealed class AssignRoleHandler(
 		if (assignResult.IsFailure)
 			return assignResult.Error;
 
-		await ChannelAccess.PublishRevocationsAsync(eventBus, guild, snapshot, cancellationToken);
+		await ChannelAccess.PublishAccessChangesAsync(eventBus, guild, snapshot, cancellationToken);
 
 		await eventBus.PublishAsync(
 			new GuildMemberUpdated(command.GuildId, command.TargetUserId), cancellationToken);

--- a/services/guild/src/Guild.Application/Features/Membership/AssignRole/AssignRoleHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Membership/AssignRole/AssignRoleHandler.cs
@@ -3,6 +3,7 @@ using Guild.Application.Abstractions.Messaging;
 using Guild.Application.Abstractions.Persistence;
 using Guild.Application.Abstractions.Security;
 using Guild.Application.Authorization;
+using Guild.Application.Contracts;
 using Guild.Domain.Guild;
 using Guild.Domain.Results;
 
@@ -49,6 +50,9 @@ internal sealed class AssignRoleHandler(
 			return assignResult.Error;
 
 		await ChannelAccess.PublishRevocationsAsync(eventBus, guild, snapshot, cancellationToken);
+
+		await eventBus.PublishAsync(
+			new GuildMemberUpdated(command.GuildId, command.TargetUserId), cancellationToken);
 
 		await unitOfWork.SaveChangesAsync(cancellationToken);
 

--- a/services/guild/src/Guild.Application/Features/Membership/UnassignRole/UnassignRoleHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Membership/UnassignRole/UnassignRoleHandler.cs
@@ -43,7 +43,7 @@ internal sealed class UnassignRoleHandler(
 		if (unassignResult.IsFailure)
 			return unassignResult.Error;
 
-		await ChannelAccess.PublishRevocationsAsync(eventBus, guild, snapshot, cancellationToken);
+		await ChannelAccess.PublishAccessChangesAsync(eventBus, guild, snapshot, cancellationToken);
 
 		await eventBus.PublishAsync(
 			new GuildMemberUpdated(command.GuildId, command.TargetUserId), cancellationToken);

--- a/services/guild/src/Guild.Application/Features/Membership/UnassignRole/UnassignRoleHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Membership/UnassignRole/UnassignRoleHandler.cs
@@ -3,6 +3,7 @@ using Guild.Application.Abstractions.Messaging;
 using Guild.Application.Abstractions.Persistence;
 using Guild.Application.Abstractions.Security;
 using Guild.Application.Authorization;
+using Guild.Application.Contracts;
 using Guild.Domain.Guild;
 using Guild.Domain.Results;
 
@@ -43,6 +44,9 @@ internal sealed class UnassignRoleHandler(
 			return unassignResult.Error;
 
 		await ChannelAccess.PublishRevocationsAsync(eventBus, guild, snapshot, cancellationToken);
+
+		await eventBus.PublishAsync(
+			new GuildMemberUpdated(command.GuildId, command.TargetUserId), cancellationToken);
 
 		await unitOfWork.SaveChangesAsync(cancellationToken);
 

--- a/services/guild/src/Guild.Application/Features/Membership/UpdateNickname/UpdateNicknameHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Membership/UpdateNickname/UpdateNicknameHandler.cs
@@ -1,7 +1,9 @@
+using Guild.Application.Abstractions;
 using Guild.Application.Abstractions.Messaging;
 using Guild.Application.Abstractions.Persistence;
 using Guild.Application.Abstractions.Security;
 using Guild.Application.Authorization;
+using Guild.Application.Contracts;
 using Guild.Application.Features.Membership.Common;
 using Guild.Domain.Guild;
 using Guild.Domain.Results;
@@ -10,6 +12,7 @@ namespace Guild.Application.Features.Membership.UpdateNickname;
 
 internal sealed class UpdateNicknameHandler(
 	IGuildRepository guilds,
+	IEventBus eventBus,
 	ICurrentUser currentUser,
 	IUnitOfWork unitOfWork)
 	: ICommandHandler<UpdateNicknameCommand, Result<MemberResponse>>
@@ -39,6 +42,9 @@ internal sealed class UpdateNicknameHandler(
 		var updateResult = guild.UpdateMemberNickname(command.TargetUserId, command.Nickname);
 		if (updateResult.IsFailure)
 			return updateResult.Error;
+
+		await eventBus.PublishAsync(
+			new GuildMemberUpdated(guild.Id, command.TargetUserId), cancellationToken);
 
 		await unitOfWork.SaveChangesAsync(cancellationToken);
 

--- a/services/guild/src/Guild.Application/Features/Roles/CreateRole/CreateRoleHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Roles/CreateRole/CreateRoleHandler.cs
@@ -3,6 +3,7 @@ using Guild.Application.Abstractions.Messaging;
 using Guild.Application.Abstractions.Persistence;
 using Guild.Application.Abstractions.Security;
 using Guild.Application.Authorization;
+using Guild.Application.Contracts;
 using Guild.Application.Features.Roles.Common;
 using Guild.Domain.Guild;
 using Guild.Domain.Results;
@@ -11,6 +12,7 @@ namespace Guild.Application.Features.Roles.CreateRole;
 
 internal sealed class CreateRoleHandler(
 	IGuildRepository guilds,
+	IEventBus eventBus,
 	IIdGenerator ids,
 	IClock clock,
 	ICurrentUser currentUser,
@@ -41,6 +43,8 @@ internal sealed class CreateRoleHandler(
 			now: clock.UtcNow);
 		if (addResult.IsFailure)
 			return addResult.Error;
+
+		await eventBus.PublishAsync(new GuildRolesChanged(command.GuildId), cancellationToken);
 
 		await unitOfWork.SaveChangesAsync(cancellationToken);
 

--- a/services/guild/src/Guild.Application/Features/Roles/DeleteRole/DeleteRoleHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Roles/DeleteRole/DeleteRoleHandler.cs
@@ -57,7 +57,7 @@ internal sealed class DeleteRoleHandler(
 			return removeResult.Error;
 
 		if (snapshot is { } snap)
-			await ChannelAccess.PublishRevocationsAsync(eventBus, guild, snap, cancellationToken);
+			await ChannelAccess.PublishAccessChangesAsync(eventBus, guild, snap, cancellationToken);
 
 		await eventBus.PublishAsync(new GuildRolesChanged(command.GuildId), cancellationToken);
 

--- a/services/guild/src/Guild.Application/Features/Roles/DeleteRole/DeleteRoleHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Roles/DeleteRole/DeleteRoleHandler.cs
@@ -3,6 +3,7 @@ using Guild.Application.Abstractions.Messaging;
 using Guild.Application.Abstractions.Persistence;
 using Guild.Application.Abstractions.Security;
 using Guild.Application.Authorization;
+using Guild.Application.Contracts;
 using Guild.Domain.Guild;
 using Guild.Domain.Results;
 
@@ -57,6 +58,8 @@ internal sealed class DeleteRoleHandler(
 
 		if (snapshot is { } snap)
 			await ChannelAccess.PublishRevocationsAsync(eventBus, guild, snap, cancellationToken);
+
+		await eventBus.PublishAsync(new GuildRolesChanged(command.GuildId), cancellationToken);
 
 		await unitOfWork.SaveChangesAsync(cancellationToken);
 

--- a/services/guild/src/Guild.Application/Features/Roles/ReorderRoles/ReorderRolesHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Roles/ReorderRoles/ReorderRolesHandler.cs
@@ -3,6 +3,7 @@ using Guild.Application.Abstractions.Messaging;
 using Guild.Application.Abstractions.Persistence;
 using Guild.Application.Abstractions.Security;
 using Guild.Application.Authorization;
+using Guild.Application.Contracts;
 using Guild.Application.Features.Roles.Common;
 using Guild.Application.Features.Roles.ListRoles;
 using Guild.Domain.Guild;
@@ -12,6 +13,7 @@ namespace Guild.Application.Features.Roles.ReorderRoles;
 
 internal sealed class ReorderRolesHandler(
 	IGuildRepository guilds,
+	IEventBus eventBus,
 	IClock clock,
 	ICurrentUser currentUser,
 	IUnitOfWork unitOfWork)
@@ -54,6 +56,8 @@ internal sealed class ReorderRolesHandler(
 		var result = guild.ReorderRoles(moves, clock.UtcNow);
 		if (result.IsFailure)
 			return result.Error;
+
+		await eventBus.PublishAsync(new GuildRolesChanged(command.GuildId), cancellationToken);
 
 		await unitOfWork.SaveChangesAsync(cancellationToken);
 

--- a/services/guild/src/Guild.Application/Features/Roles/UpdateRole/UpdateRoleHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Roles/UpdateRole/UpdateRoleHandler.cs
@@ -47,11 +47,12 @@ internal sealed class UpdateRoleHandler(
 		    && !PermissionResolver.CanGrantPermissions(mask, newPerms))
 			return GuildFailures.CannotGrantPermissionsYouLack;
 
-		// read can only be revoked when the role loses READ_MESSAGES or ADMINISTRATOR
-		// (base perms are additive, so a grant never removes read)
+		// capture whenever READ_MESSAGES or ADMINISTRATOR is toggled (added OR
+		// removed): removing flips holders to denied (revocation), adding flips
+		// them to readable (grant). XOR catches both directions.
 		const long readAffecting = (long)Permission.ReadMessages | (long)Permission.Administrator;
 		ChannelReadSnapshot? snapshot = null;
-		if (command.Permissions is long updatedPerms && (role.Permissions & ~updatedPerms & readAffecting) != 0)
+		if (command.Permissions is long updatedPerms && ((role.Permissions ^ updatedPerms) & readAffecting) != 0)
 		{
 			var affected = role.IsDefault
 				? guild.Members.Select(m => m.UserId).ToList()
@@ -72,7 +73,7 @@ internal sealed class UpdateRoleHandler(
 			return updateResult.Error;
 
 		if (snapshot is { } snap)
-			await ChannelAccess.PublishRevocationsAsync(eventBus, guild, snap, cancellationToken);
+			await ChannelAccess.PublishAccessChangesAsync(eventBus, guild, snap, cancellationToken);
 
 		await eventBus.PublishAsync(new GuildRolesChanged(command.GuildId), cancellationToken);
 

--- a/services/guild/src/Guild.Application/Features/Roles/UpdateRole/UpdateRoleHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Roles/UpdateRole/UpdateRoleHandler.cs
@@ -3,6 +3,7 @@ using Guild.Application.Abstractions.Messaging;
 using Guild.Application.Abstractions.Persistence;
 using Guild.Application.Abstractions.Security;
 using Guild.Application.Authorization;
+using Guild.Application.Contracts;
 using Guild.Application.Features.Roles.Common;
 using Guild.Domain.Guild;
 using Guild.Domain.Results;
@@ -72,6 +73,8 @@ internal sealed class UpdateRoleHandler(
 
 		if (snapshot is { } snap)
 			await ChannelAccess.PublishRevocationsAsync(eventBus, guild, snap, cancellationToken);
+
+		await eventBus.PublishAsync(new GuildRolesChanged(command.GuildId), cancellationToken);
 
 		await unitOfWork.SaveChangesAsync(cancellationToken);
 

--- a/services/guild/src/Guild.Infrastructure/DependencyInjection.cs
+++ b/services/guild/src/Guild.Infrastructure/DependencyInjection.cs
@@ -82,6 +82,8 @@ public static class DependencyInjection
 				cfg.Message<GuildDeleted>(m => m.SetEntityName("guild.deleted"));
 				cfg.Message<GuildOwnerTransferred>(m => m.SetEntityName("guild.owner_transferred"));
 				cfg.Message<GuildUpdated>(m => m.SetEntityName("guild.updated"));
+				cfg.Message<GuildRolesChanged>(m => m.SetEntityName("guild.roles_changed"));
+				cfg.Message<GuildMemberUpdated>(m => m.SetEntityName("guild.member_updated"));
 				cfg.Message<ChannelAccessRevoked>(m => m.SetEntityName("channel.access_revoked"));
 				cfg.Message<GuildChannelCreated>(m => m.SetEntityName("channel.created"));
 				cfg.Message<GuildChannelUpdated>(m => m.SetEntityName("channel.updated"));

--- a/services/guild/src/Guild.Infrastructure/DependencyInjection.cs
+++ b/services/guild/src/Guild.Infrastructure/DependencyInjection.cs
@@ -85,6 +85,9 @@ public static class DependencyInjection
 				cfg.Message<GuildChannelCreated>(m => m.SetEntityName("channel.created"));
 				cfg.Message<GuildChannelUpdated>(m => m.SetEntityName("channel.updated"));
 				cfg.Message<GuildChannelDeleted>(m => m.SetEntityName("channel.deleted"));
+				cfg.Message<GuildCategoryCreated>(m => m.SetEntityName("category.created"));
+				cfg.Message<GuildCategoryUpdated>(m => m.SetEntityName("category.updated"));
+				cfg.Message<GuildCategoryDeleted>(m => m.SetEntityName("category.deleted"));
 
 				// inbound: bind the consumer's receive endpoint to Auth's user.deleted
 				// exchange. must match the SetEntityName Auth publishes under.

--- a/services/guild/src/Guild.Infrastructure/DependencyInjection.cs
+++ b/services/guild/src/Guild.Infrastructure/DependencyInjection.cs
@@ -82,6 +82,9 @@ public static class DependencyInjection
 				cfg.Message<GuildDeleted>(m => m.SetEntityName("guild.deleted"));
 				cfg.Message<GuildOwnerTransferred>(m => m.SetEntityName("guild.owner_transferred"));
 				cfg.Message<ChannelAccessRevoked>(m => m.SetEntityName("channel.access_revoked"));
+				cfg.Message<GuildChannelCreated>(m => m.SetEntityName("channel.created"));
+				cfg.Message<GuildChannelUpdated>(m => m.SetEntityName("channel.updated"));
+				cfg.Message<GuildChannelDeleted>(m => m.SetEntityName("channel.deleted"));
 
 				// inbound: bind the consumer's receive endpoint to Auth's user.deleted
 				// exchange. must match the SetEntityName Auth publishes under.

--- a/services/guild/src/Guild.Infrastructure/DependencyInjection.cs
+++ b/services/guild/src/Guild.Infrastructure/DependencyInjection.cs
@@ -81,6 +81,7 @@ public static class DependencyInjection
 				cfg.Message<GuildInviteCreated>(m => m.SetEntityName("guild.invite_created"));
 				cfg.Message<GuildDeleted>(m => m.SetEntityName("guild.deleted"));
 				cfg.Message<GuildOwnerTransferred>(m => m.SetEntityName("guild.owner_transferred"));
+				cfg.Message<GuildUpdated>(m => m.SetEntityName("guild.updated"));
 				cfg.Message<ChannelAccessRevoked>(m => m.SetEntityName("channel.access_revoked"));
 				cfg.Message<GuildChannelCreated>(m => m.SetEntityName("channel.created"));
 				cfg.Message<GuildChannelUpdated>(m => m.SetEntityName("channel.updated"));

--- a/services/guild/src/Guild.Infrastructure/DependencyInjection.cs
+++ b/services/guild/src/Guild.Infrastructure/DependencyInjection.cs
@@ -85,6 +85,7 @@ public static class DependencyInjection
 				cfg.Message<GuildRolesChanged>(m => m.SetEntityName("guild.roles_changed"));
 				cfg.Message<GuildMemberUpdated>(m => m.SetEntityName("guild.member_updated"));
 				cfg.Message<ChannelAccessRevoked>(m => m.SetEntityName("channel.access_revoked"));
+				cfg.Message<ChannelAccessGranted>(m => m.SetEntityName("channel.access_granted"));
 				cfg.Message<GuildChannelCreated>(m => m.SetEntityName("channel.created"));
 				cfg.Message<GuildChannelUpdated>(m => m.SetEntityName("channel.updated"));
 				cfg.Message<GuildChannelDeleted>(m => m.SetEntityName("channel.deleted"));

--- a/services/guild/src/Guild.Presentation/Endpoints/UserGuildsEndpoint.cs
+++ b/services/guild/src/Guild.Presentation/Endpoints/UserGuildsEndpoint.cs
@@ -1,0 +1,41 @@
+using Guild.Application.Abstractions.Messaging;
+using Guild.Application.Features.Guilds.UserGuildIds;
+using Guild.Domain.Results;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+
+namespace Guild.Presentation.Endpoints;
+
+/// <summary>
+/// internal guild-membership lookup used by the Chat Service on hub connect to
+/// join a connection to every <c>guild:{id}</c> SignalR group the user belongs
+/// to. mounted under <c>/internal</c> by <c>Program.cs</c>; unreachable from the
+/// gateway, which only forwards <c>/api/{service}/vN/...</c>. ids are serialized
+/// as quoted strings to match the wire policy.
+/// </summary>
+public static class UserGuildsEndpoint
+{
+	public static void MapInternalRoutes(IEndpointRouteBuilder endpoints)
+	{
+		endpoints.MapGet("/users/{userId:long}/guilds", GetAsync);
+	}
+
+	private static async Task<Results<
+		Ok<IReadOnlyList<string>>,
+		BadRequest<ErrorBody>>>
+	GetAsync(
+		long userId,
+		IQueryHandler<GetUserGuildIdsQuery, Result<IReadOnlyList<long>>> handler,
+		CancellationToken cancellationToken)
+	{
+		if (userId <= 0)
+			return TypedResults.BadRequest(new ErrorBody("user_id must be a positive snowflake."));
+
+		var result = await handler.HandleAsync(new GetUserGuildIdsQuery(userId), cancellationToken);
+
+		// guild-less/unknown users resolve to an empty list upstream, so a
+		// well-formed request always succeeds - same shape as visible-channels
+		var ids = result.Value.Select(id => id.ToString()).ToList();
+		return TypedResults.Ok<IReadOnlyList<string>>(ids);
+	}
+}

--- a/services/guild/src/Guild.Presentation/Program.cs
+++ b/services/guild/src/Guild.Presentation/Program.cs
@@ -168,6 +168,7 @@ ChannelMembershipEndpoint.MapInternalRoutes(internalRoutes);
 OwnedGuildsCountEndpoint.MapInternalRoutes(internalRoutes);
 UserDataExportEndpoint.MapInternalRoutes(internalRoutes);
 VisibleChannelsEndpoint.MapInternalRoutes(internalRoutes);
+UserGuildsEndpoint.MapInternalRoutes(internalRoutes);
 
 app.Run();
 

--- a/services/guild/tests/Guild.UnitTests/Application/ChannelAccessRevokedTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/ChannelAccessRevokedTests.cs
@@ -209,9 +209,10 @@ public sealed class ChannelAccessRevokedTests
 	}
 
 	[Fact]
-	public async Task UpdateRole_GrantsReadBit_NoRevocation()
+	public async Task UpdateRole_GrantsReadBit_PublishesGrant_NotRevocation()
 	{
-		// a grant can never revoke (base perms are additive), so no event
+		// granting a read bit flips the holder from denied to readable, so the
+		// mirror grant fires (never a revocation, base perms are additive).
 		var (guilds, channels, ow, guild) = Setup(everyonePerms: 0);
 		DomainSeed.AddCustomRole(guild, 200, "R", permissions: 0, position: 1, Now);
 		DomainSeed.AssignRole(guild, Member, 200, Now);
@@ -224,6 +225,9 @@ public sealed class ChannelAccessRevokedTests
 
 		Assert.True(result.Succeeded);
 		Assert.False(bus.Has<ChannelAccessRevoked>());
+		var grant = bus.Single<ChannelAccessGranted>();
+		Assert.Equal(Member, grant.UserId);
+		Assert.Equal(100, grant.GuildId);
 	}
 
 	[Fact]

--- a/services/guild/tests/Guild.UnitTests/Application/ChannelAccessRevokedTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/ChannelAccessRevokedTests.cs
@@ -77,7 +77,7 @@ public sealed class ChannelAccessRevokedTests
 		var result = await handler.HandleAsync(new DeleteOverwriteCommand(ChannelId, Member));
 
 		Assert.True(result.Succeeded);
-		Assert.Empty(bus.Published);
+		Assert.False(bus.Has<ChannelAccessRevoked>());
 	}
 
 	[Fact]
@@ -135,7 +135,7 @@ public sealed class ChannelAccessRevokedTests
 		var result = await handler.HandleAsync(new AssignRoleCommand(100, Member, 200));
 
 		Assert.True(result.Succeeded);
-		Assert.Empty(bus.Published);
+		Assert.False(bus.Has<ChannelAccessRevoked>());
 	}
 
 	[Fact]
@@ -170,7 +170,7 @@ public sealed class ChannelAccessRevokedTests
 		var result = await handler.HandleAsync(new UnassignRoleCommand(100, Member, 200));
 
 		Assert.True(result.Succeeded);
-		Assert.Empty(bus.Published);
+		Assert.False(bus.Has<ChannelAccessRevoked>());
 	}
 
 	[Fact]
@@ -223,7 +223,7 @@ public sealed class ChannelAccessRevokedTests
 			100, 200, Name: null, Color: null, Permissions: Read, IsHoisted: null, IsMentionable: null));
 
 		Assert.True(result.Succeeded);
-		Assert.Empty(bus.Published);
+		Assert.False(bus.Has<ChannelAccessRevoked>());
 	}
 
 	[Fact]
@@ -238,6 +238,6 @@ public sealed class ChannelAccessRevokedTests
 		var result = await handler.HandleAsync(new DeleteRoleCommand(100, 200));
 
 		Assert.True(result.Succeeded);
-		Assert.Empty(bus.Published);
+		Assert.False(bus.Has<ChannelAccessRevoked>());
 	}
 }

--- a/services/guild/tests/Guild.UnitTests/Application/CreateCategoryHandlerTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/CreateCategoryHandlerTests.cs
@@ -20,7 +20,7 @@ public sealed class CreateCategoryHandlerTests
 		var guildRepo = new FakeGuildRepository();
 		var catRepo = new FakeChannelCategoryRepository();
 		var handler = HandlerFactory.CreateCommand<CreateCategoryCommand, Result<CategoryResponse>>(
-			guildRepo, catRepo, new FakeIdGenerator(), new FakeClock(), new FakeCurrentUser { Id = 1 });
+			guildRepo, catRepo, new FakeEventBus(),new FakeIdGenerator(), new FakeClock(), new FakeCurrentUser { Id = 1 });
 
 		var result = await handler.HandleAsync(
 			new CreateCategoryCommand(GuildId: 999, Name: "Text", Position: null));
@@ -36,7 +36,7 @@ public sealed class CreateCategoryHandlerTests
 		Seed(guildRepo, ownerId: 1);
 		var catRepo = new FakeChannelCategoryRepository();
 		var handler = HandlerFactory.CreateCommand<CreateCategoryCommand, Result<CategoryResponse>>(
-			guildRepo, catRepo, new FakeIdGenerator(), new FakeClock(), new FakeCurrentUser { Id = 99 });
+			guildRepo, catRepo, new FakeEventBus(),new FakeIdGenerator(), new FakeClock(), new FakeCurrentUser { Id = 99 });
 
 		var result = await handler.HandleAsync(
 			new CreateCategoryCommand(GuildId: 100, Name: "Text", Position: null));
@@ -54,7 +54,7 @@ public sealed class CreateCategoryHandlerTests
 		guildRepo.Add(guild);
 
 		var handler = HandlerFactory.CreateCommand<CreateCategoryCommand, Result<CategoryResponse>>(
-			guildRepo, catRepo, new FakeIdGenerator(), new FakeClock(), new FakeCurrentUser { Id = 2 });
+			guildRepo, catRepo, new FakeEventBus(),new FakeIdGenerator(), new FakeClock(), new FakeCurrentUser { Id = 2 });
 
 		var result = await handler.HandleAsync(
 			new CreateCategoryCommand(GuildId: 100, Name: "Text", Position: null));
@@ -71,7 +71,7 @@ public sealed class CreateCategoryHandlerTests
 		Seed(guildRepo, ownerId: 1);
 
 		var handler = HandlerFactory.CreateCommand<CreateCategoryCommand, Result<CategoryResponse>>(
-			guildRepo, catRepo, new FakeIdGenerator(), new FakeClock(), new FakeCurrentUser { Id = 1 });
+			guildRepo, catRepo, new FakeEventBus(),new FakeIdGenerator(), new FakeClock(), new FakeCurrentUser { Id = 1 });
 
 		var result = await handler.HandleAsync(
 			new CreateCategoryCommand(GuildId: 100, Name: "", Position: null));
@@ -89,7 +89,7 @@ public sealed class CreateCategoryHandlerTests
 		Seed(guildRepo, ownerId: 1);
 
 		var handler = HandlerFactory.CreateCommand<CreateCategoryCommand, Result<CategoryResponse>>(
-			guildRepo, catRepo, new FakeIdGenerator(), new FakeClock(), new FakeCurrentUser { Id = 1 });
+			guildRepo, catRepo, new FakeEventBus(),new FakeIdGenerator(), new FakeClock(), new FakeCurrentUser { Id = 1 });
 
 		var result = await handler.HandleAsync(
 			new CreateCategoryCommand(GuildId: 100, Name: "Text", Position: 5));
@@ -110,7 +110,7 @@ public sealed class CreateCategoryHandlerTests
 		Seed(guildRepo, ownerId: 1);
 
 		var handler = HandlerFactory.CreateCommand<CreateCategoryCommand, Result<CategoryResponse>>(
-			guildRepo, catRepo, new FakeIdGenerator(), new FakeClock(), new FakeCurrentUser { Id = 1 });
+			guildRepo, catRepo, new FakeEventBus(),new FakeIdGenerator(), new FakeClock(), new FakeCurrentUser { Id = 1 });
 
 		var result = await handler.HandleAsync(
 			new CreateCategoryCommand(GuildId: 100, Name: "First", Position: null));
@@ -131,7 +131,7 @@ public sealed class CreateCategoryHandlerTests
 		catRepo.Seed(ChannelCategory.Create(id: 9002, guildId: 100, name: "B", position: 5, now: Now).Value);
 
 		var handler = HandlerFactory.CreateCommand<CreateCategoryCommand, Result<CategoryResponse>>(
-			guildRepo, catRepo, new FakeIdGenerator(), new FakeClock(), new FakeCurrentUser { Id = 1 });
+			guildRepo, catRepo, new FakeEventBus(),new FakeIdGenerator(), new FakeClock(), new FakeCurrentUser { Id = 1 });
 
 		var result = await handler.HandleAsync(
 			new CreateCategoryCommand(GuildId: 100, Name: "C", Position: null));
@@ -155,7 +155,7 @@ public sealed class CreateCategoryHandlerTests
 		guildRepo.Add(guild);
 
 		var handler = HandlerFactory.CreateCommand<CreateCategoryCommand, Result<CategoryResponse>>(
-			guildRepo, catRepo, new FakeIdGenerator(), new FakeClock(), new FakeCurrentUser { Id = 1 });
+			guildRepo, catRepo, new FakeEventBus(),new FakeIdGenerator(), new FakeClock(), new FakeCurrentUser { Id = 1 });
 
 		var result = await handler.HandleAsync(
 			new CreateCategoryCommand(GuildId: 100, Name: "General", Position: 0));

--- a/services/guild/tests/Guild.UnitTests/Application/CreateChannelHandlerTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/CreateChannelHandlerTests.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using Guild.Application.Contracts;
 using Guild.Application.Features.Channels.Common;
 using Guild.Application.Features.Channels.CreateChannel;
 using Guild.Domain.Guild;
@@ -51,7 +52,7 @@ public sealed class CreateChannelHandlerTests
 		guildRepo.Add(guild);
 
 		var handler = HandlerFactory.CreateCommand<CreateChannelCommand, Result<ChannelResponse>>(
-			guildRepo, channelRepo, categoryRepo,
+			guildRepo, channelRepo, categoryRepo, new FakeEventBus(),
 			new FakeIdGenerator(), new FakeClock(), new FakeCurrentUser { Id = 2 });
 
 		var result = await handler.HandleAsync(
@@ -60,6 +61,33 @@ public sealed class CreateChannelHandlerTests
 
 		Assert.True(result.IsFailure);
 		Assert.Equal("Guild.MissingPermission", result.Error.Code);
+	}
+
+	[Fact]
+	public async Task HappyPath_PublishesChannelCreated_WithCreatorEligible()
+	{
+		var guilds = new FakeGuildRepository();
+		var channels = new FakeChannelRepository();
+		var cats = new FakeChannelCategoryRepository();
+		var bus = new FakeEventBus();
+		var guild = GuildEntity.Create(
+			id: 100, name: "Test", description: null, iconUrl: null, bannerUrl: null,
+			ownerId: 1, everyoneRoleId: 101, adminRoleId: 102, now: Now).Value;
+		guilds.Add(guild);
+
+		var handler = HandlerFactory.CreateCommand<CreateChannelCommand, Result<ChannelResponse>>(
+			guilds, channels, cats, bus,
+			new FakeIdGenerator(), new FakeClock(), new FakeCurrentUser { Id = 1 });
+
+		var result = await handler.HandleAsync(
+			new CreateChannelCommand(GuildId: 100, Name: "general", Type: "text",
+				CategoryId: null, Topic: null, Position: 0));
+
+		Assert.True(result.Succeeded);
+		var evt = bus.Single<GuildChannelCreated>();
+		Assert.Equal(100, evt.GuildId);
+		Assert.Equal(result.Value.Id, evt.Channel.Id);
+		Assert.Contains(1L, evt.EligibleUserIds);
 	}
 
 	[Fact]
@@ -197,7 +225,7 @@ public sealed class CreateChannelHandlerTests
 		guilds.Add(guild);
 
 		var handler = HandlerFactory.CreateCommand<CreateChannelCommand, Result<ChannelResponse>>(
-			guilds, channels, cats,
+			guilds, channels, cats, new FakeEventBus(),
 			new FakeIdGenerator(), new FakeClock(), new FakeCurrentUser { Id = 1 });
 
 		var result = await handler.HandleAsync(
@@ -228,7 +256,7 @@ public sealed class CreateChannelHandlerTests
 		}
 
 		return HandlerFactory.CreateCommand<CreateChannelCommand, Result<ChannelResponse>>(
-			guilds, channels, categories,
+			guilds, channels, categories, new FakeEventBus(),
 			new FakeIdGenerator(), new FakeClock(), new FakeCurrentUser { Id = currentUser });
 	}
 

--- a/services/guild/tests/Guild.UnitTests/Application/CreateRoleHandlerTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/CreateRoleHandlerTests.cs
@@ -124,7 +124,7 @@ public sealed class CreateRoleHandlerTests
 			ownerId: 1, everyoneRoleId: 101, adminRoleId: 102, now: Now).Value;
 		guilds.Add(guild);
 		var handler = HandlerFactory.CreateCommand<CreateRoleCommand, Result<RoleResponse>>(
-			guilds, new FakeIdGenerator(seed: 1000), new FakeClock(Now),
+			guilds, new FakeEventBus(), new FakeIdGenerator(seed: 1000), new FakeClock(Now),
 			new FakeCurrentUser { Id = currentUser });
 		return (handler, guilds);
 	}

--- a/services/guild/tests/Guild.UnitTests/Application/DeleteCategoryHandlerTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/DeleteCategoryHandlerTests.cs
@@ -19,7 +19,7 @@ public sealed class DeleteCategoryHandlerTests
 		var guildRepo = new FakeGuildRepository();
 		var catRepo = new FakeChannelCategoryRepository();
 		var handler = HandlerFactory.CreateCommand<DeleteCategoryCommand, Result>(
-			guildRepo, catRepo, new FakeCurrentUser { Id = 1 });
+			guildRepo, catRepo, new FakeEventBus(),new FakeCurrentUser { Id = 1 });
 
 		var result = await handler.HandleAsync(
 			new DeleteCategoryCommand(GuildId: 999, CategoryId: 1));
@@ -36,7 +36,7 @@ public sealed class DeleteCategoryHandlerTests
 		Seed(guildRepo, catRepo, ownerId: 1);
 
 		var handler = HandlerFactory.CreateCommand<DeleteCategoryCommand, Result>(
-			guildRepo, catRepo, new FakeCurrentUser { Id = 99 });
+			guildRepo, catRepo, new FakeEventBus(),new FakeCurrentUser { Id = 99 });
 
 		var result = await handler.HandleAsync(
 			new DeleteCategoryCommand(GuildId: 100, CategoryId: 500));
@@ -55,7 +55,7 @@ public sealed class DeleteCategoryHandlerTests
 		SeedCategory(catRepo, id: 500);
 
 		var handler = HandlerFactory.CreateCommand<DeleteCategoryCommand, Result>(
-			guildRepo, catRepo, new FakeCurrentUser { Id = 2 });
+			guildRepo, catRepo, new FakeEventBus(),new FakeCurrentUser { Id = 2 });
 
 		var result = await handler.HandleAsync(
 			new DeleteCategoryCommand(GuildId: 100, CategoryId: 500));
@@ -72,7 +72,7 @@ public sealed class DeleteCategoryHandlerTests
 		Seed(guildRepo, catRepo, ownerId: 1, seedCategory: false);
 
 		var handler = HandlerFactory.CreateCommand<DeleteCategoryCommand, Result>(
-			guildRepo, catRepo, new FakeCurrentUser { Id = 1 });
+			guildRepo, catRepo, new FakeEventBus(),new FakeCurrentUser { Id = 1 });
 
 		var result = await handler.HandleAsync(
 			new DeleteCategoryCommand(GuildId: 100, CategoryId: 9999));
@@ -89,7 +89,7 @@ public sealed class DeleteCategoryHandlerTests
 		Seed(guildRepo, catRepo, ownerId: 1);
 
 		var handler = HandlerFactory.CreateCommand<DeleteCategoryCommand, Result>(
-			guildRepo, catRepo, new FakeCurrentUser { Id = 1 });
+			guildRepo, catRepo, new FakeEventBus(),new FakeCurrentUser { Id = 1 });
 
 		var result = await handler.HandleAsync(
 			new DeleteCategoryCommand(GuildId: 100, CategoryId: 500));
@@ -113,7 +113,7 @@ public sealed class DeleteCategoryHandlerTests
 		SeedCategory(catRepo, id: 500);
 
 		var handler = HandlerFactory.CreateCommand<DeleteCategoryCommand, Result>(
-			guildRepo, catRepo, new FakeCurrentUser { Id = 1 });
+			guildRepo, catRepo, new FakeEventBus(),new FakeCurrentUser { Id = 1 });
 
 		var result = await handler.HandleAsync(
 			new DeleteCategoryCommand(GuildId: 100, CategoryId: 500));

--- a/services/guild/tests/Guild.UnitTests/Application/DeleteChannelHandlerTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/DeleteChannelHandlerTests.cs
@@ -1,3 +1,4 @@
+using Guild.Application.Contracts;
 using Guild.Application.Features.Channels.DeleteChannel;
 using Guild.Domain.Guild;
 using Guild.Domain.Results;
@@ -33,6 +34,30 @@ public sealed class DeleteChannelHandlerTests
 
 		Assert.True(result.Succeeded);
 		Assert.Empty(channels.Store);
+	}
+
+	[Fact]
+	public async Task HappyPath_PublishesChannelDeleted()
+	{
+		var guilds = new FakeGuildRepository();
+		var channels = new FakeChannelRepository();
+		var bus = new FakeEventBus();
+		var guild = GuildEntity.Create(
+			id: 100, name: "Test", description: null, iconUrl: null, bannerUrl: null,
+			ownerId: 1, everyoneRoleId: 101, adminRoleId: 102, now: Now).Value;
+		guilds.Add(guild);
+		channels.Seed(Channel.Create(5, 100, null, "g", null, ChannelType.Text, 0, Now).Value);
+
+		var handler = HandlerFactory.CreateCommand<DeleteChannelCommand, Result>(
+			guilds, channels, new FakeChannelPermissionOverwriteRepository(), bus,
+			new FakeCurrentUser { Id = 1 });
+
+		var result = await handler.HandleAsync(new DeleteChannelCommand(100, 5));
+
+		Assert.True(result.Succeeded);
+		var evt = bus.Single<GuildChannelDeleted>();
+		Assert.Equal(5, evt.ChannelId);
+		Assert.Contains(1L, evt.EligibleUserIds);
 	}
 
 	[Fact]
@@ -74,7 +99,8 @@ public sealed class DeleteChannelHandlerTests
 		guilds.Add(guild);
 
 		var handler = HandlerFactory.CreateCommand<DeleteChannelCommand, Result>(
-			guilds, channels, new FakeCurrentUser { Id = currentUser });
+			guilds, channels, new FakeChannelPermissionOverwriteRepository(), new FakeEventBus(),
+			new FakeCurrentUser { Id = currentUser });
 		return (handler, guilds, channels);
 	}
 }

--- a/services/guild/tests/Guild.UnitTests/Application/DeleteGuildHandlerTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/DeleteGuildHandlerTests.cs
@@ -1,5 +1,6 @@
 using Guild.Application.Contracts;
 using Guild.Application.Features.Guilds.DeleteGuild;
+using Guild.Domain.Guild;
 using Guild.Domain.Results;
 using Guild.UnitTests.Fakes;
 using Xunit;
@@ -17,7 +18,7 @@ public sealed class DeleteGuildHandlerTests
 	{
 		var (repo, bus) = (new FakeGuildRepository(), new FakeEventBus());
 		var handler = HandlerFactory.CreateCommand<DeleteGuildCommand, Result>(
-			repo, bus, new FakeCurrentUser { Id = 1 });
+			repo, new FakeChannelRepository(), bus, new FakeCurrentUser { Id = 1 });
 
 		var result = await handler.HandleAsync(new DeleteGuildCommand(GuildId: 999));
 
@@ -32,7 +33,7 @@ public sealed class DeleteGuildHandlerTests
 		var (repo, bus) = (new FakeGuildRepository(), new FakeEventBus());
 		Seed(repo, ownerId: 1);
 		var handler = HandlerFactory.CreateCommand<DeleteGuildCommand, Result>(
-			repo, bus, new FakeCurrentUser { Id = 99 });
+			repo, new FakeChannelRepository(), bus, new FakeCurrentUser { Id = 99 });
 
 		var result = await handler.HandleAsync(new DeleteGuildCommand(GuildId: 100));
 
@@ -46,14 +47,18 @@ public sealed class DeleteGuildHandlerTests
 	{
 		var (repo, bus) = (new FakeGuildRepository(), new FakeEventBus());
 		Seed(repo, ownerId: 1);
+		var channels = new FakeChannelRepository();
+		channels.Seed(Channel.Create(5, 100, null, "general", null, ChannelType.Text, 0, Now).Value);
 		var handler = HandlerFactory.CreateCommand<DeleteGuildCommand, Result>(
-			repo, bus, new FakeCurrentUser { Id = 1 });
+			repo, channels, bus, new FakeCurrentUser { Id = 1 });
 
 		var result = await handler.HandleAsync(new DeleteGuildCommand(GuildId: 100));
 
 		Assert.True(result.Succeeded);
 		Assert.Empty(repo.Store);
-		Assert.Equal(100, bus.Single<GuildDeleted>().GuildId);
+		var evt = bus.Single<GuildDeleted>();
+		Assert.Equal(100, evt.GuildId);
+		Assert.Equal(new long[] { 5 }, evt.ChannelIds);
 	}
 
 	private static void Seed(FakeGuildRepository repo, long ownerId)

--- a/services/guild/tests/Guild.UnitTests/Application/ReorderRolesHandlerTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/ReorderRolesHandlerTests.cs
@@ -136,7 +136,7 @@ public sealed class ReorderRolesHandlerTests
 			ownerId: 1, everyoneRoleId: 101, adminRoleId: 102, now: Now).Value;
 		guilds.Add(guild);
 		var handler = HandlerFactory.CreateCommand<ReorderRolesCommand, Result<RoleListResponse>>(
-			guilds, new FakeClock(Now), new FakeCurrentUser { Id = currentUser });
+			guilds, new FakeEventBus(), new FakeClock(Now), new FakeCurrentUser { Id = currentUser });
 		return (handler, guilds);
 	}
 }

--- a/services/guild/tests/Guild.UnitTests/Application/UpdateCategoryHandlerTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/UpdateCategoryHandlerTests.cs
@@ -20,7 +20,7 @@ public sealed class UpdateCategoryHandlerTests
 		var guildRepo = new FakeGuildRepository();
 		var catRepo = new FakeChannelCategoryRepository();
 		var handler = HandlerFactory.CreateCommand<UpdateCategoryCommand, Result<CategoryResponse>>(
-			guildRepo, catRepo, new FakeClock(), new FakeCurrentUser { Id = 1 });
+			guildRepo, catRepo, new FakeEventBus(),new FakeClock(), new FakeCurrentUser { Id = 1 });
 
 		var result = await handler.HandleAsync(
 			new UpdateCategoryCommand(GuildId: 999, CategoryId: 1, Name: "x", Position: null));
@@ -37,7 +37,7 @@ public sealed class UpdateCategoryHandlerTests
 		Seed(guildRepo, catRepo, ownerId: 1);
 
 		var handler = HandlerFactory.CreateCommand<UpdateCategoryCommand, Result<CategoryResponse>>(
-			guildRepo, catRepo, new FakeClock(), new FakeCurrentUser { Id = 99 });
+			guildRepo, catRepo, new FakeEventBus(),new FakeClock(), new FakeCurrentUser { Id = 99 });
 
 		var result = await handler.HandleAsync(
 			new UpdateCategoryCommand(GuildId: 100, CategoryId: 500, Name: "x", Position: null));
@@ -56,7 +56,7 @@ public sealed class UpdateCategoryHandlerTests
 		SeedCategory(catRepo, id: 500);
 
 		var handler = HandlerFactory.CreateCommand<UpdateCategoryCommand, Result<CategoryResponse>>(
-			guildRepo, catRepo, new FakeClock(), new FakeCurrentUser { Id = 2 });
+			guildRepo, catRepo, new FakeEventBus(),new FakeClock(), new FakeCurrentUser { Id = 2 });
 
 		var result = await handler.HandleAsync(
 			new UpdateCategoryCommand(GuildId: 100, CategoryId: 500, Name: "x", Position: null));
@@ -73,7 +73,7 @@ public sealed class UpdateCategoryHandlerTests
 		Seed(guildRepo, catRepo, ownerId: 1, seedCategory: false);
 
 		var handler = HandlerFactory.CreateCommand<UpdateCategoryCommand, Result<CategoryResponse>>(
-			guildRepo, catRepo, new FakeClock(), new FakeCurrentUser { Id = 1 });
+			guildRepo, catRepo, new FakeEventBus(),new FakeClock(), new FakeCurrentUser { Id = 1 });
 
 		var result = await handler.HandleAsync(
 			new UpdateCategoryCommand(GuildId: 100, CategoryId: 9999, Name: "x", Position: null));
@@ -90,7 +90,7 @@ public sealed class UpdateCategoryHandlerTests
 		Seed(guildRepo, catRepo, ownerId: 1);
 
 		var handler = HandlerFactory.CreateCommand<UpdateCategoryCommand, Result<CategoryResponse>>(
-			guildRepo, catRepo, new FakeClock(), new FakeCurrentUser { Id = 1 });
+			guildRepo, catRepo, new FakeEventBus(),new FakeClock(), new FakeCurrentUser { Id = 1 });
 
 		var result = await handler.HandleAsync(
 			new UpdateCategoryCommand(GuildId: 100, CategoryId: 500, Name: "", Position: null));
@@ -109,7 +109,7 @@ public sealed class UpdateCategoryHandlerTests
 		var originalPosition = original.Position;
 
 		var handler = HandlerFactory.CreateCommand<UpdateCategoryCommand, Result<CategoryResponse>>(
-			guildRepo, catRepo, new FakeClock(), new FakeCurrentUser { Id = 1 });
+			guildRepo, catRepo, new FakeEventBus(),new FakeClock(), new FakeCurrentUser { Id = 1 });
 
 		var result = await handler.HandleAsync(
 			new UpdateCategoryCommand(GuildId: 100, CategoryId: 500, Name: "Renamed", Position: null));
@@ -128,7 +128,7 @@ public sealed class UpdateCategoryHandlerTests
 		var originalName = catRepo.Store[500].Name;
 
 		var handler = HandlerFactory.CreateCommand<UpdateCategoryCommand, Result<CategoryResponse>>(
-			guildRepo, catRepo, new FakeClock(), new FakeCurrentUser { Id = 1 });
+			guildRepo, catRepo, new FakeEventBus(),new FakeClock(), new FakeCurrentUser { Id = 1 });
 
 		var result = await handler.HandleAsync(
 			new UpdateCategoryCommand(GuildId: 100, CategoryId: 500, Name: null, Position: 9));
@@ -146,7 +146,7 @@ public sealed class UpdateCategoryHandlerTests
 		Seed(guildRepo, catRepo, ownerId: 1);
 
 		var handler = HandlerFactory.CreateCommand<UpdateCategoryCommand, Result<CategoryResponse>>(
-			guildRepo, catRepo, new FakeClock(), new FakeCurrentUser { Id = 1 });
+			guildRepo, catRepo, new FakeEventBus(),new FakeClock(), new FakeCurrentUser { Id = 1 });
 
 		var result = await handler.HandleAsync(
 			new UpdateCategoryCommand(GuildId: 100, CategoryId: 500, Name: "New", Position: 12));
@@ -167,7 +167,7 @@ public sealed class UpdateCategoryHandlerTests
 		var originalPosition = catRepo.Store[500].Position;
 
 		var handler = HandlerFactory.CreateCommand<UpdateCategoryCommand, Result<CategoryResponse>>(
-			guildRepo, catRepo, new FakeClock(), new FakeCurrentUser { Id = 1 });
+			guildRepo, catRepo, new FakeEventBus(),new FakeClock(), new FakeCurrentUser { Id = 1 });
 
 		var result = await handler.HandleAsync(
 			new UpdateCategoryCommand(GuildId: 100, CategoryId: 500, Name: null, Position: null));
@@ -192,7 +192,7 @@ public sealed class UpdateCategoryHandlerTests
 		SeedCategory(catRepo, id: 500);
 
 		var handler = HandlerFactory.CreateCommand<UpdateCategoryCommand, Result<CategoryResponse>>(
-			guildRepo, catRepo, new FakeClock(), new FakeCurrentUser { Id = 1 });
+			guildRepo, catRepo, new FakeEventBus(),new FakeClock(), new FakeCurrentUser { Id = 1 });
 
 		var result = await handler.HandleAsync(
 			new UpdateCategoryCommand(GuildId: 100, CategoryId: 500, Name: "Renamed", Position: null));

--- a/services/guild/tests/Guild.UnitTests/Application/UpdateChannelHandlerTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/UpdateChannelHandlerTests.cs
@@ -1,3 +1,4 @@
+using Guild.Application.Contracts;
 using Guild.Application.Features.Channels.Common;
 using Guild.Application.Features.Channels.UpdateChannel;
 using Guild.Domain.Guild;
@@ -174,6 +175,34 @@ public sealed class UpdateChannelHandlerTests
 		Assert.Null(result.Value.CategoryId);
 	}
 
+	[Fact]
+	public async Task HappyPath_PublishesChannelUpdated()
+	{
+		var guilds = new FakeGuildRepository();
+		var channels = new FakeChannelRepository();
+		var categories = new FakeChannelCategoryRepository();
+		var bus = new FakeEventBus();
+		var guild = GuildEntity.Create(
+			id: 100, name: "Test", description: null, iconUrl: null, bannerUrl: null,
+			ownerId: 1, everyoneRoleId: 101, adminRoleId: 102, now: Now).Value;
+		guilds.Add(guild);
+		channels.Seed(Channel.Create(5, 100, null, "old", null, ChannelType.Text, 0, Now).Value);
+
+		var handler = HandlerFactory.CreateCommand<UpdateChannelCommand, Result<ChannelResponse>>(
+			guilds, channels, categories, new FakeChannelPermissionOverwriteRepository(), bus,
+			new FakeClock(), new FakeCurrentUser { Id = 1 });
+
+		var result = await handler.HandleAsync(
+			new UpdateChannelCommand(100, 5, Name: "new", Topic: null,
+				Position: null, CategoryId: null, CategoryIdProvided: false, TopicProvided: false));
+
+		Assert.True(result.Succeeded);
+		var evt = bus.Single<GuildChannelUpdated>();
+		Assert.Equal("5", evt.Channel.Id);
+		Assert.Equal("new", evt.Channel.Name);
+		Assert.Contains(1L, evt.EligibleUserIds);
+	}
+
 	private static (
 		Guild.Application.Abstractions.Messaging.ICommandHandler<UpdateChannelCommand, Result<ChannelResponse>> Handler,
 		FakeGuildRepository Guilds,
@@ -193,7 +222,7 @@ public sealed class UpdateChannelHandlerTests
 		}
 
 		var handler = HandlerFactory.CreateCommand<UpdateChannelCommand, Result<ChannelResponse>>(
-			guilds, channels, categories,
+			guilds, channels, categories, new FakeChannelPermissionOverwriteRepository(), new FakeEventBus(),
 			new FakeClock(), new FakeCurrentUser { Id = currentUser });
 
 		return (handler, guilds, channels);

--- a/services/guild/tests/Guild.UnitTests/Application/UpdateGuildHandlerTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/UpdateGuildHandlerTests.cs
@@ -19,7 +19,7 @@ public sealed class UpdateGuildHandlerTests
 	{
 		var repo = new FakeGuildRepository();
 		var handler = HandlerFactory.CreateCommand<UpdateGuildCommand, Result<GuildDto>>(
-			repo, new FakeClock(), new FakeCurrentUser { Id = 1 });
+			repo, new FakeEventBus(), new FakeClock(), new FakeCurrentUser { Id = 1 });
 
 		var result = await handler.HandleAsync(
 			new UpdateGuildCommand(GuildId: 999, Name: "x", Description: null, IconUrl: null, BannerUrl: null));
@@ -34,7 +34,7 @@ public sealed class UpdateGuildHandlerTests
 		var repo = new FakeGuildRepository();
 		Seed(repo, ownerId: 1);
 		var handler = HandlerFactory.CreateCommand<UpdateGuildCommand, Result<GuildDto>>(
-			repo, new FakeClock(), new FakeCurrentUser { Id = 99 });
+			repo, new FakeEventBus(), new FakeClock(), new FakeCurrentUser { Id = 99 });
 
 		var result = await handler.HandleAsync(
 			new UpdateGuildCommand(GuildId: 100, Name: "x", Description: null, IconUrl: null, BannerUrl: null));
@@ -61,7 +61,7 @@ public sealed class UpdateGuildHandlerTests
 		repo.Add(guild);
 
 		var handler = HandlerFactory.CreateCommand<UpdateGuildCommand, Result<GuildDto>>(
-			repo, new FakeClock(), new FakeCurrentUser { Id = 2 });
+			repo, new FakeEventBus(), new FakeClock(), new FakeCurrentUser { Id = 2 });
 
 		var result = await handler.HandleAsync(
 			new UpdateGuildCommand(GuildId: 100, Name: "x", Description: null, IconUrl: null, BannerUrl: null));
@@ -76,7 +76,7 @@ public sealed class UpdateGuildHandlerTests
 		var repo = new FakeGuildRepository();
 		Seed(repo, ownerId: 1);
 		var handler = HandlerFactory.CreateCommand<UpdateGuildCommand, Result<GuildDto>>(
-			repo, new FakeClock(), new FakeCurrentUser { Id = 1 });
+			repo, new FakeEventBus(), new FakeClock(), new FakeCurrentUser { Id = 1 });
 
 		var result = await handler.HandleAsync(
 			new UpdateGuildCommand(GuildId: 100, Name: "Renamed", Description: null, IconUrl: null, BannerUrl: null));
@@ -101,7 +101,7 @@ public sealed class UpdateGuildHandlerTests
 		repo.Add(guild);
 
 		var handler = HandlerFactory.CreateCommand<UpdateGuildCommand, Result<GuildDto>>(
-			repo, new FakeClock(), new FakeCurrentUser { Id = 2 });
+			repo, new FakeEventBus(), new FakeClock(), new FakeCurrentUser { Id = 2 });
 
 		var result = await handler.HandleAsync(
 			new UpdateGuildCommand(GuildId: 100, Name: "ByMod", Description: null, IconUrl: null, BannerUrl: null));

--- a/services/guild/tests/Guild.UnitTests/Application/UpdateNicknameHandlerTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/UpdateNicknameHandlerTests.cs
@@ -187,7 +187,7 @@ public sealed class UpdateNicknameHandlerTests
 		guilds.Add(guild);
 
 		var handler = HandlerFactory.CreateCommand<UpdateNicknameCommand, Result<MemberResponse>>(
-			guilds, new FakeCurrentUser { Id = currentUser });
+			guilds, new FakeEventBus(), new FakeCurrentUser { Id = currentUser });
 		return (handler, guilds);
 	}
 }

--- a/services/guild/tests/Guild.UnitTests/Serialization/EventSerializationTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Serialization/EventSerializationTests.cs
@@ -83,18 +83,20 @@ public sealed class EventSerializationTests
 	[Fact]
 	public void GuildDeleted_SerializesWith_SnakeCaseFields()
 	{
-		var json = JsonSerializer.Serialize(new GuildDeleted(100), Wire);
+		var json = JsonSerializer.Serialize(new GuildDeleted(100, [10, 20]), Wire);
 
-		Assert.Equal("{\"guild_id\":\"100\"}", json);
+		Assert.Equal("{\"guild_id\":\"100\",\"channel_ids\":[\"10\",\"20\"]}", json);
 	}
 
 	[Fact]
 	public void GuildDeleted_RoundTrips()
 	{
-		var original = new GuildDeleted(100);
+		var original = new GuildDeleted(100, [10, 20]);
 		var json = JsonSerializer.Serialize(original, Wire);
 
-		Assert.Equal(original, JsonSerializer.Deserialize<GuildDeleted>(json, Wire));
+		var deserialized = JsonSerializer.Deserialize<GuildDeleted>(json, Wire)!;
+		Assert.Equal(original.GuildId, deserialized.GuildId);
+		Assert.Equal(original.ChannelIds, deserialized.ChannelIds);
 	}
 
 	[Fact]

--- a/services/notification/db/migrations/20260712120000_add_friend_accept_type.sql
+++ b/services/notification/db/migrations/20260712120000_add_friend_accept_type.sql
@@ -1,0 +1,7 @@
+-- +goose NO TRANSACTION
+-- +goose Up
+ALTER TYPE notification_type ADD VALUE IF NOT EXISTS 'friend_accept';
+
+-- +goose Down
+-- Postgres cannot remove a value from an enum type; the value is harmless if unused.
+SELECT 1;

--- a/services/notification/internal/core/orchestrator.go
+++ b/services/notification/internal/core/orchestrator.go
@@ -71,6 +71,18 @@ func (o *Orchestrator) CreateNotif(ctx context.Context, in CreateInput) error {
 	return nil
 }
 
+// PushFriendsChanged sends a transient signal (no persisted row, no badge) telling
+// the user's client that their friend graph changed so it re-fetches the friends
+// list. used for unfriends, which we do not surface to the removed user as a
+// visible notification. the client recognises the sentinel type and reloads.
+func (o *Orchestrator) PushFriendsChanged(userID int64) {
+	o.hub.Push(userID, NotificationSSE{
+		ID:      "0",
+		Type:    "friends_changed",
+		Payload: json.RawMessage("{}"),
+	})
+}
+
 type ListInput struct {
 	Read             *bool
 	IncludeDismissed *bool

--- a/services/notification/transport/broker/consumer.go
+++ b/services/notification/transport/broker/consumer.go
@@ -22,6 +22,7 @@ const (
 // published to the shared `events` direct exchange by the Go/NestJS services
 var directEvents = []string{
 	"friend.request_sent",
+	"friend.accepted",
 	"data.export_ready",
 }
 

--- a/services/notification/transport/broker/consumer.go
+++ b/services/notification/transport/broker/consumer.go
@@ -23,6 +23,7 @@ const (
 var directEvents = []string{
 	"friend.request_sent",
 	"friend.accepted",
+	"friend.removed",
 	"data.export_ready",
 }
 

--- a/services/notification/transport/broker/dispatch.go
+++ b/services/notification/transport/broker/dispatch.go
@@ -155,6 +155,19 @@ func dispatch(ctx context.Context, orch *core.Orchestrator, d amqp.Delivery) err
 			Payload:  FriendAcceptPayload{},
 		})
 
+	case "friend.removed":
+		ev, err := parse[FriendRemovedEvent](d)
+		if err != nil {
+			return err
+		}
+
+		// unfriend is not a visible notification; push a transient "friends
+		// changed" signal to both parties so their friends lists re-fetch. the
+		// actor already updated optimistically, so their re-fetch is a no-op.
+		orch.PushFriendsChanged(ev.RequesterID)
+		orch.PushFriendsChanged(ev.AddresseeID)
+		return nil
+
 	case "guild.invite_created":
 		ev, err := parse[GuildInviteCreatedEvent](d)
 		if err != nil {

--- a/services/notification/transport/broker/dispatch.go
+++ b/services/notification/transport/broker/dispatch.go
@@ -19,6 +19,7 @@ const (
 	TypeMention                   = "mention"
 	TypeDM                        = "dm"
 	TypeFriendRequest             = "friend_request"
+	TypeFriendAccept              = "friend_accept"
 	TypeGuildInvite               = "guild_invite"
 	TypeGuildWelcome              = "guild_welcome"
 	TypeIncomingCall              = "incoming_call"
@@ -136,6 +137,22 @@ func dispatch(ctx context.Context, orch *core.Orchestrator, d amqp.Delivery) err
 			ActorID:  &ev.RequesterID,
 			SourceID: &ev.FriendshipID,
 			Payload:  FriendRequestPayload{},
+		})
+
+	case "friend.accepted":
+		ev, err := parse[FriendAcceptedEvent](d)
+		if err != nil {
+			return err
+		}
+
+		// the requester (who sent the pending request) is told the addressee
+		// accepted it; the addressee already knows (they clicked accept).
+		return orch.CreateNotif(ctx, core.CreateInput{
+			UserID:   ev.RequesterID,
+			Type:     TypeFriendAccept,
+			ActorID:  &ev.AddresseeID,
+			SourceID: &ev.FriendshipID,
+			Payload:  FriendAcceptPayload{},
 		})
 
 	case "guild.invite_created":

--- a/services/notification/transport/broker/events.go
+++ b/services/notification/transport/broker/events.go
@@ -78,6 +78,25 @@ func (e FriendRequestSentEvent) Validate() error {
 	return nil
 }
 
+type FriendAcceptedEvent struct {
+	FriendshipID int64 `json:"friendship_id,string"`
+	RequesterID  int64 `json:"requester_id,string"`
+	AddresseeID  int64 `json:"addressee_id,string"`
+}
+
+func (e FriendAcceptedEvent) Validate() error {
+	if e.FriendshipID == 0 {
+		return fmt.Errorf("friend.accepted: missing friendship_id")
+	}
+	if e.RequesterID == 0 {
+		return fmt.Errorf("friend.accepted: missing requester_id")
+	}
+	if e.AddresseeID == 0 {
+		return fmt.Errorf("friend.accepted: missing addressee_id")
+	}
+	return nil
+}
+
 type GuildInviteCreatedEvent struct {
 	GuildID         int64  `json:"guild_id,string"`
 	GuildName       string `json:"guild_name"`

--- a/services/notification/transport/broker/events.go
+++ b/services/notification/transport/broker/events.go
@@ -97,6 +97,21 @@ func (e FriendAcceptedEvent) Validate() error {
 	return nil
 }
 
+type FriendRemovedEvent struct {
+	RequesterID int64 `json:"requester_id,string"`
+	AddresseeID int64 `json:"addressee_id,string"`
+}
+
+func (e FriendRemovedEvent) Validate() error {
+	if e.RequesterID == 0 {
+		return fmt.Errorf("friend.removed: missing requester_id")
+	}
+	if e.AddresseeID == 0 {
+		return fmt.Errorf("friend.removed: missing addressee_id")
+	}
+	return nil
+}
+
 type GuildInviteCreatedEvent struct {
 	GuildID         int64  `json:"guild_id,string"`
 	GuildName       string `json:"guild_name"`

--- a/services/notification/transport/broker/payloads.go
+++ b/services/notification/transport/broker/payloads.go
@@ -14,6 +14,9 @@ type DmPayload struct {
 type FriendRequestPayload struct {
 }
 
+type FriendAcceptPayload struct {
+}
+
 type GuildInvitePayload struct {
 	GuildName string `json:"guild_name"`
 }

--- a/services/user/src/users/events/rabbitmq-relationship-events.publisher.ts
+++ b/services/user/src/users/events/rabbitmq-relationship-events.publisher.ts
@@ -1,6 +1,6 @@
 import { Injectable, OnApplicationShutdown } from '@nestjs/common';
 import { ChannelModel, ConfirmChannel, connect } from 'amqplib';
-import { FriendRequestSentEvent } from '../users.types';
+import { FriendAcceptedEvent, FriendRequestSentEvent } from '../users.types';
 import { RelationshipEventsPublisher } from './relationship-events.publisher';
 
 @Injectable()
@@ -16,10 +16,18 @@ export class RabbitMqRelationshipEventsPublisher
   async publishFriendRequestSent(
     event: FriendRequestSentEvent,
   ): Promise<void> {
+    await this.publish('friend.request_sent', event);
+  }
+
+  async publishFriendAccepted(event: FriendAcceptedEvent): Promise<void> {
+    await this.publish('friend.accepted', event);
+  }
+
+  private async publish(routingKey: string, event: unknown): Promise<void> {
     const channel = await this.ensureChannel();
     channel.publish(
       RabbitMqRelationshipEventsPublisher.exchangeName,
-      'friend.request_sent',
+      routingKey,
       Buffer.from(JSON.stringify(event), 'utf8'),
       {
         contentType: 'application/json',

--- a/services/user/src/users/events/rabbitmq-relationship-events.publisher.ts
+++ b/services/user/src/users/events/rabbitmq-relationship-events.publisher.ts
@@ -1,6 +1,10 @@
 import { Injectable, OnApplicationShutdown } from '@nestjs/common';
 import { ChannelModel, ConfirmChannel, connect } from 'amqplib';
-import { FriendAcceptedEvent, FriendRequestSentEvent } from '../users.types';
+import {
+  FriendAcceptedEvent,
+  FriendRemovedEvent,
+  FriendRequestSentEvent,
+} from '../users.types';
 import { RelationshipEventsPublisher } from './relationship-events.publisher';
 
 @Injectable()
@@ -21,6 +25,10 @@ export class RabbitMqRelationshipEventsPublisher
 
   async publishFriendAccepted(event: FriendAcceptedEvent): Promise<void> {
     await this.publish('friend.accepted', event);
+  }
+
+  async publishFriendRemoved(event: FriendRemovedEvent): Promise<void> {
+    await this.publish('friend.removed', event);
   }
 
   private async publish(routingKey: string, event: unknown): Promise<void> {

--- a/services/user/src/users/events/relationship-events.publisher.ts
+++ b/services/user/src/users/events/relationship-events.publisher.ts
@@ -1,11 +1,16 @@
 import { Injectable } from '@nestjs/common';
-import { FriendAcceptedEvent, FriendRequestSentEvent } from '../users.types';
+import {
+  FriendAcceptedEvent,
+  FriendRemovedEvent,
+  FriendRequestSentEvent,
+} from '../users.types';
 
 export abstract class RelationshipEventsPublisher {
   abstract publishFriendRequestSent(
     event: FriendRequestSentEvent,
   ): Promise<void>;
   abstract publishFriendAccepted(event: FriendAcceptedEvent): Promise<void>;
+  abstract publishFriendRemoved(event: FriendRemovedEvent): Promise<void>;
 }
 
 @Injectable()
@@ -17,6 +22,10 @@ export class NoopRelationshipEventsPublisher
   }
 
   async publishFriendAccepted(): Promise<void> {
+    return;
+  }
+
+  async publishFriendRemoved(): Promise<void> {
     return;
   }
 }

--- a/services/user/src/users/events/relationship-events.publisher.ts
+++ b/services/user/src/users/events/relationship-events.publisher.ts
@@ -1,10 +1,11 @@
 import { Injectable } from '@nestjs/common';
-import { FriendRequestSentEvent } from '../users.types';
+import { FriendAcceptedEvent, FriendRequestSentEvent } from '../users.types';
 
 export abstract class RelationshipEventsPublisher {
   abstract publishFriendRequestSent(
     event: FriendRequestSentEvent,
   ): Promise<void>;
+  abstract publishFriendAccepted(event: FriendAcceptedEvent): Promise<void>;
 }
 
 @Injectable()
@@ -12,6 +13,10 @@ export class NoopRelationshipEventsPublisher
   implements RelationshipEventsPublisher
 {
   async publishFriendRequestSent(): Promise<void> {
+    return;
+  }
+
+  async publishFriendAccepted(): Promise<void> {
     return;
   }
 }

--- a/services/user/src/users/internal-users.controller.ts
+++ b/services/user/src/users/internal-users.controller.ts
@@ -52,4 +52,13 @@ export class InternalUsersController {
   ): Promise<UserDataExportResponse> {
     return this.users.getInternalDataExport(userId);
   }
+
+  // accepted-friend ids for the Chat Service's real-time fan-out (presence,
+  // profile, social). ids are quoted strings to match the wire policy.
+  @Get(':userId/friend-ids')
+  async getFriendIds(
+    @Param('userId', ParseSnowflakePipe) userId: string,
+  ): Promise<string[]> {
+    return this.users.listFriendIds(userId);
+  }
 }

--- a/services/user/src/users/repositories/friendships.repository.ts
+++ b/services/user/src/users/repositories/friendships.repository.ts
@@ -347,6 +347,7 @@ export class FriendshipsRepository {
   private toFriendSummary(row: FriendListRow): FriendSummaryResponse {
     return {
       id: row.id,
+      friendship_id: row.friendship_id,
       username: row.username,
       display_name: row.display_name,
       avatar_url: row.avatar_url,

--- a/services/user/src/users/repositories/friendships.repository.ts
+++ b/services/user/src/users/repositories/friendships.repository.ts
@@ -83,6 +83,45 @@ export class FriendshipsRepository {
     return result.rows.map((row) => this.toFriendSummary(row));
   }
 
+  // accepted-friend ids for real-time fan-out (presence, profile, social).
+  // excludes either-direction blocks so a blocked user never receives the
+  // subject's presence, matching listFriends' visibility rules.
+  async listFriendIds(userId: string): Promise<string[]> {
+    const result = await this.database.client.query<{ id: string }>(
+      `
+        SELECT
+          CASE
+            WHEN friendship.requester_id = $1::bigint THEN friendship.addressee_id::text
+            ELSE friendship.requester_id::text
+          END AS id
+        FROM friendships AS friendship
+        WHERE friendship.status = 'accepted'
+          AND (friendship.requester_id = $1::bigint OR friendship.addressee_id = $1::bigint)
+          AND NOT EXISTS (
+            SELECT 1
+            FROM user_blocks AS block
+            WHERE block.blocker_id = $1::bigint
+              AND block.blocked_id = CASE
+                WHEN friendship.requester_id = $1::bigint THEN friendship.addressee_id
+                ELSE friendship.requester_id
+              END
+          )
+          AND NOT EXISTS (
+            SELECT 1
+            FROM user_blocks AS block
+            WHERE block.blocked_id = $1::bigint
+              AND block.blocker_id = CASE
+                WHEN friendship.requester_id = $1::bigint THEN friendship.addressee_id
+                ELSE friendship.requester_id
+              END
+          )
+      `,
+      [userId],
+    );
+
+    return result.rows.map((row) => row.id);
+  }
+
   async listFriendRequests(
     viewerId: string,
     direction: FriendRequestDirection,

--- a/services/user/src/users/repositories/friendships.repository.ts
+++ b/services/user/src/users/repositories/friendships.repository.ts
@@ -307,7 +307,11 @@ export class FriendshipsRepository {
   async deleteFriendRequest(
     friendshipId: string,
     callerId: string,
-  ): Promise<'not_found' | 'forbidden' | 'deleted'> {
+  ): Promise<
+    | 'not_found'
+    | 'forbidden'
+    | { requesterId: string; addresseeId: string; wasAccepted: boolean }
+  > {
     const friendship = await this.database.client.query<FriendshipRow>(
       `
         SELECT
@@ -341,7 +345,11 @@ export class FriendshipsRepository {
       [friendshipId],
     );
 
-    return 'deleted';
+    return {
+      requesterId: row.requester_id,
+      addresseeId: row.addressee_id,
+      wasAccepted: row.status === 'accepted',
+    };
   }
 
   private toFriendSummary(row: FriendListRow): FriendSummaryResponse {

--- a/services/user/src/users/users.service.ts
+++ b/services/user/src/users/users.service.ts
@@ -262,6 +262,10 @@ export class UsersService {
     return this.friendshipsRepository.listFriendRequests(viewerId, direction);
   }
 
+  async listFriendIds(userId: string): Promise<string[]> {
+    return this.friendshipsRepository.listFriendIds(userId);
+  }
+
   async createFriendRequest(
     requesterId: string,
     addresseeId: string,

--- a/services/user/src/users/users.service.ts
+++ b/services/user/src/users/users.service.ts
@@ -319,7 +319,24 @@ export class UsersService {
     friendshipId: string,
     callerId: string,
   ): Promise<'not_found' | 'forbidden' | 'deleted'> {
-    return this.friendshipsRepository.deleteFriendRequest(friendshipId, callerId);
+    const result = await this.friendshipsRepository.deleteFriendRequest(
+      friendshipId,
+      callerId,
+    );
+    if (typeof result === 'string') {
+      return result;
+    }
+
+    // only an actual unfriend (an accepted friendship being removed) needs to
+    // tell the other party; declining/cancelling a pending request does not.
+    if (result.wasAccepted) {
+      await this.relationshipEventsPublisher.publishFriendRemoved({
+        requester_id: result.requesterId,
+        addressee_id: result.addresseeId,
+      });
+    }
+
+    return 'deleted';
   }
 
   async listBlockedUsers(viewerId: string): Promise<BlockListItemResponse[]> {

--- a/services/user/src/users/users.service.ts
+++ b/services/user/src/users/users.service.ts
@@ -296,11 +296,23 @@ export class UsersService {
     callerId: string,
     status: 'accepted' | 'blocked',
   ): Promise<FriendshipResponse | 'not_found' | 'forbidden' | 'conflict'> {
-    return this.friendshipsRepository.updateFriendRequest(
+    const result = await this.friendshipsRepository.updateFriendRequest(
       friendshipId,
       callerId,
       status,
     );
+
+    // notify the requester that their pending request was accepted, so their
+    // client shows the notification and refreshes the friends list.
+    if (typeof result !== 'string' && result.status === 'accepted') {
+      await this.relationshipEventsPublisher.publishFriendAccepted({
+        friendship_id: result.id,
+        requester_id: result.requester_id,
+        addressee_id: result.addressee_id,
+      });
+    }
+
+    return result;
   }
 
   async deleteFriendRequest(

--- a/services/user/src/users/users.types.ts
+++ b/services/user/src/users/users.types.ts
@@ -83,6 +83,11 @@ export interface FriendAcceptedEvent {
   addressee_id: string;
 }
 
+export interface FriendRemovedEvent {
+  requester_id: string;
+  addressee_id: string;
+}
+
 export type UserDataExportFriendState =
   | 'accepted'
   | 'pending_outgoing'

--- a/services/user/src/users/users.types.ts
+++ b/services/user/src/users/users.types.ts
@@ -40,6 +40,7 @@ export interface UpdateUserProfileInput {
 
 export interface FriendSummaryResponse {
   id: string;
+  friendship_id: string;
   username: string;
   display_name: string | null;
   avatar_url: string | null;

--- a/services/user/src/users/users.types.ts
+++ b/services/user/src/users/users.types.ts
@@ -76,6 +76,12 @@ export interface FriendRequestSentEvent {
   addressee_id: string;
 }
 
+export interface FriendAcceptedEvent {
+  friendship_id: string;
+  requester_id: string;
+  addressee_id: string;
+}
+
 export type UserDataExportFriendState =
   | 'accepted'
   | 'pending_outgoing'


### PR DESCRIPTION
## Real-time propagation across guild, channel, presence, roles, and friends

Makes the app reflect changes live instead of only after a manual refresh. Previously only message-level events and notifications were real-time; guild/channel structure, membership, presence, roles, permissions, and friend changes all required a refresh (which led to pretty bad secenarios)

### What now propagates live
- **Channels** create / update / delete, targeted per-eligible-member so private (overwrite-restricted) channels never leak
- **Guild membership** join / left roster updates, plus a fix for the "Caller is not a member" race after accepting an invite
- **Guild deletion** drops the guild from every member's client, and purges the deleted channels' message history
- **Presence** online / offline fanned out to co-guild-members and friends
- **Categories** create / update / delete
- **Guild** name / icon updates
- **Roles** create / update / delete / reorder, plus nickname and role assign / unassign
- **Channel access grants** (mirror of the existing revoke): a newly-visible channel appears live
- **Friends** a request being accepted refreshes both parties' lists (and notifies the requester), and unfriending refreshes both parties' lists

### Also included :D
- **Unfriend action** in the profile card (there was previously no UI to remove an established friend). Surfaces `friendship_id` on the friends endpoint so the client can delete without a lookup.

### How
Guild and Chat are both ASP.NET/MassTransit, so guild-scoped events flow Guild -> RabbitMQ -> Chat, which fans them out over its SignalR hub (new per-guild group + per-user targeting). Friend events reuse the proven User -> `events` -> Notification path: accept becomes a `friend_accept` notification, unfriend becomes a transient `friends_changed` SSE signal (no stored row, no badge) pushed to both parties.

### Notes for review
- **Deferred** (still fetch-on-load): block / unblock, and profile (avatar / name / bio) changes. These originate in the NestJS User service, whose direct-exchange topology has no proven bridge to Chat's MassTransit consumers. I'm WAY too tired to do figure this our right now
