### PR TITLE
Feat(guid, front): channel overwrites, role management, ownership transfer & member-list scoping

### DIFF
--- a/docs/contracts/chat.md
+++ b/docs/contracts/chat.md
@@ -1155,5 +1155,6 @@ Relayed verbatim from the remote peer.
 |-------|--------|
 | `guild.member_joined` | Broadcast `GuildJoined` to all connections of the user; clients call `JoinChannel` themselves when navigating to a channel in that guild |
 | `guild.member_left` | Broadcast `GuildLeft` to all connections of the user; clients call `LeaveChannel` for any open subscription in that guild |
+| `guild.owner_transferred` | Broadcast `GuildOwnerTransferred { guild_id, old_owner_id, new_owner_id }` to the `guild:{guild_id}` group so members' clients flip owner-only UI live. No group membership changes (both owners stay members). |
 | `user.logged_out` | Force-disconnect any active WebSocket for that user |
 | `user.deleted` | Force-disconnect any active WebSocket; delete the user's `user_conversations`, `channel_read_states`, and `dm_unread_counts` rows. Messages stay - the user's profile becomes unresolvable in User Service, so the frontend renders them as "Deleted User". |

--- a/docs/contracts/guild.md
+++ b/docs/contracts/guild.md
@@ -1067,7 +1067,7 @@ Same shape as `GET /guilds/{id}/channels`. A channel is included when the user's
 | `guild.member_left` | `{ guild_id, user_id }` | User leaves, is kicked, or banned |
 | `guild.invite_created` | `{ guild_id, guild_name, invited_by_user_id, invited_user_id? }` | Invite created; `invited_user_id` present only for targeted invites |
 | `guild.deleted` | `{ guild_id, channel_ids }` | Guild deleted by its owner. `channel_ids` lists the guild's channels at deletion time so Chat (which cannot read Guild's DB) can purge each channel's message history. Chat also broadcasts `GuildDeleted` over SignalR so members' clients drop the guild live. Other downstream services cascade their own cleanup by `guild_id` (Notification rows, membership references). |
-| `guild.owner_transferred` | `{ guild_id, old_owner_id, new_owner_id }` | Ownership transferred to another member. At least Notification reacts (notify old and/or new owner). |
+| `guild.owner_transferred` | `{ guild_id, old_owner_id, new_owner_id }` | Ownership transferred to another member. Notification reacts (notify old and/or new owner). Chat broadcasts `GuildOwnerTransferred` over SignalR to the guild group so members' clients flip owner-only UI (crown, management controls) live for both the old and new owner. |
 | `channel.access_revoked` | `{ channel_id, user_id }` | A member lost `READ_MESSAGES` on a channel via a role or overwrite change (role permission update, role assignment or unassignment, role deletion, or a channel-overwrite put/delete). One event per (channel, member) whose effective read flipped from allowed to denied. Chat consumes it to evict the member's live SignalR subscription (`EvictFromChannelAsync`). |
 
 ## RabbitMQ Events Consumed

--- a/docs/contracts/guild.md
+++ b/docs/contracts/guild.md
@@ -539,11 +539,16 @@ Create a channel. Requires `MANAGE_CHANNELS` permission.
   "position": 0,
   "topic": "general chat",
   "is_nsfw": false,
