### PR TITLE
fix(front): no error toast after a repeated failed login/register attempt

### DIFF
--- a/frontend/app/auth/login/page.tsx
+++ b/frontend/app/auth/login/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { LogIn } from 'lucide-react';
 import { AuthCard } from '../../../src/components/auth-card';
@@ -15,19 +15,8 @@ export default function LoginPage() {
   const router = useRouter();
   const { refreshGuilds } = useGuilds();
   const [errors, setErrors] = useState<LoginFormErrors>({});
-  const [serverError, setServerError] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
   const { pushToast } = useToast();
-
-  useEffect(() => {
-    if (serverError) {
-      pushToast({
-        title: 'Login failed',
-        description: serverError,
-        tone: 'error'
-      });
-    }
-  }, [serverError, pushToast]);
 
   async function handleSubmit(formData: FormData) {
     const email = String(formData.get('email') ?? '');
@@ -35,7 +24,6 @@ export default function LoginPage() {
 
     const nextErrors = validateLoginForm({ email, password });
     setErrors(nextErrors);
-    setServerError('');
 
     if (Object.keys(nextErrors).length > 0) {
       return;
@@ -48,7 +36,11 @@ export default function LoginPage() {
       void refreshGuilds();
       router.push('/chat');
     } catch (error) {
-      setServerError(describeLoginError(error));
+      pushToast({
+        title: 'Login failed',
+        description: describeLoginError(error),
+        tone: 'error'
+      });
     } finally {
       setIsSubmitting(false);
     }

--- a/frontend/app/auth/register/page.tsx
+++ b/frontend/app/auth/register/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { UserPlus } from 'lucide-react';
 import { AuthCard } from '../../../src/components/auth-card';
@@ -16,19 +16,8 @@ import { useToast } from '../../../src/shared/ui/toast';
 export default function RegisterPage() {
   const router = useRouter();
   const [errors, setErrors] = useState<RegisterFormErrors>({});
-  const [serverError, setServerError] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
   const { pushToast } = useToast();
-
-  useEffect(() => {
-    if (serverError) {
-      pushToast({
-        title: 'Registration failed',
-        description: serverError,
-        tone: 'error'
-      });
-    }
-  }, [serverError, pushToast]);
 
   async function handleSubmit(formData: FormData) {
     const email = String(formData.get('email') ?? '');
@@ -37,7 +26,6 @@ export default function RegisterPage() {
     const nextErrors = validateRegisterForm({ email, password, confirm });
 
     setErrors(nextErrors);
-    setServerError('');
 
     if (Object.keys(nextErrors).length > 0) {
       return;
@@ -49,7 +37,11 @@ export default function RegisterPage() {
       establishSession(access_token, user_id);
       router.push('/chat');
     } catch (error) {
-      setServerError(describeRegisterError(error));
+      pushToast({
+        title: 'Registration failed',
+        description: describeRegisterError(error),
+        tone: 'error'
+      });
     } finally {
       setIsSubmitting(false);
     }


### PR DESCRIPTION
## About

- serverError state + effect only fired on a **change**, so two failed attempts in a row with the same error message showed a toast on the first but silently did **nothing** on the second
- login and register now push the toast **directly** from the `catch` block