### PR TITLE
Front/right click

### DIFF
--- a/frontend/src/components/app-providers.tsx
+++ b/frontend/src/components/app-providers.tsx
@@ -3,6 +3,7 @@
 import type { ReactNode } from 'react';
 import { GuildProvider } from '../shared/guilds/guild-store';
 import { CurrentUserProvider } from '../shared/user/user-store';
+import { NotificationPrefsProvider } from '../shared/lib/notification-prefs-store';
 import { SessionExpiryRedirect } from './session-expiry-redirect';
 import { ToastProvider } from '../shared/ui/toast';
 
@@ -10,10 +11,12 @@ export function AppProviders({ children }: { children: ReactNode }) {
   return (
     <CurrentUserProvider>
       <GuildProvider>
-        <ToastProvider>
-          <SessionExpiryRedirect />
-          {children}
-        </ToastProvider>
+        <NotificationPrefsProvider>
+          <ToastProvider>
+            <SessionExpiryRedirect />
+            {children}
+          </ToastProvider>
+        </NotificationPrefsProvider>
       </GuildProvider>
     </CurrentUserProvider>
   );

--- a/frontend/src/components/channel-list.tsx
+++ b/frontend/src/components/channel-list.tsx
@@ -1,12 +1,13 @@
 'use client';
 
-import { useEffect, useMemo, useRef, useState, type RefObject } from 'react';
+import { useMemo, useState, type RefObject } from 'react';
 import Link from 'next/link';
-import { CircleEllipsis, Hash, Lock } from 'lucide-react';
+import { CircleEllipsis, Hash } from 'lucide-react';
 import { ConversationListFooter } from './conversation-list-footer';
 import { SearchInput } from './search-input';
+import { GuildContextMenu, type GuildContextMenuTarget } from './guild/guild-context-menu';
 import { useGuilds } from '../shared/guilds/guild-store';
-import { useCloseOnEscape } from '../shared/hooks/use-close-on-escape';
+import { useNotificationPrefs } from '../shared/lib/notification-prefs-store';
 import type { CurrentUserProfile } from '../shared/mappers/user';
 import { FortyTwoIcon } from './icons/brand-icons';
 
@@ -43,61 +44,6 @@ type ChannelListProps = {
   onOpenChannelPermissions?: (channel: TextChannel) => void;
 };
 
-type ChannelMenuState = {
-  channel: TextChannel;
-  x: number;
-  y: number;
-};
-
-function ChannelContextMenu({
-  menu,
-  onOpenPermissions,
-  onClose
-}: {
-  menu: ChannelMenuState;
-  onOpenPermissions: (channel: TextChannel) => void;
-  onClose: () => void;
-}) {
-  const menuRef = useRef<HTMLDivElement>(null);
-
-  useCloseOnEscape(onClose);
-
-  useEffect(() => {
-    function handleMouseDown(event: MouseEvent) {
-      if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
-        onClose();
-      }
-    }
-
-    document.addEventListener('mousedown', handleMouseDown);
-    return () => document.removeEventListener('mousedown', handleMouseDown);
-  }, [onClose]);
-
-  return (
-    <div
-      ref={menuRef}
-      className="fixed z-50 w-56 rounded-md border border-stroke bg-panel p-1.5 shadow-lg"
-      style={{
-        left: Math.min(menu.x, window.innerWidth - 240),
-        top: Math.min(menu.y, window.innerHeight - 88)
-      }}
-    >
-      <p className="mono-detail truncate px-2 py-1 text-xs text-white/35"># {menu.channel.name}</p>
-      <button
-        type="button"
-        onClick={() => {
-          onOpenPermissions(menu.channel);
-          onClose();
-        }}
-        className="flex h-9 w-full items-center gap-2.5 rounded-md px-2 text-left text-sm font-semibold text-white/70 transition hover:bg-frame hover:text-white"
-      >
-        <Lock className="h-4 w-4 shrink-0 text-aqua" strokeWidth={1.9} />
-        Channel permissions
-      </button>
-    </div>
-  );
-}
-
 export function getChannelName(channelId: string, channels: TextChannel[]) {
   if (channelId.length === 0)
     return channelId;
@@ -128,8 +74,9 @@ export function ChannelList({
   onOpenChannelPermissions
 }: ChannelListProps) {
   const { selectedGuild } = useGuilds();
+  const { isMuted } = useNotificationPrefs();
   const [search, setSearch] = useState('');
-  const [channelMenu, setChannelMenu] = useState<ChannelMenuState | null>(null);
+  const [contextMenu, setContextMenu] = useState<GuildContextMenuTarget | null>(null);
 
   const filteredCategories = useMemo(() => {
     const term = search.trim().toLowerCase();
@@ -147,6 +94,7 @@ export function ChannelList({
   }, [search, categories]);
 
   return (
+    <>
     <div
       className={`${
         mobilePane === 'channels' ? 'flex' : 'hidden'
@@ -190,6 +138,7 @@ export function ChannelList({
                 {category.channels.map((channel) => {
                   const isActive = channel.id === activeChannel;
                   const unreadCount = unreadCounts[channel.id] ?? 0;
+                  const channelMuted = isMuted('channel', channel.id);
 
                   return (
                     <button
@@ -197,20 +146,37 @@ export function ChannelList({
                       type="button"
                       onClick={() => onSelectChannel(channel.id)}
                       onContextMenu={(event) => {
-                        if (!canManageChannels || !onOpenChannelPermissions) {
-                          return;
-                        }
                         event.preventDefault();
-                        setChannelMenu({ channel, x: event.clientX, y: event.clientY });
+                        setContextMenu({
+                          scope: 'channel',
+                          channelId: channel.id,
+                          channelName: channel.name,
+                          // fold the permissions entry in when the viewer can manage it
+                          onOpenPermissions:
+                            canManageChannels && onOpenChannelPermissions
+                              ? () => onOpenChannelPermissions(channel)
+                              : undefined,
+                          x: event.clientX,
+                          y: event.clientY
+                        });
                       }}
                       className={`mono-detail flex h-10 w-full items-center gap-3 rounded-md px-3 text-left text-[1rem] transition ${
-                        isActive ? 'bg-frame text-white' : 'text-grey-link hover:bg-frame/60'
+                        isActive
+                          ? 'bg-frame text-white'
+                          : channelMuted
+                            ? 'text-white/15 hover:bg-frame/60'
+                            : 'text-grey-link hover:bg-frame/60'
                       }`}
                     >
-                      <Hash className="h-4 w-4 shrink-0 text-[#8a8a96]" strokeWidth={1.8} />
+                      <Hash
+                        className={`h-4 w-4 shrink-0 ${
+                          channelMuted && !isActive ? 'text-white/15' : 'text-[#8a8a96]'
+                        }`}
+                        strokeWidth={1.8}
+                      />
                       <span
                         className={`min-w-0 flex-1 truncate ${
-                          isActive || unreadCount > 0 ? 'font-bold' : 'font-normal'
+                          isActive || (unreadCount > 0 && !channelMuted) ? 'font-bold' : 'font-normal'
                         }`}
                       >
                         {channel.name}
@@ -240,14 +206,10 @@ export function ChannelList({
         onOpenNotifications={onOpenNotifications}
         onOpenSettings={onOpenSettings}
       />
-
-      {channelMenu && onOpenChannelPermissions ? (
-        <ChannelContextMenu
-          menu={channelMenu}
-          onOpenPermissions={onOpenChannelPermissions}
-          onClose={() => setChannelMenu(null)}
-        />
-      ) : null}
     </div>
+    {contextMenu ? (
+      <GuildContextMenu target={contextMenu} onClose={() => setContextMenu(null)} />
+    ) : null}
+    </>
   );
 }

--- a/frontend/src/components/chat-workspace.tsx
+++ b/frontend/src/components/chat-workspace.tsx
@@ -868,7 +868,10 @@ export function ChatWorkspace() {
   };
 
   return (
-    <div className="mx-auto flex h-screen w-full gap-4 px-3 py-4 md:px-5 md:py-9">
+    <div
+      className="mx-auto flex h-screen w-full gap-4 px-3 py-4 md:px-5 md:py-9"
+      onContextMenu={(event) => event.preventDefault()}
+    >
       {!isHydrated ? (
         <div className="flex min-h-0 flex-1 rounded-[1rem] bg-secondary-bg ring-1 ring-stroke" />
       ) : (

--- a/frontend/src/components/guild-sidebar.tsx
+++ b/frontend/src/components/guild-sidebar.tsx
@@ -5,6 +5,7 @@ import type { MouseEvent } from 'react';
 import Link from 'next/link';
 import { MessageCircle, Plus } from 'lucide-react';
 import { AddGuildModal } from './guild/add-guild-modal';
+import { GuildContextMenu, type GuildContextMenuTarget } from './guild/guild-context-menu';
 import { GuildIcon } from './guild/guild-icon';
 import { FortyTwoIcon } from './icons/brand-icons';
 import { useGuilds } from '../shared/guilds/guild-store';
@@ -23,8 +24,9 @@ const SCROLL_EDGE_SLACK_PX = 4;
 export function GuildSidebar({ activeMode, onOpenDms, onOpenGuild }: GuildSidebarProps) {
   const sidebarRef = useRef<HTMLElement>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
-  const { guilds, isLoading, error, selectedGuildId, selectGuild } = useGuilds();
+  const { guilds, isLoading, error, selectedGuildId, selectGuild, refreshGuilds } = useGuilds();
   const [tooltip, setTooltip] = useState<{ name: string; top: number } | null>(null);
+  const [contextMenu, setContextMenu] = useState<GuildContextMenuTarget | null>(null);
   const [isAddGuildOpen, setIsAddGuildOpen] = useState(false);
   const [croppedEdges, setCroppedEdges] = useState({ top: false, bottom: false });
   const { pushToast } = useToast();
@@ -69,6 +71,15 @@ export function GuildSidebar({ activeMode, onOpenDms, onOpenGuild }: GuildSideba
   function handleSelectGuild(guildId: string) {
     selectGuild(guildId);
     onOpenGuild();
+  }
+
+  function handleOpenContextMenu(
+    guild: { id: string; name: string },
+    event: MouseEvent<HTMLButtonElement>
+  ) {
+    event.preventDefault();
+    setTooltip(null);
+    setContextMenu({ guildId: guild.id, guildName: guild.name, x: event.clientX, y: event.clientY });
   }
 
   function handleShowLabel(name: string, event: MouseEvent<HTMLButtonElement>) {
@@ -131,6 +142,7 @@ export function GuildSidebar({ activeMode, onOpenDms, onOpenGuild }: GuildSideba
               key={guild.id}
               type="button"
               onClick={() => handleSelectGuild(guild.id)}
+              onContextMenu={(event) => handleOpenContextMenu(guild, event)}
               onMouseEnter={(event) => handleShowLabel(guild.name, event)}
               onMouseLeave={() => setTooltip(null)}
               className={`h-[4.9rem] shrink-0 overflow-hidden rounded-xl border transition ${
@@ -181,6 +193,18 @@ export function GuildSidebar({ activeMode, onOpenDms, onOpenGuild }: GuildSideba
         </div>
       ) : null}
       {isAddGuildOpen ? <AddGuildModal onClose={() => setIsAddGuildOpen(false)} /> : null}
+      {contextMenu ? (
+        <GuildContextMenu
+          target={contextMenu}
+          onClose={() => setContextMenu(null)}
+          onLeft={(guildId) => {
+            if (guildId === selectedGuildId) {
+              onOpenDms();
+            }
+            void refreshGuilds();
+          }}
+        />
+      ) : null}
     </aside>
   );
 }

--- a/frontend/src/components/guild-sidebar.tsx
+++ b/frontend/src/components/guild-sidebar.tsx
@@ -80,6 +80,7 @@ export function GuildSidebar({ activeMode, onOpenDms, onOpenGuild }: GuildSideba
     event.preventDefault();
     setTooltip(null);
     setContextMenu({
+      scope: 'guild',
       guildId: guild.id,
       guildName: guild.name,
       ownerId: guild.owner_id,

--- a/frontend/src/components/guild-sidebar.tsx
+++ b/frontend/src/components/guild-sidebar.tsx
@@ -74,12 +74,18 @@ export function GuildSidebar({ activeMode, onOpenDms, onOpenGuild }: GuildSideba
   }
 
   function handleOpenContextMenu(
-    guild: { id: string; name: string },
+    guild: { id: string; name: string; owner_id: string },
     event: MouseEvent<HTMLButtonElement>
   ) {
     event.preventDefault();
     setTooltip(null);
-    setContextMenu({ guildId: guild.id, guildName: guild.name, x: event.clientX, y: event.clientY });
+    setContextMenu({
+      guildId: guild.id,
+      guildName: guild.name,
+      ownerId: guild.owner_id,
+      x: event.clientX,
+      y: event.clientY
+    });
   }
 
   function handleShowLabel(name: string, event: MouseEvent<HTMLButtonElement>) {

--- a/frontend/src/components/guild/guild-context-menu.tsx
+++ b/frontend/src/components/guild/guild-context-menu.tsx
@@ -1,10 +1,12 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
-import { Bell, BellOff, Link2, LogOut } from 'lucide-react';
+import { Bell, BellOff, ChevronRight, Link2, LogOut } from 'lucide-react';
 import { ActionModal } from '../action-modal';
 import { useCloseOnEscape } from '../../shared/hooks/use-close-on-escape';
+import { useCurrentUserId } from '../../shared/hooks/use-current-user-id';
 import { useToast } from '../../shared/ui/toast';
+import { muteDurations, muteDurationToIso, type MuteDuration } from '../../shared/lib/mute-durations';
 import { createGuildInvite, leaveGuild } from '../../shared/api/guild';
 import {
   deleteNotificationPreference,
@@ -19,11 +21,13 @@ const FAST_INVITE_EXPIRES_IN_HOURS = 1;
 // keep the menu off the viewport edges; a rough width/height is enough since we
 // only need to avoid clipping, not pixel-perfect placement.
 const MENU_WIDTH_PX = 224;
+const SUBMENU_WIDTH_PX = 160;
 const MENU_MARGIN_PX = 8;
 
 export type GuildContextMenuTarget = {
   guildId: string;
   guildName: string;
+  ownerId: string;
   x: number;
   y: number;
 };
@@ -34,14 +38,40 @@ type GuildContextMenuProps = {
   onLeft: (guildId: string) => void;
 };
 
+// null while the mute preference is still loading; false/true once known.
+type MuteState = { muted: boolean } | null;
+
 export function GuildContextMenu({ target, onClose, onLeft }: GuildContextMenuProps) {
   const menuRef = useRef<HTMLDivElement>(null);
   const { pushToast } = useToast();
-  const [isMuted, setIsMuted] = useState<boolean | null>(null);
+  const currentUserId = useCurrentUserId();
+  const [muteState, setMuteState] = useState<MuteState>(null);
   const [isInviting, setIsInviting] = useState(false);
   const [isTogglingMute, setIsTogglingMute] = useState(false);
+  const [isMuteSubmenuOpen, setIsMuteSubmenuOpen] = useState(false);
   const [isConfirmingLeave, setIsConfirmingLeave] = useState(false);
   const [isLeaving, setIsLeaving] = useState(false);
+
+  const isOwner = currentUserId != null && currentUserId === target.ownerId;
+
+  // a short grace period before closing the submenu tolerates the diagonal
+  // mouse path from the parent item, which briefly leaves both elements
+  const closeSubmenuTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  function openMuteSubmenu() {
+    if (closeSubmenuTimer.current) {
+      clearTimeout(closeSubmenuTimer.current);
+      closeSubmenuTimer.current = null;
+    }
+    setIsMuteSubmenuOpen(true);
+  }
+  function scheduleCloseMuteSubmenu() {
+    closeSubmenuTimer.current = setTimeout(() => setIsMuteSubmenuOpen(false), 220);
+  }
+  useEffect(() => () => {
+    if (closeSubmenuTimer.current) {
+      clearTimeout(closeSubmenuTimer.current);
+    }
+  }, []);
 
   useCloseOnEscape(onClose);
 
@@ -63,7 +93,7 @@ export function GuildContextMenu({ target, onClose, onLeft }: GuildContextMenuPr
     return () => window.removeEventListener('mousedown', handlePointerDown);
   }, [isConfirmingLeave, onClose]);
 
-  // load the current mute state so the toggle shows the right label. a failure
+  // load the current mute state so the entry shows the right label. a failure
   // here just leaves the entry disabled rather than blocking the whole menu.
   useEffect(() => {
     let cancelled = false;
@@ -76,10 +106,10 @@ export function GuildContextMenu({ target, onClose, onLeft }: GuildContextMenuPr
         const pref = preferences.find(
           (candidate) => candidate.scope_type === 'guild' && candidate.scope_id === target.guildId
         );
-        setIsMuted(pref?.muted ?? false);
+        setMuteState({ muted: pref?.muted ?? false });
       })
       .catch(() => {
-        // best effort: leave isMuted null so the toggle renders disabled
+        // best effort: leave muteState null so the entry renders disabled
       });
 
     return () => {
@@ -111,25 +141,42 @@ export function GuildContextMenu({ target, onClose, onLeft }: GuildContextMenuPr
     }
   }
 
-  async function handleToggleMute() {
-    if (isMuted === null) {
-      return;
-    }
-
-    const nextMuted = !isMuted;
+  async function handleMuteFor(duration: MuteDuration) {
     setIsTogglingMute(true);
     try {
-      if (nextMuted) {
-        await setNotificationPreference('guild', target.guildId, { muted: true });
-      } else {
-        await deleteNotificationPreference('guild', target.guildId);
-      }
-      setIsMuted(nextMuted);
+      await setNotificationPreference('guild', target.guildId, {
+        muted: true,
+        muted_until: muteDurationToIso(duration)
+      });
+      const chosen = muteDurations.find((option) => option.value === duration);
       pushToast({
-        title: nextMuted ? 'Server muted' : 'Server unmuted',
-        description: nextMuted
-          ? `You won't get notifications from ${target.guildName}.`
-          : `Notifications from ${target.guildName} are back on.`,
+        title: 'Server muted',
+        description:
+          duration === 'forever'
+            ? `You won't get notifications from ${target.guildName}.`
+            : `${target.guildName} muted for ${chosen?.longLabel ?? duration}.`,
+        tone: 'success'
+      });
+      onClose();
+    } catch (error) {
+      pushToast({
+        title: 'Notifications',
+        description:
+          error instanceof Error ? error.message : 'Could not update notification settings.',
+        tone: 'error'
+      });
+    } finally {
+      setIsTogglingMute(false);
+    }
+  }
+
+  async function handleUnmute() {
+    setIsTogglingMute(true);
+    try {
+      await deleteNotificationPreference('guild', target.guildId);
+      pushToast({
+        title: 'Server unmuted',
+        description: `Notifications from ${target.guildName} are back on.`,
         tone: 'success'
       });
       onClose();
@@ -169,6 +216,11 @@ export function GuildContextMenu({ target, onClose, onLeft }: GuildContextMenuPr
 
   const left = Math.min(target.x, window.innerWidth - MENU_WIDTH_PX - MENU_MARGIN_PX);
   const top = Math.min(target.y, window.innerHeight - MENU_MARGIN_PX);
+  const menuLeft = Math.max(MENU_MARGIN_PX, left);
+  // flip the submenu to the left of the menu when it would overflow the viewport
+  const submenuOnLeft = menuLeft + MENU_WIDTH_PX + SUBMENU_WIDTH_PX + MENU_MARGIN_PX > window.innerWidth;
+
+  const isMuted = muteState?.muted ?? false;
 
   return (
     <>
@@ -176,8 +228,8 @@ export function GuildContextMenu({ target, onClose, onLeft }: GuildContextMenuPr
         ref={menuRef}
         role="menu"
         aria-label={`${target.guildName} actions`}
-        className="fixed z-[60] w-56 overflow-hidden rounded-lg border border-stroke bg-panel py-1.5 text-sm shadow-2xl shadow-black/50"
-        style={{ left: Math.max(MENU_MARGIN_PX, left), top: Math.max(MENU_MARGIN_PX, top) }}
+        className="fixed z-[60] w-56 rounded-lg border border-stroke bg-panel py-1.5 text-sm shadow-2xl shadow-black/50"
+        style={{ left: menuLeft, top: Math.max(MENU_MARGIN_PX, top) }}
       >
         <p className="truncate px-3 pb-1.5 pt-1 text-xs font-semibold uppercase tracking-wide text-white/35">
           {target.guildName}
@@ -189,17 +241,57 @@ export function GuildContextMenu({ target, onClose, onLeft }: GuildContextMenuPr
           disabled={isInviting}
           onClick={() => void handleFastInvite()}
         />
-        <MenuItem
-          icon={isMuted ? Bell : BellOff}
-          label={isMuted ? 'Unmute notifications' : 'Mute notifications'}
-          disabled={isMuted === null || isTogglingMute}
-          onClick={() => void handleToggleMute()}
-        />
+
+        {isMuted ? (
+          <MenuItem
+            icon={Bell}
+            label="Unmute notifications"
+            disabled={muteState === null || isTogglingMute}
+            onClick={() => void handleUnmute()}
+          />
+        ) : (
+          <div
+            className="relative"
+            onMouseEnter={openMuteSubmenu}
+            onMouseLeave={scheduleCloseMuteSubmenu}
+          >
+            <MenuItem
+              icon={BellOff}
+              label="Mute notifications"
+              disabled={muteState === null || isTogglingMute}
+              trailing={<ChevronRight className="h-4 w-4 text-white/40" strokeWidth={1.9} />}
+              onClick={openMuteSubmenu}
+            />
+            {isMuteSubmenuOpen && muteState !== null ? (
+              // overlap the parent by 1px (no visual gap) so the diagonal path to
+              // the submenu never crosses dead space and dismisses it
+              <div
+                role="menu"
+                aria-label="Mute duration"
+                className={`absolute top-0 w-40 rounded-lg border border-stroke bg-panel py-1.5 shadow-2xl shadow-black/50 ${
+                  submenuOnLeft ? 'right-full -mr-px' : 'left-full -ml-px'
+                }`}
+              >
+                {muteDurations.map((option) => (
+                  <MenuItem
+                    key={option.value}
+                    label={option.longLabel}
+                    disabled={isTogglingMute}
+                    onClick={() => void handleMuteFor(option.value)}
+                  />
+                ))}
+              </div>
+            ) : null}
+          </div>
+        )}
+
         <div className="my-1 border-t border-stroke" />
         <MenuItem
           icon={LogOut}
           label="Leave server"
           destructive
+          disabled={isOwner}
+          hint={isOwner ? 'Owner' : undefined}
           onClick={() => setIsConfirmingLeave(true)}
         />
       </div>
@@ -223,13 +315,15 @@ function MenuItem({
   icon: Icon,
   label,
   hint,
+  trailing,
   destructive = false,
   disabled = false,
   onClick
 }: {
-  icon: typeof Link2;
+  icon?: typeof Link2;
   label: string;
   hint?: string;
+  trailing?: React.ReactNode;
   destructive?: boolean;
   disabled?: boolean;
   onClick: () => void;
@@ -244,9 +338,10 @@ function MenuItem({
         destructive ? 'text-pink hover:bg-pink/10' : 'text-white/80 hover:bg-frame hover:text-white'
       }`}
     >
-      <Icon className="h-4 w-4 shrink-0" strokeWidth={1.9} />
+      {Icon ? <Icon className="h-4 w-4 shrink-0" strokeWidth={1.9} /> : null}
       <span className="flex-1 truncate">{label}</span>
       {hint ? <span className="text-xs text-white/35">{hint}</span> : null}
+      {trailing}
     </button>
   );
 }

--- a/frontend/src/components/guild/guild-context-menu.tsx
+++ b/frontend/src/components/guild/guild-context-menu.tsx
@@ -1,0 +1,252 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { Bell, BellOff, Link2, LogOut } from 'lucide-react';
+import { ActionModal } from '../action-modal';
+import { useCloseOnEscape } from '../../shared/hooks/use-close-on-escape';
+import { useToast } from '../../shared/ui/toast';
+import { createGuildInvite, leaveGuild } from '../../shared/api/guild';
+import {
+  deleteNotificationPreference,
+  listNotificationPreferences,
+  setNotificationPreference
+} from '../../shared/api/notification';
+
+// invites can only expire on whole-hour boundaries (the guild service takes an
+// int? of hours), so the "fast" invite settles on the shortest sensible window.
+const FAST_INVITE_EXPIRES_IN_HOURS = 1;
+
+// keep the menu off the viewport edges; a rough width/height is enough since we
+// only need to avoid clipping, not pixel-perfect placement.
+const MENU_WIDTH_PX = 224;
+const MENU_MARGIN_PX = 8;
+
+export type GuildContextMenuTarget = {
+  guildId: string;
+  guildName: string;
+  x: number;
+  y: number;
+};
+
+type GuildContextMenuProps = {
+  target: GuildContextMenuTarget;
+  onClose: () => void;
+  onLeft: (guildId: string) => void;
+};
+
+export function GuildContextMenu({ target, onClose, onLeft }: GuildContextMenuProps) {
+  const menuRef = useRef<HTMLDivElement>(null);
+  const { pushToast } = useToast();
+  const [isMuted, setIsMuted] = useState<boolean | null>(null);
+  const [isInviting, setIsInviting] = useState(false);
+  const [isTogglingMute, setIsTogglingMute] = useState(false);
+  const [isConfirmingLeave, setIsConfirmingLeave] = useState(false);
+  const [isLeaving, setIsLeaving] = useState(false);
+
+  useCloseOnEscape(onClose);
+
+  // close when clicking anywhere outside the menu. the leave-confirmation modal
+  // renders its own overlay, so suspend this while it is open to avoid the menu
+  // swallowing that click and tearing itself down mid-action.
+  useEffect(() => {
+    if (isConfirmingLeave) {
+      return;
+    }
+
+    function handlePointerDown(event: MouseEvent) {
+      if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
+        onClose();
+      }
+    }
+
+    window.addEventListener('mousedown', handlePointerDown);
+    return () => window.removeEventListener('mousedown', handlePointerDown);
+  }, [isConfirmingLeave, onClose]);
+
+  // load the current mute state so the toggle shows the right label. a failure
+  // here just leaves the entry disabled rather than blocking the whole menu.
+  useEffect(() => {
+    let cancelled = false;
+
+    listNotificationPreferences()
+      .then((preferences) => {
+        if (cancelled) {
+          return;
+        }
+        const pref = preferences.find(
+          (candidate) => candidate.scope_type === 'guild' && candidate.scope_id === target.guildId
+        );
+        setIsMuted(pref?.muted ?? false);
+      })
+      .catch(() => {
+        // best effort: leave isMuted null so the toggle renders disabled
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [target.guildId]);
+
+  async function handleFastInvite() {
+    setIsInviting(true);
+    try {
+      const invite = await createGuildInvite(target.guildId, {
+        expires_in_hours: FAST_INVITE_EXPIRES_IN_HOURS
+      });
+      await navigator.clipboard.writeText(invite.code);
+      pushToast({
+        title: 'Invite copied',
+        description: `Code ${invite.code} copied — expires in 1 hour.`,
+        tone: 'success'
+      });
+      onClose();
+    } catch (error) {
+      pushToast({
+        title: 'Fast invite',
+        description: error instanceof Error ? error.message : 'Could not create an invite.',
+        tone: 'error'
+      });
+    } finally {
+      setIsInviting(false);
+    }
+  }
+
+  async function handleToggleMute() {
+    if (isMuted === null) {
+      return;
+    }
+
+    const nextMuted = !isMuted;
+    setIsTogglingMute(true);
+    try {
+      if (nextMuted) {
+        await setNotificationPreference('guild', target.guildId, { muted: true });
+      } else {
+        await deleteNotificationPreference('guild', target.guildId);
+      }
+      setIsMuted(nextMuted);
+      pushToast({
+        title: nextMuted ? 'Server muted' : 'Server unmuted',
+        description: nextMuted
+          ? `You won't get notifications from ${target.guildName}.`
+          : `Notifications from ${target.guildName} are back on.`,
+        tone: 'success'
+      });
+      onClose();
+    } catch (error) {
+      pushToast({
+        title: 'Notifications',
+        description:
+          error instanceof Error ? error.message : 'Could not update notification settings.',
+        tone: 'error'
+      });
+    } finally {
+      setIsTogglingMute(false);
+    }
+  }
+
+  async function confirmLeave() {
+    setIsLeaving(true);
+    try {
+      await leaveGuild(target.guildId);
+      onLeft(target.guildId);
+      pushToast({
+        title: 'Left server',
+        description: `You left ${target.guildName}.`,
+        tone: 'success'
+      });
+      onClose();
+    } catch (error) {
+      pushToast({
+        title: 'Leave server',
+        description: error instanceof Error ? error.message : 'Could not leave the server.',
+        tone: 'error'
+      });
+      setIsLeaving(false);
+      setIsConfirmingLeave(false);
+    }
+  }
+
+  const left = Math.min(target.x, window.innerWidth - MENU_WIDTH_PX - MENU_MARGIN_PX);
+  const top = Math.min(target.y, window.innerHeight - MENU_MARGIN_PX);
+
+  return (
+    <>
+      <div
+        ref={menuRef}
+        role="menu"
+        aria-label={`${target.guildName} actions`}
+        className="fixed z-[60] w-56 overflow-hidden rounded-lg border border-stroke bg-panel py-1.5 text-sm shadow-2xl shadow-black/50"
+        style={{ left: Math.max(MENU_MARGIN_PX, left), top: Math.max(MENU_MARGIN_PX, top) }}
+      >
+        <p className="truncate px-3 pb-1.5 pt-1 text-xs font-semibold uppercase tracking-wide text-white/35">
+          {target.guildName}
+        </p>
+        <MenuItem
+          icon={Link2}
+          label="Fast invite"
+          hint="Copy a 1h link"
+          disabled={isInviting}
+          onClick={() => void handleFastInvite()}
+        />
+        <MenuItem
+          icon={isMuted ? Bell : BellOff}
+          label={isMuted ? 'Unmute notifications' : 'Mute notifications'}
+          disabled={isMuted === null || isTogglingMute}
+          onClick={() => void handleToggleMute()}
+        />
+        <div className="my-1 border-t border-stroke" />
+        <MenuItem
+          icon={LogOut}
+          label="Leave server"
+          destructive
+          onClick={() => setIsConfirmingLeave(true)}
+        />
+      </div>
+
+      {isConfirmingLeave ? (
+        <ActionModal
+          title={`Leave ${target.guildName}?`}
+          description="You'll lose access to its channels until someone invites you back."
+          confirmLabel="Leave server"
+          destructive
+          isBusy={isLeaving}
+          onClose={() => setIsConfirmingLeave(false)}
+          onConfirm={confirmLeave}
+        />
+      ) : null}
+    </>
+  );
+}
+
+function MenuItem({
+  icon: Icon,
+  label,
+  hint,
+  destructive = false,
+  disabled = false,
+  onClick
+}: {
+  icon: typeof Link2;
+  label: string;
+  hint?: string;
+  destructive?: boolean;
+  disabled?: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      role="menuitem"
+      disabled={disabled}
+      onClick={onClick}
+      className={`flex w-full items-center gap-3 px-3 py-2 text-left font-medium transition disabled:cursor-not-allowed disabled:opacity-40 ${
+        destructive ? 'text-pink hover:bg-pink/10' : 'text-white/80 hover:bg-frame hover:text-white'
+      }`}
+    >
+      <Icon className="h-4 w-4 shrink-0" strokeWidth={1.9} />
+      <span className="flex-1 truncate">{label}</span>
+      {hint ? <span className="text-xs text-white/35">{hint}</span> : null}
+    </button>
+  );
+}

--- a/frontend/src/components/guild/guild-context-menu.tsx
+++ b/frontend/src/components/guild/guild-context-menu.tsx
@@ -301,9 +301,11 @@ export function GuildContextMenu({ target, onClose, onLeft }: GuildContextMenuPr
           </div>
         )}
 
-        {target.scope === 'channel' ? (
-          <MenuItem icon={Copy} label="Copy channel ID" onClick={() => void handleCopyId()} />
-        ) : null}
+        <MenuItem
+          icon={Copy}
+          label={target.scope === 'guild' ? 'Copy server ID' : 'Copy channel ID'}
+          onClick={() => void handleCopyId()}
+        />
 
         {target.scope === 'channel' && target.onOpenPermissions ? (
           <>

--- a/frontend/src/components/guild/guild-context-menu.tsx
+++ b/frontend/src/components/guild/guild-context-menu.tsx
@@ -1,13 +1,13 @@
 'use client';
 
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { Bell, BellOff, ChevronRight, Copy, Link2, Lock as LockIcon, LogOut } from 'lucide-react';
 import { ActionModal } from '../action-modal';
 import { useCloseOnEscape } from '../../shared/hooks/use-close-on-escape';
-import { useCurrentUserId } from '../../shared/hooks/use-current-user-id';
+import { useCurrentUserProfile } from '../../shared/user/user-store';
 import { useToast } from '../../shared/ui/toast';
 import { useNotificationPrefs } from '../../shared/lib/notification-prefs-store';
-import { muteDurations, type MuteDuration } from '../../shared/lib/mute-durations';
+import { muteDurations, muteDurationToIso, type MuteDuration } from '../../shared/lib/mute-durations';
 import { createGuildInvite, leaveGuild } from '../../shared/api/guild';
 
 // invites can only expire on whole-hour boundaries (the guild service takes an
@@ -52,7 +52,8 @@ type GuildContextMenuProps = {
 export function GuildContextMenu({ target, onClose, onLeft }: GuildContextMenuProps) {
   const menuRef = useRef<HTMLDivElement>(null);
   const { pushToast } = useToast();
-  const currentUserId = useCurrentUserId();
+  const { currentUser } = useCurrentUserProfile();
+  const currentUserId = currentUser?.id ?? null;
   const { isMuted, mute, unmute } = useNotificationPrefs();
 
   const [isInviting, setIsInviting] = useState(false);
@@ -60,6 +61,9 @@ export function GuildContextMenu({ target, onClose, onLeft }: GuildContextMenuPr
   const [isMuteSubmenuOpen, setIsMuteSubmenuOpen] = useState(false);
   const [isConfirmingLeave, setIsConfirmingLeave] = useState(false);
   const [isLeaving, setIsLeaving] = useState(false);
+  // measured after mount so the vertical clamp can reserve the real menu height;
+  // 0 until then, which just means the first frame uses the raw cursor y
+  const [menuHeight, setMenuHeight] = useState(0);
 
   const scopeType = target.scope;
   const scopeId = target.scope === 'guild' ? target.guildId : target.channelId;
@@ -67,6 +71,13 @@ export function GuildContextMenu({ target, onClose, onLeft }: GuildContextMenuPr
   const muted = isMuted(scopeType, scopeId);
   const isOwner =
     target.scope === 'guild' && currentUserId != null && currentUserId === target.ownerId;
+
+  // measure the rendered menu so the vertical clamp knows its real height
+  useLayoutEffect(() => {
+    if (menuRef.current) {
+      setMenuHeight(menuRef.current.offsetHeight);
+    }
+  }, [muted, target.scope]);
 
   // a short grace period before closing the submenu tolerates the diagonal
   // mouse path from the parent item, which briefly leaves both elements
@@ -158,7 +169,7 @@ export function GuildContextMenu({ target, onClose, onLeft }: GuildContextMenuPr
   async function handleMuteFor(duration: MuteDuration) {
     setIsTogglingMute(true);
     try {
-      await mute(scopeType, scopeId, duration);
+      await mute(scopeType, scopeId, muteDurationToIso(duration));
       const chosen = muteDurations.find((option) => option.value === duration);
       pushToast({
         title: scopeType === 'guild' ? 'Server muted' : 'Channel muted',
@@ -229,7 +240,7 @@ export function GuildContextMenu({ target, onClose, onLeft }: GuildContextMenuPr
   }
 
   const left = Math.min(target.x, window.innerWidth - MENU_WIDTH_PX - MENU_MARGIN_PX);
-  const top = Math.min(target.y, window.innerHeight - MENU_MARGIN_PX);
+  const top = Math.min(target.y, window.innerHeight - menuHeight - MENU_MARGIN_PX);
   const menuLeft = Math.max(MENU_MARGIN_PX, left);
   // flip the submenu to the left of the menu when it would overflow the viewport
   const submenuOnLeft =

--- a/frontend/src/components/guild/guild-context-menu.tsx
+++ b/frontend/src/components/guild/guild-context-menu.tsx
@@ -101,7 +101,9 @@ export function GuildContextMenu({ target, onClose, onLeft }: GuildContextMenuPr
     []
   );
 
-  useCloseOnEscape(onClose);
+  // while the leave-confirmation modal is open, let it own Escape (it has its
+  // own handler); otherwise one press would close both the modal and the menu
+  useCloseOnEscape(isConfirmingLeave ? () => {} : onClose);
 
   // close when clicking anywhere outside the menu. the leave-confirmation modal
   // renders its own overlay, so suspend this while it is open to avoid the menu
@@ -172,7 +174,7 @@ export function GuildContextMenu({ target, onClose, onLeft }: GuildContextMenuPr
       await mute(scopeType, scopeId, muteDurationToIso(duration));
       const chosen = muteDurations.find((option) => option.value === duration);
       pushToast({
-        title: scopeType === 'guild' ? 'Server muted' : 'Channel muted',
+        title: scopeType === 'guild' ? 'Guild muted' : 'Channel muted',
         description:
           duration === 'forever'
             ? `You won't get notifications from ${scopeName}.`
@@ -197,7 +199,7 @@ export function GuildContextMenu({ target, onClose, onLeft }: GuildContextMenuPr
     try {
       await unmute(scopeType, scopeId);
       pushToast({
-        title: scopeType === 'guild' ? 'Server unmuted' : 'Channel unmuted',
+        title: scopeType === 'guild' ? 'Guild unmuted' : 'Channel unmuted',
         description: `Notifications from ${scopeName} are back on.`,
         tone: 'success'
       });
@@ -223,15 +225,15 @@ export function GuildContextMenu({ target, onClose, onLeft }: GuildContextMenuPr
       await leaveGuild(target.guildId);
       onLeft?.(target.guildId);
       pushToast({
-        title: 'Left server',
+        title: 'Left guild',
         description: `You left ${target.guildName}.`,
         tone: 'success'
       });
       onClose();
     } catch (error) {
       pushToast({
-        title: 'Leave server',
-        description: error instanceof Error ? error.message : 'Could not leave the server.',
+        title: 'Leave guild',
+        description: error instanceof Error ? error.message : 'Could not leave the guild.',
         tone: 'error'
       });
       setIsLeaving(false);
@@ -248,6 +250,9 @@ export function GuildContextMenu({ target, onClose, onLeft }: GuildContextMenuPr
 
   return (
     <>
+      {/* hidden while confirming a leave so it doesn't sit on top of the modal's
+          dimmed backdrop (the modal renders below at z-50) */}
+      {!isConfirmingLeave ? (
       <div
         ref={menuRef}
         role="menu"
@@ -314,7 +319,7 @@ export function GuildContextMenu({ target, onClose, onLeft }: GuildContextMenuPr
 
         <MenuItem
           icon={Copy}
-          label={target.scope === 'guild' ? 'Copy server ID' : 'Copy channel ID'}
+          label={target.scope === 'guild' ? 'Copy guild ID' : 'Copy channel ID'}
           onClick={() => void handleCopyId()}
         />
 
@@ -337,7 +342,7 @@ export function GuildContextMenu({ target, onClose, onLeft }: GuildContextMenuPr
             <div className="my-1 border-t border-stroke" />
             <MenuItem
               icon={LogOut}
-              label="Leave server"
+              label="Leave guild"
               destructive
               disabled={isOwner}
               hint={isOwner ? 'Owner' : undefined}
@@ -346,12 +351,13 @@ export function GuildContextMenu({ target, onClose, onLeft }: GuildContextMenuPr
           </>
         ) : null}
       </div>
+      ) : null}
 
       {isConfirmingLeave && target.scope === 'guild' ? (
         <ActionModal
           title={`Leave ${target.guildName}?`}
           description="You'll lose access to its channels until someone invites you back."
-          confirmLabel="Leave server"
+          confirmLabel="Leave guild"
           destructive
           isBusy={isLeaving}
           onClose={() => setIsConfirmingLeave(false)}

--- a/frontend/src/components/guild/guild-context-menu.tsx
+++ b/frontend/src/components/guild/guild-context-menu.tsx
@@ -1,18 +1,14 @@
 'use client';
 
 import { useEffect, useRef, useState } from 'react';
-import { Bell, BellOff, ChevronRight, Link2, LogOut } from 'lucide-react';
+import { Bell, BellOff, ChevronRight, Copy, Link2, Lock as LockIcon, LogOut } from 'lucide-react';
 import { ActionModal } from '../action-modal';
 import { useCloseOnEscape } from '../../shared/hooks/use-close-on-escape';
 import { useCurrentUserId } from '../../shared/hooks/use-current-user-id';
 import { useToast } from '../../shared/ui/toast';
-import { muteDurations, muteDurationToIso, type MuteDuration } from '../../shared/lib/mute-durations';
+import { useNotificationPrefs } from '../../shared/lib/notification-prefs-store';
+import { muteDurations, type MuteDuration } from '../../shared/lib/mute-durations';
 import { createGuildInvite, leaveGuild } from '../../shared/api/guild';
-import {
-  deleteNotificationPreference,
-  listNotificationPreferences,
-  setNotificationPreference
-} from '../../shared/api/notification';
 
 // invites can only expire on whole-hour boundaries (the guild service takes an
 // int? of hours), so the "fast" invite settles on the shortest sensible window.
@@ -24,35 +20,53 @@ const MENU_WIDTH_PX = 224;
 const SUBMENU_WIDTH_PX = 160;
 const MENU_MARGIN_PX = 8;
 
-export type GuildContextMenuTarget = {
-  guildId: string;
-  guildName: string;
-  ownerId: string;
-  x: number;
-  y: number;
-};
+// a guild target carries owner/name for the invite + leave actions; a channel
+// target only ever offers mute + copy-id.
+export type GuildContextMenuTarget =
+  | {
+      scope: 'guild';
+      guildId: string;
+      guildName: string;
+      ownerId: string;
+      x: number;
+      y: number;
+    }
+  | {
+      scope: 'channel';
+      channelId: string;
+      channelName: string;
+      // present only when the viewer may manage the channel; renders the
+      // "Channel permissions" entry
+      onOpenPermissions?: () => void;
+      x: number;
+      y: number;
+    };
 
 type GuildContextMenuProps = {
   target: GuildContextMenuTarget;
   onClose: () => void;
-  onLeft: (guildId: string) => void;
+  /** Only fired for guild targets, when the user leaves the guild. */
+  onLeft?: (guildId: string) => void;
 };
-
-// null while the mute preference is still loading; false/true once known.
-type MuteState = { muted: boolean } | null;
 
 export function GuildContextMenu({ target, onClose, onLeft }: GuildContextMenuProps) {
   const menuRef = useRef<HTMLDivElement>(null);
   const { pushToast } = useToast();
   const currentUserId = useCurrentUserId();
-  const [muteState, setMuteState] = useState<MuteState>(null);
+  const { isMuted, mute, unmute } = useNotificationPrefs();
+
   const [isInviting, setIsInviting] = useState(false);
   const [isTogglingMute, setIsTogglingMute] = useState(false);
   const [isMuteSubmenuOpen, setIsMuteSubmenuOpen] = useState(false);
   const [isConfirmingLeave, setIsConfirmingLeave] = useState(false);
   const [isLeaving, setIsLeaving] = useState(false);
 
-  const isOwner = currentUserId != null && currentUserId === target.ownerId;
+  const scopeType = target.scope;
+  const scopeId = target.scope === 'guild' ? target.guildId : target.channelId;
+  const scopeName = target.scope === 'guild' ? target.guildName : target.channelName;
+  const muted = isMuted(scopeType, scopeId);
+  const isOwner =
+    target.scope === 'guild' && currentUserId != null && currentUserId === target.ownerId;
 
   // a short grace period before closing the submenu tolerates the diagonal
   // mouse path from the parent item, which briefly leaves both elements
@@ -67,11 +81,14 @@ export function GuildContextMenu({ target, onClose, onLeft }: GuildContextMenuPr
   function scheduleCloseMuteSubmenu() {
     closeSubmenuTimer.current = setTimeout(() => setIsMuteSubmenuOpen(false), 220);
   }
-  useEffect(() => () => {
-    if (closeSubmenuTimer.current) {
-      clearTimeout(closeSubmenuTimer.current);
-    }
-  }, []);
+  useEffect(
+    () => () => {
+      if (closeSubmenuTimer.current) {
+        clearTimeout(closeSubmenuTimer.current);
+      }
+    },
+    []
+  );
 
   useCloseOnEscape(onClose);
 
@@ -93,31 +110,10 @@ export function GuildContextMenu({ target, onClose, onLeft }: GuildContextMenuPr
     return () => window.removeEventListener('mousedown', handlePointerDown);
   }, [isConfirmingLeave, onClose]);
 
-  // load the current mute state so the entry shows the right label. a failure
-  // here just leaves the entry disabled rather than blocking the whole menu.
-  useEffect(() => {
-    let cancelled = false;
-
-    listNotificationPreferences()
-      .then((preferences) => {
-        if (cancelled) {
-          return;
-        }
-        const pref = preferences.find(
-          (candidate) => candidate.scope_type === 'guild' && candidate.scope_id === target.guildId
-        );
-        setMuteState({ muted: pref?.muted ?? false });
-      })
-      .catch(() => {
-        // best effort: leave muteState null so the entry renders disabled
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [target.guildId]);
-
   async function handleFastInvite() {
+    if (target.scope !== 'guild') {
+      return;
+    }
     setIsInviting(true);
     try {
       const invite = await createGuildInvite(target.guildId, {
@@ -141,20 +137,35 @@ export function GuildContextMenu({ target, onClose, onLeft }: GuildContextMenuPr
     }
   }
 
+  async function handleCopyId() {
+    try {
+      await navigator.clipboard.writeText(scopeId);
+      pushToast({
+        title: 'Copied',
+        description: `${scopeName} ID copied to the clipboard.`,
+        tone: 'success'
+      });
+      onClose();
+    } catch {
+      pushToast({
+        title: 'Copy failed',
+        description: 'Could not access the clipboard.',
+        tone: 'error'
+      });
+    }
+  }
+
   async function handleMuteFor(duration: MuteDuration) {
     setIsTogglingMute(true);
     try {
-      await setNotificationPreference('guild', target.guildId, {
-        muted: true,
-        muted_until: muteDurationToIso(duration)
-      });
+      await mute(scopeType, scopeId, duration);
       const chosen = muteDurations.find((option) => option.value === duration);
       pushToast({
-        title: 'Server muted',
+        title: scopeType === 'guild' ? 'Server muted' : 'Channel muted',
         description:
           duration === 'forever'
-            ? `You won't get notifications from ${target.guildName}.`
-            : `${target.guildName} muted for ${chosen?.longLabel ?? duration}.`,
+            ? `You won't get notifications from ${scopeName}.`
+            : `${scopeName} muted for ${chosen?.longLabel ?? duration}.`,
         tone: 'success'
       });
       onClose();
@@ -173,10 +184,10 @@ export function GuildContextMenu({ target, onClose, onLeft }: GuildContextMenuPr
   async function handleUnmute() {
     setIsTogglingMute(true);
     try {
-      await deleteNotificationPreference('guild', target.guildId);
+      await unmute(scopeType, scopeId);
       pushToast({
-        title: 'Server unmuted',
-        description: `Notifications from ${target.guildName} are back on.`,
+        title: scopeType === 'guild' ? 'Server unmuted' : 'Channel unmuted',
+        description: `Notifications from ${scopeName} are back on.`,
         tone: 'success'
       });
       onClose();
@@ -193,10 +204,13 @@ export function GuildContextMenu({ target, onClose, onLeft }: GuildContextMenuPr
   }
 
   async function confirmLeave() {
+    if (target.scope !== 'guild') {
+      return;
+    }
     setIsLeaving(true);
     try {
       await leaveGuild(target.guildId);
-      onLeft(target.guildId);
+      onLeft?.(target.guildId);
       pushToast({
         title: 'Left server',
         description: `You left ${target.guildName}.`,
@@ -218,35 +232,37 @@ export function GuildContextMenu({ target, onClose, onLeft }: GuildContextMenuPr
   const top = Math.min(target.y, window.innerHeight - MENU_MARGIN_PX);
   const menuLeft = Math.max(MENU_MARGIN_PX, left);
   // flip the submenu to the left of the menu when it would overflow the viewport
-  const submenuOnLeft = menuLeft + MENU_WIDTH_PX + SUBMENU_WIDTH_PX + MENU_MARGIN_PX > window.innerWidth;
-
-  const isMuted = muteState?.muted ?? false;
+  const submenuOnLeft =
+    menuLeft + MENU_WIDTH_PX + SUBMENU_WIDTH_PX + MENU_MARGIN_PX > window.innerWidth;
 
   return (
     <>
       <div
         ref={menuRef}
         role="menu"
-        aria-label={`${target.guildName} actions`}
+        aria-label={`${scopeName} actions`}
         className="fixed z-[60] w-56 rounded-lg border border-stroke bg-panel py-1.5 text-sm shadow-2xl shadow-black/50"
         style={{ left: menuLeft, top: Math.max(MENU_MARGIN_PX, top) }}
       >
         <p className="truncate px-3 pb-1.5 pt-1 text-xs font-semibold uppercase tracking-wide text-white/35">
-          {target.guildName}
+          {scopeName}
         </p>
-        <MenuItem
-          icon={Link2}
-          label="Fast invite"
-          hint="Copy a 1h link"
-          disabled={isInviting}
-          onClick={() => void handleFastInvite()}
-        />
 
-        {isMuted ? (
+        {target.scope === 'guild' ? (
+          <MenuItem
+            icon={Link2}
+            label="Fast invite"
+            hint="Copy a 1h link"
+            disabled={isInviting}
+            onClick={() => void handleFastInvite()}
+          />
+        ) : null}
+
+        {muted ? (
           <MenuItem
             icon={Bell}
             label="Unmute notifications"
-            disabled={muteState === null || isTogglingMute}
+            disabled={isTogglingMute}
             onClick={() => void handleUnmute()}
           />
         ) : (
@@ -258,11 +274,11 @@ export function GuildContextMenu({ target, onClose, onLeft }: GuildContextMenuPr
             <MenuItem
               icon={BellOff}
               label="Mute notifications"
-              disabled={muteState === null || isTogglingMute}
+              disabled={isTogglingMute}
               trailing={<ChevronRight className="h-4 w-4 text-white/40" strokeWidth={1.9} />}
               onClick={openMuteSubmenu}
             />
-            {isMuteSubmenuOpen && muteState !== null ? (
+            {isMuteSubmenuOpen ? (
               // overlap the parent by 1px (no visual gap) so the diagonal path to
               // the submenu never crosses dead space and dismisses it
               <div
@@ -285,18 +301,40 @@ export function GuildContextMenu({ target, onClose, onLeft }: GuildContextMenuPr
           </div>
         )}
 
-        <div className="my-1 border-t border-stroke" />
-        <MenuItem
-          icon={LogOut}
-          label="Leave server"
-          destructive
-          disabled={isOwner}
-          hint={isOwner ? 'Owner' : undefined}
-          onClick={() => setIsConfirmingLeave(true)}
-        />
+        {target.scope === 'channel' ? (
+          <MenuItem icon={Copy} label="Copy channel ID" onClick={() => void handleCopyId()} />
+        ) : null}
+
+        {target.scope === 'channel' && target.onOpenPermissions ? (
+          <>
+            <div className="my-1 border-t border-stroke" />
+            <MenuItem
+              icon={LockIcon}
+              label="Channel permissions"
+              onClick={() => {
+                target.onOpenPermissions?.();
+                onClose();
+              }}
+            />
+          </>
+        ) : null}
+
+        {target.scope === 'guild' ? (
+          <>
+            <div className="my-1 border-t border-stroke" />
+            <MenuItem
+              icon={LogOut}
+              label="Leave server"
+              destructive
+              disabled={isOwner}
+              hint={isOwner ? 'Owner' : undefined}
+              onClick={() => setIsConfirmingLeave(true)}
+            />
+          </>
+        ) : null}
       </div>
 
-      {isConfirmingLeave ? (
+      {isConfirmingLeave && target.scope === 'guild' ? (
         <ActionModal
           title={`Leave ${target.guildName}?`}
           description="You'll lose access to its channels until someone invites you back."

--- a/frontend/src/components/notification-card.tsx
+++ b/frontend/src/components/notification-card.tsx
@@ -25,6 +25,7 @@ import { getUsersByIds } from '../shared/api/user';
 import { type UseNotificationsResult } from '../shared/lib/use-notifications';
 import { useCloseOnEscape } from '../shared/hooks/use-close-on-escape';
 import { useToast } from '../shared/ui/toast';
+import { muteDurations, muteDurationToIso, type MuteDuration } from '../shared/lib/mute-durations';
 
 type NotificationTone = 'aqua' | 'yellow' | 'pink';
 

--- a/frontend/src/shared/lib/mute-durations.ts
+++ b/frontend/src/shared/lib/mute-durations.ts
@@ -1,0 +1,20 @@
+// Shared mute-duration options so the notification card and the guild context
+// menu offer the same choices and compute muted_until identically.
+
+// `label` stays compact for the notification card's 4-up button row; `longLabel`
+// reads naturally in the guild context submenu's vertical list.
+export const muteDurations = [
+  { value: '1h', label: '1h', longLabel: '1 hour', hours: 1 },
+  { value: '8h', label: '8h', longLabel: '8 hours', hours: 8 },
+  { value: '24h', label: '24h', longLabel: '1 day', hours: 24 },
+  { value: 'forever', label: 'Forever', longLabel: 'Forever', hours: null }
+] as const;
+
+export type MuteDuration = (typeof muteDurations)[number]['value'];
+
+// null means an indefinite mute (no expiry); otherwise an ISO timestamp `hours`
+// from now.
+export function muteDurationToIso(duration: MuteDuration): string | null {
+  const hours = muteDurations.find((option) => option.value === duration)?.hours ?? null;
+  return hours === null ? null : new Date(Date.now() + hours * 3_600_000).toISOString();
+}

--- a/frontend/src/shared/lib/notification-mute.ts
+++ b/frontend/src/shared/lib/notification-mute.ts
@@ -1,0 +1,57 @@
+// Pure mute helpers shared by the notification hook and the preferences store.
+// Kept in their own module so those two can both import them without forming an
+// import cycle.
+
+import type {
+  NotificationDto,
+  NotificationPreferenceDto,
+  NotificationScopeType
+} from '../api/notification';
+
+export type NotificationMuteScope = {
+  scopeType: NotificationScopeType;
+  scopeId: string;
+};
+
+export function isScopeMuted(
+  preferences: NotificationPreferenceDto[],
+  scopeType: NotificationScopeType,
+  scopeId: string
+): boolean {
+  const now = Date.now();
+  return preferences.some(
+    (preference) =>
+      preference.scope_type === scopeType &&
+      preference.scope_id === scopeId &&
+      preference.muted &&
+      (preference.muted_until == null || Date.parse(preference.muted_until) > now)
+  );
+}
+
+// the scopes a notification can be muted under; also drives the per-item mute buttons
+export function getNotificationMuteScopes(notification: NotificationDto): NotificationMuteScope[] {
+  switch (notification.type) {
+    case 'mention':
+      return [
+        { scopeType: 'channel', scopeId: notification.payload.channel_id },
+        { scopeType: 'guild', scopeId: notification.payload.guild_id }
+      ];
+    case 'guild_invite':
+    case 'guild_welcome':
+      // source_id carries the guild id for both types
+      return notification.source_id
+        ? [{ scopeType: 'guild', scopeId: notification.source_id }]
+        : [];
+    default:
+      return [];
+  }
+}
+
+export function isSuppressedByMute(
+  notification: NotificationDto,
+  preferences: NotificationPreferenceDto[]
+): boolean {
+  return getNotificationMuteScopes(notification).some(({ scopeType, scopeId }) =>
+    isScopeMuted(preferences, scopeType, scopeId)
+  );
+}

--- a/frontend/src/shared/lib/notification-prefs-store.tsx
+++ b/frontend/src/shared/lib/notification-prefs-store.tsx
@@ -9,17 +9,19 @@ import {
   type NotificationPreferenceDto,
   type NotificationScopeType
 } from '../api/notification';
+import { ApiError } from '../api/client';
 import { getAccessToken } from './session';
-import { isScopeMuted } from './use-notifications';
-import { muteDurationToIso, type MuteDuration } from './mute-durations';
+import { isScopeMuted } from './notification-mute';
 
 type NotificationPrefsValue = {
+  /** The raw preference rows, so consumers can filter live SSE inserts. */
+  preferences: NotificationPreferenceDto[];
   /** True (and still in the future) if this scope is currently muted. */
   isMuted: (scopeType: NotificationScopeType, scopeId: string) => boolean;
   mute: (
     scopeType: NotificationScopeType,
     scopeId: string,
-    duration: MuteDuration
+    mutedUntil: string | null
   ) => Promise<void>;
   unmute: (scopeType: NotificationScopeType, scopeId: string) => Promise<void>;
 };
@@ -86,10 +88,10 @@ export function NotificationPrefsProvider({ children }: { children: ReactNode })
   );
 
   const mute = useCallback(
-    async (scopeType: NotificationScopeType, scopeId: string, duration: MuteDuration) => {
+    async (scopeType: NotificationScopeType, scopeId: string, mutedUntil: string | null) => {
       const updated = await setNotificationPreference(scopeType, scopeId, {
         muted: true,
-        muted_until: muteDurationToIso(duration)
+        muted_until: mutedUntil
       });
       setPreferences((current) => upsert(current, updated));
     },
@@ -97,11 +99,21 @@ export function NotificationPrefsProvider({ children }: { children: ReactNode })
   );
 
   const unmute = useCallback(async (scopeType: NotificationScopeType, scopeId: string) => {
-    await deleteNotificationPreference(scopeType, scopeId);
+    try {
+      await deleteNotificationPreference(scopeType, scopeId);
+    } catch (err) {
+      // 404 means no preference row, which is already the unmuted default
+      if (!(err instanceof ApiError && err.status === 404)) {
+        throw err;
+      }
+    }
     setPreferences((current) => removeScope(current, scopeType, scopeId));
   }, []);
 
-  const value = useMemo(() => ({ isMuted, mute, unmute }), [isMuted, mute, unmute]);
+  const value = useMemo(
+    () => ({ preferences, isMuted, mute, unmute }),
+    [preferences, isMuted, mute, unmute]
+  );
 
   return (
     <NotificationPrefsContext.Provider value={value}>{children}</NotificationPrefsContext.Provider>

--- a/frontend/src/shared/lib/notification-prefs-store.tsx
+++ b/frontend/src/shared/lib/notification-prefs-store.tsx
@@ -1,0 +1,119 @@
+'use client';
+
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import type { ReactNode } from 'react';
+import {
+  deleteNotificationPreference,
+  listNotificationPreferences,
+  setNotificationPreference,
+  type NotificationPreferenceDto,
+  type NotificationScopeType
+} from '../api/notification';
+import { getAccessToken } from './session';
+import { isScopeMuted } from './use-notifications';
+import { muteDurationToIso, type MuteDuration } from './mute-durations';
+
+type NotificationPrefsValue = {
+  /** True (and still in the future) if this scope is currently muted. */
+  isMuted: (scopeType: NotificationScopeType, scopeId: string) => boolean;
+  mute: (
+    scopeType: NotificationScopeType,
+    scopeId: string,
+    duration: MuteDuration
+  ) => Promise<void>;
+  unmute: (scopeType: NotificationScopeType, scopeId: string) => Promise<void>;
+};
+
+const NotificationPrefsContext = createContext<NotificationPrefsValue | null>(null);
+
+function hasSession() {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+  return Boolean(getAccessToken());
+}
+
+// replace the entry for a scope (drop any existing one first) so optimistic
+// updates never leave a stale duplicate behind.
+function upsert(
+  preferences: NotificationPreferenceDto[],
+  next: NotificationPreferenceDto
+): NotificationPreferenceDto[] {
+  const without = preferences.filter(
+    (pref) => !(pref.scope_type === next.scope_type && pref.scope_id === next.scope_id)
+  );
+  return [...without, next];
+}
+
+function removeScope(
+  preferences: NotificationPreferenceDto[],
+  scopeType: NotificationScopeType,
+  scopeId: string
+): NotificationPreferenceDto[] {
+  return preferences.filter(
+    (pref) => !(pref.scope_type === scopeType && pref.scope_id === scopeId)
+  );
+}
+
+export function NotificationPrefsProvider({ children }: { children: ReactNode }) {
+  const [preferences, setPreferences] = useState<NotificationPreferenceDto[]>([]);
+
+  useEffect(() => {
+    if (!hasSession()) {
+      return;
+    }
+
+    let cancelled = false;
+    listNotificationPreferences()
+      .then((prefs) => {
+        if (!cancelled) {
+          setPreferences(prefs);
+        }
+      })
+      .catch(() => {
+        // best effort: an empty list just means nothing renders as muted
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const isMuted = useCallback(
+    (scopeType: NotificationScopeType, scopeId: string) =>
+      isScopeMuted(preferences, scopeType, scopeId),
+    [preferences]
+  );
+
+  const mute = useCallback(
+    async (scopeType: NotificationScopeType, scopeId: string, duration: MuteDuration) => {
+      const updated = await setNotificationPreference(scopeType, scopeId, {
+        muted: true,
+        muted_until: muteDurationToIso(duration)
+      });
+      setPreferences((current) => upsert(current, updated));
+    },
+    []
+  );
+
+  const unmute = useCallback(async (scopeType: NotificationScopeType, scopeId: string) => {
+    await deleteNotificationPreference(scopeType, scopeId);
+    setPreferences((current) => removeScope(current, scopeType, scopeId));
+  }, []);
+
+  const value = useMemo(() => ({ isMuted, mute, unmute }), [isMuted, mute, unmute]);
+
+  return (
+    <NotificationPrefsContext.Provider value={value}>{children}</NotificationPrefsContext.Provider>
+  );
+}
+
+export function useNotificationPrefs() {
+  const context = useContext(NotificationPrefsContext);
+
+  if (!context) {
+    throw new Error('useNotificationPrefs must be used within a NotificationPrefsProvider.');
+  }
+
+  return context;
+}

--- a/frontend/src/shared/lib/notification-prefs-store.tsx
+++ b/frontend/src/shared/lib/notification-prefs-store.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import type { ReactNode } from 'react';
 import {
   deleteNotificationPreference,
@@ -57,8 +57,34 @@ function removeScope(
   );
 }
 
+function scopeKey(scopeType: NotificationScopeType, scopeId: string) {
+  return `${scopeType}:${scopeId}`;
+}
+
+// the mount-time fetch below can resolve after a mute/unmute has already landed
+// locally; for any scope the user has since mutated, that local state is newer
+// than the fetch snapshot, so keep it and only take the fetch's word for the
+// untouched scopes.
+function mergeFetchedPreferences(
+  fetched: NotificationPreferenceDto[],
+  current: NotificationPreferenceDto[],
+  mutatedScopes: ReadonlySet<string>
+): NotificationPreferenceDto[] {
+  if (mutatedScopes.size === 0) {
+    return fetched;
+  }
+  const fromFetch = fetched.filter(
+    (pref) => !mutatedScopes.has(scopeKey(pref.scope_type, pref.scope_id))
+  );
+  const fromCurrent = current.filter(
+    (pref) => mutatedScopes.has(scopeKey(pref.scope_type, pref.scope_id))
+  );
+  return [...fromFetch, ...fromCurrent];
+}
+
 export function NotificationPrefsProvider({ children }: { children: ReactNode }) {
   const [preferences, setPreferences] = useState<NotificationPreferenceDto[]>([]);
+  const mutatedScopesRef = useRef<Set<string>>(new Set());
 
   useEffect(() => {
     if (!hasSession()) {
@@ -69,7 +95,9 @@ export function NotificationPrefsProvider({ children }: { children: ReactNode })
     listNotificationPreferences()
       .then((prefs) => {
         if (!cancelled) {
-          setPreferences(prefs);
+          setPreferences((current) =>
+            mergeFetchedPreferences(prefs, current, mutatedScopesRef.current)
+          );
         }
       })
       .catch(() => {
@@ -93,6 +121,7 @@ export function NotificationPrefsProvider({ children }: { children: ReactNode })
         muted: true,
         muted_until: mutedUntil
       });
+      mutatedScopesRef.current.add(scopeKey(scopeType, scopeId));
       setPreferences((current) => upsert(current, updated));
     },
     []
@@ -107,6 +136,7 @@ export function NotificationPrefsProvider({ children }: { children: ReactNode })
         throw err;
       }
     }
+    mutatedScopesRef.current.add(scopeKey(scopeType, scopeId));
     setPreferences((current) => removeScope(current, scopeType, scopeId));
   }, []);
 

--- a/frontend/src/shared/lib/use-notifications.ts
+++ b/frontend/src/shared/lib/use-notifications.ts
@@ -1,23 +1,26 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { ApiError } from '../api/client';
 import { dispatchFriendsChanged } from './friends-events';
 import {
   buildNotificationEventsUrl,
-  deleteNotificationPreference,
   dismissNotification,
   getUnreadNotificationCount,
-  listNotificationPreferences,
   listNotifications,
   markAllNotificationsRead,
   markNotificationRead,
   NOTIFICATION_RECEIVE_EVENT,
-  setNotificationPreference,
   type ListNotificationsQuery,
-  type NotificationDto,
-  type NotificationPreferenceDto,
-  type NotificationScopeType
+  type NotificationDto
 } from '../api/notification';
 import { getAccessToken } from './session';
+import { useNotificationPrefs } from './notification-prefs-store';
+import { isSuppressedByMute } from './notification-mute';
+
+// re-exported so existing importers (notification-card) keep their import path
+export {
+  isScopeMuted,
+  getNotificationMuteScopes,
+  type NotificationMuteScope
+} from './notification-mute';
 
 const PAGE_SIZE = 50;
 const RECONNECT_BASE_DELAY_MS = 2_000;
@@ -27,54 +30,6 @@ export type NotificationFilter = {
   unreadOnly: boolean;
   includeDismissed: boolean;
 };
-
-export type NotificationMuteScope = {
-  scopeType: NotificationScopeType;
-  scopeId: string;
-};
-
-export function isScopeMuted(
-  preferences: NotificationPreferenceDto[],
-  scopeType: NotificationScopeType,
-  scopeId: string
-): boolean {
-  const now = Date.now();
-  return preferences.some(
-    (preference) =>
-      preference.scope_type === scopeType &&
-      preference.scope_id === scopeId &&
-      preference.muted &&
-      (preference.muted_until == null || Date.parse(preference.muted_until) > now)
-  );
-}
-
-// the scopes a notification can be muted under; also drives the per-item mute buttons
-export function getNotificationMuteScopes(notification: NotificationDto): NotificationMuteScope[] {
-  switch (notification.type) {
-    case 'mention':
-      return [
-        { scopeType: 'channel', scopeId: notification.payload.channel_id },
-        { scopeType: 'guild', scopeId: notification.payload.guild_id }
-      ];
-    case 'guild_invite':
-    case 'guild_welcome':
-      // source_id carries the guild id for both types
-      return notification.source_id
-        ? [{ scopeType: 'guild', scopeId: notification.source_id }]
-        : [];
-    default:
-      return [];
-  }
-}
-
-function isSuppressedByMute(
-  notification: NotificationDto,
-  preferences: NotificationPreferenceDto[]
-): boolean {
-  return getNotificationMuteScopes(notification).some(({ scopeType, scopeId }) =>
-    isScopeMuted(preferences, scopeType, scopeId)
-  );
-}
 
 function buildListQuery(filter: NotificationFilter): ListNotificationsQuery {
   return {
@@ -96,7 +51,9 @@ export function useNotifications() {
     unreadOnly: true,
     includeDismissed: false
   });
-  const [preferences, setPreferences] = useState<NotificationPreferenceDto[]>([]);
+  // preferences (and their mutations) are owned by the shared store so the
+  // notification panel, the sidebar dimming and the context menus stay in sync
+  const { preferences, mute, unmute } = useNotificationPrefs();
 
   // bumped on every feed fetch; responses that come back after a newer fetch
   // started are discarded instead of clobbering the newer results
@@ -138,20 +95,6 @@ export function useNotifications() {
   useEffect(() => {
     void fetchFeed();
   }, [fetchFeed]);
-
-  useEffect(() => {
-    let active = true;
-    listNotificationPreferences()
-      .then((items) => {
-        if (active) setPreferences(items);
-      })
-      .catch(() => {
-        // best-effort: without preferences the server still filters muted inserts
-      });
-    return () => {
-      active = false;
-    };
-  }, []);
 
   const loadMore = useCallback(async () => {
     const oldest = notifications[notifications.length - 1];
@@ -375,38 +318,6 @@ export function useNotifications() {
     },
     [notifications, filter.includeDismissed, fetchFeed]
   );
-
-  const mute = useCallback(
-    async (scopeType: NotificationScopeType, scopeId: string, mutedUntil?: string | null) => {
-      const updated = await setNotificationPreference(scopeType, scopeId, {
-        muted: true,
-        muted_until: mutedUntil ?? null
-      });
-      setPreferences((current) => [
-        ...current.filter(
-          (preference) => !(preference.scope_type === scopeType && preference.scope_id === scopeId)
-        ),
-        updated
-      ]);
-    },
-    []
-  );
-
-  const unmute = useCallback(async (scopeType: NotificationScopeType, scopeId: string) => {
-    try {
-      await deleteNotificationPreference(scopeType, scopeId);
-    } catch (err) {
-      // 404 means no preference row, which is already the unmuted default
-      if (!(err instanceof ApiError && err.status === 404)) {
-        throw err;
-      }
-    }
-    setPreferences((current) =>
-      current.filter(
-        (preference) => !(preference.scope_type === scopeType && preference.scope_id === scopeId)
-      )
-    );
-  }, []);
 
   return {
     notifications,


### PR DESCRIPTION
## About

This pullrequest is a small front addition, firstly it disables the right click as default, it only works when right clicking on the guild or channel.
Take it as a quick panel, to create a quick invite, mute the server without having to fill the guild id, copy the guild id, and fast leave (not for owner), the channel also has a panel for mute channel and copy channel id.