### PR TITLE
Front/channels/permissions

### DIFF
--- a/frontend/src/components/channel-list.tsx
+++ b/frontend/src/components/channel-list.tsx
@@ -1,12 +1,13 @@
 'use client';
 
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import Link from 'next/link';
 import {
   CircleEllipsis,
   Bell,
   Hash,
   Headphones,
+  Lock,
   Mic,
   MicOff,
   Settings,
@@ -14,6 +15,7 @@ import {
 } from 'lucide-react';
 import { SearchInput } from './search-input';
 import { useGuilds } from '../shared/guilds/guild-store';
+import { useCloseOnEscape } from '../shared/hooks/use-close-on-escape';
 import { toSidebarStatus, type CurrentUserProfile } from '../shared/mappers/user';
 import { AvatarWithStatus } from './avatar-with-status';
 import { FortyTwoIcon } from './icons/brand-icons';
@@ -38,13 +40,71 @@ type ChannelListProps = {
   isMicMuted: boolean;
   isDeafened: boolean;
   unreadNotifications: number;
+  /** Enables the right-click channel menu; keep off for callers the server would 403. */
+  canManageChannels?: boolean;
   onToggleDeafen: () => void;
   onToggleMicMute: () => void;
   onOpenNotifications: () => void;
   onOpenSettings: () => void;
   onOpenGuildSettings: () => void;
   onSelectChannel: (channelId: string) => void;
+  onOpenChannelPermissions?: (channel: TextChannel) => void;
 };
+
+type ChannelMenuState = {
+  channel: TextChannel;
+  x: number;
+  y: number;
+};
+
+function ChannelContextMenu({
+  menu,
+  onOpenPermissions,
+  onClose
+}: {
+  menu: ChannelMenuState;
+  onOpenPermissions: (channel: TextChannel) => void;
+  onClose: () => void;
+}) {
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  useCloseOnEscape(onClose);
+
+  useEffect(() => {
+    function handleMouseDown(event: MouseEvent) {
+      if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
+        onClose();
+      }
+    }
+
+    document.addEventListener('mousedown', handleMouseDown);
+    return () => document.removeEventListener('mousedown', handleMouseDown);
+  }, [onClose]);
+
+  return (
+    <div
+      ref={menuRef}
+      className="fixed z-50 w-56 rounded-md border border-stroke bg-panel p-1.5 shadow-lg"
+      style={{
+        left: Math.min(menu.x, window.innerWidth - 240),
+        top: Math.min(menu.y, window.innerHeight - 88)
+      }}
+    >
+      <p className="mono-detail truncate px-2 py-1 text-xs text-white/35"># {menu.channel.name}</p>
+      <button
+        type="button"
+        onClick={() => {
+          onOpenPermissions(menu.channel);
+          onClose();
+        }}
+        className="flex h-9 w-full items-center gap-2.5 rounded-md px-2 text-left text-sm font-semibold text-white/70 transition hover:bg-frame hover:text-white"
+      >
+        <Lock className="h-4 w-4 shrink-0 text-aqua" strokeWidth={1.9} />
+        Channel permissions
+      </button>
+    </div>
+  );
+}
 
 export function getChannelName(channelId: string, channels: TextChannel[]) {
   if (channelId.length === 0)
@@ -65,15 +125,18 @@ export function ChannelList({
   isMicMuted,
   isDeafened,
   unreadNotifications,
+  canManageChannels = false,
   onToggleDeafen,
   onToggleMicMute,
   onOpenNotifications,
   onOpenSettings,
   onOpenGuildSettings,
-  onSelectChannel
+  onSelectChannel,
+  onOpenChannelPermissions
 }: ChannelListProps) {
   const { selectedGuild } = useGuilds();
   const [search, setSearch] = useState('');
+  const [channelMenu, setChannelMenu] = useState<ChannelMenuState | null>(null);
 
   const filteredCategories = useMemo(() => {
     const term = search.trim().toLowerCase();
@@ -140,6 +203,13 @@ export function ChannelList({
                       key={channel.id}
                       type="button"
                       onClick={() => onSelectChannel(channel.id)}
+                      onContextMenu={(event) => {
+                        if (!canManageChannels || !onOpenChannelPermissions) {
+                          return;
+                        }
+                        event.preventDefault();
+                        setChannelMenu({ channel, x: event.clientX, y: event.clientY });
+                      }}
                       className={`mono-detail flex h-10 w-full items-center gap-3 rounded-md px-3 text-left text-[1rem] transition ${
                         isActive ? 'bg-frame text-white' : 'text-grey-link hover:bg-frame/60'
                       }`}
@@ -236,6 +306,14 @@ export function ChannelList({
           </div>
         </div>
       </div>
+
+      {channelMenu && onOpenChannelPermissions ? (
+        <ChannelContextMenu
+          menu={channelMenu}
+          onOpenPermissions={onOpenChannelPermissions}
+          onClose={() => setChannelMenu(null)}
+        />
+      ) : null}
     </div>
   );
 }

--- a/frontend/src/components/chat-workspace.tsx
+++ b/frontend/src/components/chat-workspace.tsx
@@ -6,7 +6,7 @@ import { type ChatMessageData } from './chat-message';
 import { ConversationHeader } from './chat/conversation-header';
 import { MessageComposer } from './chat/message-composer';
 import { MessageList } from './chat/message-list';
-import { ChannelList, getChannelName } from './channel-list';
+import { ChannelList, getChannelName, type TextChannel } from './channel-list';
 import { DmList, getDmDetails, getDmName } from './dm-list';
 import {
   getGuildMemberByName,
@@ -16,6 +16,7 @@ import {
 } from './guild-member-list';
 import { GuildSidebar } from './guild-sidebar';
 import { GuildSettingsModal } from './guild/guild-settings-modal';
+import { ChannelPermissionsModal } from './guild/channel-permissions-modal';
 import { NotificationCard } from './notification-card';
 import { ProfileCard } from './profile-card';
 import { SettingsModal } from './settings-modal';
@@ -40,6 +41,7 @@ import { CallWindow } from './call/call-window';
 import { useCurrentUserProfile } from '../shared/user/user-store';
 import { useGuilds } from '../shared/guilds/guild-store';
 import { useGuildMembers } from '../shared/guilds/use-guild-members';
+import { effectivePermissions, hasPermission, PERMISSIONS } from '../shared/guilds/role-permissions';
 import { toSidebarStatus } from '../shared/mappers/user';
 import { accentForId } from '../shared/lib/accent';
 
@@ -66,6 +68,7 @@ export function ChatWorkspace() {
   const [isNotificationCardOpen, setIsNotificationCardOpen] = useState(false);
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
   const [isGuildSettingsOpen, setIsGuildSettingsOpen] = useState(false);
+  const [permissionsChannel, setPermissionsChannel] = useState<TextChannel | null>(null);
   const [isMicMuted, setIsMicMuted] = useState(false);
   const [isDeafened, setIsDeafened] = useState(false);
   const [isMemberListOpen, setIsMemberListOpen] = useState(true);
@@ -93,7 +96,7 @@ export function ChatWorkspace() {
   const currentUserId = useCurrentUserId();
   const guildWorkspace = useGuildWorkspace();
   const dmWorkspace = useDmWorkspace(currentUserId);
-  const { members: currentGuildMembers } = useGuildMembers(
+  const { members: currentGuildMembers, roles: currentGuildRoles } = useGuildMembers(
     selectedGuild?.id ?? null,
     selectedGuild?.owner_id ?? null
   );
@@ -101,6 +104,25 @@ export function ChatWorkspace() {
     () => currentGuildMembers.find((member) => member.userId === currentUserId) ?? null,
     [currentGuildMembers, currentUserId]
   );
+  // Gates the channel right-click menu to callers the server would authorize
+  // for the channel-permissions endpoints (ManageChannels).
+  const canManageChannels = useMemo(() => {
+    if (!currentGuildMember) {
+      return false;
+    }
+
+    const mask = effectivePermissions(
+      currentGuildMember.roles,
+      currentGuildRoles,
+      currentGuildMember.isOwner
+    );
+    return hasPermission(mask, PERMISSIONS.ManageChannels);
+  }, [currentGuildMember, currentGuildRoles]);
+
+  // A guild switch invalidates any channel-scoped dialog left open.
+  useEffect(() => {
+    setPermissionsChannel(null);
+  }, [selectedGuild?.id]);
 
   function toProfileMemberFromUser(user: UserSummaryDto) {
     return {
@@ -875,7 +897,9 @@ export function ChatWorkspace() {
               activeChannel={guildWorkspace.activeChannel ?? ''}
               categories={guildWorkspace.channelCategories}
               unreadCounts={channelUnreadCounts}
+              canManageChannels={canManageChannels}
               onSelectChannel={handleSelectChannel}
+              onOpenChannelPermissions={setPermissionsChannel}
             />
           )}
 
@@ -991,6 +1015,15 @@ export function ChatWorkspace() {
               guildId={selectedGuild.id}
               onClose={handleCloseGuildSettings}
               onChannelsChanged={guildWorkspace.refreshChannels}
+            />
+          ) : null}
+
+          {permissionsChannel && selectedGuild ? (
+            <ChannelPermissionsModal
+              guildId={selectedGuild.id}
+              channelId={permissionsChannel.id}
+              channelName={permissionsChannel.name}
+              onClose={() => setPermissionsChannel(null)}
             />
           ) : null}
 

--- a/frontend/src/components/guild/channel-permissions-modal.tsx
+++ b/frontend/src/components/guild/channel-permissions-modal.tsx
@@ -1,0 +1,607 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useRef, useState, type RefObject } from 'react';
+import { Check, Lock, Minus, Plus, Trash2, UserRound, X } from 'lucide-react';
+import {
+  deleteChannelPermissionOverwrite,
+  listChannelPermissionOverwrites,
+  putChannelPermissionOverwrite,
+  type ChannelOverwriteDto,
+  type GuildRoleDto
+} from '../../shared/api/guild';
+import { PERMISSIONS } from '../../shared/guilds/role-permissions';
+import { useGuilds } from '../../shared/guilds/guild-store';
+import { useGuildMembers, type HydratedGuildMember } from '../../shared/guilds/use-guild-members';
+import { useCloseOnEscape } from '../../shared/hooks/use-close-on-escape';
+import { useToast } from '../../shared/ui/toast';
+import { ActionModal } from '../action-modal';
+
+// Channel-scoped subset of the permission bitmask: bits that make sense as a
+// per-channel allow/deny overwrite. Guild-wide bits (kick, ban, manage guild,
+// administrator...) are deliberately left out of the editor.
+const OVERWRITE_FLAGS = [
+  {
+    value: PERMISSIONS.ReadMessages,
+    label: 'Read messages',
+    description: 'See this channel and its message history.'
+  },
+  {
+    value: PERMISSIONS.SendMessages,
+    label: 'Send messages',
+    description: 'Post messages in this channel.'
+  },
+  {
+    value: PERMISSIONS.ManageMessages,
+    label: 'Manage messages',
+    description: "Delete other members' messages in this channel."
+  },
+  {
+    value: PERMISSIONS.MentionEveryone,
+    label: 'Mention everyone',
+    description: 'Use @everyone mentions in this channel.'
+  },
+  {
+    value: PERMISSIONS.CreateInvite,
+    label: 'Create invite',
+    description: 'Create invites pointing to this channel.'
+  },
+  {
+    value: PERMISSIONS.ManageChannels,
+    label: 'Manage channel',
+    description: 'Edit or delete this channel and its permissions.'
+  }
+];
+
+type OverwriteState = 'allow' | 'inherit' | 'deny';
+
+function overwriteKey(overwrite: Pick<ChannelOverwriteDto, 'target_type' | 'target_id'>) {
+  return `${overwrite.target_type}:${overwrite.target_id}`;
+}
+
+function bitState(overwrite: ChannelOverwriteDto, bit: number): OverwriteState {
+  if ((overwrite.allow & bit) !== 0) {
+    return 'allow';
+  }
+  if ((overwrite.deny & bit) !== 0) {
+    return 'deny';
+  }
+  return 'inherit';
+}
+
+function TriStateControl({
+  state,
+  disabled,
+  onSelect
+}: {
+  state: OverwriteState;
+  disabled: boolean;
+  onSelect: (state: OverwriteState) => void;
+}) {
+  const options: { value: OverwriteState; icon: typeof Check; label: string; active: string }[] = [
+    { value: 'deny', icon: X, label: 'Deny', active: 'bg-pink/20 text-pink' },
+    { value: 'inherit', icon: Minus, label: 'Inherit', active: 'bg-frame text-white' },
+    { value: 'allow', icon: Check, label: 'Allow', active: 'bg-lime/20 text-lime' }
+  ];
+
+  return (
+    <div className="flex shrink-0 overflow-hidden rounded-md border border-stroke">
+      {options.map((option) => {
+        const Icon = option.icon;
+        const isActive = state === option.value;
+
+        return (
+          <button
+            key={option.value}
+            type="button"
+            disabled={disabled}
+            onClick={() => onSelect(option.value)}
+            title={option.label}
+            aria-label={option.label}
+            aria-pressed={isActive}
+            className={`flex h-7 w-9 items-center justify-center transition disabled:cursor-not-allowed disabled:opacity-50 ${
+              isActive ? option.active : 'text-[#8b8b8f] hover:bg-frame hover:text-white'
+            }`}
+          >
+            <Icon className="h-3.5 w-3.5" strokeWidth={2.2} />
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function RoleDot({ role }: { role: GuildRoleDto }) {
+  return (
+    <span
+      className="h-2.5 w-2.5 shrink-0 rounded-full"
+      style={{ backgroundColor: role.color || '#8b8b8f' }}
+    />
+  );
+}
+
+type AddTargetPopoverProps = {
+  roles: GuildRoleDto[];
+  members: HydratedGuildMember[];
+  onAdd: (targetType: 'role' | 'user', targetId: string) => void;
+  onClose: () => void;
+  /** Wrapper holding the trigger button and this popover; clicks outside it close the popover. */
+  containerRef: RefObject<HTMLElement | null>;
+};
+
+function AddTargetPopover({ roles, members, onAdd, onClose, containerRef }: AddTargetPopoverProps) {
+  useEffect(() => {
+    function handleMouseDown(event: MouseEvent) {
+      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
+        onClose();
+      }
+    }
+
+    document.addEventListener('mousedown', handleMouseDown);
+    return () => document.removeEventListener('mousedown', handleMouseDown);
+  }, [containerRef, onClose]);
+
+  const rowClasses =
+    'flex h-8 w-full items-center gap-2 rounded-md px-1.5 text-left text-sm text-white/60 transition hover:bg-frame hover:text-white';
+
+  return (
+    <div className="absolute left-0 top-9 z-20 w-64 rounded-md border border-stroke bg-panel p-2 shadow-lg">
+      <div className="mb-1 flex items-center justify-between">
+        <p className="px-1 text-xs font-bold uppercase tracking-wide text-white/40">
+          Add role or member
+        </p>
+        <button
+          type="button"
+          onClick={onClose}
+          className="flex h-6 w-6 items-center justify-center rounded-md text-[#8b8b8f] transition hover:bg-frame hover:text-white"
+          aria-label="Close target list"
+        >
+          <X className="h-3.5 w-3.5" strokeWidth={2} />
+        </button>
+      </div>
+      {roles.length === 0 && members.length === 0 ? (
+        <p className="px-1 pb-1 text-sm text-white/35">
+          Every role and member already has an overwrite.
+        </p>
+      ) : (
+        <div className="grid max-h-64 gap-1 overflow-y-auto">
+          {roles.length > 0 ? (
+            <div>
+              <p className="px-1 py-0.5 text-[0.65rem] font-bold uppercase tracking-wide text-white/30">
+                Roles
+              </p>
+              {roles.map((role) => (
+                <button
+                  key={role.id}
+                  type="button"
+                  onClick={() => onAdd('role', role.id)}
+                  className={rowClasses}
+                >
+                  <RoleDot role={role} />
+                  <span className="min-w-0 flex-1 truncate">{role.name}</span>
+                </button>
+              ))}
+            </div>
+          ) : null}
+          {members.length > 0 ? (
+            <div>
+              <p className="px-1 py-0.5 text-[0.65rem] font-bold uppercase tracking-wide text-white/30">
+                Members
+              </p>
+              {members.map((member) => (
+                <button
+                  key={member.userId}
+                  type="button"
+                  onClick={() => onAdd('user', member.userId)}
+                  className={rowClasses}
+                >
+                  <UserRound className="h-3.5 w-3.5 shrink-0 text-[#8a8a96]" strokeWidth={1.9} />
+                  <span className="min-w-0 flex-1 truncate">{member.displayName}</span>
+                </button>
+              ))}
+            </div>
+          ) : null}
+        </div>
+      )}
+    </div>
+  );
+}
+
+type ChannelPermissionsModalProps = {
+  guildId: string;
+  channelId: string;
+  channelName: string;
+  onClose: () => void;
+};
+
+export function ChannelPermissionsModal({
+  guildId,
+  channelId,
+  channelName,
+  onClose
+}: ChannelPermissionsModalProps) {
+  const { selectedGuild } = useGuilds();
+  const { members, roles } = useGuildMembers(
+    guildId,
+    selectedGuild?.id === guildId ? selectedGuild.owner_id : null
+  );
+  const [overwrites, setOverwrites] = useState<ChannelOverwriteDto[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [selectedKey, setSelectedKey] = useState<string | null>(null);
+  const [busyKey, setBusyKey] = useState<string | null>(null);
+  const [isAddOpen, setIsAddOpen] = useState(false);
+  const [removeTarget, setRemoveTarget] = useState<ChannelOverwriteDto | null>(null);
+  const [isRemoveBusy, setIsRemoveBusy] = useState(false);
+  const [error, setError] = useState('');
+  const addContainerRef = useRef<HTMLDivElement>(null);
+  const { pushToast } = useToast();
+
+  useCloseOnEscape(onClose);
+
+  const load = useCallback(async () => {
+    setIsLoading(true);
+    setError('');
+
+    try {
+      setOverwrites(await listChannelPermissionOverwrites(channelId));
+    } catch (loadError) {
+      setError(
+        loadError instanceof Error ? loadError.message : 'Failed to load channel permissions.'
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  }, [channelId]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  useEffect(() => {
+    if (error) {
+      pushToast({
+        title: 'Channel permissions',
+        description: error,
+        tone: 'error'
+      });
+    }
+  }, [error, pushToast]);
+
+  const rolesById = useMemo(() => new Map(roles.map((role) => [role.id, role])), [roles]);
+  const membersById = useMemo(
+    () => new Map(members.map((member) => [member.userId, member])),
+    [members]
+  );
+
+  // Roles first (hierarchy order, @everyone last), then members by name;
+  // targets whose role/member has since vanished sink to the bottom.
+  const sortedOverwrites = useMemo(() => {
+    const rolePosition = (overwrite: ChannelOverwriteDto) => {
+      const role = rolesById.get(overwrite.target_id);
+      if (!role) {
+        return -Infinity;
+      }
+      return role.is_default ? -1 : role.position;
+    };
+
+    return [...overwrites].sort((a, b) => {
+      if (a.target_type !== b.target_type) {
+        return a.target_type === 'role' ? -1 : 1;
+      }
+      if (a.target_type === 'role') {
+        return rolePosition(b) - rolePosition(a);
+      }
+      const aName = membersById.get(a.target_id)?.displayName ?? '';
+      const bName = membersById.get(b.target_id)?.displayName ?? '';
+      return aName.localeCompare(bName);
+    });
+  }, [overwrites, rolesById, membersById]);
+
+  const selected = sortedOverwrites.find((overwrite) => overwriteKey(overwrite) === selectedKey);
+
+  // Keep something sensible selected as overwrites load, get added or removed.
+  useEffect(() => {
+    if (!selected && sortedOverwrites.length > 0) {
+      setSelectedKey(overwriteKey(sortedOverwrites[0]));
+    }
+  }, [selected, sortedOverwrites]);
+
+  const overwrittenKeys = useMemo(
+    () => new Set(overwrites.map((overwrite) => overwriteKey(overwrite))),
+    [overwrites]
+  );
+  const availableRoles = useMemo(
+    () =>
+      roles
+        .filter((role) => !overwrittenKeys.has(`role:${role.id}`))
+        .sort((a, b) => {
+          if (a.is_default !== b.is_default) {
+            return a.is_default ? 1 : -1;
+          }
+          return b.position - a.position;
+        }),
+    [roles, overwrittenKeys]
+  );
+  const availableMembers = useMemo(
+    () => members.filter((member) => !overwrittenKeys.has(`user:${member.userId}`)),
+    [members, overwrittenKeys]
+  );
+
+  function targetName(overwrite: ChannelOverwriteDto) {
+    if (overwrite.target_type === 'role') {
+      return rolesById.get(overwrite.target_id)?.name ?? 'Unknown role';
+    }
+    return membersById.get(overwrite.target_id)?.displayName ?? 'Unknown member';
+  }
+
+  function patchLocal(key: string, allow: number, deny: number) {
+    setOverwrites((current) =>
+      current.map((overwrite) =>
+        overwriteKey(overwrite) === key ? { ...overwrite, allow, deny } : overwrite
+      )
+    );
+  }
+
+  async function handleSetBit(overwrite: ChannelOverwriteDto, bit: number, state: OverwriteState) {
+    const allow = state === 'allow' ? overwrite.allow | bit : overwrite.allow & ~bit;
+    const deny = state === 'deny' ? overwrite.deny | bit : overwrite.deny & ~bit;
+
+    if (allow === overwrite.allow && deny === overwrite.deny) {
+      return;
+    }
+
+    const key = overwriteKey(overwrite);
+    setError('');
+    setBusyKey(key);
+    patchLocal(key, allow, deny);
+
+    try {
+      await putChannelPermissionOverwrite(channelId, overwrite.target_id, {
+        target_type: overwrite.target_type,
+        allow,
+        deny
+      });
+    } catch (putError) {
+      patchLocal(key, overwrite.allow, overwrite.deny);
+      setError(putError instanceof Error ? putError.message : 'Failed to update permissions.');
+    } finally {
+      setBusyKey(null);
+    }
+  }
+
+  async function handleAddTarget(targetType: 'role' | 'user', targetId: string) {
+    const created: ChannelOverwriteDto = {
+      target_id: targetId,
+      target_type: targetType,
+      allow: 0,
+      deny: 0
+    };
+    const key = overwriteKey(created);
+
+    setIsAddOpen(false);
+    setError('');
+    setBusyKey(key);
+    setOverwrites((current) => [...current, created]);
+    setSelectedKey(key);
+
+    try {
+      await putChannelPermissionOverwrite(channelId, targetId, {
+        target_type: targetType,
+        allow: 0,
+        deny: 0
+      });
+    } catch (addError) {
+      setOverwrites((current) => current.filter((overwrite) => overwriteKey(overwrite) !== key));
+      setSelectedKey(null);
+      setError(addError instanceof Error ? addError.message : 'Failed to add overwrite.');
+    } finally {
+      setBusyKey(null);
+    }
+  }
+
+  async function confirmRemoveOverwrite() {
+    if (!removeTarget) {
+      return;
+    }
+
+    setError('');
+
+    try {
+      setIsRemoveBusy(true);
+      await deleteChannelPermissionOverwrite(channelId, removeTarget.target_id);
+      const key = overwriteKey(removeTarget);
+      setOverwrites((current) => current.filter((overwrite) => overwriteKey(overwrite) !== key));
+      if (selectedKey === key) {
+        setSelectedKey(null);
+      }
+      setRemoveTarget(null);
+    } catch (removeError) {
+      setError(removeError instanceof Error ? removeError.message : 'Failed to remove overwrite.');
+    } finally {
+      setIsRemoveBusy(false);
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/55 px-4 py-6">
+      <button
+        type="button"
+        className="absolute inset-0 cursor-default"
+        onClick={onClose}
+        aria-label="Close channel permissions"
+      />
+      <section className="relative w-full max-w-[46rem] overflow-hidden rounded-[1rem] bg-secondary-bg shadow-2xl shadow-black/50 ring-1 ring-stroke">
+        <div className="flex h-[4.75rem] items-center justify-between border-b border-stroke px-5">
+          <div className="flex min-w-0 items-center gap-3">
+            <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-md bg-aqua/10 text-aqua">
+              <Lock className="h-5 w-5" strokeWidth={1.9} />
+            </span>
+            <div className="min-w-0">
+              <h2 className="truncate text-[1.15rem] font-bold tracking-[-0.03em] text-white">
+                #{channelName}
+              </h2>
+              <p className="font-category text-[0.7rem] uppercase tracking-[0.14em] text-white/35">
+                Channel permissions
+              </p>
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="flex h-9 w-9 items-center justify-center rounded-md text-[#8b8b8f] transition hover:bg-frame hover:text-white"
+            aria-label="Close channel permissions"
+          >
+            <X className="h-4 w-4" strokeWidth={2} />
+          </button>
+        </div>
+
+        <div className="grid max-h-[calc(100vh-12rem)] min-h-[30rem] gap-4 overflow-y-auto p-5 sm:grid-cols-[14rem_minmax(0,1fr)]">
+          <div className="min-w-0">
+            <div className="relative flex items-center justify-between" ref={addContainerRef}>
+              <p className="font-category px-1 text-[0.68rem] uppercase tracking-[0.14em] text-white/30">
+                Roles &amp; members
+              </p>
+              <button
+                type="button"
+                onClick={() => setIsAddOpen((open) => !open)}
+                className="flex h-7 w-7 items-center justify-center rounded-md text-[#8b8b8f] transition hover:bg-frame hover:text-white"
+                aria-label="Add role or member overwrite"
+                title="Add role or member"
+              >
+                <Plus className="h-4 w-4" strokeWidth={2} />
+              </button>
+              {isAddOpen ? (
+                <AddTargetPopover
+                  roles={availableRoles}
+                  members={availableMembers}
+                  onAdd={(targetType, targetId) => void handleAddTarget(targetType, targetId)}
+                  onClose={() => setIsAddOpen(false)}
+                  containerRef={addContainerRef}
+                />
+              ) : null}
+            </div>
+
+            {isLoading ? (
+              <div className="mt-2 h-24 animate-pulse rounded-md bg-panel" />
+            ) : sortedOverwrites.length === 0 ? (
+              <div className="mt-2 grid gap-3">
+                <p className="px-1 text-sm leading-6 text-white/35">
+                  No overwrites yet. Add a role or member to customise who can see and use this
+                  channel.
+                </p>
+                <button
+                  type="button"
+                  onClick={() => setIsAddOpen(true)}
+                  className="flex h-10 items-center justify-center gap-2 rounded-md border border-dashed border-stroke-strong text-sm font-semibold text-white/50 transition hover:border-aqua/40 hover:text-aqua"
+                >
+                  <Plus className="h-4 w-4" strokeWidth={2} />
+                  Add role or member
+                </button>
+              </div>
+            ) : (
+              <ul className="mt-2 grid gap-1">
+                {sortedOverwrites.map((overwrite) => {
+                  const key = overwriteKey(overwrite);
+                  const isActive = key === selectedKey;
+                  const role =
+                    overwrite.target_type === 'role' ? rolesById.get(overwrite.target_id) : null;
+
+                  return (
+                    <li key={key}>
+                      <button
+                        type="button"
+                        onClick={() => setSelectedKey(key)}
+                        className={`flex h-9 w-full items-center gap-2 rounded-md px-2 text-left text-sm font-semibold transition ${
+                          isActive ? 'bg-frame text-white' : 'text-white/60 hover:bg-frame/60'
+                        }`}
+                      >
+                        {role ? (
+                          <RoleDot role={role} />
+                        ) : (
+                          <UserRound
+                            className="h-3.5 w-3.5 shrink-0 text-[#8a8a96]"
+                            strokeWidth={1.9}
+                          />
+                        )}
+                        <span className="min-w-0 flex-1 truncate">{targetName(overwrite)}</span>
+                      </button>
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </div>
+
+          <div className="min-w-0 rounded-md border border-stroke bg-panel p-4">
+            {selected ? (
+              <>
+                <div className="flex items-center justify-between gap-3">
+                  <div className="min-w-0">
+                    <p className="truncate text-[0.95rem] font-bold text-white">
+                      {targetName(selected)}
+                    </p>
+                    <p className="text-xs text-white/35">
+                      {selected.target_type === 'role' ? 'Role overwrite' : 'Member overwrite'}
+                    </p>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => setRemoveTarget(selected)}
+                    className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-[#8b8b8f] transition hover:bg-frame hover:text-pink"
+                    aria-label={`Remove overwrite for ${targetName(selected)}`}
+                    title="Remove overwrite"
+                  >
+                    <Trash2 className="h-4 w-4" strokeWidth={1.9} />
+                  </button>
+                </div>
+
+                <ul className="mt-4 grid gap-2">
+                  {OVERWRITE_FLAGS.map((flag) => (
+                    <li
+                      key={flag.value}
+                      className="flex items-center justify-between gap-4 rounded-md border border-stroke bg-secondary-bg px-3 py-2"
+                    >
+                      <div className="min-w-0">
+                        <p className="text-sm font-semibold text-white/80">{flag.label}</p>
+                        <p className="text-xs leading-5 text-white/35">{flag.description}</p>
+                      </div>
+                      <TriStateControl
+                        state={bitState(selected, flag.value)}
+                        disabled={busyKey === overwriteKey(selected)}
+                        onSelect={(state) => void handleSetBit(selected, flag.value, state)}
+                      />
+                    </li>
+                  ))}
+                </ul>
+
+                <p className="mt-3 text-xs leading-5 text-white/35">
+                  Inherit falls back to the permissions granted by the member&apos;s roles. Member
+                  overwrites win over role overwrites; deny wins over allow at the same level.
+                </p>
+              </>
+            ) : (
+              <div className="flex h-full items-center justify-center">
+                <p className="max-w-[18rem] text-center text-sm leading-6 text-white/35">
+                  {sortedOverwrites.length === 0
+                    ? 'This channel has no overwrites: everyone sees it with the permissions their roles grant.'
+                    : 'Select a role or member on the left to edit what it can do in this channel.'}
+                </p>
+              </div>
+            )}
+          </div>
+        </div>
+      </section>
+
+      {removeTarget ? (
+        <ActionModal
+          title={`Remove overwrite for ${targetName(removeTarget)}?`}
+          description="This channel will fall back to the permissions granted by roles alone."
+          confirmLabel="Remove overwrite"
+          destructive
+          isBusy={isRemoveBusy}
+          onClose={() => setRemoveTarget(null)}
+          onConfirm={confirmRemoveOverwrite}
+        />
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/components/guild/guild-channels-panel.tsx
+++ b/frontend/src/components/guild/guild-channels-panel.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useState } from 'react';
 import type { FormEvent } from 'react';
-import { Check, Hash, Pencil, Trash2, X } from 'lucide-react';
+import { Check, Hash, Lock, Pencil, Trash2, X } from 'lucide-react';
 import {
   createGuildChannel,
   deleteGuildChannel,
@@ -13,6 +13,7 @@ import {
   type GuildChannelDto
 } from '../../shared/api/guild';
 import { ActionModal } from '../action-modal';
+import { ChannelPermissionsModal } from './channel-permissions-modal';
 import { useToast } from '../../shared/ui/toast';
 
 const inputClasses =
@@ -58,6 +59,7 @@ export function GuildChannelsPanel({ guildId, onChannelsChanged }: GuildChannels
   const [editDraft, setEditDraft] = useState<EditDraft | null>(null);
   const [isBusy, setIsBusy] = useState(false);
   const [deleteTarget, setDeleteTarget] = useState<GuildChannelDto | null>(null);
+  const [permissionsTarget, setPermissionsTarget] = useState<GuildChannelDto | null>(null);
   const { pushToast } = useToast();
 
   const load = useCallback(async () => {
@@ -355,6 +357,15 @@ export function GuildChannelsPanel({ guildId, onChannelsChanged }: GuildChannels
                   </div>
                   <button
                     type="button"
+                    onClick={() => setPermissionsTarget(channel)}
+                    className={iconButtonClasses}
+                    aria-label={`Edit permissions of channel ${channel.name}`}
+                    title="Channel permissions"
+                  >
+                    <Lock className="h-4 w-4 text-aqua" strokeWidth={1.9} />
+                  </button>
+                  <button
+                    type="button"
                     onClick={() => startEdit(channel)}
                     className={iconButtonClasses}
                     aria-label={`Edit channel ${channel.name}`}
@@ -376,6 +387,15 @@ export function GuildChannelsPanel({ guildId, onChannelsChanged }: GuildChannels
           ))}
         </ul>
       )}
+
+      {permissionsTarget ? (
+        <ChannelPermissionsModal
+          guildId={guildId}
+          channelId={permissionsTarget.id}
+          channelName={permissionsTarget.name}
+          onClose={() => setPermissionsTarget(null)}
+        />
+      ) : null}
 
       {deleteTarget ? (
         <ActionModal

--- a/frontend/src/shared/api/guild.ts
+++ b/frontend/src/shared/api/guild.ts
@@ -132,6 +132,21 @@ export type CreateRolePayload = {
 
 export type UpdateRolePayload = Partial<CreateRolePayload>;
 
+export type ChannelOverwriteTargetType = 'role' | 'user';
+
+export type ChannelOverwriteDto = {
+  target_id: string;
+  target_type: ChannelOverwriteTargetType;
+  allow: number;
+  deny: number;
+};
+
+export type PutChannelOverwritePayload = {
+  target_type: ChannelOverwriteTargetType;
+  allow: number;
+  deny: number;
+};
+
 export type CreateCategoryPayload = {
   name: string;
   position?: number;
@@ -254,6 +269,27 @@ export function updateGuildChannel(
 
 export function deleteGuildChannel(guildId: string, channelId: string) {
   return apiFetch<void>('guild', `/guilds/${guildId}/channels/${channelId}`, {
+    method: 'DELETE'
+  });
+}
+
+export function listChannelPermissionOverwrites(channelId: string) {
+  return apiFetch<ChannelOverwriteDto[]>('guild', `/channels/${channelId}/permissions`);
+}
+
+export function putChannelPermissionOverwrite(
+  channelId: string,
+  targetId: string,
+  payload: PutChannelOverwritePayload
+) {
+  return apiFetch<void>('guild', `/channels/${channelId}/permissions/${targetId}`, {
+    method: 'PUT',
+    body: payload
+  });
+}
+
+export function deleteChannelPermissionOverwrite(channelId: string, targetId: string) {
+  return apiFetch<void>('guild', `/channels/${channelId}/permissions/${targetId}`, {
     method: 'DELETE'
   });
 }

--- a/frontend/src/shared/guilds/role-permissions.ts
+++ b/frontend/src/shared/guilds/role-permissions.ts
@@ -4,8 +4,18 @@ import type { GuildRoleDto } from '../api/guild';
 // the member-role UI so users don't see actions the server would 403. The
 // server remains the source of truth for every mutation.
 export const PERMISSIONS = {
+  SendMessages: 1,
+  ReadMessages: 2,
+  ManageMessages: 4,
+  ManageChannels: 8,
+  KickMembers: 16,
+  BanMembers: 32,
   ManageRoles: 64,
-  Administrator: 256
+  ManageGuild: 128,
+  Administrator: 256,
+  CreateInvite: 512,
+  MentionEveryone: 1024,
+  ManageNicknames: 2048
 } as const;
 
 export function rolePermissionBits(role: GuildRoleDto): number {


### PR DESCRIPTION
Wire channel permissions into the frontend

- `Permission editor modal` - Discord-style: pick a role or member, then set Allow / Inherit / Deny per channel-scoped permission (read, send, manage messages, mention everyone, create invite, manage channel). Changes apply immediately with rollback on failure; removing an overwrite asks for confirmation.
- `Two entry points` - right-click a channel in the sidebar (only shown to users with ManageChannels), or the lock button per row in guild settings -> Channels.
- `Groundwork` - typed API wrappers for the overwrite endpoints, and the client-side permission mirror now covers all 12 server bits instead of 2.