### PR TITLE
refactor(frontend): make accentForId unique source of truth for user accent-color

### DIFF
--- a/frontend/src/components/chat-workspace.tsx
+++ b/frontend/src/components/chat-workspace.tsx
@@ -40,7 +40,8 @@ import { CallWindow } from './call/call-window';
 import { useCurrentUserProfile } from '../shared/user/user-store';
 import { useGuilds } from '../shared/guilds/guild-store';
 import { useGuildMembers } from '../shared/guilds/use-guild-members';
-import { accentForUserId, toSidebarStatus } from '../shared/mappers/user';
+import { toSidebarStatus } from '../shared/mappers/user';
+import { accentForId } from '../shared/lib/accent';
 
 const LAST_CHAT_MODE_KEY = 'ft_transcendence_last_chat_mode';
 const TOP_THRESHOLD_PX = 96;
@@ -107,7 +108,7 @@ export function ChatWorkspace() {
       name: user.display_name || user.username,
       role: 'Member' as const,
       status: toSidebarStatus(user.status),
-      accent: accentForUserId(user.id),
+      accent: accentForId(user.id),
       activity: 'No recent activity',
       bio: user.bio,
       avatarUrl: user.avatar_url ?? null,
@@ -746,7 +747,7 @@ export function ChatWorkspace() {
               name: currentUser.displayName,
               role: 'Member',
               status: toSidebarStatus(currentUser.status),
-              accent: accentForUserId(currentUser.id),
+              accent: accentForId(currentUser.id),
               activity: 'No recent activity',
               bio: currentUser.bio,
               avatarUrl: currentUser.avatarUrl,

--- a/frontend/src/components/friends-list.tsx
+++ b/frontend/src/components/friends-list.tsx
@@ -15,12 +15,8 @@ import { AvatarWithStatus } from './avatar-with-status';
 import type { ChatMessageData } from './chat-message';
 import type { DirectMessage } from './dm-list';
 import { SearchInput } from './search-input';
-import {
-  accentForUserId,
-  toSidebarStatus,
-  toUserStatusLabel,
-  type CurrentUserProfile
-} from '../shared/mappers/user';
+import { accentForId } from '../shared/lib/accent';
+import { toSidebarStatus, toUserStatusLabel } from '../shared/mappers/user';
 import {
   blockUser,
   deleteFriendship,
@@ -455,7 +451,7 @@ export function FriendsList({
                     >
                       <AvatarWithStatus
                         name={user.display_name || user.username}
-                        accent={accentForUserId(user.id)}
+                        accent={accentForId(user.id)}
                         status={toSidebarStatus(user.status)}
                         avatarUrl={user.avatar_url ?? null}
                       />
@@ -659,7 +655,7 @@ function RequestRow({
     <div className="flex items-center gap-3 rounded-lg px-3 py-2 text-left text-grey-link transition hover:bg-frame/60 hover:text-white">
       <AvatarWithStatus
         name={request.user.display_name || request.user.username}
-        accent={accentForUserId(request.user.id)}
+        accent={accentForId(request.user.id)}
         status={toSidebarStatus(request.user.status)}
         avatarUrl={request.user.avatar_url ?? null}
       />

--- a/frontend/src/components/guild-member-list.tsx
+++ b/frontend/src/components/guild-member-list.tsx
@@ -12,7 +12,7 @@ import { useGuilds } from '../shared/guilds/guild-store';
 import { useGuildMembers, type HydratedGuildMember } from '../shared/guilds/use-guild-members';
 import { countPermissionBits, rolePermissionBits } from '../shared/guilds/role-permissions';
 import { useGroupMembersByRole } from '../shared/hooks/use-group-members-by-role';
-import { hashToIndex } from '../shared/lib/hash';
+import { accentForId } from '../shared/lib/accent';
 import { useToast } from '../shared/ui/toast';
 
 export type GuildMember = {
@@ -33,12 +33,6 @@ export type GuildMember = {
 // TODO(api:chat): message authors still come from mocks until Epic 4 wires real chat history.
 export function getGuildMemberByName(name: string) {
   return guildMembers.find((member) => member.name.toLowerCase() === name.toLowerCase()) ?? null;
-}
-
-const ACCENTS: ChatMessageData['accent'][] = ['aqua', 'yellow', 'lime', 'lavender', 'pink'];
-
-function getAccentForId(id: string): ChatMessageData['accent'] {
-  return ACCENTS[hashToIndex(id, ACCENTS.length)];
 }
 
 function toSidebarStatus(status: UserStatus): DirectMessage['status'] {
@@ -62,7 +56,7 @@ export function toProfileMember(member: HydratedGuildMember): GuildMember {
     role: member.isOwner ? 'Owner' : (topRole?.name ?? 'Member'),
     roleColor: member.isOwner ? null : (topRole?.color ?? null),
     status: toSidebarStatus(member.status),
-    accent: getAccentForId(member.userId),
+    accent: accentForId(member.userId),
     activity: member.joinedAt ? `Joined ${formatJoinedAt(member.joinedAt)}` : 'Member',
     bio: member.bio,
     avatarUrl: member.avatarUrl,
@@ -109,7 +103,7 @@ function MemberRow({
       <AvatarWithStatus
         size="sm"
         name={member.displayName}
-        accent={getAccentForId(member.userId)}
+        accent={accentForId(member.userId)}
         status={toSidebarStatus(member.status)}
         avatarUrl={member.avatarUrl}
       />

--- a/frontend/src/shared/api/hydrate.ts
+++ b/frontend/src/shared/api/hydrate.ts
@@ -1,20 +1,8 @@
-import type { ChatMessageData } from '../../components/chat-message';
 import type { DirectMessage } from '../../components/dm-list';
 import type { Friend } from '../../components/friends-list';
 import type { DirectMessageConversationDto } from './chat';
 import type { FriendDto, UserProfileDto, UserStatus } from './user';
-
-const ACCENTS: ChatMessageData['accent'][] = ['aqua', 'yellow', 'lime', 'lavender', 'pink'];
-
-// deterministic accent so a given user keeps the same colour across renders
-// (the avatar chips are colour-coded but the API carries no accent field).
-export function accentForId(id: string): ChatMessageData['accent'] {
-  let hash = 0;
-  for (let i = 0; i < id.length; i += 1) {
-    hash = (hash * 31 + id.charCodeAt(i)) >>> 0;
-  }
-  return ACCENTS[hash % ACCENTS.length];
-}
+import { accentForId } from '../lib/accent';
 
 // the sidebar only renders three presence dots; collapse the richer user status
 // set onto them (dnd is shown idle-style, anything unknown as offline).

--- a/frontend/src/shared/hooks/use-conversation-history.ts
+++ b/frontend/src/shared/hooks/use-conversation-history.ts
@@ -17,8 +17,8 @@ import {
 import { ApiError } from '../api/client';
 import { getUsersByIds, type UserSummaryDto } from '../api/user';
 import { onChatHubEvent } from '../api/chat-hub';
+import { accentForId } from '../lib/accent';
 import {
-  accentForAuthor,
   authorLabel,
   formatMessageTimestamp,
   mapChannelMessage,
@@ -408,7 +408,7 @@ export function useConversationHistory(
       id: nonce,
       authorId: currentUserId ?? undefined,
       author: authorLabel(currentUserId ?? '', currentUserId),
-      accent: accentForAuthor(currentUserId ?? ''),
+      accent: accentForId(currentUserId ?? ''),
       content: content ? splitMessageLines(content) : [],
       timestamp: formatMessageTimestamp(nowIso),
       createdAt: nowIso,

--- a/frontend/src/shared/hooks/use-dm-workspace.ts
+++ b/frontend/src/shared/hooks/use-dm-workspace.ts
@@ -6,8 +6,8 @@ import { archiveDirectMessageConversation, listDirectMessages } from '../api/cha
 import { getUsersByIds } from '../api/user';
 import { onChatHubEvent } from '../api/chat-hub';
 import { subscribeProfileUpdated } from '../lib/profile-events';
+import { accentForId } from '../lib/accent';
 import {
-  accentForAuthor,
   authorLabel,
   formatMessageTimestamp,
   mapDirectMessageConversation,
@@ -131,7 +131,7 @@ export function useDmWorkspace(currentUserId: string | null): DmWorkspace {
             id: partnerId,
             name: authorLabel(partnerId, currentUserId),
             status: 'offline',
-            accent: accentForAuthor(partnerId),
+            accent: accentForId(partnerId),
             lastMessage: preview,
             lastMessageAt,
             lastActivityAt,

--- a/frontend/src/shared/lib/accent.ts
+++ b/frontend/src/shared/lib/accent.ts
@@ -1,0 +1,11 @@
+import type { ChatMessageData } from '../../components/chat-message';
+import { hashToIndex } from './hash';
+
+// single source of truth for user/message accent colors - keeps a given
+// user's color consistent across the profile card, guild member list, and
+// chat messages
+const ACCENTS: ChatMessageData['accent'][] = ['aqua', 'yellow', 'lime', 'lavender', 'pink'];
+
+export function accentForId(id: string): ChatMessageData['accent'] {
+  return ACCENTS[hashToIndex(id, ACCENTS.length)];
+}

--- a/frontend/src/shared/mappers/chat.ts
+++ b/frontend/src/shared/mappers/chat.ts
@@ -7,11 +7,7 @@ import type {
   MessageReactionDto
 } from '../api/chat';
 import type { UserSummaryDto } from '../api/user';
-import { hashToIndex } from '../lib/hash';
-
-type MessageAccent = ChatMessageData['accent'];
-
-const MESSAGE_ACCENTS: MessageAccent[] = ['aqua', 'yellow', 'lime', 'lavender', 'pink'];
+import { accentForId } from '../lib/accent';
 
 export function formatMessageTimestamp(isoTimestamp: string): string {
   return new Date(isoTimestamp).toLocaleTimeString('en-US', {
@@ -22,10 +18,6 @@ export function formatMessageTimestamp(isoTimestamp: string): string {
 
 export function splitMessageLines(content: string): string[] {
   return content.split(/\r?\n/);
-}
-
-export function accentForAuthor(authorId: string): MessageAccent {
-  return MESSAGE_ACCENTS[hashToIndex(authorId, MESSAGE_ACCENTS.length)];
 }
 
 export function authorLabel(
@@ -66,7 +58,7 @@ export function mapChannelMessage(
     id: dto.id,
     authorId: dto.author_id,
     author: authorLabel(dto.author_id, currentUserId, usersById),
-    accent: accentForAuthor(dto.author_id),
+    accent: accentForId(dto.author_id),
     content: splitMessageLines(dto.content ?? ''),
     timestamp: formatMessageTimestamp(dto.created_at),
     createdAt: dto.created_at,
@@ -87,7 +79,7 @@ export function mapDirectMessage(
     id: dto.id,
     authorId: dto.sender_id,
     author: authorLabel(dto.sender_id, currentUserId, usersById),
-    accent: accentForAuthor(dto.sender_id),
+    accent: accentForId(dto.sender_id),
     content: splitMessageLines(dto.content ?? ''),
     timestamp: formatMessageTimestamp(dto.created_at),
     createdAt: dto.created_at,
@@ -105,7 +97,7 @@ export function mapDirectMessageConversation(
     id: dto.partner_id,
     name: profile?.display_name || profile?.username || `User ${dto.partner_id}`,
     status: 'offline',
-    accent: accentForAuthor(dto.partner_id),
+    accent: accentForId(dto.partner_id),
     lastMessage: dto.last_preview,
     lastMessageAt: formatMessageTimestamp(dto.last_message_at),
     lastActivityAt: Date.parse(dto.last_message_at),

--- a/frontend/src/shared/mappers/user.ts
+++ b/frontend/src/shared/mappers/user.ts
@@ -1,9 +1,5 @@
-import type { ChatMessageData } from '../../components/chat-message';
 import type { DirectMessage } from '../../components/dm-list';
-import type { Friend } from '../../components/friends-list';
 import type { UserProfileDto, UserStatus } from '../api/user';
-
-const ACCENTS: ChatMessageData['accent'][] = ['aqua', 'yellow', 'lime', 'lavender', 'pink'];
 
 export type CurrentUserProfile = {
   id: string;
@@ -16,18 +12,6 @@ export type CurrentUserProfile = {
   lastSeenAt: string;
   lastSeenLabel: string;
 };
-
-function hashToAccent(id: string): ChatMessageData['accent'] {
-  let hash = 0;
-  for (let index = 0; index < id.length; index += 1) {
-    hash = (hash * 31 + id.charCodeAt(index)) >>> 0;
-  }
-  return ACCENTS[hash % ACCENTS.length];
-}
-
-export function accentForUserId(id: string): ChatMessageData['accent'] {
-  return hashToAccent(id);
-}
 
 export function toSidebarStatus(status: UserStatus): DirectMessage['status'] {
   switch (status) {


### PR DESCRIPTION
Consolidate duplicated accent-color hashing into one shared function

## What found

`accentForUserId` (`mappers/user.ts`), `accentForId` (`api/hydrate.ts`), `accentForAuthor` (`mappers/chat.ts`), and `getAccentForId` (`guild-member-list.tsx`) were four copies of the same hash-to-color logic, two of them using a different hash variant - causing the same user to show different colors in different views.

## What does
Replaced all four with one `accentForId` in new `shared/lib/accent.ts`, used everywhere a user/message accent color is needed.
> `hashToIndex` (`shared/lib/hash.ts`) is untouched and still used separately by `guild-icon.tsx` (different palette, different domain)

**Not addressed here**: two different users can still land on the same color (5-color palette, no collision avoidance).