-  "slowmode_seconds": 0
+  "slowmode_seconds": 0,
+  "overwrites": [
+    { "target_id": "<snowflake>", "target_type": "role", "allow": 0, "deny": 2 }
+  ]
 }
 ```
 
 `name` must follow channel naming rules (see above). `type` must be `text` or `announcement`. `category_id` is optional (null = uncategorised).
+
+`overwrites` is optional. When present, the listed permission overwrites are applied atomically as the channel is created, so it spawns already carrying its intended per-role/per-member permissions (no window where it is briefly world-readable before overwrites are `PUT`). Each entry has the same shape and rules as `PUT /channels/{channel_id}/permissions/{target_id}`: `target_type` is `"role"` or `"user"`, `target_id` must reference a real role or member of this guild, a target may appear at most once, `allow` and `deny` may not overlap, and only channel-scoped bits are permitted (see [Channel overwrite permissions](#channel-overwrite-permissions)).
 
 > Voice channels are intentionally not supported. The voice/video bonus module is 1-on-1 peer-to-peer WebRTC, initiated between two users via the Chat Service signaling hub (see `chat.md`). A Discord-style N-way voice channel would require an SFU which is WAY beyond the scope, please have some consideration for your infra cats (me)
 
@@ -552,7 +557,7 @@ Create a channel. Requires `MANAGE_CHANNELS` permission.
 **Errors:**
 | Status | Reason |
 |--------|--------|
-| 400 | Invalid name or type |
+| 400 | Invalid name or type; overwrite `target_id` not a snowflake string; overwrite target not a role/member of the guild; duplicate overwrite target; `allow`/`deny` overlap; non-channel-scoped bit in `allow`/`deny` |
 | 403 | Missing `MANAGE_CHANNELS` permission |
 
 ---
@@ -934,7 +939,13 @@ Create or update a permission overwrite. Requires `MANAGE_CHANNELS`.
 
 `target_type`: `"role"` or `"user"`. `target_id` is the role or user snowflake.
 
+`allow` and `deny` may not share a bit, and only channel-scoped bits are accepted (see below); either violation returns `400`.
+
 **Response `204`:** No content.
+
+#### Channel overwrite permissions
+
+A channel overwrite may only set channel-scoped bits: `SEND_MESSAGES`, `READ_MESSAGES`, `MANAGE_MESSAGES`, `MANAGE_CHANNELS`, `CREATE_INVITE`, `MENTION_EVERYONE`. Guild-wide authority (`KICK_MEMBERS`, `BAN_MEMBERS`, `MANAGE_ROLES`, `MANAGE_GUILD`, `ADMINISTRATOR`, `MANAGE_NICKNAMES`) is rejected with `400`, so an overwrite can never escalate a member past their role-granted guild permissions. This applies wherever overwrites are supplied: `PUT /channels/{channel_id}/permissions/{target_id}` and the `overwrites` array on `POST /guilds/{id}/channels`.
 
 ---
 

--- a/docs/contracts/guild.md
+++ b/docs/contracts/guild.md
@@ -511,6 +511,21 @@ List all channels in a guild. Caller must be a member.
 
 ---
 
+### GET /guilds/{id}/channels/{channel_id}/members
+
+The snowflake ids of the members who can `READ_MESSAGES` on the channel. Caller must be a member (any member, no `MANAGE_CHANNELS` needed). Used by the frontend to scope the guild member list to who can actually see the currently open channel (Discord parity). Owner and `ADMINISTRATOR` short-circuit to all bits, per-channel overwrites applied: same resolution as `GET /internal/channels/{channel_id}/membership`.
+
+**Response `200`:**
+```json
+{
+  "user_ids": ["<snowflake>", "<snowflake>"]
+}
+```
+
+Returns `404` if the channel does not exist or belongs to a different guild, `403` if the caller is not a member. Order is unspecified.
+
+---
+
 ### POST /guilds/{id}/channels
 
 Create a channel. Requires `MANAGE_CHANNELS` permission.

--- a/docs/contracts/notification.md
+++ b/docs/contracts/notification.md
@@ -66,6 +66,7 @@ Fetch notifications for the authenticated user. Dismissed notifications are excl
 | `friend_accept` | `addressee_id` (who accepted) | friendship row id | `{}` |
 | `guild_invite` | `invited_by_user_id` | `guild_id` | `{ guild_name }` |
 | `guild_welcome` | NULL (system event) | `guild_id` | `{ guild_name }` |
+| `guild_ownership_transferred` | `old_owner_id` | `guild_id` | `{}` |
 | `incoming_call` | `caller_id` | NULL (call is ephemeral) | `{ call_type: "audio" \| "video" }` |
 
 ---
@@ -278,6 +279,7 @@ This is the internal-perspective twin of `GET /notifications/preferences`: every
 | `friend.removed` | Always | no stored notification; pushes a transient `friends_changed` SSE signal to both `requester_id` and `addressee_id` so their friends lists re-fetch |
 | `guild.invite_created` | `invited_user_id` is present | `type: guild_invite` for `invited_user_id` |
 | `guild.member_joined` | Always | `type: guild_welcome` for the joining user |
+| `guild.owner_transferred` | Always | `type: guild_ownership_transferred` for `new_owner_id`; `actor_id` is `old_owner_id`, `source_id` is `guild_id` |
 | `user.deleted` | Always | Delete every notification row where `user_id` or `actor_id` matches the deleted user, and drop the user's `notification_preferences` rows. Also sends the `account_deleted` confirmation email (see [Email delivery](#email-delivery)). |
 | `data.export_ready` | Always | No in-app notification row. Sends the `data_export_ready` email carrying the presigned `download_url` (see [Email delivery](#email-delivery)). |
 

--- a/frontend/src/components/chat-workspace.tsx
+++ b/frontend/src/components/chat-workspace.tsx
@@ -40,7 +40,14 @@ import { CallWindow } from './call/call-window';
 import { useCurrentUserProfile } from '../shared/user/user-store';
 import { useGuilds } from '../shared/guilds/guild-store';
 import { useGuildMembers } from '../shared/guilds/use-guild-members';
-import { effectivePermissions, hasPermission, PERMISSIONS } from '../shared/guilds/role-permissions';
+import {
+  canManageMemberRoles,
+  effectivePermissions,
+  hasPermission,
+  memberRank,
+  PERMISSIONS,
+  type RoleCaller
+} from '../shared/guilds/role-permissions';
 import { toSidebarStatus } from '../shared/mappers/user';
 import { accentForId } from '../shared/lib/accent';
 
@@ -97,10 +104,11 @@ export function ChatWorkspace() {
   const currentUserId = currentUser?.id ?? null;
   const guildWorkspace = useGuildWorkspace();
   const dmWorkspace = useDmWorkspace(currentUserId);
-  const { members: currentGuildMembers, roles: currentGuildRoles } = useGuildMembers(
-    selectedGuild?.id ?? null,
-    selectedGuild?.owner_id ?? null
-  );
+  const {
+    members: currentGuildMembers,
+    roles: currentGuildRoles,
+    refresh: refreshGuildMembers
+  } = useGuildMembers(selectedGuild?.id ?? null, selectedGuild?.owner_id ?? null);
   const currentGuildMember = useMemo(
     () => currentGuildMembers.find((member) => member.userId === currentUserId) ?? null,
     [currentGuildMembers, currentUserId]
@@ -119,6 +127,58 @@ export function ChatWorkspace() {
     );
     return hasPermission(mask, PERMISSIONS.ManageChannels);
   }, [currentGuildMember, currentGuildRoles]);
+
+  // Callers holding MANAGE_ROLES (or the owner) may assign roles; null hides the
+  // profile-card role editor. Mirrors the members panel's gating.
+  const roleCaller = useMemo<RoleCaller | null>(() => {
+    if (!currentGuildMember) {
+      return null;
+    }
+
+    const permissions = effectivePermissions(
+      currentGuildMember.roles,
+      currentGuildRoles,
+      currentGuildMember.isOwner
+    );
+    if (!canManageMemberRoles(permissions, currentGuildMember.isOwner)) {
+      return null;
+    }
+
+    return {
+      rank: memberRank(currentGuildMember.roles, currentGuildMember.isOwner),
+      permissions,
+      isOwner: currentGuildMember.isOwner
+    };
+  }, [currentGuildMember, currentGuildRoles]);
+
+  // Role management for the open profile card: only when the profile is a member
+  // of the current guild and the viewer can manage roles.
+  const profileRoleManagement = useMemo(() => {
+    if (chatMode !== 'guild' || !selectedGuild || !roleCaller || !profileMember) {
+      return undefined;
+    }
+
+    const target = currentGuildMembers.find((member) => member.userId === profileMember.id);
+    if (!target) {
+      return undefined;
+    }
+
+    return {
+      guildId: selectedGuild.id,
+      member: target,
+      roles: currentGuildRoles,
+      caller: roleCaller,
+      onChanged: () => void refreshGuildMembers()
+    };
+  }, [
+    chatMode,
+    selectedGuild,
+    roleCaller,
+    profileMember,
+    currentGuildMembers,
+    currentGuildRoles,
+    refreshGuildMembers
+  ]);
 
   // A guild switch invalidates any channel-scoped dialog left open.
   useEffect(() => {
@@ -992,6 +1052,7 @@ export function ChatWorkspace() {
           {profileMember ? (
             <ProfileCard
               member={profileMember}
+              roleManagement={profileRoleManagement}
               onClose={handleCloseAuthorProfile}
               onSendMessage={profileMember.id === currentUserId ? undefined : handleSendMessageToProfile}
               onUnfriend={

--- a/frontend/src/components/chat-workspace.tsx
+++ b/frontend/src/components/chat-workspace.tsx
@@ -975,7 +975,10 @@ export function ChatWorkspace() {
           </section>
 
           {chatMode === 'guild' && isMemberListOpen ? (
-            <GuildMemberList onOpenProfile={setProfileMember} />
+            <GuildMemberList
+              activeChannelId={guildWorkspace.activeChannel ?? null}
+              onOpenProfile={setProfileMember}
+            />
           ) : null}
 
           {chatMode === 'dm' && isDmProfileOpen && activeDmProfileMember ? (

--- a/frontend/src/components/guild-member-list.tsx
+++ b/frontend/src/components/guild-member-list.tsx
@@ -9,6 +9,7 @@ import { guildMembers } from './mocks/guild-member-mocks';
 import type { GuildRoleDto } from '../shared/api/guild';
 import type { UserStatus } from '../shared/api/user';
 import { useGuilds } from '../shared/guilds/guild-store';
+import { useChannelReaders } from '../shared/guilds/use-channel-readers';
 import { useGuildMembers, type HydratedGuildMember } from '../shared/guilds/use-guild-members';
 import { countPermissionBits, rolePermissionBits } from '../shared/guilds/role-permissions';
 import { useGroupMembersByRole } from '../shared/hooks/use-group-members-by-role';
@@ -189,15 +190,17 @@ export function buildMemberGroups(
 }
 
 type GuildMemberListProps = {
+  activeChannelId: string | null;
   onOpenProfile: (member: GuildMember) => void;
 };
 
-export function GuildMemberList({ onOpenProfile }: GuildMemberListProps) {
+export function GuildMemberList({ activeChannelId, onOpenProfile }: GuildMemberListProps) {
   const { selectedGuild } = useGuilds();
   const { members, isLoading, error } = useGuildMembers(
     selectedGuild?.id ?? null,
     selectedGuild?.owner_id ?? null
   );
+  const readerIds = useChannelReaders(selectedGuild?.id ?? null, activeChannelId);
   const groupByRole = useGroupMembersByRole();
   const { pushToast } = useToast();
 
@@ -211,8 +214,15 @@ export function GuildMemberList({ onOpenProfile }: GuildMemberListProps) {
     }
   }, [error, pushToast]);
 
-  const memberGroups = buildMemberGroups(members, groupByRole);
-  const onlineCount = members.filter((member) => member.status !== 'offline').length;
+  // scope to the members who can read the active channel (Discord parity); a
+  // null reader set means "unknown" (no channel, loading, or lookup failed), in
+  // which case we show everyone rather than blanking the list.
+  const visibleMembers = readerIds
+    ? members.filter((member) => readerIds.has(member.userId))
+    : members;
+
+  const memberGroups = buildMemberGroups(visibleMembers, groupByRole);
+  const onlineCount = visibleMembers.filter((member) => member.status !== 'offline').length;
 
   return (
     <aside className="hidden min-h-0 w-[18rem] shrink-0 flex-col overflow-hidden rounded-[1rem] bg-secondary-bg ring-1 ring-stroke xl:flex">
@@ -220,7 +230,7 @@ export function GuildMemberList({ onOpenProfile }: GuildMemberListProps) {
         <div>
           <h2 className="text-[1.05rem] font-bold tracking-[-0.03em] text-white">Members</h2>
           <p className="font-category mt-1 text-[0.7rem] uppercase tracking-[0.14em] text-white/35">
-            {onlineCount} online · {members.length - onlineCount} offline
+            {onlineCount} online · {visibleMembers.length - onlineCount} offline
           </p>
         </div>
       </div>

--- a/frontend/src/components/guild-member-list.tsx
+++ b/frontend/src/components/guild-member-list.tsx
@@ -1,17 +1,20 @@
 'use client';
 
-import { useEffect } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import type { MouseEvent } from 'react';
 import { Crown, Shield } from 'lucide-react';
 import { AvatarWithStatus } from './avatar-with-status';
 import type { ChatMessageData } from './chat-message';
 import type { DirectMessage } from './dm-list';
 import { guildMembers } from './mocks/guild-member-mocks';
+import { ActionModal } from './action-modal';
 import type { GuildRoleDto } from '../shared/api/guild';
 import type { UserStatus } from '../shared/api/user';
 import { useGuilds } from '../shared/guilds/guild-store';
 import { useChannelReaders } from '../shared/guilds/use-channel-readers';
 import { useGuildMembers, type HydratedGuildMember } from '../shared/guilds/use-guild-members';
 import { countPermissionBits, rolePermissionBits } from '../shared/guilds/role-permissions';
+import { useCloseOnEscape } from '../shared/hooks/use-close-on-escape';
 import { useGroupMembersByRole } from '../shared/hooks/use-group-members-by-role';
 import { accentForId } from '../shared/lib/accent';
 import { useToast } from '../shared/ui/toast';
@@ -86,10 +89,12 @@ function RoleIcon({ member }: { member: HydratedGuildMember }) {
 
 function MemberRow({
   member,
-  onOpenProfile
+  onOpenProfile,
+  onContextMenu
 }: {
   member: HydratedGuildMember;
   onOpenProfile: (member: GuildMember) => void;
+  onContextMenu?: (event: MouseEvent, member: HydratedGuildMember) => void;
 }) {
   const topRole = member.isOwner ? 'Owner' : (member.roles[0]?.name ?? null);
   const joined = formatJoinedAt(member.joinedAt);
@@ -99,6 +104,7 @@ function MemberRow({
     <button
       type="button"
       onClick={() => onOpenProfile(toProfileMember(member))}
+      onContextMenu={onContextMenu ? (event) => onContextMenu(event, member) : undefined}
       className="flex h-14 w-full items-center gap-3 rounded-md px-2 text-left text-grey-link transition hover:bg-frame/60 hover:text-white"
     >
       <AvatarWithStatus
@@ -189,20 +195,81 @@ export function buildMemberGroups(
     : roleGroups;
 }
 
+type MemberMenuState = {
+  member: HydratedGuildMember;
+  x: number;
+  y: number;
+};
+
+function MemberContextMenu({
+  menu,
+  onTransferOwnership,
+  onClose
+}: {
+  menu: MemberMenuState;
+  onTransferOwnership: (member: HydratedGuildMember) => void;
+  onClose: () => void;
+}) {
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  useCloseOnEscape(onClose);
+
+  useEffect(() => {
+    function handleMouseDown(event: globalThis.MouseEvent) {
+      if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
+        onClose();
+      }
+    }
+
+    document.addEventListener('mousedown', handleMouseDown);
+    return () => document.removeEventListener('mousedown', handleMouseDown);
+  }, [onClose]);
+
+  return (
+    <div
+      ref={menuRef}
+      className="fixed z-50 w-56 rounded-md border border-stroke bg-panel p-1.5 shadow-lg"
+      style={{
+        left: Math.min(menu.x, window.innerWidth - 240),
+        top: Math.min(menu.y, window.innerHeight - 88)
+      }}
+    >
+      <p className="mono-detail truncate px-2 py-1 text-xs text-white/35">{menu.member.displayName}</p>
+      <button
+        type="button"
+        onClick={() => {
+          onTransferOwnership(menu.member);
+          onClose();
+        }}
+        className="flex h-9 w-full items-center gap-2.5 rounded-md px-2 text-left text-sm font-semibold text-white/70 transition hover:bg-frame hover:text-white"
+      >
+        <Crown className="h-4 w-4 shrink-0 text-yellow" strokeWidth={1.9} />
+        Transfer ownership
+      </button>
+    </div>
+  );
+}
+
 type GuildMemberListProps = {
   activeChannelId: string | null;
   onOpenProfile: (member: GuildMember) => void;
 };
 
 export function GuildMemberList({ activeChannelId, onOpenProfile }: GuildMemberListProps) {
-  const { selectedGuild } = useGuilds();
-  const { members, isLoading, error } = useGuildMembers(
+  const { selectedGuild, currentUserId, transferOwnership } = useGuilds();
+  const { members, isLoading, error, refresh } = useGuildMembers(
     selectedGuild?.id ?? null,
     selectedGuild?.owner_id ?? null
   );
   const readerIds = useChannelReaders(selectedGuild?.id ?? null, activeChannelId);
   const groupByRole = useGroupMembersByRole();
   const { pushToast } = useToast();
+  const [memberMenu, setMemberMenu] = useState<MemberMenuState | null>(null);
+  const [transferTarget, setTransferTarget] = useState<HydratedGuildMember | null>(null);
+  const [isTransferBusy, setIsTransferBusy] = useState(false);
+
+  const isCurrentUserOwner =
+    Boolean(currentUserId) && selectedGuild?.owner_id === currentUserId;
 
   useEffect(() => {
     if (error) {
@@ -213,6 +280,37 @@ export function GuildMemberList({ activeChannelId, onOpenProfile }: GuildMemberL
       });
     }
   }, [error, pushToast]);
+
+  // owner-only right-click action; never on the owner's own row.
+  const handleMemberContextMenu = (event: MouseEvent, member: HydratedGuildMember) => {
+    if (!isCurrentUserOwner || member.isOwner || member.isDeleted) {
+      return;
+    }
+    event.preventDefault();
+    setMemberMenu({ member, x: event.clientX, y: event.clientY });
+  };
+
+  async function confirmTransferOwnership() {
+    if (!transferTarget) {
+      return;
+    }
+
+    try {
+      setIsTransferBusy(true);
+      await transferOwnership(selectedGuild!.id, transferTarget.userId);
+      void refresh();
+      setTransferTarget(null);
+    } catch (transferError) {
+      pushToast({
+        title: 'Transfer ownership',
+        description:
+          transferError instanceof Error ? transferError.message : 'Failed to transfer ownership.',
+        tone: 'error'
+      });
+    } finally {
+      setIsTransferBusy(false);
+    }
+  }
 
   // scope to the members who can read the active channel (Discord parity); a
   // null reader set means "unknown" (no channel, loading, or lookup failed), in
@@ -265,7 +363,12 @@ export function GuildMemberList({ activeChannelId, onOpenProfile }: GuildMemberL
                 ) : null}
                 <div className="mt-2 space-y-1">
                   {group.members.map((member) => (
-                    <MemberRow key={member.userId} member={member} onOpenProfile={onOpenProfile} />
+                    <MemberRow
+                      key={member.userId}
+                      member={member}
+                      onOpenProfile={onOpenProfile}
+                      onContextMenu={isCurrentUserOwner ? handleMemberContextMenu : undefined}
+                    />
                   ))}
                 </div>
               </section>
@@ -273,6 +376,26 @@ export function GuildMemberList({ activeChannelId, onOpenProfile }: GuildMemberL
           </div>
         )}
       </div>
+
+      {memberMenu ? (
+        <MemberContextMenu
+          menu={memberMenu}
+          onTransferOwnership={setTransferTarget}
+          onClose={() => setMemberMenu(null)}
+        />
+      ) : null}
+
+      {transferTarget ? (
+        <ActionModal
+          title={`Transfer ownership to ${transferTarget.displayName}?`}
+          description="They become the guild owner with full control. You keep your membership but lose owner privileges. This can only be undone if the new owner transfers it back."
+          confirmLabel="Transfer ownership"
+          destructive
+          isBusy={isTransferBusy}
+          onClose={() => setTransferTarget(null)}
+          onConfirm={confirmTransferOwnership}
+        />
+      ) : null}
     </aside>
   );
 }

--- a/frontend/src/components/guild-member-list.tsx
+++ b/frontend/src/components/guild-member-list.tsx
@@ -57,9 +57,23 @@ function formatJoinedAt(joinedAt: string) {
     : date.toLocaleDateString('en-US', { day: '2-digit', month: 'short', year: 'numeric' });
 }
 
+// The member's "top" role for display (name badge / color): the highest by
+// hierarchy position, so assigning a higher role promotes the badge to it.
+export function topRoleByPosition(roles: GuildRoleDto[]): GuildRoleDto | null {
+  let top: GuildRoleDto | null = null;
+  for (const role of roles) {
+    if (role.is_default) {
+      continue;
+    }
+    if (!top || role.position > top.position) {
+      top = role;
+    }
+  }
+  return top;
+}
+
 export function toProfileMember(member: HydratedGuildMember): GuildMember {
-  // roles come sorted by display priority, so [0] is the highest role
-  const topRole = member.roles[0] ?? null;
+  const topRole = topRoleByPosition(member.roles);
 
   return {
     id: member.userId,

--- a/frontend/src/components/guild-member-list.tsx
+++ b/frontend/src/components/guild-member-list.tsx
@@ -13,11 +13,16 @@ import type { UserStatus } from '../shared/api/user';
 import { useGuilds } from '../shared/guilds/guild-store';
 import { useChannelReaders } from '../shared/guilds/use-channel-readers';
 import { useGuildMembers, type HydratedGuildMember } from '../shared/guilds/use-guild-members';
-import { countPermissionBits, rolePermissionBits } from '../shared/guilds/role-permissions';
 import { useCloseOnEscape } from '../shared/hooks/use-close-on-escape';
 import { useGroupMembersByRole } from '../shared/hooks/use-group-members-by-role';
 import { accentForId } from '../shared/lib/accent';
 import { useToast } from '../shared/ui/toast';
+
+export type GuildMemberRole = {
+  id: string;
+  name: string;
+  color: string | null;
+};
 
 export type GuildMember = {
   id: string;
@@ -26,6 +31,8 @@ export type GuildMember = {
   role: string;
   /** The highest role's color, used to tint the role token. */
   roleColor?: string | null;
+  /** All assigned (non-@everyone) roles, for the profile card. Absent for non-guild profiles (DMs). */
+  roles?: GuildMemberRole[];
   status: DirectMessage['status'];
   accent: ChatMessageData['accent'];
   activity: string;
@@ -59,6 +66,10 @@ export function toProfileMember(member: HydratedGuildMember): GuildMember {
     name: member.displayName,
     role: member.isOwner ? 'Owner' : (topRole?.name ?? 'Member'),
     roleColor: member.isOwner ? null : (topRole?.color ?? null),
+    // every assigned role (minus @everyone), so the profile card lists them all
+    roles: member.roles
+      .filter((role) => !role.is_default)
+      .map((role) => ({ id: role.id, name: role.name, color: role.color })),
     status: toSidebarStatus(member.status),
     accent: accentForId(member.userId),
     activity: member.joinedAt ? `Joined ${formatJoinedAt(member.joinedAt)}` : 'Member',
@@ -134,11 +145,28 @@ export type MemberGroup = {
   members: HydratedGuildMember[];
 };
 
-// The guild owner is pinned first in a dedicated "Owner" section no matter
-// what roles they hold. Everyone else sections under their top role (most
-// permissions first, matching the display priority of the roles themselves);
-// role-less members go last under "Members". With grouping off, everyone
-// merges into one alphabetical list.
+// A member's section is their highest HOISTED role (Discord's "Display role
+// members separately"); a role with hoisting off never creates a section, so
+// its members fall through to their next hoisted role or to "Members". Highest
+// = greatest position in the role hierarchy.
+function highestHoistedRole(member: HydratedGuildMember): GuildRoleDto | null {
+  let best: GuildRoleDto | null = null;
+  for (const role of member.roles) {
+    if (!role.is_hoisted || role.is_default) {
+      continue;
+    }
+    if (!best || role.position > best.position) {
+      best = role;
+    }
+  }
+  return best;
+}
+
+// The guild owner is pinned first in a dedicated "Owner" section no matter what
+// roles they hold. Everyone else sections under their highest hoisted role
+// (highest position first, matching the hierarchy); members with no hoisted
+// role go last under "Members". With grouping off, everyone merges into one
+// alphabetical list.
 export function buildMemberGroups(
   members: HydratedGuildMember[],
   groupByRole: boolean
@@ -161,9 +189,9 @@ export function buildMemberGroups(
       continue;
     }
 
-    const topRole = member.roles[0] ?? null;
-    const key = topRole?.id ?? 'members';
-    const group = groupsByRole.get(key) ?? { role: topRole, members: [] };
+    const hoisted = highestHoistedRole(member);
+    const key = hoisted?.id ?? 'members';
+    const group = groupsByRole.get(key) ?? { role: hoisted, members: [] };
     group.members.push(member);
     groupsByRole.set(key, group);
   }
@@ -173,14 +201,9 @@ export function buildMemberGroups(
       if (!a.role || !b.role) {
         return a.role ? -1 : b.role ? 1 : 0;
       }
-
-      const byPermissionCount =
-        countPermissionBits(rolePermissionBits(b.role)) -
-        countPermissionBits(rolePermissionBits(a.role));
-      if (byPermissionCount !== 0) {
-        return byPermissionCount;
+      if (a.role.position !== b.role.position) {
+        return b.role.position - a.role.position;
       }
-
       return a.role.name.localeCompare(b.role.name);
     })
     .map((group) => ({

--- a/frontend/src/components/guild/channel-create-modal.tsx
+++ b/frontend/src/components/guild/channel-create-modal.tsx
@@ -1,0 +1,405 @@
+'use client';
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { Hash, Plus, Trash2, UserRound, X } from 'lucide-react';
+import {
+  createGuildChannel,
+  type ChannelOverwriteDto,
+  type GuildChannelDto
+} from '../../shared/api/guild';
+import { useGuilds } from '../../shared/guilds/guild-store';
+import { useGuildMembers } from '../../shared/guilds/use-guild-members';
+import { useCloseOnEscape } from '../../shared/hooks/use-close-on-escape';
+import { useToast } from '../../shared/ui/toast';
+import {
+  AddTargetPopover,
+  bitState,
+  OVERWRITE_FLAGS,
+  overwriteKey,
+  RoleDot,
+  TriStateControl,
+  type OverwriteState
+} from './channel-permissions-modal';
+
+const inputClasses =
+  'h-10 w-full rounded-md border border-transparent bg-input-bg px-3 text-sm text-white outline-none transition placeholder:text-input-placeholder focus:border-aqua/35';
+
+const selectClasses =
+  'h-10 w-full rounded-md border border-transparent bg-input-bg px-3 text-sm text-white outline-none transition focus:border-aqua/35';
+
+type ChannelCreateModalProps = {
+  guildId: string;
+  initialName?: string;
+  initialType?: 'text' | 'announcement';
+  onClose: () => void;
+  onCreated: (channel: GuildChannelDto) => void;
+};
+
+export function ChannelCreateModal({
+  guildId,
+  initialName = '',
+  initialType = 'text',
+  onClose,
+  onCreated
+}: ChannelCreateModalProps) {
+  const { selectedGuild } = useGuilds();
+  const { members, roles } = useGuildMembers(
+    guildId,
+    selectedGuild?.id === guildId ? selectedGuild.owner_id : null
+  );
+  const [name, setName] = useState(initialName);
+  const [type, setType] = useState<'text' | 'announcement'>(initialType);
+  // overwrites are staged entirely in memory here and sent atomically with the
+  // channel on submit, so it is created already carrying these permissions.
+  const [overwrites, setOverwrites] = useState<ChannelOverwriteDto[]>([]);
+  const [selectedKey, setSelectedKey] = useState<string | null>(null);
+  const [isAddOpen, setIsAddOpen] = useState(false);
+  const [isBusy, setIsBusy] = useState(false);
+  const [error, setError] = useState('');
+  const addContainerRef = useRef<HTMLDivElement>(null);
+  const { pushToast } = useToast();
+
+  useCloseOnEscape(onClose);
+
+  useEffect(() => {
+    if (error) {
+      pushToast({ title: 'Create channel', description: error, tone: 'error' });
+    }
+  }, [error, pushToast]);
+
+  const rolesById = useMemo(() => new Map(roles.map((role) => [role.id, role])), [roles]);
+  const membersById = useMemo(
+    () => new Map(members.map((member) => [member.userId, member])),
+    [members]
+  );
+
+  const overwrittenKeys = useMemo(
+    () => new Set(overwrites.map((overwrite) => overwriteKey(overwrite))),
+    [overwrites]
+  );
+  const availableRoles = useMemo(
+    () =>
+      roles
+        .filter((role) => !overwrittenKeys.has(`role:${role.id}`))
+        .sort((a, b) => {
+          if (a.is_default !== b.is_default) {
+            return a.is_default ? 1 : -1;
+          }
+          return b.position - a.position;
+        }),
+    [roles, overwrittenKeys]
+  );
+  const availableMembers = useMemo(
+    () => members.filter((member) => !overwrittenKeys.has(`user:${member.userId}`)),
+    [members, overwrittenKeys]
+  );
+
+  // roles first (hierarchy order, @everyone last), then members by name.
+  const sortedOverwrites = useMemo(() => {
+    const rolePosition = (overwrite: ChannelOverwriteDto) => {
+      const role = rolesById.get(overwrite.target_id);
+      if (!role) {
+        return -Infinity;
+      }
+      return role.is_default ? -1 : role.position;
+    };
+
+    return [...overwrites].sort((a, b) => {
+      if (a.target_type !== b.target_type) {
+        return a.target_type === 'role' ? -1 : 1;
+      }
+      if (a.target_type === 'role') {
+        return rolePosition(b) - rolePosition(a);
+      }
+      const aName = membersById.get(a.target_id)?.displayName ?? '';
+      const bName = membersById.get(b.target_id)?.displayName ?? '';
+      return aName.localeCompare(bName);
+    });
+  }, [overwrites, rolesById, membersById]);
+
+  const selected = sortedOverwrites.find((overwrite) => overwriteKey(overwrite) === selectedKey);
+
+  useEffect(() => {
+    if (!selected && sortedOverwrites.length > 0) {
+      setSelectedKey(overwriteKey(sortedOverwrites[0]));
+    }
+  }, [selected, sortedOverwrites]);
+
+  function targetName(overwrite: ChannelOverwriteDto) {
+    if (overwrite.target_type === 'role') {
+      return rolesById.get(overwrite.target_id)?.name ?? 'Unknown role';
+    }
+    return membersById.get(overwrite.target_id)?.displayName ?? 'Unknown member';
+  }
+
+  function handleAddTarget(targetType: 'role' | 'user', targetId: string) {
+    const created: ChannelOverwriteDto = {
+      target_id: targetId,
+      target_type: targetType,
+      allow: 0,
+      deny: 0
+    };
+    setIsAddOpen(false);
+    setOverwrites((current) => [...current, created]);
+    setSelectedKey(overwriteKey(created));
+  }
+
+  function handleRemove(overwrite: ChannelOverwriteDto) {
+    const key = overwriteKey(overwrite);
+    setOverwrites((current) => current.filter((item) => overwriteKey(item) !== key));
+    if (selectedKey === key) {
+      setSelectedKey(null);
+    }
+  }
+
+  function handleSetBit(overwrite: ChannelOverwriteDto, bit: number, state: OverwriteState) {
+    const allow = state === 'allow' ? overwrite.allow | bit : overwrite.allow & ~bit;
+    const deny = state === 'deny' ? overwrite.deny | bit : overwrite.deny & ~bit;
+    const key = overwriteKey(overwrite);
+    setOverwrites((current) =>
+      current.map((item) => (overwriteKey(item) === key ? { ...item, allow, deny } : item))
+    );
+  }
+
+  async function handleSubmit() {
+    const trimmed = name.trim();
+    if (!trimmed) {
+      setError('Channel name is required.');
+      return;
+    }
+
+    setError('');
+
+    try {
+      setIsBusy(true);
+      const channel = await createGuildChannel(guildId, {
+        name: trimmed,
+        type,
+        // drop no-op overwrites (allow & deny both empty) so we never create a row
+        // that has no effect; the backend would accept them but they add noise.
+        overwrites: overwrites
+          .filter((overwrite) => overwrite.allow !== 0 || overwrite.deny !== 0)
+          .map((overwrite) => ({
+            target_id: overwrite.target_id,
+            target_type: overwrite.target_type,
+            allow: overwrite.allow,
+            deny: overwrite.deny
+          }))
+      });
+      onCreated(channel);
+    } catch (createError) {
+      setError(createError instanceof Error ? createError.message : 'Failed to create channel.');
+    } finally {
+      setIsBusy(false);
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/55 px-4 py-6">
+      <button
+        type="button"
+        className="absolute inset-0 cursor-default"
+        onClick={onClose}
+        aria-label="Close create channel"
+      />
+      <section className="relative w-full max-w-[46rem] overflow-hidden rounded-[1rem] bg-secondary-bg shadow-2xl shadow-black/50 ring-1 ring-stroke">
+        <div className="flex h-[4.75rem] items-center justify-between border-b border-stroke px-5">
+          <div className="flex min-w-0 items-center gap-3">
+            <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-md bg-aqua/10 text-aqua">
+              <Hash className="h-5 w-5" strokeWidth={1.9} />
+            </span>
+            <div className="min-w-0">
+              <h2 className="truncate text-[1.15rem] font-bold tracking-[-0.03em] text-white">
+                Create channel
+              </h2>
+              <p className="font-category text-[0.7rem] uppercase tracking-[0.14em] text-white/35">
+                Name, type &amp; permissions
+              </p>
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="flex h-9 w-9 items-center justify-center rounded-md text-[#8b8b8f] transition hover:bg-frame hover:text-white"
+            aria-label="Close create channel"
+          >
+            <X className="h-4 w-4" strokeWidth={2} />
+          </button>
+        </div>
+
+        <div className="max-h-[calc(100vh-12rem)] overflow-y-auto p-5">
+          <div className="flex flex-wrap gap-3">
+            <input
+              value={name}
+              onChange={(event) => setName(event.target.value)}
+              placeholder="channel name"
+              maxLength={100}
+              autoFocus
+              className={`${inputClasses} max-w-[20rem]`}
+            />
+            <select
+              value={type}
+              onChange={(event) => setType(event.target.value as 'text' | 'announcement')}
+              className={`${selectClasses} max-w-[12rem]`}
+            >
+              <option value="text">Text</option>
+              <option value="announcement">Announcement</option>
+            </select>
+          </div>
+
+          <div className="mt-5 grid gap-4 sm:grid-cols-[14rem_minmax(0,1fr)]">
+            <div className="min-w-0">
+              <div className="relative flex items-center justify-between" ref={addContainerRef}>
+                <p className="font-category px-1 text-[0.68rem] uppercase tracking-[0.14em] text-white/30">
+                  Roles &amp; members
+                </p>
+                <button
+                  type="button"
+                  onClick={() => setIsAddOpen((open) => !open)}
+                  className="flex h-7 w-7 items-center justify-center rounded-md text-[#8b8b8f] transition hover:bg-frame hover:text-white"
+                  aria-label="Add role or member overwrite"
+                  title="Add role or member"
+                >
+                  <Plus className="h-4 w-4" strokeWidth={2} />
+                </button>
+                {isAddOpen ? (
+                  <AddTargetPopover
+                    roles={availableRoles}
+                    members={availableMembers}
+                    onAdd={handleAddTarget}
+                    onClose={() => setIsAddOpen(false)}
+                    containerRef={addContainerRef}
+                  />
+                ) : null}
+              </div>
+
+              {sortedOverwrites.length === 0 ? (
+                <div className="mt-2 grid gap-3">
+                  <p className="px-1 text-sm leading-6 text-white/35">
+                    No overwrites yet. Add a role or member to control who can see and use this
+                    channel from the moment it is created.
+                  </p>
+                  <button
+                    type="button"
+                    onClick={() => setIsAddOpen(true)}
+                    className="flex h-10 items-center justify-center gap-2 rounded-md border border-dashed border-stroke-strong text-sm font-semibold text-white/50 transition hover:border-aqua/40 hover:text-aqua"
+                  >
+                    <Plus className="h-4 w-4" strokeWidth={2} />
+                    Add role or member
+                  </button>
+                </div>
+              ) : (
+                <ul className="mt-2 grid gap-1">
+                  {sortedOverwrites.map((overwrite) => {
+                    const key = overwriteKey(overwrite);
+                    const isActive = key === selectedKey;
+                    const role =
+                      overwrite.target_type === 'role' ? rolesById.get(overwrite.target_id) : null;
+
+                    return (
+                      <li key={key}>
+                        <button
+                          type="button"
+                          onClick={() => setSelectedKey(key)}
+                          className={`flex h-9 w-full items-center gap-2 rounded-md px-2 text-left text-sm font-semibold transition ${
+                            isActive ? 'bg-frame text-white' : 'text-white/60 hover:bg-frame/60'
+                          }`}
+                        >
+                          {role ? (
+                            <RoleDot role={role} />
+                          ) : (
+                            <UserRound
+                              className="h-3.5 w-3.5 shrink-0 text-[#8a8a96]"
+                              strokeWidth={1.9}
+                            />
+                          )}
+                          <span className="min-w-0 flex-1 truncate">{targetName(overwrite)}</span>
+                        </button>
+                      </li>
+                    );
+                  })}
+                </ul>
+              )}
+            </div>
+
+            <div className="min-w-0 rounded-md border border-stroke bg-panel p-4">
+              {selected ? (
+                <>
+                  <div className="flex items-center justify-between gap-3">
+                    <div className="min-w-0">
+                      <p className="truncate text-[0.95rem] font-bold text-white">
+                        {targetName(selected)}
+                      </p>
+                      <p className="text-xs text-white/35">
+                        {selected.target_type === 'role' ? 'Role overwrite' : 'Member overwrite'}
+                      </p>
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => handleRemove(selected)}
+                      className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md text-[#8b8b8f] transition hover:bg-frame hover:text-pink"
+                      aria-label={`Remove overwrite for ${targetName(selected)}`}
+                      title="Remove overwrite"
+                    >
+                      <Trash2 className="h-4 w-4" strokeWidth={1.9} />
+                    </button>
+                  </div>
+
+                  <ul className="mt-4 grid gap-2">
+                    {OVERWRITE_FLAGS.map((flag) => (
+                      <li
+                        key={flag.value}
+                        className="flex items-center justify-between gap-4 rounded-md border border-stroke bg-secondary-bg px-3 py-2"
+                      >
+                        <div className="min-w-0">
+                          <p className="text-sm font-semibold text-white/80">{flag.label}</p>
+                          <p className="text-xs leading-5 text-white/35">{flag.description}</p>
+                        </div>
+                        <TriStateControl
+                          state={bitState(selected, flag.value)}
+                          disabled={isBusy}
+                          onSelect={(state) => handleSetBit(selected, flag.value, state)}
+                        />
+                      </li>
+                    ))}
+                  </ul>
+
+                  <p className="mt-3 text-xs leading-5 text-white/35">
+                    Inherit falls back to the permissions granted by the member&apos;s roles. Member
+                    overwrites win over role overwrites; deny wins over allow at the same level.
+                  </p>
+                </>
+              ) : (
+                <div className="flex h-full items-center justify-center">
+                  <p className="max-w-[18rem] text-center text-sm leading-6 text-white/35">
+                    {sortedOverwrites.length === 0
+                      ? 'This channel will use the permissions each role grants. Add an overwrite to make it private or grant extra access.'
+                      : 'Select a role or member on the left to edit what it can do in this channel.'}
+                  </p>
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+
+        <div className="flex items-center justify-end gap-3 border-t border-stroke px-5 py-4">
+          <button
+            type="button"
+            onClick={onClose}
+            className="h-10 rounded-md border border-stroke px-5 text-sm font-bold text-white/60 transition hover:text-white"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={() => void handleSubmit()}
+            disabled={isBusy}
+            className="h-10 rounded-md bg-aqua px-5 text-sm font-bold text-primary-bg transition hover:bg-white disabled:cursor-not-allowed disabled:bg-frame disabled:text-white/25"
+          >
+            {isBusy ? 'Creating...' : 'Create channel'}
+          </button>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/components/guild/channel-permissions-modal.tsx
+++ b/frontend/src/components/guild/channel-permissions-modal.tsx
@@ -19,7 +19,7 @@ import { ActionModal } from '../action-modal';
 // Channel-scoped subset of the permission bitmask: bits that make sense as a
 // per-channel allow/deny overwrite. Guild-wide bits (kick, ban, manage guild,
 // administrator...) are deliberately left out of the editor.
-const OVERWRITE_FLAGS = [
+export const OVERWRITE_FLAGS = [
   {
     value: PERMISSIONS.ReadMessages,
     label: 'Read messages',
@@ -52,13 +52,13 @@ const OVERWRITE_FLAGS = [
   }
 ];
 
-type OverwriteState = 'allow' | 'inherit' | 'deny';
+export type OverwriteState = 'allow' | 'inherit' | 'deny';
 
-function overwriteKey(overwrite: Pick<ChannelOverwriteDto, 'target_type' | 'target_id'>) {
+export function overwriteKey(overwrite: Pick<ChannelOverwriteDto, 'target_type' | 'target_id'>) {
   return `${overwrite.target_type}:${overwrite.target_id}`;
 }
 
-function bitState(overwrite: ChannelOverwriteDto, bit: number): OverwriteState {
+export function bitState(overwrite: ChannelOverwriteDto, bit: number): OverwriteState {
   if ((overwrite.allow & bit) !== 0) {
     return 'allow';
   }
@@ -68,7 +68,7 @@ function bitState(overwrite: ChannelOverwriteDto, bit: number): OverwriteState {
   return 'inherit';
 }
 
-function TriStateControl({
+export function TriStateControl({
   state,
   disabled,
   onSelect
@@ -110,7 +110,7 @@ function TriStateControl({
   );
 }
 
-function RoleDot({ role }: { role: GuildRoleDto }) {
+export function RoleDot({ role }: { role: GuildRoleDto }) {
   return (
     <span
       className="h-2.5 w-2.5 shrink-0 rounded-full"
@@ -128,7 +128,13 @@ type AddTargetPopoverProps = {
   containerRef: RefObject<HTMLElement | null>;
 };
 
-function AddTargetPopover({ roles, members, onAdd, onClose, containerRef }: AddTargetPopoverProps) {
+export function AddTargetPopover({
+  roles,
+  members,
+  onAdd,
+  onClose,
+  containerRef
+}: AddTargetPopoverProps) {
   useEffect(() => {
     function handleMouseDown(event: MouseEvent) {
       if (containerRef.current && !containerRef.current.contains(event.target as Node)) {

--- a/frontend/src/components/guild/guild-channels-panel.tsx
+++ b/frontend/src/components/guild/guild-channels-panel.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useState } from 'react';
 import type { FormEvent } from 'react';
-import { Check, Hash, Lock, Pencil, Trash2, X } from 'lucide-react';
+import { Check, Hash, Lock, Pencil, SlidersHorizontal, Trash2, X } from 'lucide-react';
 import {
   createGuildChannel,
   deleteGuildChannel,
@@ -13,6 +13,7 @@ import {
   type GuildChannelDto
 } from '../../shared/api/guild';
 import { ActionModal } from '../action-modal';
+import { ChannelCreateModal } from './channel-create-modal';
 import { ChannelPermissionsModal } from './channel-permissions-modal';
 import { useToast } from '../../shared/ui/toast';
 
@@ -60,6 +61,7 @@ export function GuildChannelsPanel({ guildId, onChannelsChanged }: GuildChannels
   const [isBusy, setIsBusy] = useState(false);
   const [deleteTarget, setDeleteTarget] = useState<GuildChannelDto | null>(null);
   const [permissionsTarget, setPermissionsTarget] = useState<GuildChannelDto | null>(null);
+  const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
   const { pushToast } = useToast();
 
   const load = useCallback(async () => {
@@ -231,6 +233,16 @@ export function GuildChannelsPanel({ guildId, onChannelsChanged }: GuildChannels
             <option value="announcement">Announcement</option>
           </select>
           <button
+            type="button"
+            onClick={() => setIsCreateModalOpen(true)}
+            disabled={isBusy}
+            className="flex h-10 shrink-0 items-center gap-2 rounded-md border border-stroke px-4 text-sm font-bold text-white/60 transition hover:border-aqua/40 hover:text-aqua disabled:cursor-not-allowed disabled:opacity-50"
+            title="Create with permissions"
+          >
+            <SlidersHorizontal className="h-4 w-4" strokeWidth={1.9} />
+            Permissions
+          </button>
+          <button
             type="submit"
             disabled={isBusy}
             className="h-10 shrink-0 rounded-md bg-aqua px-5 text-sm font-bold text-primary-bg transition hover:bg-white disabled:cursor-not-allowed disabled:bg-frame disabled:text-white/25"
@@ -387,6 +399,22 @@ export function GuildChannelsPanel({ guildId, onChannelsChanged }: GuildChannels
           ))}
         </ul>
       )}
+
+      {isCreateModalOpen ? (
+        <ChannelCreateModal
+          guildId={guildId}
+          initialName={newName.trim()}
+          initialType={newType}
+          onClose={() => setIsCreateModalOpen(false)}
+          onCreated={() => {
+            setIsCreateModalOpen(false);
+            setNewName('');
+            setNewType('text');
+            void load();
+            onChannelsChanged?.();
+          }}
+        />
+      ) : null}
 
       {permissionsTarget ? (
         <ChannelPermissionsModal

--- a/frontend/src/components/guild/guild-members-panel.tsx
+++ b/frontend/src/components/guild/guild-members-panel.tsx
@@ -58,10 +58,12 @@ type MemberRowProps = {
   roles: GuildRoleDto[];
   caller: RoleCaller | null;
   canBan: boolean;
+  canTransferOwnership: boolean;
   onChanged: () => void;
   onError: (message: string) => void;
   onRequestKick: (member: HydratedGuildMember) => void;
   onRequestBan: (member: HydratedGuildMember) => void;
+  onRequestTransfer: (member: HydratedGuildMember) => void;
 };
 
 function MemberRow({
@@ -70,10 +72,12 @@ function MemberRow({
   roles,
   caller,
   canBan,
+  canTransferOwnership,
   onChanged,
   onError,
   onRequestKick,
-  onRequestBan
+  onRequestBan,
+  onRequestTransfer
 }: MemberRowProps) {
   const [isEditingNickname, setIsEditingNickname] = useState(false);
   const [isRolesOpen, setIsRolesOpen] = useState(false);
@@ -204,6 +208,18 @@ function MemberRow({
           </button>
           {!member.isOwner ? (
             <>
+              {canTransferOwnership && !member.isDeleted ? (
+                <button
+                  type="button"
+                  onClick={() => onRequestTransfer(member)}
+                  disabled={isBusy}
+                  className={iconButtonClasses}
+                  aria-label={`Transfer ownership to ${member.displayName}`}
+                  title="Transfer ownership"
+                >
+                  <Crown className="h-4 w-4 text-yellow" strokeWidth={1.9} />
+                </button>
+              ) : null}
               <button
                 type="button"
                 onClick={() => onRequestKick(member)}
@@ -239,7 +255,7 @@ type GuildMembersPanelProps = {
 };
 
 export function GuildMembersPanel({ guildId }: GuildMembersPanelProps) {
-  const { selectedGuild, currentUserId } = useGuilds();
+  const { selectedGuild, currentUserId, transferOwnership } = useGuilds();
   const { members, roles, isLoading, error, refresh } = useGuildMembers(
     guildId,
     selectedGuild?.id === guildId ? selectedGuild.owner_id : null
@@ -248,8 +264,14 @@ export function GuildMembersPanel({ guildId }: GuildMembersPanelProps) {
   const [kickTarget, setKickTarget] = useState<HydratedGuildMember | null>(null);
   const [banTarget, setBanTarget] = useState<HydratedGuildMember | null>(null);
   const [banReason, setBanReason] = useState('');
+  const [transferTarget, setTransferTarget] = useState<HydratedGuildMember | null>(null);
   const [isActionBusy, setIsActionBusy] = useState(false);
   const { pushToast } = useToast();
+
+  // only the owner may hand the guild over; derived from the loaded roster so a
+  // caller missing from the page safely hides the action.
+  const isCurrentUserOwner =
+    members.find((member) => member.userId === currentUserId)?.isOwner ?? false;
 
   // Base info for the caller's own permissions; the caller missing from the
   // loaded members (pagination edge) safely resolves to no permissions.
@@ -337,6 +359,27 @@ export function GuildMembersPanel({ guildId }: GuildMembersPanelProps) {
     }
   }
 
+  async function confirmTransferOwnership() {
+    if (!transferTarget) {
+      return;
+    }
+
+    setActionError('');
+
+    try {
+      setIsActionBusy(true);
+      await transferOwnership(guildId, transferTarget.userId);
+      void refresh();
+      setTransferTarget(null);
+    } catch (transferError) {
+      setActionError(
+        transferError instanceof Error ? transferError.message : 'Failed to transfer ownership.'
+      );
+    } finally {
+      setIsActionBusy(false);
+    }
+  }
+
   return (
     <div className="grid gap-3">
       {isLoading && members.length === 0 ? (
@@ -351,6 +394,7 @@ export function GuildMembersPanel({ guildId }: GuildMembersPanelProps) {
               roles={roles}
               caller={caller}
               canBan={canBan}
+              canTransferOwnership={isCurrentUserOwner}
               onChanged={() => {
                 setActionError('');
                 void refresh();
@@ -361,6 +405,7 @@ export function GuildMembersPanel({ guildId }: GuildMembersPanelProps) {
                 setBanTarget(target);
                 setBanReason('');
               }}
+              onRequestTransfer={setTransferTarget}
             />
           ))}
         </ul>
@@ -403,6 +448,18 @@ export function GuildMembersPanel({ guildId }: GuildMembersPanelProps) {
             />
           </label>
         </ActionModal>
+      ) : null}
+
+      {transferTarget ? (
+        <ActionModal
+          title={`Transfer ownership to ${transferTarget.displayName}?`}
+          description="They become the guild owner with full control. You keep your membership but lose owner privileges. This can only be undone if the new owner transfers it back."
+          confirmLabel="Transfer ownership"
+          destructive
+          isBusy={isActionBusy}
+          onClose={() => setTransferTarget(null)}
+          onConfirm={confirmTransferOwnership}
+        />
       ) : null}
     </div>
   );

--- a/frontend/src/components/guild/guild-roles-panel.tsx
+++ b/frontend/src/components/guild/guild-roles-panel.tsx
@@ -1,13 +1,15 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
-import { ShieldPlus, Trash2 } from 'lucide-react';
+import { useCallback, useEffect, useRef, useState, type DragEvent } from 'react';
+import { GripVertical, ShieldPlus, Trash2 } from 'lucide-react';
 import {
   createGuildRole,
   deleteGuildRole,
   listGuildRoles,
+  reorderGuildRoles,
   updateGuildRole,
-  type GuildRoleDto
+  type GuildRoleDto,
+  type ReorderRoleEntry
 } from '../../shared/api/guild';
 import { ActionModal } from '../action-modal';
 import { useToast } from '../../shared/ui/toast';
@@ -54,6 +56,34 @@ function draftFromRole(role: GuildRoleDto): RoleDraft {
     isHoisted: role.is_hoisted,
     isMentionable: role.is_mentionable
   };
+}
+
+// reorder the draggable (non-default) roles so `draggedId` takes `targetId`'s
+// slot, keeping the pinned @everyone role (position 0) at the bottom.
+function reorderRoleList(
+  roles: GuildRoleDto[],
+  draggedId: string,
+  targetId: string
+): GuildRoleDto[] {
+  const nonDefault = roles.filter((role) => !role.is_default);
+  const defaults = roles.filter((role) => role.is_default);
+  const from = nonDefault.findIndex((role) => role.id === draggedId);
+  const to = nonDefault.findIndex((role) => role.id === targetId);
+  if (from === -1 || to === -1 || from === to) {
+    return roles;
+  }
+  const next = [...nonDefault];
+  const [moved] = next.splice(from, 1);
+  next.splice(to, 0, moved);
+  return [...next, ...defaults];
+}
+
+// map the visual order (top row = highest rank) onto the position values the
+// moved roles currently occupy, yielding a permutation the backend accepts.
+function movesFromOrder(roles: GuildRoleDto[]): ReorderRoleEntry[] {
+  const nonDefault = roles.filter((role) => !role.is_default);
+  const positionsDesc = nonDefault.map((role) => role.position).sort((a, b) => b - a);
+  return nonDefault.map((role, index) => ({ id: role.id, position: positionsDesc[index] }));
 }
 
 type RoleEditorProps = {
@@ -173,6 +203,8 @@ export function GuildRolesPanel({ guildId }: GuildRolesPanelProps) {
   const [editDraft, setEditDraft] = useState<RoleDraft>(emptyDraft);
   const [isBusy, setIsBusy] = useState(false);
   const [deleteTarget, setDeleteTarget] = useState<GuildRoleDto | null>(null);
+  const [draggingId, setDraggingId] = useState<string | null>(null);
+  const preDragRolesRef = useRef<GuildRoleDto[] | null>(null);
   const { pushToast } = useToast();
 
   const load = useCallback(async () => {
@@ -262,6 +294,53 @@ export function GuildRolesPanel({ guildId }: GuildRolesPanelProps) {
     setDeleteTarget(role);
   }
 
+  function handleDragStart(role: GuildRoleDto) {
+    if (role.is_default) {
+      return;
+    }
+    preDragRolesRef.current = roles;
+    setDraggingId(role.id);
+  }
+
+  function handleDragOver(event: DragEvent, overRole: GuildRoleDto) {
+    if (!draggingId) {
+      return;
+    }
+    event.preventDefault();
+    if (draggingId === overRole.id || overRole.is_default) {
+      return;
+    }
+    setRoles((current) => reorderRoleList(current, draggingId, overRole.id));
+  }
+
+  async function handleDragEnd() {
+    const snapshot = preDragRolesRef.current;
+    setDraggingId(null);
+    preDragRolesRef.current = null;
+
+    if (!snapshot) {
+      return;
+    }
+
+    // nothing to persist if the drag left the order unchanged
+    const before = snapshot.map((role) => role.id).join(',');
+    const after = roles.map((role) => role.id).join(',');
+    if (before === after) {
+      return;
+    }
+
+    try {
+      setIsBusy(true);
+      const updated = await reorderGuildRoles(guildId, movesFromOrder(roles));
+      setRoles([...updated].sort((a, b) => b.position - a.position));
+    } catch (reorderError) {
+      setRoles(snapshot);
+      setError(reorderError instanceof Error ? reorderError.message : 'Failed to reorder roles.');
+    } finally {
+      setIsBusy(false);
+    }
+  }
+
   async function confirmDeleteRole() {
     if (!deleteTarget) {
       return;
@@ -302,7 +381,16 @@ export function GuildRolesPanel({ guildId }: GuildRolesPanelProps) {
       ) : (
         <ul className="grid gap-2">
           {roles.map((role) => (
-            <li key={role.id} className="rounded-md border border-stroke bg-panel px-3 py-2.5">
+            <li
+              key={role.id}
+              draggable={!role.is_default && editingRoleId !== role.id}
+              onDragStart={() => handleDragStart(role)}
+              onDragOver={(event) => handleDragOver(event, role)}
+              onDragEnd={() => void handleDragEnd()}
+              className={`rounded-md border bg-panel px-3 py-2.5 transition ${
+                draggingId === role.id ? 'border-aqua/50 opacity-50' : 'border-stroke'
+              }`}
+            >
               {editingRoleId === role.id ? (
                 <RoleEditor
                   draft={editDraft}
@@ -315,6 +403,15 @@ export function GuildRolesPanel({ guildId }: GuildRolesPanelProps) {
                 />
               ) : (
                 <div className="flex items-center gap-3">
+                  {role.is_default ? (
+                    <span className="w-4 shrink-0" aria-hidden />
+                  ) : (
+                    <GripVertical
+                      className="h-4 w-4 shrink-0 cursor-grab text-white/25 transition hover:text-white/50 active:cursor-grabbing"
+                      strokeWidth={1.9}
+                      aria-hidden
+                    />
+                  )}
                   <span
                     className="h-3.5 w-3.5 shrink-0 rounded-full"
                     style={{ backgroundColor: role.color || '#8b8b8f' }}

--- a/frontend/src/components/guild/member-roles-popover.tsx
+++ b/frontend/src/components/guild/member-roles-popover.tsx
@@ -35,42 +35,21 @@ export function MemberRoleChips({ roles }: { roles: GuildRoleDto[] }) {
   );
 }
 
-type MemberRolesPopoverProps = {
+type RoleToggleListProps = {
   guildId: string;
   member: HydratedGuildMember;
   roles: GuildRoleDto[];
   caller: RoleCaller;
-  /** Wrapper holding the trigger button and this popover; clicks outside it close the popover. */
-  containerRef: RefObject<HTMLElement | null>;
   onChanged: () => void;
-  onClose: () => void;
 };
 
-export function MemberRolesPopover({
-  guildId,
-  member,
-  roles,
-  caller,
-  containerRef,
-  onChanged,
-  onClose
-}: MemberRolesPopoverProps) {
+// Assignable-role checklist with hierarchy-aware gating; each toggle assigns or
+// unassigns via the guild API. Shared by the members-panel popover and the
+// profile card so the assignment rules live in one place.
+export function RoleToggleList({ guildId, member, roles, caller, onChanged }: RoleToggleListProps) {
   const [pendingRoleIds, setPendingRoleIds] = useState<Set<string>>(new Set());
   const [error, setError] = useState('');
   const { pushToast } = useToast();
-
-  useCloseOnEscape(onClose);
-
-  useEffect(() => {
-    function handleMouseDown(event: MouseEvent) {
-      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
-        onClose();
-      }
-    }
-
-    document.addEventListener('mousedown', handleMouseDown);
-    return () => document.removeEventListener('mousedown', handleMouseDown);
-  }, [containerRef, onClose]);
 
   useEffect(() => {
     if (error) {
@@ -110,6 +89,80 @@ export function MemberRolesPopover({
     }
   }
 
+  if (assignableRoles.length === 0) {
+    return (
+      <p className="px-1 pb-1 text-sm text-white/35">No roles yet. Create one in the Roles tab.</p>
+    );
+  }
+
+  return (
+    <ul className="grid max-h-64 gap-0.5 overflow-y-auto">
+      {assignableRoles.map((role) => {
+        const isAssigned = assignedRoleIds.has(role.id);
+        const isPending = pendingRoleIds.has(role.id);
+        const check = canToggleRole(role, isAssigned, caller);
+
+        return (
+          <li key={role.id}>
+            <label
+              title={check.reason ?? undefined}
+              className={`flex items-center gap-2 rounded-md px-1.5 py-1 text-sm text-white/60 ${
+                check.allowed ? 'cursor-pointer hover:bg-frame' : 'cursor-not-allowed opacity-50'
+              }`}
+            >
+              <input
+                type="checkbox"
+                checked={isAssigned}
+                disabled={!check.allowed || isPending}
+                onChange={() => void handleToggle(role, isAssigned)}
+                className="h-4 w-4 accent-[#78dce8]"
+              />
+              <span
+                className="h-2.5 w-2.5 shrink-0 rounded-full"
+                style={{ backgroundColor: role.color || '#8b8b8f' }}
+              />
+              <span className="min-w-0 flex-1 truncate">{role.name}</span>
+            </label>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+type MemberRolesPopoverProps = {
+  guildId: string;
+  member: HydratedGuildMember;
+  roles: GuildRoleDto[];
+  caller: RoleCaller;
+  /** Wrapper holding the trigger button and this popover; clicks outside it close the popover. */
+  containerRef: RefObject<HTMLElement | null>;
+  onChanged: () => void;
+  onClose: () => void;
+};
+
+export function MemberRolesPopover({
+  guildId,
+  member,
+  roles,
+  caller,
+  containerRef,
+  onChanged,
+  onClose
+}: MemberRolesPopoverProps) {
+  useCloseOnEscape(onClose);
+
+  useEffect(() => {
+    function handleMouseDown(event: MouseEvent) {
+      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
+        onClose();
+      }
+    }
+
+    document.addEventListener('mousedown', handleMouseDown);
+    return () => document.removeEventListener('mousedown', handleMouseDown);
+  }, [containerRef, onClose]);
+
   return (
     <div className="absolute right-0 top-9 z-20 w-64 rounded-md border border-stroke bg-panel p-2 shadow-lg">
       <div className="mb-1 flex items-center justify-between">
@@ -123,45 +176,13 @@ export function MemberRolesPopover({
           <X className="h-3.5 w-3.5" strokeWidth={2} />
         </button>
       </div>
-      {assignableRoles.length === 0 ? (
-        <p className="px-1 pb-1 text-sm text-white/35">
-          No roles yet. Create one in the Roles tab.
-        </p>
-      ) : (
-        <ul className="grid max-h-64 gap-0.5 overflow-y-auto">
-          {assignableRoles.map((role) => {
-            const isAssigned = assignedRoleIds.has(role.id);
-            const isPending = pendingRoleIds.has(role.id);
-            const check = canToggleRole(role, isAssigned, caller);
-
-            return (
-              <li key={role.id}>
-                <label
-                  title={check.reason ?? undefined}
-                  className={`flex items-center gap-2 rounded-md px-1.5 py-1 text-sm text-white/60 ${
-                    check.allowed
-                      ? 'cursor-pointer hover:bg-frame'
-                      : 'cursor-not-allowed opacity-50'
-                  }`}
-                >
-                  <input
-                    type="checkbox"
-                    checked={isAssigned}
-                    disabled={!check.allowed || isPending}
-                    onChange={() => void handleToggle(role, isAssigned)}
-                    className="h-4 w-4 accent-[#78dce8]"
-                  />
-                  <span
-                    className="h-2.5 w-2.5 shrink-0 rounded-full"
-                    style={{ backgroundColor: role.color || '#8b8b8f' }}
-                  />
-                  <span className="min-w-0 flex-1 truncate">{role.name}</span>
-                </label>
-              </li>
-            );
-          })}
-        </ul>
-      )}
+      <RoleToggleList
+        guildId={guildId}
+        member={member}
+        roles={roles}
+        caller={caller}
+        onChanged={onChanged}
+      />
     </div>
   );
 }

--- a/frontend/src/components/notification-card.tsx
+++ b/frontend/src/components/notification-card.tsx
@@ -170,6 +170,16 @@ export function describeNotification(
         Icon: Phone
       };
     }
+    default:
+      // a type the frontend doesn't know (new backend type, or a malformed row):
+      // render it generically rather than returning undefined and crashing the
+      // whole notification list on one bad entry.
+      return {
+        title: 'Notification',
+        detail: actorName ?? '',
+        tone: 'aqua',
+        Icon: Bell
+      };
   }
 }
 

--- a/frontend/src/components/notification-card.tsx
+++ b/frontend/src/components/notification-card.tsx
@@ -7,6 +7,7 @@ import {
   BellOff,
   Check,
   CheckCheck,
+  Crown,
   Mail,
   MessageCircle,
   Phone,
@@ -160,6 +161,15 @@ export function describeNotification(
         detail: `You are now a member of ${notification.payload.guild_name}!`,
         tone: 'yellow',
         Icon: Sparkles
+      };
+    case 'guild_ownership_transferred':
+      return {
+        title: 'Ownership transferred',
+        detail: actorName
+          ? `${actorName} made you the owner of their guild.`
+          : 'You are now the owner of the guild.',
+        tone: 'yellow',
+        Icon: Crown
       };
     case 'incoming_call': {
       const kind = notification.payload.call_type === 'video' ? 'video' : 'audio';

--- a/frontend/src/components/profile-card.tsx
+++ b/frontend/src/components/profile-card.tsx
@@ -91,6 +91,28 @@ export function ProfileCard({
           </p>
         </div>
 
+        {member.roles && member.roles.length > 0 ? (
+          <div className="mt-4 rounded-md border border-stroke bg-panel px-3 py-3">
+            <p className="font-category text-[0.68rem] uppercase tracking-[0.14em] text-white/35">
+              Roles
+            </p>
+            <div className="mt-2 flex flex-wrap gap-1.5">
+              {member.roles.map((role) => (
+                <span
+                  key={role.id}
+                  className="inline-flex items-center gap-1.5 rounded-full border border-stroke bg-frame px-2 py-0.5 text-[0.72rem] font-semibold text-white/70"
+                >
+                  <span
+                    className="h-2 w-2 shrink-0 rounded-full"
+                    style={{ backgroundColor: role.color || '#8b8b8f' }}
+                  />
+                  {role.name}
+                </span>
+              ))}
+            </div>
+          </div>
+        ) : null}
+
         {onSendMessage ? (
           <button
             type="button"

--- a/frontend/src/components/profile-card.tsx
+++ b/frontend/src/components/profile-card.tsx
@@ -1,13 +1,29 @@
 'use client';
 
+import { useState } from 'react';
 import { MessageCircle, Shield, Trophy, UserMinus, X } from 'lucide-react';
 import { AvatarWithStatus } from './avatar-with-status';
-import type { GuildMember } from './guild-member-list';
+import { topRoleByPosition, type GuildMember, type GuildMemberRole } from './guild-member-list';
+import { RoleToggleList } from './guild/member-roles-popover';
+import type { GuildRoleDto } from '../shared/api/guild';
+import type { RoleCaller } from '../shared/guilds/role-permissions';
+import type { HydratedGuildMember } from '../shared/guilds/use-guild-members';
 import { useCloseOnEscape } from '../shared/hooks/use-close-on-escape';
+
+// When present, the caller may assign/unassign roles on this member from the
+// card. Only supplied for guild members whose viewer holds MANAGE_ROLES.
+export type ProfileRoleManagement = {
+  guildId: string;
+  member: HydratedGuildMember;
+  roles: GuildRoleDto[];
+  caller: RoleCaller;
+  onChanged: () => void;
+};
 
 type ProfileCardProps = {
   member: GuildMember;
   variant?: 'modal' | 'side';
+  roleManagement?: ProfileRoleManagement;
   onClose: () => void;
   onSendMessage?: (member: GuildMember) => void;
   onUnfriend?: (member: GuildMember) => void;
@@ -16,11 +32,34 @@ type ProfileCardProps = {
 export function ProfileCard({
   member,
   variant = 'modal',
+  roleManagement,
   onClose,
   onSendMessage,
   onUnfriend
 }: ProfileCardProps) {
   useCloseOnEscape(onClose);
+  const [isEditingRoles, setIsEditingRoles] = useState(false);
+
+  // when the caller can manage roles, derive from the live guild member so the
+  // chips AND the top-role badge stay in sync as roles are toggled; otherwise
+  // fall back to the snapshot captured when the card opened.
+  const liveMember = roleManagement?.member ?? null;
+
+  const displayedRoles: GuildMemberRole[] = liveMember
+    ? liveMember.roles
+        .filter((role) => !role.is_default)
+        .map((role) => ({ id: role.id, name: role.name, color: role.color }))
+    : (member.roles ?? []);
+
+  // badge tracks the live highest role (by hierarchy) when managing, so putting a
+  // higher role on the member promotes the tag immediately; snapshot otherwise.
+  const topRole = liveMember ? topRoleByPosition(liveMember.roles) : null;
+  const badgeLabel = liveMember
+    ? liveMember.isOwner
+      ? 'Owner'
+      : (topRole?.name ?? 'Member')
+    : member.role;
+  const badgeColor = liveMember ? (liveMember.isOwner ? null : (topRole?.color ?? null)) : member.roleColor;
 
   const card = (
     <section
@@ -61,17 +100,17 @@ export function ProfileCard({
           <span
             className="font-category mb-2 max-w-[11rem] truncate rounded-full border border-stroke bg-panel px-3 py-1 text-[0.68rem] uppercase tracking-[0.14em] text-white/45"
             style={
-              member.roleColor
+              badgeColor
                 ? {
-                    color: member.roleColor,
-                    borderColor: `${member.roleColor}59`,
-                    backgroundColor: `${member.roleColor}1a`
+                    color: badgeColor,
+                    borderColor: `${badgeColor}59`,
+                    backgroundColor: `${badgeColor}1a`
                   }
                 : undefined
             }
-            title={member.role}
+            title={badgeLabel}
           >
-            {member.role}
+            {badgeLabel}
           </span>
         </div>
 
@@ -91,25 +130,55 @@ export function ProfileCard({
           </p>
         </div>
 
-        {member.roles && member.roles.length > 0 ? (
+        {displayedRoles.length > 0 || roleManagement ? (
           <div className="mt-4 rounded-md border border-stroke bg-panel px-3 py-3">
-            <p className="font-category text-[0.68rem] uppercase tracking-[0.14em] text-white/35">
-              Roles
-            </p>
-            <div className="mt-2 flex flex-wrap gap-1.5">
-              {member.roles.map((role) => (
-                <span
-                  key={role.id}
-                  className="inline-flex items-center gap-1.5 rounded-full border border-stroke bg-frame px-2 py-0.5 text-[0.72rem] font-semibold text-white/70"
+            <div className="flex items-center justify-between gap-2">
+              <p className="font-category text-[0.68rem] uppercase tracking-[0.14em] text-white/35">
+                Roles
+              </p>
+              {roleManagement ? (
+                <button
+                  type="button"
+                  onClick={() => setIsEditingRoles((open) => !open)}
+                  className="flex h-7 items-center gap-1.5 rounded-md px-2 text-xs font-semibold text-white/50 transition hover:bg-frame hover:text-white"
+                  aria-label="Manage roles"
                 >
-                  <span
-                    className="h-2 w-2 shrink-0 rounded-full"
-                    style={{ backgroundColor: role.color || '#8b8b8f' }}
-                  />
-                  {role.name}
-                </span>
-              ))}
+                  <Shield className="h-3.5 w-3.5 text-aqua" strokeWidth={1.9} />
+                  {isEditingRoles ? 'Done' : 'Manage'}
+                </button>
+              ) : null}
             </div>
+
+            {displayedRoles.length > 0 ? (
+              <div className="mt-2 flex flex-wrap gap-1.5">
+                {displayedRoles.map((role) => (
+                  <span
+                    key={role.id}
+                    className="inline-flex items-center gap-1.5 rounded-full border border-stroke bg-frame px-2 py-0.5 text-[0.72rem] font-semibold text-white/70"
+                  >
+                    <span
+                      className="h-2 w-2 shrink-0 rounded-full"
+                      style={{ backgroundColor: role.color || '#8b8b8f' }}
+                    />
+                    {role.name}
+                  </span>
+                ))}
+              </div>
+            ) : (
+              <p className="mt-2 text-sm text-white/35">No roles assigned.</p>
+            )}
+
+            {roleManagement && isEditingRoles ? (
+              <div className="mt-3 border-t border-stroke pt-3">
+                <RoleToggleList
+                  guildId={roleManagement.guildId}
+                  member={roleManagement.member}
+                  roles={roleManagement.roles}
+                  caller={roleManagement.caller}
+                  onChanged={roleManagement.onChanged}
+                />
+              </div>
+            ) : null}
           </div>
         ) : null}
 

--- a/frontend/src/shared/api/chat-hub.ts
+++ b/frontend/src/shared/api/chat-hub.ts
@@ -76,6 +76,12 @@ export type GuildUpdatedEvent = {
   icon_url?: string | null;
 };
 
+export type GuildOwnerTransferredEvent = {
+  guild_id: string;
+  old_owner_id: string;
+  new_owner_id: string;
+};
+
 export type ChannelDeletedEvent = {
   guild_id: string;
   channel_id: string;
@@ -118,6 +124,7 @@ export type ChatHubEvents = {
   GuildLeft: (event: GuildLeftEvent) => void;
   GuildDeleted: (guildId: string) => void;
   GuildUpdated: (event: GuildUpdatedEvent) => void;
+  GuildOwnerTransferred: (event: GuildOwnerTransferredEvent) => void;
   ChannelCreated: (event: GuildChannelDto) => void;
   ChannelUpdated: (event: GuildChannelDto) => void;
   ChannelDeleted: (event: ChannelDeletedEvent) => void;

--- a/frontend/src/shared/api/guild.ts
+++ b/frontend/src/shared/api/guild.ts
@@ -190,6 +190,15 @@ export function deleteGuild(guildId: string) {
   });
 }
 
+// hand the guild over to another member; the current owner becomes a regular
+// member. owner-only, irreversible without the new owner transferring it back.
+export function transferGuildOwnership(guildId: string, newOwnerId: string) {
+  return apiFetch<GuildDto>('guild', `/guilds/${guildId}/owner`, {
+    method: 'PATCH',
+    body: { new_owner_id: newOwnerId }
+  });
+}
+
 export function joinGuild(guildId: string, inviteCode: string) {
   return apiFetch<GuildDto>('guild', `/guilds/${guildId}/join`, {
     method: 'POST',

--- a/frontend/src/shared/api/guild.ts
+++ b/frontend/src/shared/api/guild.ts
@@ -257,6 +257,16 @@ export function listGuildChannels(guildId: string) {
   return apiFetch<GuildChannelDto[]>('guild', `/guilds/${guildId}/channels`);
 }
 
+// snowflake ids of the members who can READ the channel; used to scope the
+// guild member list to who can actually see the currently open channel.
+export async function listChannelReaders(guildId: string, channelId: string) {
+  const { user_ids } = await apiFetch<{ user_ids: string[] }>(
+    'guild',
+    `/guilds/${guildId}/channels/${channelId}/members`
+  );
+  return user_ids;
+}
+
 export function createGuildChannel(guildId: string, payload: CreateChannelPayload) {
   return apiFetch<GuildChannelDto>('guild', `/guilds/${guildId}/channels`, {
     method: 'POST',

--- a/frontend/src/shared/api/guild.ts
+++ b/frontend/src/shared/api/guild.ts
@@ -52,6 +52,13 @@ export type GuildChannelDto = {
   slowmode_seconds?: number;
 };
 
+export type CreateChannelOverwriteInput = {
+  target_id: string;
+  target_type: ChannelOverwriteTargetType;
+  allow: number;
+  deny: number;
+};
+
 export type CreateChannelPayload = {
   name: string;
   type: 'text' | 'announcement';
@@ -60,6 +67,7 @@ export type CreateChannelPayload = {
   topic?: string | null;
   is_nsfw?: boolean;
   slowmode_seconds?: number;
+  overwrites?: CreateChannelOverwriteInput[];
 };
 
 export type UpdateChannelPayload = Partial<CreateChannelPayload>;

--- a/frontend/src/shared/api/guild.ts
+++ b/frontend/src/shared/api/guild.ts
@@ -354,6 +354,18 @@ export function deleteGuildRole(guildId: string, roleId: string) {
   });
 }
 
+export type ReorderRoleEntry = { id: string; position: number };
+
+// bulk reorder: `moves` must cover every non-@everyone role, and their target
+// positions must be a permutation of the positions those roles currently hold.
+// returns the full, freshly-ordered role list.
+export function reorderGuildRoles(guildId: string, moves: ReorderRoleEntry[]) {
+  return apiFetch<GuildRoleDto[]>('guild', `/guilds/${guildId}/roles`, {
+    method: 'PATCH',
+    body: moves
+  });
+}
+
 export function createGuildInvite(guildId: string, payload: CreateInvitePayload = {}) {
   return apiFetch<GuildInviteDto>('guild', `/guilds/${guildId}/invites`, {
     method: 'POST',

--- a/frontend/src/shared/api/notification.ts
+++ b/frontend/src/shared/api/notification.ts
@@ -8,6 +8,7 @@ export type NotificationType =
   | 'friend_accept'
   | 'guild_invite'
   | 'guild_welcome'
+  | 'guild_ownership_transferred'
   | 'incoming_call';
 
 export type NotificationPayloadMap = {
@@ -17,6 +18,8 @@ export type NotificationPayloadMap = {
   friend_accept: Record<string, never>;
   guild_invite: { guild_name: string };
   guild_welcome: { guild_name: string };
+  // actor_id is the previous owner, source_id is the guild id; payload is empty.
+  guild_ownership_transferred: Record<string, never>;
   incoming_call: { call_type: 'audio' | 'video' };
 };
 

--- a/frontend/src/shared/guilds/guild-store.tsx
+++ b/frontend/src/shared/guilds/guild-store.tsx
@@ -14,6 +14,7 @@ import {
   type MyGuildDto
 } from '../api/guild';
 import { ApiError } from '../api/client';
+import { onChatHubEvent } from '../api/chat-hub';
 import { getCurrentUser } from '../api/user';
 import { getAccessToken, invalidateSession } from '../lib/session';
 
@@ -128,6 +129,24 @@ export function GuildProvider({ children }: { children: ReactNode }) {
     setSelectedGuildId(guildId);
     persistGuildId(guildId);
   }, []);
+
+  // live ownership changes (broadcast by Chat to the guild group): patch owner_id
+  // in place so every owner-derived view (crown, management controls) flips for
+  // both the old and new owner without a refresh. gated on a session so we never
+  // open the hub before login.
+  useEffect(() => {
+    if (!currentUserId) {
+      return;
+    }
+
+    return onChatHubEvent('GuildOwnerTransferred', (event) => {
+      setGuilds((current) =>
+        current.map((guild) =>
+          guild.id === event.guild_id ? { ...guild, owner_id: event.new_owner_id } : guild
+        )
+      );
+    });
+  }, [currentUserId]);
 
   const createGuild = useCallback(
     async (payload: CreateGuildPayload) => {

--- a/frontend/src/shared/guilds/guild-store.tsx
+++ b/frontend/src/shared/guilds/guild-store.tsx
@@ -8,6 +8,7 @@ import {
   joinGuild,
   listMyGuilds,
   previewInvite,
+  transferGuildOwnership,
   type CreateGuildPayload,
   type GuildDto,
   type MyGuildDto
@@ -31,6 +32,7 @@ type GuildStoreValue = {
   refreshGuilds: () => Promise<void>;
   createGuild: (payload: CreateGuildPayload) => Promise<GuildDto>;
   joinGuildWithCode: (code: string) => Promise<GuildDto>;
+  transferOwnership: (guildId: string, newOwnerId: string) => Promise<void>;
 };
 
 const GuildStoreContext = createContext<GuildStoreValue | null>(null);
@@ -172,6 +174,16 @@ export function GuildProvider({ children }: { children: ReactNode }) {
     [applyGuilds]
   );
 
+  // after handing ownership over, re-fetch the guild list so owner_id (and the
+  // owner-only UI derived from it) reflects the new owner everywhere.
+  const transferOwnership = useCallback(
+    async (guildId: string, newOwnerId: string) => {
+      await transferGuildOwnership(guildId, newOwnerId);
+      await refreshGuilds();
+    },
+    [refreshGuilds]
+  );
+
   const selectedGuild = useMemo(
     () => guilds.find((guild) => guild.id === selectedGuildId) ?? null,
     [guilds, selectedGuildId]
@@ -189,7 +201,8 @@ export function GuildProvider({ children }: { children: ReactNode }) {
       selectGuild,
       refreshGuilds,
       createGuild,
-      joinGuildWithCode
+      joinGuildWithCode,
+      transferOwnership
     }),
     [
       guilds,
@@ -202,7 +215,8 @@ export function GuildProvider({ children }: { children: ReactNode }) {
       selectGuild,
       refreshGuilds,
       createGuild,
-      joinGuildWithCode
+      joinGuildWithCode,
+      transferOwnership
     ]
   );
 

--- a/frontend/src/shared/guilds/use-channel-readers.ts
+++ b/frontend/src/shared/guilds/use-channel-readers.ts
@@ -1,0 +1,74 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { listChannelReaders } from '../api/guild';
+import { onChatHubEvent } from '../api/chat-hub';
+
+// Set of member ids that can READ the given channel, or null when unknown (no
+// channel selected, still loading, or the lookup failed). A null result means
+// "don't filter" so a transient error never blanks the whole member list.
+export function useChannelReaders(guildId: string | null, channelId: string | null) {
+  const [readerIds, setReaderIds] = useState<Set<string> | null>(null);
+
+  const load = useCallback(async () => {
+    if (!guildId || !channelId) {
+      setReaderIds(null);
+      return;
+    }
+
+    try {
+      const ids = await listChannelReaders(guildId, channelId);
+      setReaderIds(new Set(ids));
+    } catch {
+      setReaderIds(null);
+    }
+  }, [guildId, channelId]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  // refetch when guild membership, roles, or the channel's permissions change,
+  // so the list tracks who can see the channel without a manual refresh.
+  useEffect(() => {
+    if (!guildId || !channelId) {
+      return;
+    }
+
+    const reloadIfThisGuild = (event: { guild_id: string }) => {
+      if (event.guild_id === guildId) {
+        void load();
+      }
+    };
+    const reloadIfThisChannel = (event: { channel_id: string }) => {
+      if (event.channel_id === channelId) {
+        void load();
+      }
+    };
+
+    const unsubscribers = [
+      onChatHubEvent('MemberJoined', reloadIfThisGuild),
+      onChatHubEvent('MemberLeft', reloadIfThisGuild),
+      onChatHubEvent('MemberUpdated', reloadIfThisGuild),
+      onChatHubEvent('RolesChanged', (changedGuildId) => {
+        if (changedGuildId === guildId) {
+          void load();
+        }
+      }),
+      onChatHubEvent('ChannelUpdated', (channel) => {
+        if (channel.id === channelId) {
+          void load();
+        }
+      }),
+      onChatHubEvent('ChannelAccessGranted', reloadIfThisChannel)
+    ];
+
+    return () => {
+      for (const unsubscribe of unsubscribers) {
+        unsubscribe();
+      }
+    };
+  }, [guildId, channelId, load]);
+
+  return readerIds;
+}

--- a/frontend/tests/channel-list.test.tsx
+++ b/frontend/tests/channel-list.test.tsx
@@ -3,6 +3,7 @@ import { describe, it } from 'node:test';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { ChannelList, type ChannelCategory } from '../src/components/channel-list';
 import { GuildProvider } from '../src/shared/guilds/guild-store';
+import { NotificationPrefsProvider } from '../src/shared/lib/notification-prefs-store';
 
 const categories: ChannelCategory[] = [
   {
@@ -16,22 +17,24 @@ describe('ChannelList', () => {
   it('renders a guild settings entry in chat mode', () => {
     const html = renderToStaticMarkup(
       <GuildProvider>
-        <ChannelList
-          activeChannel="chan-1"
-          categories={categories}
-          unreadCounts={{}}
-          mobilePane="channels"
-          currentUser={null}
-          isMicMuted={false}
-          isDeafened={false}
-          unreadNotifications={0}
-          onToggleDeafen={() => undefined}
-          onToggleMicMute={() => undefined}
-          onOpenNotifications={() => undefined}
-          onOpenSettings={() => undefined}
-          onOpenGuildSettings={() => undefined}
-          onSelectChannel={() => undefined}
-        />
+        <NotificationPrefsProvider>
+          <ChannelList
+            activeChannel="chan-1"
+            categories={categories}
+            unreadCounts={{}}
+            mobilePane="channels"
+            currentUser={null}
+            isMicMuted={false}
+            isDeafened={false}
+            unreadNotifications={0}
+            onToggleDeafen={() => undefined}
+            onToggleMicMute={() => undefined}
+            onOpenNotifications={() => undefined}
+            onOpenSettings={() => undefined}
+            onOpenGuildSettings={() => undefined}
+            onSelectChannel={() => undefined}
+          />
+        </NotificationPrefsProvider>
       </GuildProvider>
     );
 

--- a/frontend/tests/guild-member-list.test.tsx
+++ b/frontend/tests/guild-member-list.test.tsx
@@ -62,17 +62,33 @@ describe('toProfileMember', () => {
     assert.equal(profile.role, 'Member');
     assert.equal(profile.roleColor, null);
   });
+
+  it('exposes every assigned role (minus @everyone) for the profile card', () => {
+    const a = makeRole({ id: 'r-a', name: 'A', color: '#ff6188' });
+    const b = makeRole({ id: 'r-b', name: 'B', color: '#a9dc76' });
+    const everyone = makeRole({ id: 'r-everyone', name: 'everyone', is_default: true });
+    const profile = toProfileMember(makeMember({ roles: [a, b, everyone] }));
+
+    assert.deepEqual(
+      profile.roles?.map((role) => role.name),
+      ['A', 'B']
+    );
+    assert.deepEqual(
+      profile.roles?.map((role) => role.color),
+      ['#ff6188', '#a9dc76']
+    );
+  });
 });
 
 describe('buildMemberGroups', () => {
-  const test = makeRole({ id: 'r-test', name: 'test', color: '#ff6188', permissions: '4095' });
-  const plouf = makeRole({ id: 'r-plouf', name: 'plouf', color: '#a9dc76', permissions: '0' });
+  const test = makeRole({ id: 'r-test', name: 'test', color: '#ff6188', is_hoisted: true, position: 5 });
+  const plouf = makeRole({ id: 'r-plouf', name: 'plouf', color: '#a9dc76', is_hoisted: true, position: 2 });
   const tester = makeMember({ userId: 'u-tester', displayName: 'Tester', roles: [test] });
   const ploufer = makeMember({ userId: 'u-ploufer', displayName: 'Ploufer', roles: [plouf] });
   const owner = makeMember({ userId: 'u-owner', displayName: 'Owner', isOwner: true });
   const nobody = makeMember({ userId: 'u-nobody', displayName: 'Anna' });
 
-  it('groups each member under their top role, ordered by permission count', () => {
+  it('groups members under their highest hoisted role, ordered by position', () => {
     const groups = buildMemberGroups([nobody, ploufer, tester], true);
 
     assert.deepEqual(
@@ -90,6 +106,35 @@ describe('buildMemberGroups', () => {
     );
   });
 
+  it('does not create a section for a non-hoisted role', () => {
+    const casual = makeRole({ id: 'r-casual', name: 'casual', is_hoisted: false, position: 9 });
+    const casualMember = makeMember({ userId: 'u-casual', displayName: 'Casual', roles: [casual] });
+
+    const groups = buildMemberGroups([casualMember], true);
+
+    assert.deepEqual(
+      groups.map((group) => group.title),
+      ['Members']
+    );
+    assert.deepEqual(
+      groups[0].members.map((member) => member.displayName),
+      ['Casual']
+    );
+  });
+
+  it('groups under the highest hoisted role even when a non-hoisted role sits higher', () => {
+    const bigNonHoist = makeRole({ id: 'r-big', name: 'Big', is_hoisted: false, position: 20 });
+    const modHoist = makeRole({ id: 'r-mod', name: 'Mod', is_hoisted: true, position: 3 });
+    const member = makeMember({ userId: 'u-mixed', displayName: 'Mixed', roles: [bigNonHoist, modHoist] });
+
+    const groups = buildMemberGroups([member], true);
+
+    assert.deepEqual(
+      groups.map((group) => group.title),
+      ['Mod']
+    );
+  });
+
   it('pins the owner in an Owner group at the top', () => {
     const groups = buildMemberGroups([tester, owner], true);
 
@@ -103,27 +148,9 @@ describe('buildMemberGroups', () => {
     );
   });
 
-  it('keeps the owner on top even when another role grants more permissions', () => {
-    const adminRole = makeRole({ id: 'r-admin', name: 'Administrator', permissions: '256' });
-    const richOwner = makeMember({
-      userId: 'u-owner',
-      displayName: 'Owner',
-      isOwner: true,
-      roles: [adminRole]
-    });
-
-    // "test" has all 12 permission flags; the owner's Administrator role has 1
-    const groups = buildMemberGroups([tester, richOwner], true);
-
-    assert.deepEqual(
-      groups.map((group) => group.title),
-      ['Owner', 'test']
-    );
-  });
-
-  it('breaks equal permission counts alphabetically', () => {
-    const zeta = makeRole({ id: 'r-z', name: 'zeta', permissions: '1' });
-    const alpha = makeRole({ id: 'r-a', name: 'alpha', permissions: '2' });
+  it('orders hoisted groups by position, highest first', () => {
+    const zeta = makeRole({ id: 'r-z', name: 'zeta', is_hoisted: true, position: 1 });
+    const alpha = makeRole({ id: 'r-a', name: 'alpha', is_hoisted: true, position: 2 });
     const groups = buildMemberGroups(
       [makeMember({ userId: 'u-1', roles: [zeta] }), makeMember({ userId: 'u-2', roles: [alpha] })],
       true
@@ -132,6 +159,20 @@ describe('buildMemberGroups', () => {
     assert.deepEqual(
       groups.map((group) => group.title),
       ['alpha', 'zeta']
+    );
+  });
+
+  it('breaks equal positions alphabetically', () => {
+    const bb = makeRole({ id: 'r-bb', name: 'bb', is_hoisted: true, position: 5 });
+    const aa = makeRole({ id: 'r-aa', name: 'aa', is_hoisted: true, position: 5 });
+    const groups = buildMemberGroups(
+      [makeMember({ userId: 'u-1', roles: [bb] }), makeMember({ userId: 'u-2', roles: [aa] })],
+      true
+    );
+
+    assert.deepEqual(
+      groups.map((group) => group.title),
+      ['aa', 'bb']
     );
   });
 

--- a/frontend/tests/notification-card.test.tsx
+++ b/frontend/tests/notification-card.test.tsx
@@ -114,4 +114,17 @@ describe('describeNotification', () => {
       'Incoming audio call.'
     );
   });
+
+  it('falls back to a generic view for an unknown type instead of returning undefined', () => {
+    // a type the frontend does not handle (e.g. a newer backend type) must not
+    // crash the whole notification list when destructured.
+    const unknownNotification = {
+      ...dmNotification,
+      type: 'guild_owner_transferred'
+    } as unknown as NotificationDto;
+
+    const view = describeNotification(unknownNotification, 'Testa');
+    assert.equal(view.title, 'Notification');
+    assert.ok(view.Icon);
+  });
 });

--- a/frontend/tests/notification-card.test.tsx
+++ b/frontend/tests/notification-card.test.tsx
@@ -115,12 +115,30 @@ describe('describeNotification', () => {
     );
   });
 
+  it('describes a guild ownership transfer, naming the previous owner as actor', () => {
+    const ownershipNotification = {
+      ...dmNotification,
+      type: 'guild_ownership_transferred',
+      payload: {}
+    } as unknown as NotificationDto;
+
+    assert.equal(describeNotification(ownershipNotification, 'Testa').title, 'Ownership transferred');
+    assert.equal(
+      describeNotification(ownershipNotification, 'Testa').detail,
+      'Testa made you the owner of their guild.'
+    );
+    assert.equal(
+      describeNotification(ownershipNotification, null).detail,
+      'You are now the owner of the guild.'
+    );
+  });
+
   it('falls back to a generic view for an unknown type instead of returning undefined', () => {
-    // a type the frontend does not handle (e.g. a newer backend type) must not
+    // a type the frontend does not handle (e.g. a future backend type) must not
     // crash the whole notification list when destructured.
     const unknownNotification = {
       ...dmNotification,
-      type: 'guild_owner_transferred'
+      type: 'some_future_type'
     } as unknown as NotificationDto;
 
     const view = describeNotification(unknownNotification, 'Testa');

--- a/frontend/tests/profile-card.test.tsx
+++ b/frontend/tests/profile-card.test.tsx
@@ -1,8 +1,10 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import { renderToStaticMarkup } from 'react-dom/server';
-import { ProfileCard } from '../src/components/profile-card';
+import { ProfileCard, type ProfileRoleManagement } from '../src/components/profile-card';
 import type { GuildMember } from '../src/components/guild-member-list';
+import type { HydratedGuildMember } from '../src/shared/guilds/use-guild-members';
+import { PERMISSIONS } from '../src/shared/guilds/role-permissions';
 
 const member: GuildMember = {
   id: '123',
@@ -78,5 +80,50 @@ describe('ProfileCard', () => {
     const html = renderToStaticMarkup(<ProfileCard member={member} onClose={() => undefined} />);
 
     assert.ok(!html.includes('Roles'));
+  });
+
+  it('offers a Manage control and live roles when the viewer can manage roles', () => {
+    const liveMember: HydratedGuildMember = {
+      userId: '123',
+      displayName: 'SkyDogzz',
+      username: 'skydogzz',
+      avatarUrl: null,
+      bannerUrl: null,
+      bio: null,
+      nickname: null,
+      status: 'online',
+      roles: [
+        {
+          id: 'r-live',
+          guild_id: 'g-1',
+          name: 'LiveRole',
+          color: '#78dce8',
+          permissions: '0',
+          position: 3,
+          is_hoisted: false,
+          is_mentionable: false,
+          is_default: false
+        }
+      ],
+      joinedAt: '2026-07-11T00:00:00Z',
+      isOwner: false,
+      isDeleted: false
+    };
+
+    const roleManagement: ProfileRoleManagement = {
+      guildId: 'g-1',
+      member: liveMember,
+      roles: liveMember.roles,
+      caller: { rank: 10, permissions: PERMISSIONS.ManageRoles, isOwner: false },
+      onChanged: () => undefined
+    };
+
+    const html = renderToStaticMarkup(
+      <ProfileCard member={member} roleManagement={roleManagement} onClose={() => undefined} />
+    );
+
+    // read-only chip reflects the live guild-member roles, and a Manage toggle appears
+    assert.ok(html.includes('>LiveRole</span>'));
+    assert.ok(html.includes('Manage'));
   });
 });

--- a/frontend/tests/profile-card.test.tsx
+++ b/frontend/tests/profile-card.test.tsx
@@ -53,4 +53,30 @@ describe('ProfileCard', () => {
     assert.ok(html.includes('>Owner</span>'));
     assert.ok(!html.includes('border-color'));
   });
+
+  it('lists every assigned role in a Roles section', () => {
+    const html = renderToStaticMarkup(
+      <ProfileCard
+        member={{
+          ...member,
+          roles: [
+            { id: 'r-a', name: 'Maintainer', color: '#ff6188' },
+            { id: 'r-b', name: 'Reviewer', color: null }
+          ]
+        }}
+        onClose={() => undefined}
+      />
+    );
+
+    assert.ok(html.includes('Roles'));
+    assert.ok(html.includes('>Maintainer</span>'));
+    assert.ok(html.includes('>Reviewer</span>'));
+    assert.ok(html.includes('background-color:#ff6188'));
+  });
+
+  it('omits the Roles section when the member has no roles', () => {
+    const html = renderToStaticMarkup(<ProfileCard member={member} onClose={() => undefined} />);
+
+    assert.ok(!html.includes('Roles'));
+  });
 });

--- a/services/chat/src/Chat.Application/Abstractions/IUserBroadcaster.cs
+++ b/services/chat/src/Chat.Application/Abstractions/IUserBroadcaster.cs
@@ -27,6 +27,13 @@ public interface IUserBroadcaster
 	Task BroadcastGuildUpdatedAsync(long guildId, string name, string? iconUrl, CancellationToken ct);
 
 	/// <summary>
+	/// tells the guild:{guildId} group that ownership moved from
+	/// <paramref name="oldOwnerId"/> to <paramref name="newOwnerId"/>, so members'
+	/// owner-only UI (crown, management controls) updates live without a refresh.
+	/// </summary>
+	Task BroadcastGuildOwnerTransferredAsync(long guildId, long oldOwnerId, long newOwnerId, CancellationToken ct);
+
+	/// <summary>
 	/// subscribes every open connection of <paramref name="userId"/> to the
 	/// <c>guild:{guildId}</c> group so they receive that guild's real-time
 	/// broadcasts. called when the user joins a guild while already connected

--- a/services/chat/src/Chat.Infrastructure/DependencyInjection.cs
+++ b/services/chat/src/Chat.Infrastructure/DependencyInjection.cs
@@ -56,6 +56,7 @@ public static class DependencyInjection
 			x.AddConsumer<GuildMemberLeftConsumer>();
 			x.AddConsumer<GuildDeletedConsumer>();
 			x.AddConsumer<GuildUpdatedConsumer>();
+			x.AddConsumer<GuildOwnerTransferredConsumer>();
 			x.AddConsumer<GuildRolesChangedConsumer>();
 			x.AddConsumer<GuildMemberUpdatedConsumer>();
 			x.AddConsumer<ChannelAccessRevokedConsumer>();

--- a/services/chat/src/Chat.Infrastructure/Messaging/Consumers/MembershipConsumers.cs
+++ b/services/chat/src/Chat.Infrastructure/Messaging/Consumers/MembershipConsumers.cs
@@ -110,6 +110,26 @@ public sealed class GuildUpdatedConsumer(
 	}
 }
 
+public sealed class GuildOwnerTransferredConsumer(
+	IUserBroadcaster broadcaster,
+	ILogger<GuildOwnerTransferredConsumer> logger)
+	: IConsumer<GuildOwnerTransferred>
+{
+	public async Task Consume(ConsumeContext<GuildOwnerTransferred> context)
+	{
+		var msg = context.Message;
+
+		// ownership changes no group membership (both owners stay members), so we
+		// only tell the guild group to flip their owner-only UI live.
+		await broadcaster.BroadcastGuildOwnerTransferredAsync(
+			msg.GuildId, msg.OldOwnerId, msg.NewOwnerId, context.CancellationToken);
+
+		logger.LogDebug(
+			"guild.owner_transferred consumed: guild_id={GuildId} old_owner={OldOwner} new_owner={NewOwner}",
+			msg.GuildId, msg.OldOwnerId, msg.NewOwnerId);
+	}
+}
+
 public sealed class GuildRolesChangedConsumer(
 	IUserBroadcaster broadcaster,
 	ILogger<GuildRolesChangedConsumer> logger)

--- a/services/chat/src/Chat.Infrastructure/Messaging/Contracts/InboundEvents.cs
+++ b/services/chat/src/Chat.Infrastructure/Messaging/Contracts/InboundEvents.cs
@@ -21,6 +21,9 @@ public sealed record GuildDeleted(long GuildId, IReadOnlyList<long> ChannelIds);
 [MessageUrn("Guild.Application.Contracts:GuildUpdated")]
 public sealed record GuildUpdated(long GuildId, string Name, string? IconUrl);
 
+[MessageUrn("Guild.Application.Contracts:GuildOwnerTransferred")]
+public sealed record GuildOwnerTransferred(long GuildId, long OldOwnerId, long NewOwnerId);
+
 [MessageUrn("Guild.Application.Contracts:GuildRolesChanged")]
 public sealed record GuildRolesChanged(long GuildId);
 

--- a/services/chat/src/Chat.Presentation/Hubs/IChatClient.cs
+++ b/services/chat/src/Chat.Presentation/Hubs/IChatClient.cs
@@ -26,6 +26,7 @@ public interface IChatClient
 	Task GuildLeft(string guildId);
 	Task GuildDeleted(string guildId);
 	Task GuildUpdated(GuildUpdatedEvent evt);
+	Task GuildOwnerTransferred(GuildOwnerTransferredEvent evt);
 
 	Task ChannelCreated(GuildChannelDto channel);
 	Task ChannelUpdated(GuildChannelDto channel);
@@ -52,4 +53,5 @@ public sealed record CategoryDeletedEvent(string GuildId, string CategoryId);
 public sealed record GuildMemberEvent(string GuildId, string UserId);
 public sealed record UserPresenceEvent(string UserId, string Status);
 public sealed record GuildUpdatedEvent(string GuildId, string Name, string? IconUrl);
+public sealed record GuildOwnerTransferredEvent(string GuildId, string OldOwnerId, string NewOwnerId);
 public sealed record ChannelAccessGrantedEvent(string GuildId, string ChannelId);

--- a/services/chat/src/Chat.Presentation/Hubs/SignalRUserBroadcaster.cs
+++ b/services/chat/src/Chat.Presentation/Hubs/SignalRUserBroadcaster.cs
@@ -29,6 +29,10 @@ internal sealed class SignalRUserBroadcaster(
 	public Task BroadcastGuildUpdatedAsync(long guildId, string name, string? iconUrl, CancellationToken ct) =>
 		hub.Clients.Group($"guild:{guildId}").GuildUpdated(new GuildUpdatedEvent(guildId.ToString(), name, iconUrl));
 
+	public Task BroadcastGuildOwnerTransferredAsync(long guildId, long oldOwnerId, long newOwnerId, CancellationToken ct) =>
+		hub.Clients.Group($"guild:{guildId}").GuildOwnerTransferred(
+			new GuildOwnerTransferredEvent(guildId.ToString(), oldOwnerId.ToString(), newOwnerId.ToString()));
+
 	public async Task AddUserToGuildGroupAsync(long userId, long guildId, CancellationToken ct)
 	{
 		foreach (var connectionId in tracker.ConnectionIds(userId))

--- a/services/chat/tests/Chat.UnitTests/Fakes/FakeUserBroadcaster.cs
+++ b/services/chat/tests/Chat.UnitTests/Fakes/FakeUserBroadcaster.cs
@@ -56,6 +56,15 @@ public sealed class FakeUserBroadcaster : IUserBroadcaster
 		return Task.CompletedTask;
 	}
 
+	private readonly List<(long GuildId, long OldOwnerId, long NewOwnerId)> _guildOwnerTransferredCalls = [];
+	public IReadOnlyList<(long GuildId, long OldOwnerId, long NewOwnerId)> GuildOwnerTransferredCalls => _guildOwnerTransferredCalls;
+
+	public Task BroadcastGuildOwnerTransferredAsync(long guildId, long oldOwnerId, long newOwnerId, CancellationToken ct)
+	{
+		_guildOwnerTransferredCalls.Add((guildId, oldOwnerId, newOwnerId));
+		return Task.CompletedTask;
+	}
+
 	public Task AddUserToGuildGroupAsync(long userId, long guildId, CancellationToken ct)
 	{
 		_addGuildGroupCalls.Add((userId, guildId));

--- a/services/chat/tests/Chat.UnitTests/Infrastructure/GuildMemberJoinedConsumerTests.cs
+++ b/services/chat/tests/Chat.UnitTests/Infrastructure/GuildMemberJoinedConsumerTests.cs
@@ -64,6 +64,31 @@ public sealed class GuildMemberLeftConsumerTests
 	}
 }
 
+public sealed class GuildOwnerTransferredConsumerTests
+{
+	[Fact]
+	public async Task Consume_ForwardsOwnerChangeToGuildGroup()
+	{
+		var broadcaster = new FakeUserBroadcaster();
+		await using var provider = new ServiceCollection()
+			.AddSingleton<IUserBroadcaster>(broadcaster)
+			.AddMassTransitTestHarness(x => x.AddConsumer<GuildOwnerTransferredConsumer>())
+			.BuildServiceProvider(true);
+
+		var harness = provider.GetRequiredService<ITestHarness>();
+		await harness.Start();
+
+		await harness.Bus.Publish(new GuildOwnerTransferred(GuildId: 100, OldOwnerId: 1, NewOwnerId: 2));
+
+		Assert.True(await harness.Consumed.Any<GuildOwnerTransferred>());
+
+		var call = Assert.Single(broadcaster.GuildOwnerTransferredCalls);
+		Assert.Equal(100L, call.GuildId);
+		Assert.Equal(1L, call.OldOwnerId);
+		Assert.Equal(2L, call.NewOwnerId);
+	}
+}
+
 public sealed class GuildDeletedConsumerTests
 {
 	[Fact]

--- a/services/guild/src/Guild.Application/Authorization/ChannelAccess.cs
+++ b/services/guild/src/Guild.Application/Authorization/ChannelAccess.cs
@@ -27,12 +27,29 @@ internal static class ChannelAccess
 	{
 		var guildChannels = await channels.GetByGuildAsync(guild.Id, cancellationToken);
 		var allOverwrites = await overwrites.GetForGuildAsync(guild.Id, cancellationToken);
-		var byChannel = allOverwrites
-			.GroupBy(o => o.ChannelId)
-			.ToDictionary(g => g.Key, g => (IReadOnlyList<ChannelPermissionOverwrite>)g.ToList());
+		var byChannel = GroupByChannel(allOverwrites);
 
 		return Capture(guild, Pairs(guildChannels.Select(c => c.Id), affectedUserIds), byChannel);
 	}
+
+	// group a flat guild-wide overwrite list into per-channel lists, the shape the
+	// resolver consumes.
+	public static IReadOnlyDictionary<long, IReadOnlyList<ChannelPermissionOverwrite>> GroupByChannel(
+		IEnumerable<ChannelPermissionOverwrite> overwrites) =>
+		overwrites
+			.GroupBy(o => o.ChannelId)
+			.ToDictionary(g => g.Key, g => (IReadOnlyList<ChannelPermissionOverwrite>)g.ToList());
+
+	// the channels in <paramref name="channels"/> that <paramref name="userId"/>
+	// may READ, given the guild's overwrites. single home for the channel-list
+	// read rule shared by ListChannels and GetVisibleChannels; owners/admins
+	// short-circuit to all permissions in the resolver.
+	public static IEnumerable<Channel> ReadableChannels(
+		GuildEntity guild,
+		long userId,
+		IEnumerable<Channel> channels,
+		IReadOnlyDictionary<long, IReadOnlyList<ChannelPermissionOverwrite>> overwritesByChannel) =>
+		channels.Where(channel => CanRead(guild, channel.Id, userId, overwritesByChannel));
 
 	// overwrite mutations touch a single channel; the caller supplies the changed
 	// after-overwrites when publishing.

--- a/services/guild/src/Guild.Application/Features/Channels/CreateChannel/CreateChannelCommand.cs
+++ b/services/guild/src/Guild.Application/Features/Channels/CreateChannel/CreateChannelCommand.cs
@@ -12,4 +12,17 @@ public sealed record CreateChannelCommand(
 	string? Topic,
 	int? Position,
 	bool? IsNsfw = null,
-	int? SlowmodeSeconds = null) : ICommand<Result<ChannelResponse>>;
+	int? SlowmodeSeconds = null,
+	IReadOnlyList<ChannelOverwriteInput>? Overwrites = null) : ICommand<Result<ChannelResponse>>;
+
+/// <summary>
+/// an allow/deny overwrite to apply atomically as the channel is created, so it
+/// spawns with the intended per-role/per-member permissions instead of being
+/// briefly world-readable while overwrites are PUT afterwards. mirrors the shape
+/// of <c>PutOverwriteCommand</c>.
+/// </summary>
+public sealed record ChannelOverwriteInput(
+	long TargetId,
+	string? TargetType,
+	long Allow,
+	long Deny);

--- a/services/guild/src/Guild.Application/Features/Channels/CreateChannel/CreateChannelHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Channels/CreateChannel/CreateChannelHandler.cs
@@ -14,6 +14,7 @@ internal sealed class CreateChannelHandler(
 	IGuildRepository guilds,
 	IChannelRepository channels,
 	IChannelCategoryRepository categories,
+	IChannelPermissionOverwriteRepository overwrites,
 	IEventBus eventBus,
 	IIdGenerator ids,
 	IClock clock,
@@ -68,19 +69,78 @@ internal sealed class CreateChannelHandler(
 		if (channelResult.IsFailure)
 			return channelResult.Error;
 
-		channels.Add(channelResult.Value);
+		var channel = channelResult.Value;
 
-		// a freshly-created channel has no overwrites yet, so eligibility is the
-		// base-permission ReadMessages set. publish before SaveChanges so the
-		// outbox binds the event to the same transaction as the insert.
-		var eligible = ChannelAccess.ReadersOf(guild, channelResult.Value.Id, []);
+		// build any requested overwrites atomically so the channel is created
+		// already carrying its intended permissions -- there is no window where it
+		// is world-readable, and the GuildChannelCreated event below targets only
+		// members who can actually read it.
+		var overwritesResult = BuildOverwrites(guild, channel.Id, command.Overwrites, clock.UtcNow);
+		if (overwritesResult.IsFailure)
+			return overwritesResult.Error;
+		var createdOverwrites = overwritesResult.Value;
+
+		channels.Add(channel);
+		foreach (var overwrite in createdOverwrites)
+			overwrites.Add(overwrite);
+
+		// publish before SaveChanges so the outbox binds the event to the same
+		// transaction as the inserts.
+		var eligible = ChannelAccess.ReadersOf(guild, channel.Id, createdOverwrites);
 		await eventBus.PublishAsync(
-			new GuildChannelCreated(command.GuildId, ChannelPayload.From(channelResult.Value), eligible),
+			new GuildChannelCreated(command.GuildId, ChannelPayload.From(channel), eligible),
 			cancellationToken);
 
 		await unitOfWork.SaveChangesAsync(cancellationToken);
 
-		return ChannelResponse.From(channelResult.Value);
+		return ChannelResponse.From(channel);
+	}
+
+	private Result<IReadOnlyList<ChannelPermissionOverwrite>> BuildOverwrites(
+		Domain.Guild.Guild guild,
+		long channelId,
+		IReadOnlyList<ChannelOverwriteInput>? inputs,
+		DateTimeOffset now)
+	{
+		if (inputs is not { Count: > 0 })
+			return Result.Ok<IReadOnlyList<ChannelPermissionOverwrite>>([]);
+
+		var built = new List<ChannelPermissionOverwrite>(inputs.Count);
+		var seen = new HashSet<(OverwriteTargetType, long)>();
+
+		foreach (var input in inputs)
+		{
+			if (!TryParseTargetType(input.TargetType, out var targetType))
+				return GuildFailures.OverwriteInvalidTarget;
+
+			// target_id must reference a real role or member of *this* guild
+			var targetExists = targetType == OverwriteTargetType.Role
+				? guild.Roles.Any(r => r.Id == input.TargetId)
+				: guild.Members.Any(m => m.UserId == input.TargetId);
+			if (!targetExists)
+				return GuildFailures.OverwriteInvalidTarget;
+
+			// a target may only be listed once; a duplicate is a client error
+			if (!seen.Add((targetType, input.TargetId)))
+				return GuildFailures.OverwriteInvalidTarget;
+
+			var overwriteResult = ChannelPermissionOverwrite.Create(
+				id: ids.NextId(),
+				guildId: guild.Id,
+				channelId: channelId,
+				targetType: targetType,
+				targetId: input.TargetId,
+				allow: input.Allow,
+				deny: input.Deny,
+				now: now);
+
+			if (overwriteResult.IsFailure)
+				return overwriteResult.Error;
+
+			built.Add(overwriteResult.Value);
+		}
+
+		return Result.Ok<IReadOnlyList<ChannelPermissionOverwrite>>(built);
 	}
 
 	private static bool TryParseType(string? raw, out ChannelType type)
@@ -95,6 +155,23 @@ internal sealed class CreateChannelHandler(
 				return true;
 			case "announcement":
 				type = ChannelType.Announcement;
+				return true;
+			default:
+				type = default;
+				return false;
+		}
+	}
+
+	private static bool TryParseTargetType(string? raw, out OverwriteTargetType type)
+	{
+		switch (raw?.Trim().ToLowerInvariant())
+		{
+			case "role":
+				type = OverwriteTargetType.Role;
+				return true;
+			case "member":
+			case "user":
+				type = OverwriteTargetType.Member;
 				return true;
 			default:
 				type = default;

--- a/services/guild/src/Guild.Application/Features/Channels/ListChannelMembers/ListChannelMembersHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Channels/ListChannelMembers/ListChannelMembersHandler.cs
@@ -1,0 +1,37 @@
+using Guild.Application.Abstractions.Messaging;
+using Guild.Application.Abstractions.Persistence;
+using Guild.Application.Abstractions.Security;
+using Guild.Application.Authorization;
+using Guild.Domain.Results;
+
+namespace Guild.Application.Features.Channels.ListChannelMembers;
+
+internal sealed class ListChannelMembersHandler(
+	IGuildRepository guilds,
+	IChannelRepository channels,
+	IChannelPermissionOverwriteRepository overwrites,
+	ICurrentUser currentUser)
+	: IQueryHandler<ListChannelMembersQuery, Result<ChannelMembersResponse>>
+{
+	public async Task<Result<ChannelMembersResponse>> HandleAsync(
+		ListChannelMembersQuery query,
+		CancellationToken cancellationToken = default)
+	{
+		var guild = await guilds.GetByIdWithMembershipAsNoTrackingAsync(query.GuildId, cancellationToken);
+		if (guild is null)
+			return GuildFailures.GuildNotFound;
+
+		// any member of the guild may ask who can read a channel; non-members get 403
+		if (guild.Members.All(m => m.UserId != currentUser.Id))
+			return GuildFailures.NotAMember;
+
+		var channel = await channels.GetByIdAsync(query.ChannelId, cancellationToken);
+		if (channel is null || channel.GuildId != query.GuildId)
+			return GuildFailures.ChannelNotFound;
+
+		var channelOverwrites = await overwrites.GetForChannelAsync(query.ChannelId, cancellationToken);
+		var readers = ChannelAccess.ReadersOf(guild, query.ChannelId, channelOverwrites);
+
+		return new ChannelMembersResponse([.. readers.Select(id => id.ToString())]);
+	}
+}

--- a/services/guild/src/Guild.Application/Features/Channels/ListChannelMembers/ListChannelMembersQuery.cs
+++ b/services/guild/src/Guild.Application/Features/Channels/ListChannelMembers/ListChannelMembersQuery.cs
@@ -1,0 +1,14 @@
+using Guild.Application.Abstractions.Messaging;
+using Guild.Domain.Results;
+
+namespace Guild.Application.Features.Channels.ListChannelMembers;
+
+public sealed record ListChannelMembersQuery(long GuildId, long ChannelId)
+	: IQuery<Result<ChannelMembersResponse>>;
+
+/// <summary>
+/// wire shape for <c>GET /guilds/{id}/channels/{channelId}/members</c>: the
+/// snowflake ids of the members who can READ the channel, so the client can
+/// scope the guild member list to who can actually see the current channel.
+/// </summary>
+public sealed record ChannelMembersResponse(IReadOnlyList<string> UserIds);

--- a/services/guild/src/Guild.Application/Features/Channels/ListChannels/ListChannelsHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Channels/ListChannels/ListChannelsHandler.cs
@@ -1,8 +1,8 @@
 using Guild.Application.Abstractions.Messaging;
 using Guild.Application.Abstractions.Persistence;
 using Guild.Application.Abstractions.Security;
+using Guild.Application.Authorization;
 using Guild.Application.Features.Channels.Common;
-using Guild.Domain.Guild;
 using Guild.Domain.Results;
 
 namespace Guild.Application.Features.Channels.ListChannels;
@@ -27,22 +27,13 @@ internal sealed class ListChannelsHandler(
 
 		var entities = await channels.GetByGuildAsync(query.GuildId, cancellationToken);
 		var guildOverwrites = await overwrites.GetForGuildAsync(query.GuildId, cancellationToken);
-		var overwritesByChannel = guildOverwrites
-			.GroupBy(o => o.ChannelId)
-			.ToDictionary(g => g.Key, g => (IReadOnlyList<ChannelPermissionOverwrite>)g.ToList());
+		var overwritesByChannel = ChannelAccess.GroupByChannel(guildOverwrites);
 
 		// list only channels the caller can actually read: a READ_CHANNEL deny
 		// overwrite (on the member or one of their roles) hides the channel here,
-		// mirroring GetVisibleChannelsHandler so the sidebar no longer shows a
-		// channel the member was denied. owners/admins short-circuit to all
-		// permissions in the resolver, so management access is unaffected.
-		var dtos = entities
-			.Where(channel =>
-			{
-				var channelOverwrites = overwritesByChannel.TryGetValue(channel.Id, out var ows) ? ows : [];
-				var permissions = PermissionResolver.Resolve(guild, currentUser.Id, channelOverwrites);
-				return PermissionResolver.HasPermission(permissions, Permission.ReadMessages);
-			})
+		// so the sidebar no longer shows a channel the member was denied.
+		var dtos = ChannelAccess
+			.ReadableChannels(guild, currentUser.Id, entities, overwritesByChannel)
 			.Select(ChannelResponse.From)
 			.ToList();
 

--- a/services/guild/src/Guild.Application/Features/Channels/ListChannels/ListChannelsHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Channels/ListChannels/ListChannelsHandler.cs
@@ -2,6 +2,7 @@ using Guild.Application.Abstractions.Messaging;
 using Guild.Application.Abstractions.Persistence;
 using Guild.Application.Abstractions.Security;
 using Guild.Application.Features.Channels.Common;
+using Guild.Domain.Guild;
 using Guild.Domain.Results;
 
 namespace Guild.Application.Features.Channels.ListChannels;
@@ -9,6 +10,7 @@ namespace Guild.Application.Features.Channels.ListChannels;
 internal sealed class ListChannelsHandler(
 	IGuildRepository guilds,
 	IChannelRepository channels,
+	IChannelPermissionOverwriteRepository overwrites,
 	ICurrentUser currentUser)
 	: IQueryHandler<ListChannelsQuery, Result<ChannelListResponse>>
 {
@@ -16,16 +18,34 @@ internal sealed class ListChannelsHandler(
 		ListChannelsQuery query,
 		CancellationToken cancellationToken = default)
 	{
-		var guild = await guilds.GetByIdAsync(query.GuildId, cancellationToken);
+		var guild = await guilds.GetByIdWithMembershipAsNoTrackingAsync(query.GuildId, cancellationToken);
 		if (guild is null)
 			return GuildFailures.GuildNotFound;
 
-		var isMember = await guilds.IsMemberAsync(query.GuildId, currentUser.Id, cancellationToken);
-		if (!isMember)
+		if (guild.Members.All(m => m.UserId != currentUser.Id))
 			return GuildFailures.NotAMember;
 
 		var entities = await channels.GetByGuildAsync(query.GuildId, cancellationToken);
-		var dtos = entities.Select(ChannelResponse.From).ToList();
+		var guildOverwrites = await overwrites.GetForGuildAsync(query.GuildId, cancellationToken);
+		var overwritesByChannel = guildOverwrites
+			.GroupBy(o => o.ChannelId)
+			.ToDictionary(g => g.Key, g => (IReadOnlyList<ChannelPermissionOverwrite>)g.ToList());
+
+		// list only channels the caller can actually read: a READ_CHANNEL deny
+		// overwrite (on the member or one of their roles) hides the channel here,
+		// mirroring GetVisibleChannelsHandler so the sidebar no longer shows a
+		// channel the member was denied. owners/admins short-circuit to all
+		// permissions in the resolver, so management access is unaffected.
+		var dtos = entities
+			.Where(channel =>
+			{
+				var channelOverwrites = overwritesByChannel.TryGetValue(channel.Id, out var ows) ? ows : [];
+				var permissions = PermissionResolver.Resolve(guild, currentUser.Id, channelOverwrites);
+				return PermissionResolver.HasPermission(permissions, Permission.ReadMessages);
+			})
+			.Select(ChannelResponse.From)
+			.ToList();
+
 		return new ChannelListResponse(dtos);
 	}
 }

--- a/services/guild/src/Guild.Application/Features/Channels/VisibleChannels/GetVisibleChannelsHandler.cs
+++ b/services/guild/src/Guild.Application/Features/Channels/VisibleChannels/GetVisibleChannelsHandler.cs
@@ -1,8 +1,8 @@
 using Guild.Application.Abstractions.Messaging;
 using Guild.Application.Abstractions.Persistence;
+using Guild.Application.Authorization;
 using Guild.Application.Features.Channels.Common;
 using Guild.Application.Features.Channels.ListChannels;
-using Guild.Domain.Guild;
 using Guild.Domain.Results;
 
 namespace Guild.Application.Features.Channels.VisibleChannels;
@@ -10,7 +10,7 @@ namespace Guild.Application.Features.Channels.VisibleChannels;
 /// <summary>
 /// backs Chat Service's <c>GET /channels/read-states</c> sidebar fetch. resolves,
 /// for every guild the user belongs to, the channels where their effective
-/// permissions include <see cref="Permission.ReadMessages"/>. loads each guild's
+/// permissions include <see cref="Guild.Domain.Guild.Permission.ReadMessages"/>. loads each guild's
 /// membership/roles, channels and overwrites via the existing lean per-guild
 /// reads (no full-member hydration, no N+1 across guilds) rather than looping
 /// the per-channel membership check.
@@ -36,19 +36,10 @@ internal sealed class GetVisibleChannelsHandler(
 
 			var guildChannels = await channels.GetByGuildAsync(guildId, cancellationToken);
 			var guildOverwrites = await overwrites.GetForGuildAsync(guildId, cancellationToken);
-			var overwritesByChannel = guildOverwrites
-				.GroupBy(o => o.ChannelId)
-				.ToDictionary(g => g.Key, g => (IReadOnlyList<ChannelPermissionOverwrite>)g.ToList());
+			var overwritesByChannel = ChannelAccess.GroupByChannel(guildOverwrites);
 
-			foreach (var channel in guildChannels)
-			{
-				var channelOverwrites = overwritesByChannel.TryGetValue(channel.Id, out var ows)
-					? ows
-					: [];
-				var permissions = PermissionResolver.Resolve(guild, query.UserId, channelOverwrites);
-				if (PermissionResolver.HasPermission(permissions, Permission.ReadMessages))
-					visible.Add(ChannelResponse.From(channel));
-			}
+			foreach (var channel in ChannelAccess.ReadableChannels(guild, query.UserId, guildChannels, overwritesByChannel))
+				visible.Add(ChannelResponse.From(channel));
 		}
 
 		return new ChannelListResponse(visible);

--- a/services/guild/src/Guild.Domain/Guild/ChannelPermissionOverwrite.cs
+++ b/services/guild/src/Guild.Domain/Guild/ChannelPermissionOverwrite.cs
@@ -34,6 +34,15 @@ public sealed class ChannelPermissionOverwrite
 		UpdatedAt = updatedAt;
 	}
 
+	// bits meaningful as a per-channel allow/deny overwrite. guild-wide authority
+	// (kick, ban, manage roles/guild, administrator, manage nicknames) is excluded
+	// so an overwrite can never escalate a member past their guild-level
+	// permissions -- critically, allowing ADMINISTRATOR here would short-circuit
+	// every channel permission check for the target.
+	public const long ChannelScopedMask =
+		(long)(Permission.SendMessages | Permission.ReadMessages | Permission.ManageMessages
+			| Permission.ManageChannels | Permission.CreateInvite | Permission.MentionEveryone);
+
 	public long Id { get; private set; }
 	public long GuildId { get; private set; }
 	public long ChannelId { get; private set; }
@@ -60,6 +69,9 @@ public sealed class ChannelPermissionOverwrite
 		if ((allow & deny) != 0L)
 			return GuildFailures.OverwriteAllowDenyOverlap;
 
+		if (((allow | deny) & ~ChannelScopedMask) != 0L)
+			return GuildFailures.OverwriteUnsupportedPermission;
+
 		return new ChannelPermissionOverwrite(
 			id: id,
 			guildId: guildId,
@@ -76,6 +88,9 @@ public sealed class ChannelPermissionOverwrite
 	{
 		if ((allow & deny) != 0L)
 			return GuildFailures.OverwriteAllowDenyOverlap;
+
+		if (((allow | deny) & ~ChannelScopedMask) != 0L)
+			return GuildFailures.OverwriteUnsupportedPermission;
 
 		Allow = allow;
 		Deny = deny;

--- a/services/guild/src/Guild.Domain/Results/GuildFailures.cs
+++ b/services/guild/src/Guild.Domain/Results/GuildFailures.cs
@@ -80,6 +80,9 @@ public static class GuildFailures
 	public static readonly Failure OverwriteAllowDenyOverlap =
 		new("Guild.OverwriteAllowDenyOverlap", "A bit cannot be both allowed and denied by the same overwrite.");
 
+	public static readonly Failure OverwriteUnsupportedPermission =
+		new("Guild.OverwriteUnsupportedPermission", "Only channel-scoped permissions may be set on a channel overwrite.");
+
 	public static readonly Failure OverwriteNotFound =
 		new("Guild.OverwriteNotFound", "Channel permission overwrite not found.");
 

--- a/services/guild/src/Guild.Presentation/Endpoints/ChannelsEndpoint.cs
+++ b/services/guild/src/Guild.Presentation/Endpoints/ChannelsEndpoint.cs
@@ -3,6 +3,7 @@ using Guild.Application.Abstractions.Messaging;
 using Guild.Application.Features.Channels.Common;
 using Guild.Application.Features.Channels.CreateChannel;
 using Guild.Application.Features.Channels.DeleteChannel;
+using Guild.Application.Features.Channels.ListChannelMembers;
 using Guild.Application.Features.Channels.ListChannels;
 using Guild.Application.Features.Channels.UpdateChannel;
 using Guild.Domain.Results;
@@ -17,9 +18,23 @@ public sealed class ChannelsEndpoint : ICarterModule
 	{
 		var group = endpoints.MapGroup("/guilds/{id:long}/channels");
 		group.MapGet("/", ListAsync).ProducesGuildErrors();
+		group.MapGet("/{channelId:long}/members", ListMembersAsync).ProducesGuildErrors();
 		group.MapPost("/", CreateAsync).ProducesGuildErrors();
 		group.MapPatch("/{channelId:long}", UpdateAsync).ProducesGuildErrors();
 		group.MapDelete("/{channelId:long}", DeleteAsync).ProducesGuildErrors();
+	}
+
+	private static async Task<Results<Ok<ChannelMembersResponse>, JsonHttpResult<ErrorBody>>>
+	ListMembersAsync(
+		long id,
+		long channelId,
+		IQueryHandler<ListChannelMembersQuery, Result<ChannelMembersResponse>> handler,
+		CancellationToken cancellationToken)
+	{
+		var result = await handler.HandleAsync(new ListChannelMembersQuery(id, channelId), cancellationToken);
+		return result.Succeeded
+			? TypedResults.Ok(result.Value)
+			: EndpointResults.Problem(result.Error);
 	}
 
 	private static async Task<Results<Ok<IReadOnlyList<ChannelResponse>>, JsonHttpResult<ErrorBody>>>

--- a/services/guild/src/Guild.Presentation/Endpoints/ChannelsEndpoint.cs
+++ b/services/guild/src/Guild.Presentation/Endpoints/ChannelsEndpoint.cs
@@ -49,6 +49,18 @@ public sealed class ChannelsEndpoint : ICarterModule
 			categoryId = parsed;
 		}
 
+		List<ChannelOverwriteInput>? overwrites = null;
+		if (request.Overwrites is { Count: > 0 } rawOverwrites)
+		{
+			overwrites = new List<ChannelOverwriteInput>(rawOverwrites.Count);
+			foreach (var entry in rawOverwrites)
+			{
+				if (!long.TryParse(entry.TargetId, out var targetId))
+					return TypedResults.Json(new ErrorBody("Each overwrite target_id must be a snowflake string."), statusCode: StatusCodes.Status400BadRequest);
+				overwrites.Add(new ChannelOverwriteInput(targetId, entry.TargetType, entry.Allow, entry.Deny));
+			}
+		}
+
 		var result = await handler.HandleAsync(
 			new CreateChannelCommand(
 				GuildId: id,
@@ -58,7 +70,8 @@ public sealed class ChannelsEndpoint : ICarterModule
 				Topic: request.Topic,
 				Position: request.Position,
 				IsNsfw: request.IsNsfw,
-				SlowmodeSeconds: request.SlowmodeSeconds),
+				SlowmodeSeconds: request.SlowmodeSeconds,
+				Overwrites: overwrites),
 			cancellationToken);
 
 		return result.Succeeded
@@ -133,7 +146,16 @@ public sealed class ChannelsEndpoint : ICarterModule
 		string? Topic,
 		int? Position,
 		bool? IsNsfw,
-		int? SlowmodeSeconds);
+		int? SlowmodeSeconds,
+		IReadOnlyList<CreateChannelOverwriteRequest>? Overwrites);
+
+	// snowflake target_id arrives as a quoted string (JS precision); allow/deny are
+	// permission bitmasks. parsed/validated into ChannelOverwriteInput by CreateAsync
+	private sealed record CreateChannelOverwriteRequest(
+		string? TargetId,
+		string? TargetType,
+		long Allow,
+		long Deny);
 
 	private sealed record UpdateChannelRequest(
 		string? Name,

--- a/services/guild/tests/Guild.FunctionalTests/Endpoints/CreateChannelTests.cs
+++ b/services/guild/tests/Guild.FunctionalTests/Endpoints/CreateChannelTests.cs
@@ -160,6 +160,65 @@ public sealed class CreateChannelTests(GuildApiFactory factory) : IClassFixture<
 	}
 
 	[Fact]
+	public async Task WithMemberDenyReadOverwrite_ChannelSpawnsHiddenFromThatMember()
+	{
+		// creating with an overwrite applies it atomically: the denied member never
+		// sees the channel, so there is no window where it is world-readable
+		var owner = factory.CreateAuthenticatedClient(userId: 5113);
+		var created = await owner.CreateGuildAsync("guild");
+		var guildId = long.Parse(created.GetProperty("id").GetString()!);
+		await factory.AddBareMemberAsync(guildId, userId: 5114);
+
+		var resp = await owner.PostAsJsonAsync(
+			$"/v1/guilds/{guildId}/channels",
+			new
+			{
+				name = "secret",
+				type = "text",
+				overwrites = new[]
+				{
+					new { target_id = "5114", target_type = "member", allow = 0, deny = 2 }
+				}
+			},
+			JsonOptions.SnakeCase);
+
+		Assert.Equal(HttpStatusCode.Created, resp.StatusCode);
+
+		// the denied member does not see the freshly-created channel in their list
+		var member = factory.CreateAuthenticatedClient(userId: 5114);
+		var memberList = await member.GetAsync($"/v1/guilds/{guildId}/channels");
+		Assert.Equal(HttpStatusCode.OK, memberList.StatusCode);
+		Assert.Equal(0, (await memberList.ReadJsonAsync()).GetArrayLength());
+
+		// ...but the owner (Administrator short-circuit) still sees it
+		var ownerList = await owner.GetAsync($"/v1/guilds/{guildId}/channels");
+		Assert.Equal(1, (await ownerList.ReadJsonAsync()).GetArrayLength());
+	}
+
+	[Fact]
+	public async Task WithNonNumericOverwriteTargetId_Returns_400()
+	{
+		var owner = factory.CreateAuthenticatedClient(userId: 5115);
+		var created = await owner.CreateGuildAsync("guild");
+		var id = created.GetProperty("id").GetString()!;
+
+		var resp = await owner.PostAsJsonAsync(
+			$"/v1/guilds/{id}/channels",
+			new
+			{
+				name = "secret",
+				type = "text",
+				overwrites = new[]
+				{
+					new { target_id = "not-a-snowflake", target_type = "member", allow = 0, deny = 2 }
+				}
+			},
+			JsonOptions.SnakeCase);
+
+		Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
+	}
+
+	[Fact]
 	public async Task WithoutPosition_AutoAppendsPerCategory()
 	{
 		var client = factory.CreateAuthenticatedClient(userId: 5109);

--- a/services/guild/tests/Guild.FunctionalTests/Endpoints/ListChannelMembersTests.cs
+++ b/services/guild/tests/Guild.FunctionalTests/Endpoints/ListChannelMembersTests.cs
@@ -1,0 +1,93 @@
+using System.Net;
+using Guild.Domain.Guild;
+using Guild.FunctionalTests.Infrastructure;
+using Xunit;
+
+namespace Guild.FunctionalTests.Endpoints;
+
+public sealed class ListChannelMembersTests(GuildApiFactory factory) : IClassFixture<GuildApiFactory>
+{
+	[Fact]
+	public async Task Without_Token_Returns_401()
+	{
+		var client = factory.CreateClient();
+		var resp = await client.GetAsync("/v1/guilds/1/channels/1/members");
+		Assert.Equal(HttpStatusCode.Unauthorized, resp.StatusCode);
+	}
+
+	[Fact]
+	public async Task NonMember_Returns_403()
+	{
+		var owner = factory.CreateAuthenticatedClient(userId: 5301);
+		var created = await owner.CreateGuildAsync("guild");
+		var guildId = long.Parse(created.GetProperty("id").GetString()!);
+		var channelId = await factory.AddChannelAsync(guildId, categoryId: null, name: "general");
+
+		var stranger = factory.CreateAuthenticatedClient(userId: 5302);
+		var resp = await stranger.GetAsync($"/v1/guilds/{guildId}/channels/{channelId}/members");
+		Assert.Equal(HttpStatusCode.Forbidden, resp.StatusCode);
+	}
+
+	[Fact]
+	public async Task ChannelInOtherGuild_Returns_404()
+	{
+		var owner = factory.CreateAuthenticatedClient(userId: 5303);
+		var a = await owner.CreateGuildAsync("a");
+		var b = await owner.CreateGuildAsync("b");
+		var guildA = long.Parse(a.GetProperty("id").GetString()!);
+		var guildB = long.Parse(b.GetProperty("id").GetString()!);
+		var channelInB = await factory.AddChannelAsync(guildB, categoryId: null, name: "general");
+
+		// the channel exists but belongs to guild B, not the guild in the path
+		var resp = await owner.GetAsync($"/v1/guilds/{guildA}/channels/{channelInB}/members");
+		Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
+	}
+
+	[Fact]
+	public async Task NoOverwrites_ReturnsEveryMember()
+	{
+		var owner = factory.CreateAuthenticatedClient(userId: 5304);
+		var created = await owner.CreateGuildAsync("guild");
+		var guildId = long.Parse(created.GetProperty("id").GetString()!);
+		await factory.AddBareMemberAsync(guildId, userId: 5305);
+		var channelId = await factory.AddChannelAsync(guildId, categoryId: null, name: "general");
+
+		var resp = await owner.GetAsync($"/v1/guilds/{guildId}/channels/{channelId}/members");
+		Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+
+		var ids = await ReadUserIdsAsync(resp);
+		Assert.Contains("5304", ids);
+		Assert.Contains("5305", ids);
+	}
+
+	[Fact]
+	public async Task MemberDeniedRead_IsExcluded_ButOwnerRemains()
+	{
+		var owner = factory.CreateAuthenticatedClient(userId: 5306);
+		var created = await owner.CreateGuildAsync("guild");
+		var guildId = long.Parse(created.GetProperty("id").GetString()!);
+		await factory.AddBareMemberAsync(guildId, userId: 5307);
+		var channelId = await factory.AddChannelAsync(guildId, categoryId: null, name: "secret");
+
+		// deny READ to member 5307 on this channel
+		await factory.AddChannelOverwriteAsync(
+			channelId, OverwriteTargetType.Member, targetId: 5307,
+			allow: 0L, deny: (long)Permission.ReadMessages);
+
+		var resp = await owner.GetAsync($"/v1/guilds/{guildId}/channels/{channelId}/members");
+		var ids = await ReadUserIdsAsync(resp);
+
+		Assert.DoesNotContain("5307", ids);
+		// owner short-circuits to all permissions in the resolver, so still a reader
+		Assert.Contains("5306", ids);
+	}
+
+	private static async Task<List<string>> ReadUserIdsAsync(HttpResponseMessage response)
+	{
+		var body = await response.ReadJsonAsync();
+		var ids = new List<string>();
+		foreach (var element in body.GetProperty("user_ids").EnumerateArray())
+			ids.Add(element.GetString()!);
+		return ids;
+	}
+}

--- a/services/guild/tests/Guild.UnitTests/Application/CreateChannelHandlerTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/CreateChannelHandlerTests.cs
@@ -300,6 +300,38 @@ public sealed class CreateChannelHandlerTests
 		Assert.Empty(overwrites.Store);
 	}
 
+	[Fact]
+	public async Task WithOverwriteGrantingGuildWidePermission_ReturnsUnsupported_AndCreatesNothing()
+	{
+		// a channel overwrite may only carry channel-scoped bits; allowing a
+		// guild-wide bit (here Administrator) would escalate the target past their
+		// role permissions in the resolver, so creation is rejected outright
+		var guilds = new FakeGuildRepository();
+		var channels = new FakeChannelRepository();
+		var cats = new FakeChannelCategoryRepository();
+		var overwrites = new FakeChannelPermissionOverwriteRepository();
+		var guild = GuildEntity.Create(
+			id: 100, name: "Test", description: null, iconUrl: null, bannerUrl: null,
+			ownerId: 1, everyoneRoleId: 101, adminRoleId: 102, now: Now).Value;
+		DomainSeed.AddMember(guild, userId: 2, joinedAt: Now);
+		guilds.Add(guild);
+
+		var handler = HandlerFactory.CreateCommand<CreateChannelCommand, Result<ChannelResponse>>(
+			guilds, channels, cats, overwrites, new FakeEventBus(),
+			new FakeIdGenerator(), new FakeClock(), new FakeCurrentUser { Id = 1 });
+
+		var result = await handler.HandleAsync(
+			new CreateChannelCommand(GuildId: 100, Name: "secret", Type: "text",
+				CategoryId: null, Topic: null, Position: 0,
+				Overwrites: [new ChannelOverwriteInput(
+					TargetId: 2, TargetType: "member", Allow: (long)Permission.Administrator, Deny: 0L)]));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal("Guild.OverwriteUnsupportedPermission", result.Error.Code);
+		Assert.Empty(channels.Store);
+		Assert.Empty(overwrites.Store);
+	}
+
 	private static Guild.Application.Abstractions.Messaging.ICommandHandler<CreateChannelCommand, Result<ChannelResponse>>
 		MakeHandler(
 			out FakeGuildRepository guilds,

--- a/services/guild/tests/Guild.UnitTests/Application/CreateChannelHandlerTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/CreateChannelHandlerTests.cs
@@ -52,8 +52,8 @@ public sealed class CreateChannelHandlerTests
 		guildRepo.Add(guild);
 
 		var handler = HandlerFactory.CreateCommand<CreateChannelCommand, Result<ChannelResponse>>(
-			guildRepo, channelRepo, categoryRepo, new FakeEventBus(),
-			new FakeIdGenerator(), new FakeClock(), new FakeCurrentUser { Id = 2 });
+			guildRepo, channelRepo, categoryRepo, new FakeChannelPermissionOverwriteRepository(),
+			new FakeEventBus(), new FakeIdGenerator(), new FakeClock(), new FakeCurrentUser { Id = 2 });
 
 		var result = await handler.HandleAsync(
 			new CreateChannelCommand(GuildId: 100, Name: "general", Type: "text",
@@ -76,7 +76,7 @@ public sealed class CreateChannelHandlerTests
 		guilds.Add(guild);
 
 		var handler = HandlerFactory.CreateCommand<CreateChannelCommand, Result<ChannelResponse>>(
-			guilds, channels, cats, bus,
+			guilds, channels, cats, new FakeChannelPermissionOverwriteRepository(), bus,
 			new FakeIdGenerator(), new FakeClock(), new FakeCurrentUser { Id = 1 });
 
 		var result = await handler.HandleAsync(
@@ -225,7 +225,7 @@ public sealed class CreateChannelHandlerTests
 		guilds.Add(guild);
 
 		var handler = HandlerFactory.CreateCommand<CreateChannelCommand, Result<ChannelResponse>>(
-			guilds, channels, cats, new FakeEventBus(),
+			guilds, channels, cats, new FakeChannelPermissionOverwriteRepository(), new FakeEventBus(),
 			new FakeIdGenerator(), new FakeClock(), new FakeCurrentUser { Id = 1 });
 
 		var result = await handler.HandleAsync(
@@ -233,6 +233,71 @@ public sealed class CreateChannelHandlerTests
 				CategoryId: null, Topic: null, Position: 0));
 
 		Assert.True(result.Succeeded);
+	}
+
+	[Fact]
+	public async Task WithMemberDenyReadOverwrite_PersistsOverwrite_AndExcludesFromEligible()
+	{
+		// an overwrite supplied at creation must be applied atomically: the row is
+		// stored and the GuildChannelCreated eligibility already reflects it, so a
+		// member denied READ never appears in the eligible set (no all-readers window)
+		var guilds = new FakeGuildRepository();
+		var channels = new FakeChannelRepository();
+		var cats = new FakeChannelCategoryRepository();
+		var overwrites = new FakeChannelPermissionOverwriteRepository();
+		var bus = new FakeEventBus();
+		var guild = GuildEntity.Create(
+			id: 100, name: "Test", description: null, iconUrl: null, bannerUrl: null,
+			ownerId: 1, everyoneRoleId: 101, adminRoleId: 102, now: Now).Value;
+		DomainSeed.AddMember(guild, userId: 2, joinedAt: Now);
+		guilds.Add(guild);
+
+		var handler = HandlerFactory.CreateCommand<CreateChannelCommand, Result<ChannelResponse>>(
+			guilds, channels, cats, overwrites, bus,
+			new FakeIdGenerator(), new FakeClock(), new FakeCurrentUser { Id = 1 });
+
+		var result = await handler.HandleAsync(
+			new CreateChannelCommand(GuildId: 100, Name: "secret", Type: "text",
+				CategoryId: null, Topic: null, Position: 0,
+				Overwrites: [new ChannelOverwriteInput(
+					TargetId: 2, TargetType: "member", Allow: 0L, Deny: (long)Permission.ReadMessages)]));
+
+		Assert.True(result.Succeeded);
+		var stored = Assert.Single(overwrites.Store.Values);
+		Assert.Equal(2, stored.TargetId);
+		Assert.Equal((long)Permission.ReadMessages, stored.Deny);
+
+		var evt = bus.Single<GuildChannelCreated>();
+		Assert.Contains(1L, evt.EligibleUserIds);
+		Assert.DoesNotContain(2L, evt.EligibleUserIds);
+	}
+
+	[Fact]
+	public async Task WithOverwriteForUnknownTarget_ReturnsInvalidTarget_AndCreatesNothing()
+	{
+		var guilds = new FakeGuildRepository();
+		var channels = new FakeChannelRepository();
+		var cats = new FakeChannelCategoryRepository();
+		var overwrites = new FakeChannelPermissionOverwriteRepository();
+		var guild = GuildEntity.Create(
+			id: 100, name: "Test", description: null, iconUrl: null, bannerUrl: null,
+			ownerId: 1, everyoneRoleId: 101, adminRoleId: 102, now: Now).Value;
+		guilds.Add(guild);
+
+		var handler = HandlerFactory.CreateCommand<CreateChannelCommand, Result<ChannelResponse>>(
+			guilds, channels, cats, overwrites, new FakeEventBus(),
+			new FakeIdGenerator(), new FakeClock(), new FakeCurrentUser { Id = 1 });
+
+		var result = await handler.HandleAsync(
+			new CreateChannelCommand(GuildId: 100, Name: "secret", Type: "text",
+				CategoryId: null, Topic: null, Position: 0,
+				Overwrites: [new ChannelOverwriteInput(
+					TargetId: 999999, TargetType: "member", Allow: 0L, Deny: (long)Permission.ReadMessages)]));
+
+		Assert.True(result.IsFailure);
+		Assert.Equal("Guild.OverwriteInvalidTarget", result.Error.Code);
+		Assert.Empty(channels.Store);
+		Assert.Empty(overwrites.Store);
 	}
 
 	private static Guild.Application.Abstractions.Messaging.ICommandHandler<CreateChannelCommand, Result<ChannelResponse>>
@@ -256,7 +321,7 @@ public sealed class CreateChannelHandlerTests
 		}
 
 		return HandlerFactory.CreateCommand<CreateChannelCommand, Result<ChannelResponse>>(
-			guilds, channels, categories, new FakeEventBus(),
+			guilds, channels, categories, new FakeChannelPermissionOverwriteRepository(), new FakeEventBus(),
 			new FakeIdGenerator(), new FakeClock(), new FakeCurrentUser { Id = currentUser });
 	}
 

--- a/services/guild/tests/Guild.UnitTests/Application/ListChannelsHandlerTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Application/ListChannelsHandlerTests.cs
@@ -1,3 +1,4 @@
+using Guild.Application.Abstractions.Messaging;
 using Guild.Application.Features.Channels.Common;
 using Guild.Application.Features.Channels.ListChannels;
 using Guild.Domain.Guild;
@@ -17,9 +18,7 @@ public sealed class ListChannelsHandlerTests
 	public async Task UnknownGuild_ReturnsGuildNotFound()
 	{
 		var guildRepo = new FakeGuildRepository();
-		var channelRepo = new FakeChannelRepository();
-		var handler = HandlerFactory.CreateQuery<ListChannelsQuery, Result<ChannelListResponse>>(
-			guildRepo, channelRepo, new FakeCurrentUser { Id = 1 });
+		var handler = MakeHandler(guildRepo, new FakeChannelRepository(), userId: 1);
 
 		var result = await handler.HandleAsync(new ListChannelsQuery(GuildId: 999));
 
@@ -32,9 +31,7 @@ public sealed class ListChannelsHandlerTests
 	{
 		var guildRepo = new FakeGuildRepository();
 		Seed(guildRepo, ownerId: 1);
-		var channelRepo = new FakeChannelRepository();
-		var handler = HandlerFactory.CreateQuery<ListChannelsQuery, Result<ChannelListResponse>>(
-			guildRepo, channelRepo, new FakeCurrentUser { Id = 99 });
+		var handler = MakeHandler(guildRepo, new FakeChannelRepository(), userId: 99);
 
 		var result = await handler.HandleAsync(new ListChannelsQuery(GuildId: 100));
 
@@ -51,8 +48,7 @@ public sealed class ListChannelsHandlerTests
 		channelRepo.Seed(Channel.Create(1, 100, null, "b", null, ChannelType.Text, 2, Now).Value);
 		channelRepo.Seed(Channel.Create(2, 100, null, "a", null, ChannelType.Text, 1, Now).Value);
 
-		var handler = HandlerFactory.CreateQuery<ListChannelsQuery, Result<ChannelListResponse>>(
-			guildRepo, channelRepo, new FakeCurrentUser { Id = 1 });
+		var handler = MakeHandler(guildRepo, channelRepo, userId: 1);
 
 		var result = await handler.HandleAsync(new ListChannelsQuery(GuildId: 100));
 
@@ -62,11 +58,42 @@ public sealed class ListChannelsHandlerTests
 		Assert.Equal("b", result.Value.Items[1].Name);
 	}
 
-	private static void Seed(FakeGuildRepository repo, long ownerId)
+	[Fact]
+	public async Task Member_DeniedReadOnChannel_HasItFilteredOut()
+	{
+		var guildRepo = new FakeGuildRepository();
+		var guild = Seed(guildRepo, ownerId: 1);
+		DomainSeed.AddMember(guild, userId: 2, joinedAt: Now);
+
+		var channelRepo = new FakeChannelRepository();
+		channelRepo.Seed(Channel.Create(1, 100, null, "general", null, ChannelType.Text, 0, Now).Value);
+		channelRepo.Seed(Channel.Create(2, 100, null, "secret", null, ChannelType.Text, 1, Now).Value);
+
+		var overwrites = new FakeChannelPermissionOverwriteRepository();
+		overwrites.Seed(ChannelPermissionOverwrite.Create(
+			id: 1, guildId: 100, channelId: 2, targetType: OverwriteTargetType.Member,
+			targetId: 2, allow: 0L, deny: (long)Permission.ReadMessages, now: Now).Value);
+
+		var handler = HandlerFactory.CreateQuery<ListChannelsQuery, Result<ChannelListResponse>>(
+			guildRepo, channelRepo, overwrites, new FakeCurrentUser { Id = 2 });
+
+		var result = await handler.HandleAsync(new ListChannelsQuery(GuildId: 100));
+
+		Assert.True(result.Succeeded);
+		Assert.Equal("general", Assert.Single(result.Value.Items).Name);
+	}
+
+	private static IQueryHandler<ListChannelsQuery, Result<ChannelListResponse>> MakeHandler(
+		FakeGuildRepository guilds, FakeChannelRepository channels, long userId) =>
+		HandlerFactory.CreateQuery<ListChannelsQuery, Result<ChannelListResponse>>(
+			guilds, channels, new FakeChannelPermissionOverwriteRepository(), new FakeCurrentUser { Id = userId });
+
+	private static GuildEntity Seed(FakeGuildRepository repo, long ownerId)
 	{
 		var guild = GuildEntity.Create(
 			id: 100, name: "Test", description: null, iconUrl: null, bannerUrl: null,
 			ownerId: ownerId, everyoneRoleId: 101, adminRoleId: 102, now: Now).Value;
 		repo.Add(guild);
+		return guild;
 	}
 }

--- a/services/guild/tests/Guild.UnitTests/Domain/ChannelPermissionResolverTests.cs
+++ b/services/guild/tests/Guild.UnitTests/Domain/ChannelPermissionResolverTests.cs
@@ -60,12 +60,12 @@ public sealed class ChannelPermissionResolverTests
 		DomainSeed.AssignRole(guild, userId: 2, roleId: admin.Id, now: Now);
 		var channel = MakeChannel(guild.Id);
 
-		// even with deny-all overwrites, Administrator short-circuits before
+		// even with a deny-all overwrite, Administrator short-circuits before
 		// overwrites are applied
 		var denyAll = ChannelPermissionOverwrite.Create(
 			id: 9001, guildId: 10, channelId: channel.Id,
 			targetType: OverwriteTargetType.Member, targetId: 2,
-			allow: 0, deny: 0xFFFF, now: Now).Value;
+			allow: 0, deny: ChannelPermissionOverwrite.ChannelScopedMask, now: Now).Value;
 
 		var mask = PermissionResolver.Resolve(
 			guild, userId: 2,
@@ -114,7 +114,7 @@ public sealed class ChannelPermissionResolverTests
 
 		var channel = MakeChannel(guild.Id);
 
-		// role1 allows ManageMessages(4); role2 denies ReadMessages(2) and allows BanMembers(32)
+		// role1 allows ManageMessages(4); role2 denies ReadMessages(2) and allows ManageChannels(8)
 		var ow1 = ChannelPermissionOverwrite.Create(
 			id: 1, guildId: 10, channelId: channel.Id,
 			targetType: OverwriteTargetType.Role, targetId: role1.Id,
@@ -122,16 +122,16 @@ public sealed class ChannelPermissionResolverTests
 		var ow2 = ChannelPermissionOverwrite.Create(
 			id: 2, guildId: 10, channelId: channel.Id,
 			targetType: OverwriteTargetType.Role, targetId: role2.Id,
-			allow: (long)Permission.BanMembers,
+			allow: (long)Permission.ManageChannels,
 			deny: (long)Permission.ReadMessages, now: Now).Value;
 
 		var mask = PermissionResolver.Resolve(
 			guild, userId: 2,
 			overwrites: new[] { ow1, ow2 });
 
-		// base = 515 (1|2|512). aggDeny = 2, aggAllow = 4 | 32 = 36
-		// (515 & ~2) | 36 = 513 | 36 = 549
-		Assert.Equal(549L, mask);
+		// base = 515 (1|2|512). aggDeny = 2, aggAllow = 4 | 8 = 12
+		// (515 & ~2) | 12 = 513 | 12 = 525
+		Assert.Equal(525L, mask);
 	}
 
 	[Fact]


### PR DESCRIPTION
Guild permissions, roles, ownership, and the member list, plus the frontend that drives them.

## Channels & permissions
- Apply permission overwrites atomically when a channel is created (no world-readable window); frontend create-channel modal to set them.
- Reject guild-wide bits (Administrator, ban/kick, ...) on channel overwrites so an overwrite can never escalate past role permissions.
- Hide channels a member is denied `READ_MESSAGES` on from their channel list; shared read-filter helper.
- New `GET /guilds/{id}/channels/{channelId}/members` (readers) endpoint; the member list is scoped to who can actually see the open channel.

## Roles
- Reorder roles by drag-and-drop.
- Assign/unassign roles from the profile card (gated by `ManageRoles`), reusing the members-panel logic.
- Group the member list by hoisted roles only; show all of a member's roles on profile cards; top-role badge tracks the highest role live.

## Ownership
- Transfer guild ownership from the member list and guild settings.
- Propagate ownership changes in real time over SignalR so every member's owner-only UI flips without a refresh.

## Fixes
- Notification bell: handle the `guild_ownership_transferred` type and render any unknown type generically instead of crashing the feed.

Backends build clean; frontend typechecks, lints, and passes unit tests. Contracts (guild/chat/notification) updated to match.